### PR TITLE
chore(ci): use shared workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   ci:
-    uses: Truthdb/.github/.github/workflows/rust-ci.yml@issue-17-workflows
+    uses: Truthdb/.github/.github/workflows/rust-ci.yml@workflows-v1
     with:
       cargo_test_command: cargo test --workspace
       cargo_build_command: cargo build --release --workspace

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   release:
-    uses: Truthdb/.github/.github/workflows/rust-release.yml@issue-17-workflows
+    uses: Truthdb/.github/.github/workflows/rust-release.yml@workflows-v1
     with:
       binary_name: truthdb
       cargo_build_args: --workspace


### PR DESCRIPTION
Implements Truthdb/.github#17 by replacing duplicated CI/release workflows with calls to reusable workflows in Truthdb/.github.\n\nDepends on Truthdb/.github#18 (shared workflows). This PR references the shared workflows via the branch ref @issue-17-workflows so CI works before #18 is merged.