### PR TITLE
feat: package truthdb-server and truthdb-cli as .deb

### DIFF
--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -1,0 +1,170 @@
+name: Debian packages
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build .deb
+    runs-on: ubuntu-latest
+    # Build inside Ubuntu 22.04 so the resulting binaries link against glibc 2.35,
+    # the oldest libc across our four target distros (Debian 12/13, Ubuntu 22.04/24.04).
+    container:
+      image: ubuntu:22.04
+    defaults:
+      run:
+        shell: bash
+    outputs:
+      version: ${{ steps.get_version.outputs.version }}
+      tag: ${{ steps.get_tag.outputs.tag }}
+    steps:
+      - name: Install build prerequisites
+        run: |
+          set -euo pipefail
+          export DEBIAN_FRONTEND=noninteractive
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            ca-certificates curl build-essential pkg-config \
+            dpkg-dev lintian git
+
+      - uses: actions/checkout@v4
+
+      - name: Install Rust 1.92
+        run: |
+          set -euo pipefail
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+            | sh -s -- -y --default-toolchain 1.92.0 --profile minimal
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+
+      - name: Install cargo-deb
+        run: cargo install cargo-deb --locked
+
+      - name: Get tag
+        id: get_tag
+        run: echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+
+      - name: Get version from tag
+        id: get_version
+        run: echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
+
+      - name: Build release binaries
+        run: cargo build --release --workspace
+
+      - name: Build .deb packages
+        run: |
+          set -euo pipefail
+          cargo deb -p truthdb --no-build
+          cargo deb -p truthdb-cli --no-build
+          ls -la target/debian/
+
+      - name: Lintian (warn-only)
+        continue-on-error: true
+        run: lintian --no-tag-display-limit target/debian/*.deb || true
+
+      - name: Upload .deb artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: debs
+          path: target/debian/*.deb
+          if-no-files-found: error
+
+  smoke-test:
+    name: Smoke test (${{ matrix.image }})
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - debian:12
+          - debian:13
+          - ubuntu:22.04
+          - ubuntu:24.04
+    container:
+      image: ${{ matrix.image }}
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Install minimal deps
+        run: |
+          set -euo pipefail
+          export DEBIAN_FRONTEND=noninteractive
+          apt-get update
+          apt-get install -y --no-install-recommends ca-certificates
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: debs
+          path: debs
+
+      - name: Install both packages
+        run: |
+          set -euo pipefail
+          export DEBIAN_FRONTEND=noninteractive
+          # Install with apt-get so dependencies (adduser, init-system-helpers) resolve.
+          # In a non-systemd container the maintainer scripts no-op the deb-systemd-* calls,
+          # but user/group creation and file placement still happen.
+          apt-get install -y ./debs/truthdb-server_*.deb ./debs/truthdb-cli_*.deb
+
+      - name: Verify install
+        run: |
+          set -euo pipefail
+          test -x /usr/bin/truthdb
+          test -x /usr/bin/truthdb-cli
+          test -f /etc/truthdb/truthdb.toml
+          test -f /lib/systemd/system/truthdb.service
+          getent passwd truthdb
+          getent group truthdb
+          /usr/bin/truthdb-cli --help
+
+      - name: Verify purge cleanup
+        run: |
+          set -euo pipefail
+          export DEBIAN_FRONTEND=noninteractive
+          apt-get purge -y truthdb-server truthdb-cli
+          ! getent passwd truthdb
+          ! test -d /var/lib/truthdb
+          ! test -f /etc/truthdb/truthdb.toml
+
+  publish:
+    name: Publish to GitHub Release and dispatch apt repo
+    needs: [build, smoke-test]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: debs
+          path: debs
+
+      - name: Upload .debs to GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # Tag must already exist as a release (release.yml runs in parallel and creates it).
+          # If not yet created, retry briefly.
+          TAG="${{ needs.build.outputs.tag }}"
+          for i in 1 2 3 4 5; do
+            if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+              break
+            fi
+            echo "Release $TAG not found yet, retry $i/5..."
+            sleep 10
+          done
+          gh release upload "$TAG" debs/*.deb --clobber --repo "$GITHUB_REPOSITORY"
+
+      - name: Dispatch publish to Truthdb/apt
+        env:
+          GH_TOKEN: ${{ secrets.APT_REPO_DISPATCH_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh api -X POST repos/Truthdb/apt/dispatches \
+            -f event_type=new-debs \
+            -F "client_payload[tag]=${{ needs.build.outputs.tag }}" \
+            -F "client_payload[version]=${{ needs.build.outputs.version }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,7 @@ jobs:
           # Bundle both the executable and the systemd unit.
           tar czf "target/release/${ARCHIVE}" \
             -C target/release truthdb \
-            -C "${ROOT}" truthdb.service
+            -C "${ROOT}/packaging" truthdb.service
 
           # Keep a simple checksum file (binary checksum). Consumers may also checksum the archive.
           sha256sum target/release/truthdb > "target/release/${CHECKSUM}"

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ target
 # Added by cargo
 
 /target
+/target-deb

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,8 @@
 name = "truthdb"
 version = "0.1.0"
 edition = "2024"
+description = "TruthDB database service: io_uring-backed storage with a custom binary protocol on TCP/9623."
+license = "MIT"
 
 [workspace]
 members = [
@@ -44,3 +46,23 @@ debug = false
 
 [profile.dev.package.truthdb-core]
 debug = 2
+
+[package.metadata.deb]
+name = "truthdb-server"
+maintainer = "TruthDB Maintainers <contact@truthdb.io>"
+section = "database"
+priority = "optional"
+extended-description = """\
+TruthDB is a database service with io_uring-backed storage and a custom \
+binary protocol on TCP/9623. This package installs the truthdb daemon, its \
+hardened systemd unit, and a system user to run the service. Configuration \
+lives in /etc/truthdb/truthdb.toml; data lives in /var/lib/truthdb."""
+depends = "libc6 (>= 2.35), adduser, init-system-helpers (>= 1.52)"
+suggests = "truthdb-cli"
+assets = [
+    ["target/release/truthdb", "usr/bin/", "755"],
+    ["packaging/truthdb.service", "lib/systemd/system/", "644"],
+    ["packaging/truthdb.toml.example", "etc/truthdb/truthdb.toml", "644"],
+]
+conf-files = ["/etc/truthdb/truthdb.toml"]
+maintainer-scripts = "packaging/debian"

--- a/crates/truthdb-cli/Cargo.toml
+++ b/crates/truthdb-cli/Cargo.toml
@@ -2,6 +2,8 @@
 name = "truthdb-cli"
 version = "0.1.0"
 edition = "2024"
+description = "Command-line client and REPL for TruthDB, speaking the truthdb binary protocol on TCP/9623."
+license = "MIT"
 
 [dependencies]
 clap = { version = "4.5.53", features = ["derive", "env"] }
@@ -14,3 +16,18 @@ directories = { workspace = true }
 tokio = { workspace = true }
 truthdb-proto = { workspace = true }
 truthdb-net = { workspace = true }
+
+[package.metadata.deb]
+name = "truthdb-cli"
+maintainer = "TruthDB Maintainers <contact@truthdb.io>"
+section = "database"
+priority = "optional"
+extended-description = """\
+Command-line client and interactive REPL for TruthDB. Connects to a \
+truthdb-server over its binary protocol on TCP/9623 (default host \
+127.0.0.1; override with --host/--port or TRUTHDB_HOST/TRUTHDB_PORT)."""
+depends = "libc6 (>= 2.35)"
+suggests = "truthdb-server"
+assets = [
+    ["target/release/truthdb-cli", "usr/bin/", "755"],
+]

--- a/packaging/debian/postinst
+++ b/packaging/debian/postinst
@@ -1,0 +1,43 @@
+#!/bin/sh
+# postinst for truthdb-server. Creates the system user/group and integrates with systemd.
+set -e
+
+case "$1" in
+    configure)
+        # Create the truthdb system group/user if not already present.
+        if ! getent group truthdb >/dev/null; then
+            addgroup --system --quiet truthdb
+        fi
+        if ! getent passwd truthdb >/dev/null; then
+            adduser --system --ingroup truthdb --no-create-home \
+                    --home /var/lib/truthdb --gecos "TruthDB service" \
+                    --shell /usr/sbin/nologin --quiet truthdb
+        fi
+
+        # Reload systemd so it sees the newly-installed unit, then enable + start it.
+        if [ -d /run/systemd/system ]; then
+            systemctl --system daemon-reload >/dev/null || true
+        fi
+        if [ -x /usr/bin/deb-systemd-helper ]; then
+            deb-systemd-helper enable truthdb.service >/dev/null || true
+        fi
+        if [ -d /run/systemd/system ] && [ -x /usr/bin/deb-systemd-invoke ]; then
+            if [ -z "$2" ]; then
+                # Fresh install.
+                deb-systemd-invoke start truthdb.service >/dev/null || true
+            else
+                # Upgrade ($2 is the previously-installed version) — restart so
+                # the new binary takes effect.
+                deb-systemd-invoke try-restart truthdb.service >/dev/null || true
+            fi
+        fi
+        ;;
+    abort-upgrade|abort-remove|abort-deconfigure)
+        ;;
+    *)
+        echo "postinst called with unknown argument \`$1'" >&2
+        exit 1
+        ;;
+esac
+
+exit 0

--- a/packaging/debian/postrm
+++ b/packaging/debian/postrm
@@ -1,0 +1,35 @@
+#!/bin/sh
+# postrm for truthdb-server.
+#   remove: mask the unit so a stale enabled symlink can't auto-start a half-removed service.
+#   purge:  delete state directory, system user/group, and helper state. Conffiles
+#           (/etc/truthdb/truthdb.toml) are removed by dpkg itself.
+set -e
+
+case "$1" in
+    purge)
+        if [ -x /usr/bin/deb-systemd-helper ]; then
+            deb-systemd-helper purge truthdb.service >/dev/null || true
+            deb-systemd-helper unmask truthdb.service >/dev/null || true
+        fi
+        rm -rf /var/lib/truthdb
+        if getent passwd truthdb >/dev/null; then
+            deluser --system --quiet truthdb || true
+        fi
+        if getent group truthdb >/dev/null; then
+            delgroup --system --quiet truthdb || true
+        fi
+        ;;
+    remove)
+        if [ -x /usr/bin/deb-systemd-helper ]; then
+            deb-systemd-helper mask truthdb.service >/dev/null || true
+        fi
+        ;;
+    upgrade|failed-upgrade|abort-install|abort-upgrade|disappear)
+        ;;
+    *)
+        echo "postrm called with unknown argument \`$1'" >&2
+        exit 1
+        ;;
+esac
+
+exit 0

--- a/packaging/debian/prerm
+++ b/packaging/debian/prerm
@@ -1,0 +1,19 @@
+#!/bin/sh
+# prerm for truthdb-server. Stops the service before files are removed or replaced.
+set -e
+
+case "$1" in
+    remove|upgrade|deconfigure)
+        if [ -d /run/systemd/system ] && [ -x /usr/bin/deb-systemd-invoke ]; then
+            deb-systemd-invoke stop truthdb.service >/dev/null || true
+        fi
+        ;;
+    failed-upgrade)
+        ;;
+    *)
+        echo "prerm called with unknown argument \`$1'" >&2
+        exit 1
+        ;;
+esac
+
+exit 0

--- a/packaging/truthdb.service
+++ b/packaging/truthdb.service
@@ -9,7 +9,7 @@ User=truthdb
 Group=truthdb
 
 # TruthDB is expected to run as a long-lived Tokio process and stop on SIGTERM.
-ExecStart=/usr/local/bin/truthdb
+ExecStart=/usr/bin/truthdb
 
 Restart=on-failure
 RestartSec=2

--- a/packaging/truthdb.toml.example
+++ b/packaging/truthdb.toml.example
@@ -1,0 +1,27 @@
+# TruthDB configuration overrides.
+#
+# Every line in this file is commented out by default. The values shown are
+# the embedded defaults built into the binary; uncomment a line to override.
+# After editing, restart the service: `systemctl restart truthdb`.
+#
+# Storage paths inside this file are resolved relative to the systemd
+# StateDirectory, so the default `path = "truth.db"` ends up at
+# /var/lib/truthdb/truth.db. Use an absolute path to override.
+
+[network]
+# addr = "0.0.0.0"
+# port = 9623
+
+[storage]
+# path = "truth.db"
+# size_gib = 10
+# wal_ratio = 0.05
+# metadata_ratio = 0.08
+# snapshot_ratio = 0.02
+# allocator_ratio = 0.02
+# reserved_ratio = 0.17
+# group_sync_batches = 32
+# group_sync_ms = 5
+# backpressure_timeout_ms = 50
+# snapshot_min_interval_ms = 1000
+# snapshot_wal_threshold = 0.7

--- a/src/config.rs
+++ b/src/config.rs
@@ -177,36 +177,62 @@ fn systemd_state_directory() -> Option<PathBuf> {
     Some(Path::new(first).to_path_buf())
 }
 
+/// Path of the system-wide config file installed by the Debian package.
+const SYSTEM_CONFIG_PATH: &str = "/etc/truthdb/truthdb.toml";
+
 impl Config {
-    /// Load config: embedded default, then override with OS-standard config file if present.
+    /// Load config: embedded default, then per-user XDG override, then system-wide override.
+    ///
+    /// Apply order is lowest-priority first so later applications win for fields they set.
+    /// `/etc/truthdb/truthdb.toml` is the highest priority — when a sysadmin uncomments a
+    /// value there, it overrides anything in `~/.config/org.truthdb/truthdb/truthdb.toml`.
+    /// Missing files no-op.
     pub fn load() -> Self {
-        // Load embedded default config
         let default_str = include_str!("../config/default.toml");
         let mut config: Config = toml::from_str(default_str).unwrap_or_default();
 
-        // Try to override with OS-standard config file
+        // Per-user XDG config (dev convenience).
         if let Some(proj_dirs) = ProjectDirs::from("org", "truthdb", "truthdb") {
             let mut config_path = PathBuf::from(proj_dirs.config_dir());
             config_path.push("truthdb.toml");
-            if config_path.exists()
-                && let Ok(contents) = fs::read_to_string(&config_path)
-                && let Ok(override_cfg) = toml::from_str::<ConfigOverride>(&contents)
-            {
-                if let Some(addr) = override_cfg.addr {
-                    config.network.addr = addr;
-                }
-                if let Some(port) = override_cfg.port {
-                    config.network.port = port;
-                }
-                if let Some(network) = override_cfg.network {
-                    apply_network_override(&mut config.network, network);
-                }
-                if let Some(storage) = override_cfg.storage {
-                    apply_storage_override(&mut config.storage, storage);
-                }
-            }
+            apply_override_file(&config_path, &mut config);
         }
+
+        // System-wide config installed by the .deb (highest priority).
+        apply_override_file(Path::new(SYSTEM_CONFIG_PATH), &mut config);
+
         config
+    }
+}
+
+/// Read a TOML override file at `path` and apply it to `config`. No-op if the file
+/// does not exist, cannot be read, or fails to parse.
+fn apply_override_file(path: &Path, config: &mut Config) {
+    if !path.exists() {
+        return;
+    }
+    let Ok(contents) = fs::read_to_string(path) else {
+        return;
+    };
+    let Ok(override_cfg) = toml::from_str::<ConfigOverride>(&contents) else {
+        return;
+    };
+    apply_override(override_cfg, config);
+}
+
+/// Apply a parsed override to `config`. Each field is set only if the override specifies it.
+fn apply_override(override_cfg: ConfigOverride, config: &mut Config) {
+    if let Some(addr) = override_cfg.addr {
+        config.network.addr = addr;
+    }
+    if let Some(port) = override_cfg.port {
+        config.network.port = port;
+    }
+    if let Some(network) = override_cfg.network {
+        apply_network_override(&mut config.network, network);
+    }
+    if let Some(storage) = override_cfg.storage {
+        apply_storage_override(&mut config.storage, storage);
     }
 }
 
@@ -285,5 +311,88 @@ fn apply_storage_override(target: &mut StorageConfig, source: StorageConfigOverr
     }
     if let Some(snapshot_wal_threshold) = source.snapshot_wal_threshold {
         target.snapshot_wal_threshold = snapshot_wal_threshold;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn default_config() -> Config {
+        let default_str = include_str!("../config/default.toml");
+        toml::from_str(default_str).unwrap()
+    }
+
+    #[test]
+    fn override_sets_only_specified_fields() {
+        let toml = r#"
+            [network]
+            port = 12345
+
+            [storage]
+            size_gib = 42
+        "#;
+        let mut config = default_config();
+        let override_cfg: ConfigOverride = toml::from_str(toml).unwrap();
+        apply_override(override_cfg, &mut config);
+
+        assert_eq!(config.network.port, 12345);
+        assert_eq!(config.storage.size_gib, 42);
+        // Unset fields keep defaults.
+        assert_eq!(config.network.addr, "0.0.0.0");
+        assert_eq!(config.storage.path, "truth.db");
+    }
+
+    #[test]
+    fn override_file_missing_is_noop() {
+        let mut config = default_config();
+        apply_override_file(
+            Path::new("/nonexistent/truthdb-test-missing.toml"),
+            &mut config,
+        );
+        // Still default.
+        assert_eq!(config.network.port, 9623);
+    }
+
+    #[test]
+    fn override_file_malformed_is_noop() {
+        let dir = std::env::temp_dir().join(format!(
+            "truthdb-config-test-{}-malformed",
+            std::process::id()
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("truthdb.toml");
+        fs::write(&path, "this is not valid toml === {{{").unwrap();
+
+        let mut config = default_config();
+        apply_override_file(&path, &mut config);
+        assert_eq!(config.network.port, 9623);
+
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn override_file_applies_when_valid() {
+        let dir =
+            std::env::temp_dir().join(format!("truthdb-config-test-{}-valid", std::process::id()));
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("truthdb.toml");
+        fs::write(
+            &path,
+            r#"
+                [network]
+                addr = "127.0.0.1"
+                port = 7777
+            "#,
+        )
+        .unwrap();
+
+        let mut config = default_config();
+        apply_override_file(&path, &mut config);
+
+        assert_eq!(config.network.addr, "127.0.0.1");
+        assert_eq!(config.network.port, 7777);
+
+        fs::remove_dir_all(&dir).ok();
     }
 }


### PR DESCRIPTION
Adds Debian packaging via cargo-deb, a CI workflow that builds, smoke-tests, and publishes the two .debs on every v* tag, and a small server-side change so a packaged install reads /etc/truthdb/truthdb.toml.

Packaging:
  * packaging/truthdb.service — moved from repo root with ExecStart switched to /usr/bin/truthdb (FHS-correct for a distro package). The existing release.yml tar.gz path is updated to the new location.
  * packaging/truthdb.toml.example — installed as a conffile at /etc/truthdb/truthdb.toml; commented-out copy of config/default.toml.
  * packaging/debian/{postinst,prerm,postrm} — create/remove the truthdb system user, enable/disable the unit via deb-systemd-helper, restart on upgrade, purge /var/lib/truthdb on apt purge.
  * Cargo.toml metadata for both crates: depends on libc6 (>= 2.35) so the same .deb works on Debian 12/13 and Ubuntu 22.04/24.04.

CI (.github/workflows/deb.yml):
  * build job in ubuntu:22.04 (glibc 2.35 floor) → cargo deb both crates.
  * smoke-test matrix over the four target distros: apt-get install the .debs, verify files/user/group, then apt-get purge and verify cleanup.
  * publish job uploads to the GitHub release and repository_dispatches to Truthdb/apt for repo-side ingestion.

Config (src/config.rs):
  * /etc/truthdb/truthdb.toml is now read as the highest-priority override (above the existing XDG path). Override apply is factored into apply_override / apply_override_file helpers with unit tests.

## Summary

Describe what this PR changes and why.

## Checklist

- [ ] I kept the change focused and scoped
- [ ] I ran relevant tests/lints locally (or explained why not)
- [ ] I updated documentation where needed
- [ ] I considered backwards compatibility and migration impact

## Testing

Describe what you tested and how.
