### PR TITLE
fix(deb): version the .deb from the git tag, not Cargo.toml

### DIFF
--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -50,7 +50,17 @@ jobs:
 
       - name: Get version from tag
         id: get_version
-        run: echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
+        # The Cargo.toml version is intentionally pinned at 0.1.0; releases are
+        # driven entirely by the git tag. Translate the tag into a Debian-valid
+        # version: strip the leading `v`, replace `-` with `~` so prereleases like
+        # v0.1.40-rc1 sort BEFORE v0.1.40 (apt uses `~` as a "less than" marker),
+        # then append `-1` as the Debian revision.
+        run: |
+          set -euo pipefail
+          TAG_VERSION="${GITHUB_REF#refs/tags/v}"
+          DEB_VERSION="${TAG_VERSION//-/\~}-1"
+          echo "version=$TAG_VERSION" >> "$GITHUB_OUTPUT"
+          echo "deb_version=$DEB_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Build release binaries
         run: cargo build --release --workspace
@@ -58,8 +68,9 @@ jobs:
       - name: Build .deb packages
         run: |
           set -euo pipefail
-          cargo deb -p truthdb --no-build
-          cargo deb -p truthdb-cli --no-build
+          DEB_VERSION="${{ steps.get_version.outputs.deb_version }}"
+          cargo deb -p truthdb --no-build --deb-version "$DEB_VERSION"
+          cargo deb -p truthdb-cli --no-build --deb-version "$DEB_VERSION"
           ls -la target/debian/
 
       - name: Lintian (warn-only)


### PR DESCRIPTION
The release workflow drives versions entirely from the git tag (latest is v0.1.39) while Cargo.toml is pinned at 0.1.0. Without --deb-version every release would produce identically-named truthdb-server_0.1.0-1_amd64.deb files and apt-get upgrade would never advance.

  * Compute DEB_VERSION = ${tag#v} with `-` replaced by `~` (so v0.1.40-rc1 becomes 0.1.40~rc1, which apt sorts BEFORE 0.1.40) and append `-1` as the Debian revision.
  * Pass --deb-version to both `cargo deb` invocations.

Verified locally:
  v0.1.40-rc1 -> truthdb-server_0.1.40~rc1-1_amd64.deb
  v0.1.40     -> truthdb-server_0.1.40-1_amd64.deb

## Summary

Describe what this PR changes and why.

## Checklist

- [ ] I kept the change focused and scoped
- [ ] I ran relevant tests/lints locally (or explained why not)
- [ ] I updated documentation where needed
- [ ] I considered backwards compatibility and migration impact

## Testing

Describe what you tested and how.
