### PR TITLE
fix(version): bake the git-tag version into binaries (HelloResp, --ve…

### DIFF
--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -63,6 +63,8 @@ jobs:
           echo "deb_version=$DEB_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Build release binaries
+        env:
+          TRUTHDB_VERSION: ${{ steps.get_version.outputs.version }}
         run: cargo build --release --workspace
 
       - name: Build .deb packages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,8 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Build release
+        env:
+          TRUTHDB_VERSION: ${{ needs.create-release.outputs.version }}
         run: cargo build --release --workspace
 
       - name: Package binary

--- a/crates/truthdb-bench/build.rs
+++ b/crates/truthdb-bench/build.rs
@@ -1,0 +1,38 @@
+// Resolve the TRUTHDB_VERSION string baked into the binary at compile time.
+//
+// Precedence (highest to lowest):
+//   1. $TRUTHDB_VERSION env var — set by CI from the git tag.
+//   2. `git describe --tags --dirty --always` — useful for local dev builds.
+//   3. $CARGO_PKG_VERSION — last-resort fallback; matches the pre-build.rs behaviour.
+//
+// The Cargo.toml version is intentionally pinned at 0.1.0; real versions live on git tags.
+
+use std::process::Command;
+
+fn main() {
+    println!("cargo:rerun-if-env-changed=TRUTHDB_VERSION");
+
+    let version = std::env::var("TRUTHDB_VERSION")
+        .ok()
+        .or_else(git_describe)
+        .unwrap_or_else(|| std::env::var("CARGO_PKG_VERSION").unwrap());
+
+    println!("cargo:rustc-env=TRUTHDB_VERSION={version}");
+}
+
+fn git_describe() -> Option<String> {
+    let output = Command::new("git")
+        .args(["describe", "--tags", "--dirty", "--always"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let s = String::from_utf8(output.stdout).ok()?;
+    let trimmed = s.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    // Strip leading `v` so the format matches the CI env var (e.g. "0.1.40-rc1").
+    Some(trimmed.strip_prefix('v').unwrap_or(trimmed).to_string())
+}

--- a/crates/truthdb-bench/src/main.rs
+++ b/crates/truthdb-bench/src/main.rs
@@ -308,7 +308,7 @@ async fn connect(addr: &str) -> Result<TcpStream> {
     let req = HelloReq {
         protocol_version: PROTOCOL_VERSION,
         client_name: "truthdb-bench".to_string(),
-        client_version: env!("CARGO_PKG_VERSION").to_string(),
+        client_version: env!("TRUTHDB_VERSION").to_string(),
     };
 
     let frame = Frame {

--- a/crates/truthdb-cli/build.rs
+++ b/crates/truthdb-cli/build.rs
@@ -1,0 +1,38 @@
+// Resolve the TRUTHDB_VERSION string baked into the binary at compile time.
+//
+// Precedence (highest to lowest):
+//   1. $TRUTHDB_VERSION env var — set by CI from the git tag.
+//   2. `git describe --tags --dirty --always` — useful for local dev builds.
+//   3. $CARGO_PKG_VERSION — last-resort fallback; matches the pre-build.rs behaviour.
+//
+// The Cargo.toml version is intentionally pinned at 0.1.0; real versions live on git tags.
+
+use std::process::Command;
+
+fn main() {
+    println!("cargo:rerun-if-env-changed=TRUTHDB_VERSION");
+
+    let version = std::env::var("TRUTHDB_VERSION")
+        .ok()
+        .or_else(git_describe)
+        .unwrap_or_else(|| std::env::var("CARGO_PKG_VERSION").unwrap());
+
+    println!("cargo:rustc-env=TRUTHDB_VERSION={version}");
+}
+
+fn git_describe() -> Option<String> {
+    let output = Command::new("git")
+        .args(["describe", "--tags", "--dirty", "--always"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let s = String::from_utf8(output.stdout).ok()?;
+    let trimmed = s.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    // Strip leading `v` so the format matches the CI env var (e.g. "0.1.40-rc1").
+    Some(trimmed.strip_prefix('v').unwrap_or(trimmed).to_string())
+}

--- a/crates/truthdb-cli/src/main.rs
+++ b/crates/truthdb-cli/src/main.rs
@@ -18,7 +18,7 @@ use truthdb_proto::{
 #[derive(Parser, Debug)]
 #[command(name = "truthdb-cli")]
 #[command(about = "Command-line client for TruthDB")]
-#[command(version)]
+#[command(version = env!("TRUTHDB_VERSION"))]
 struct Cli {
     /// Host of the TruthDB server.
     #[arg(long, env = "TRUTHDB_HOST")]
@@ -173,7 +173,7 @@ async fn send_hello(stream: &mut TcpStream) -> Result<()> {
     let req = HelloReq {
         protocol_version: PROTOCOL_VERSION,
         client_name: "truthdb-cli".to_string(),
-        client_version: env!("CARGO_PKG_VERSION").to_string(),
+        client_version: env!("TRUTHDB_VERSION").to_string(),
     };
 
     let frame = Frame {

--- a/crates/truthdb-core/build.rs
+++ b/crates/truthdb-core/build.rs
@@ -1,0 +1,38 @@
+// Resolve the TRUTHDB_VERSION string baked into the binary at compile time.
+//
+// Precedence (highest to lowest):
+//   1. $TRUTHDB_VERSION env var — set by CI from the git tag.
+//   2. `git describe --tags --dirty --always` — useful for local dev builds.
+//   3. $CARGO_PKG_VERSION — last-resort fallback; matches the pre-build.rs behaviour.
+//
+// The Cargo.toml version is intentionally pinned at 0.1.0; real versions live on git tags.
+
+use std::process::Command;
+
+fn main() {
+    println!("cargo:rerun-if-env-changed=TRUTHDB_VERSION");
+
+    let version = std::env::var("TRUTHDB_VERSION")
+        .ok()
+        .or_else(git_describe)
+        .unwrap_or_else(|| std::env::var("CARGO_PKG_VERSION").unwrap());
+
+    println!("cargo:rustc-env=TRUTHDB_VERSION={version}");
+}
+
+fn git_describe() -> Option<String> {
+    let output = Command::new("git")
+        .args(["describe", "--tags", "--dirty", "--always"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let s = String::from_utf8(output.stdout).ok()?;
+    let trimmed = s.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    // Strip leading `v` so the format matches the CI env var (e.g. "0.1.40-rc1").
+    Some(trimmed.strip_prefix('v').unwrap_or(trimmed).to_string())
+}

--- a/crates/truthdb-core/src/dispatcher.rs
+++ b/crates/truthdb-core/src/dispatcher.rs
@@ -24,7 +24,7 @@ impl Dispatcher {
                 let resp = HelloResp {
                     protocol_version: PROTOCOL_VERSION,
                     server_name: "truthdb".to_string(),
-                    server_version: env!("CARGO_PKG_VERSION").to_string(),
+                    server_version: env!("TRUTHDB_VERSION").to_string(),
                     capabilities: 0,
                 };
 


### PR DESCRIPTION
…rsion)

When the REPL connected to a v0.1.40-rc1 server it printed "Connected: truthdb 0.1.0 (proto 1)" because the server stuffed env!("CARGO_PKG_VERSION") into HelloResp.server_version, and the project intentionally pins [package].version at 0.1.0 — releases live on git tags.

Same bug in three other sites that report a version to humans or other processes:
  * crates/truthdb-cli/src/main.rs — clap's #[command(version)] (so `truthdb-cli --version` was lying).
  * crates/truthdb-cli/src/main.rs — client_version in the CLI's HelloReq.
  * crates/truthdb-bench/src/main.rs — client_version in the bench's HelloReq.

Fix:
  * Add a build.rs to each of truthdb-core, truthdb-cli, truthdb-bench that resolves TRUTHDB_VERSION with the precedence $TRUTHDB_VERSION env  >  `git describe --tags --dirty --always` (stripped of leading `v`)  >  $CARGO_PKG_VERSION (last-resort). Each emits `cargo:rustc-env=TRUTHDB_VERSION=...`.
  * Switch the four `env!("CARGO_PKG_VERSION")` sites to `env!("TRUTHDB_VERSION")`.
  * release.yml and deb.yml export TRUTHDB_VERSION from the tag-derived version on the cargo build step.

Verified locally: built with TRUTHDB_VERSION=0.1.40-rc1 set, ran the server, connected via the CLI. Output:
  Connected: truthdb 0.1.40-rc1 (proto 1)
  truthdb-cli --version  ->  truthdb-cli 0.1.40-rc1

In dev checkouts without the env var set, build.rs falls back to `git describe`, so unreleased local builds will report things like `0.1.40-rc1-3-gabc123-dirty` instead of the stale 0.1.0.

## Summary

Describe what this PR changes and why.

## Checklist

- [ ] I kept the change focused and scoped
- [ ] I ran relevant tests/lints locally (or explained why not)
- [ ] I updated documentation where needed
- [ ] I considered backwards compatibility and migration impact

## Testing

Describe what you tested and how.
