### PR TITLE
feat(storage): storage substrate v2 — ARIES-ready WAL, live allocator, buffer pool (Stage 1)

### DIFF
--- a/crates/truthdb-core/src/allocator.rs
+++ b/crates/truthdb-core/src/allocator.rs
@@ -1,8 +1,23 @@
 use crate::storage_layout::PAGE_SIZE;
 
+/// Pages per allocation extent.
+pub const EXTENT_PAGES: u64 = 64;
+
+/// Bitmap page allocator over the data region.
+///
+/// v2 semantics: a single live instance is kept in memory while the engine
+/// runs. The bitmap is persisted only at checkpoint; between checkpoints,
+/// persistent alloc/free operations are WAL-logged by the storage layer and
+/// replayed on recovery. Temporary extents (spills, version store) are
+/// tracked separately, excluded from the persisted bitmap, and vanish on
+/// restart.
 pub struct PageAllocator {
     bitmap: Vec<u8>,
     total_pages: u64,
+    /// Next-fit cursor: searches resume where the last allocation ended.
+    cursor: u64,
+    /// Live temporary extents as (start_page, num_pages).
+    temp_extents: Vec<(u64, u64)>,
 }
 
 impl PageAllocator {
@@ -12,6 +27,8 @@ impl PageAllocator {
         PageAllocator {
             bitmap: vec![0u8; bitmap_bytes],
             total_pages,
+            cursor: 0,
+            temp_extents: Vec::new(),
         }
     }
 
@@ -20,25 +37,87 @@ impl PageAllocator {
         PageAllocator {
             bitmap,
             total_pages,
+            cursor: 0,
+            temp_extents: Vec::new(),
         }
     }
 
+    /// Allocates a contiguous run of `num_pages`, next-fit from the cursor.
     pub fn allocate(&mut self, num_pages: u64) -> Option<u64> {
         if num_pages == 0 || num_pages > self.total_pages {
             return None;
         }
-        let mut run_start = 0u64;
+        // Two passes: cursor -> end, then start -> cursor (runs never span
+        // the wrap because page numbers restart the run at 0).
+        if let Some(start) = self.scan_range(self.cursor, self.total_pages, num_pages) {
+            self.take_run(start, num_pages);
+            return Some(start);
+        }
+        if let Some(start) = self.scan_range(0, self.cursor, num_pages) {
+            self.take_run(start, num_pages);
+            return Some(start);
+        }
+        None
+    }
+
+    /// Allocates one standard extent ([`EXTENT_PAGES`] pages).
+    pub fn allocate_extent(&mut self) -> Option<u64> {
+        self.allocate(EXTENT_PAGES)
+    }
+
+    /// Allocates one standard extent flagged temporary: excluded from the
+    /// persisted bitmap and reclaimed wholesale on restart.
+    pub fn allocate_temp_extent(&mut self) -> Option<u64> {
+        let start = self.allocate(EXTENT_PAGES)?;
+        self.temp_extents.push((start, EXTENT_PAGES));
+        Some(start)
+    }
+
+    pub fn free(&mut self, start_page: u64, num_pages: u64) {
+        for p in start_page..start_page + num_pages {
+            self.set_free(p);
+        }
+        self.temp_extents
+            .retain(|(start, len)| !(*start == start_page && *len == num_pages));
+    }
+
+    /// Marks a run as allocated regardless of current state (recovery
+    /// reconciliation and WAL redo).
+    pub fn mark_used(&mut self, start_page: u64, num_pages: u64) {
+        for p in start_page..start_page + num_pages {
+            self.set_used(p);
+        }
+    }
+
+    /// The bitmap to persist at checkpoint: temporary extents cleared, since
+    /// they must not survive a restart.
+    pub fn persistable_bitmap(&self) -> Vec<u8> {
+        let mut bitmap = self.bitmap.clone();
+        for (start, len) in &self.temp_extents {
+            for p in *start..*start + *len {
+                let byte_idx = (p / 8) as usize;
+                if byte_idx < bitmap.len() {
+                    bitmap[byte_idx] &= !(1 << (p % 8) as u8);
+                }
+            }
+        }
+        bitmap
+    }
+
+    pub fn is_allocated(&self, page: u64) -> bool {
+        !self.is_free(page)
+    }
+
+    fn scan_range(&self, from: u64, to: u64, num_pages: u64) -> Option<u64> {
+        let mut run_start = from;
         let mut run_len = 0u64;
-        for page in 0..self.total_pages {
+        for page in from..to {
             if self.is_free(page) {
                 if run_len == 0 {
                     run_start = page;
                 }
                 run_len += 1;
                 if run_len == num_pages {
-                    for p in run_start..run_start + num_pages {
-                        self.set_used(p);
-                    }
                     return Some(run_start);
                 }
             } else {
@@ -48,20 +127,20 @@ impl PageAllocator {
         None
     }
 
-    pub fn free(&mut self, start_page: u64, num_pages: u64) {
-        for p in start_page..start_page + num_pages {
-            self.set_free(p);
+    fn take_run(&mut self, start: u64, num_pages: u64) {
+        for p in start..start + num_pages {
+            self.set_used(p);
         }
-    }
-
-    pub fn bitmap(&self) -> &[u8] {
-        &self.bitmap
+        self.cursor = start + num_pages;
+        if self.cursor >= self.total_pages {
+            self.cursor = 0;
+        }
     }
 
     fn is_free(&self, page: u64) -> bool {
         let byte_idx = (page / 8) as usize;
         let bit_idx = (page % 8) as u8;
-        if byte_idx >= self.bitmap.len() {
+        if byte_idx >= self.bitmap.len() || page >= self.total_pages {
             return false;
         }
         (self.bitmap[byte_idx] & (1 << bit_idx)) == 0
@@ -81,5 +160,85 @@ impl PageAllocator {
         if byte_idx < self.bitmap.len() {
             self.bitmap[byte_idx] &= !(1 << bit_idx);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn allocator_with_pages(pages: u64) -> PageAllocator {
+        PageAllocator::new(pages * PAGE_SIZE as u64)
+    }
+
+    #[test]
+    fn next_fit_resumes_after_last_allocation() {
+        let mut alloc = allocator_with_pages(1000);
+        assert_eq!(alloc.allocate(10), Some(0));
+        assert_eq!(alloc.allocate(10), Some(10));
+        alloc.free(0, 10);
+        // Next-fit keeps moving forward instead of reusing the freed hole.
+        assert_eq!(alloc.allocate(10), Some(20));
+        // But wraps around to find the hole once the tail is exhausted.
+        assert_eq!(alloc.allocate(970), Some(30));
+        assert_eq!(alloc.allocate(10), Some(0));
+        assert_eq!(alloc.allocate(1), None);
+    }
+
+    #[test]
+    fn extent_allocation_is_64_pages() {
+        let mut alloc = allocator_with_pages(1000);
+        let start = alloc.allocate_extent().expect("extent");
+        assert_eq!(start, 0);
+        for p in 0..EXTENT_PAGES {
+            assert!(alloc.is_allocated(p));
+        }
+        assert!(!alloc.is_allocated(EXTENT_PAGES));
+    }
+
+    #[test]
+    fn temp_extents_excluded_from_persistable_bitmap() {
+        let mut alloc = allocator_with_pages(1000);
+        let durable = alloc.allocate_extent().expect("durable");
+        let temp = alloc.allocate_temp_extent().expect("temp");
+        assert!(alloc.is_allocated(temp));
+
+        // Restart = reload from the persisted bitmap: temp extents vanish.
+        let persisted = alloc.persistable_bitmap();
+        let reloaded = PageAllocator::from_bitmap(persisted, 1000 * PAGE_SIZE as u64);
+        assert!(reloaded.is_allocated(durable));
+        assert!(!reloaded.is_allocated(temp));
+    }
+
+    #[test]
+    fn freeing_a_temp_extent_directly_drops_the_temp_tracking() {
+        let mut alloc = allocator_with_pages(1000);
+        let temp = alloc.allocate_temp_extent().expect("temp");
+        alloc.free(temp, EXTENT_PAGES);
+        assert!(!alloc.is_allocated(temp));
+        // Exhaust the tail so the next allocation wraps into the freed
+        // range; once reallocated durably it must no longer be masked out of
+        // the persisted bitmap.
+        alloc.allocate(1000 - EXTENT_PAGES).expect("fill tail");
+        let durable = alloc.allocate(EXTENT_PAGES).expect("reuse");
+        assert_eq!(durable, temp);
+        let reloaded =
+            PageAllocator::from_bitmap(alloc.persistable_bitmap(), 1000 * PAGE_SIZE as u64);
+        assert!(reloaded.is_allocated(durable));
+    }
+
+    #[test]
+    fn out_of_range_pages_are_never_free() {
+        let alloc = allocator_with_pages(10);
+        assert!(alloc.is_allocated(10));
+        assert!(alloc.is_allocated(u64::MAX));
+    }
+
+    #[test]
+    fn allocate_zero_or_oversized_fails() {
+        let mut alloc = allocator_with_pages(10);
+        assert_eq!(alloc.allocate(0), None);
+        assert_eq!(alloc.allocate(11), None);
+        assert_eq!(alloc.allocate(10), Some(0));
     }
 }

--- a/crates/truthdb-core/src/direct_io.rs
+++ b/crates/truthdb-core/src/direct_io.rs
@@ -1,3 +1,66 @@
+use crate::storage_layout::PAGE_SIZE;
+
+/// A page-sized, page-aligned, heap-allocated buffer suitable for O_DIRECT I/O.
+///
+/// Callers own these frames (buffer pool frames, WAL tail-page images) and pass
+/// them to [`DirectFile::read_page_into`] / [`DirectFile::write_page_from`].
+pub struct AlignedPageBuf {
+    ptr: std::ptr::NonNull<u8>,
+}
+
+impl AlignedPageBuf {
+    pub fn new() -> Self {
+        let layout = std::alloc::Layout::from_size_align(PAGE_SIZE, PAGE_SIZE)
+            .expect("page layout is valid");
+        // SAFETY: layout has non-zero size.
+        let ptr = unsafe { std::alloc::alloc_zeroed(layout) };
+        let Some(ptr) = std::ptr::NonNull::new(ptr) else {
+            std::alloc::handle_alloc_error(layout);
+        };
+        AlignedPageBuf { ptr }
+    }
+
+    pub fn as_slice(&self) -> &[u8] {
+        // SAFETY: ptr is valid for PAGE_SIZE bytes for the lifetime of self.
+        unsafe { std::slice::from_raw_parts(self.ptr.as_ptr(), PAGE_SIZE) }
+    }
+
+    pub fn as_mut_slice(&mut self) -> &mut [u8] {
+        // SAFETY: ptr is valid for PAGE_SIZE bytes and uniquely borrowed.
+        unsafe { std::slice::from_raw_parts_mut(self.ptr.as_ptr(), PAGE_SIZE) }
+    }
+
+    pub fn zero(&mut self) {
+        self.as_mut_slice().fill(0);
+    }
+}
+
+impl Default for AlignedPageBuf {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Clone for AlignedPageBuf {
+    fn clone(&self) -> Self {
+        let mut copy = AlignedPageBuf::new();
+        copy.as_mut_slice().copy_from_slice(self.as_slice());
+        copy
+    }
+}
+
+impl Drop for AlignedPageBuf {
+    fn drop(&mut self) {
+        let layout = std::alloc::Layout::from_size_align(PAGE_SIZE, PAGE_SIZE)
+            .expect("page layout is valid");
+        // SAFETY: ptr was allocated with this exact layout.
+        unsafe { std::alloc::dealloc(self.ptr.as_ptr(), layout) };
+    }
+}
+
+// SAFETY: AlignedPageBuf uniquely owns its allocation.
+unsafe impl Send for AlignedPageBuf {}
+
 #[cfg(target_os = "linux")]
 mod imp {
     use std::fs::{File, OpenOptions};
@@ -72,6 +135,11 @@ mod imp {
         buffers: Vec<AlignedBuffer>,
         next_user_data: u64,
         len: u64,
+        /// Set when the ring state is no longer trustworthy (submission or
+        /// wait failed with operations possibly in flight). All further
+        /// operations fail fast: consuming stale completions would let a
+        /// later fsync acknowledge a write that never happened.
+        poisoned: bool,
     }
 
     impl DirectFile {
@@ -120,6 +188,7 @@ mod imp {
                 buffers,
                 next_user_data: 1,
                 len,
+                poisoned: false,
             })
         }
 
@@ -205,6 +274,72 @@ mod imp {
             Ok(())
         }
 
+        pub fn read_page_into(
+            &mut self,
+            page_offset: u64,
+            frame: &mut super::AlignedPageBuf,
+        ) -> io::Result<()> {
+            ensure_page_aligned(page_offset)?;
+            let entry = opcode::Read::new(
+                types::Fixed(FIXED_FILE_INDEX),
+                frame.as_mut_slice().as_mut_ptr(),
+                PAGE_SIZE as u32,
+            )
+            .offset(page_offset)
+            .build()
+            .user_data(self.next_user_data());
+
+            let read = self.submit(entry)?;
+            if read != PAGE_SIZE {
+                return Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    format!("short direct read: expected {PAGE_SIZE}, got {read}"),
+                ));
+            }
+            Ok(())
+        }
+
+        pub fn write_page_from(
+            &mut self,
+            page_offset: u64,
+            frame: &super::AlignedPageBuf,
+        ) -> io::Result<()> {
+            self.write_pages_from(page_offset, &[frame])
+        }
+
+        /// Writes `frames` as consecutive pages starting at `page_offset`,
+        /// batching submissions through the ring.
+        pub fn write_pages_from(
+            &mut self,
+            page_offset: u64,
+            frames: &[&super::AlignedPageBuf],
+        ) -> io::Result<()> {
+            self.check_usable()?;
+            ensure_page_aligned(page_offset)?;
+            for (chunk_index, chunk) in frames.chunks(IO_URING_ENTRIES as usize).enumerate() {
+                let chunk_offset =
+                    page_offset + (chunk_index * IO_URING_ENTRIES as usize * PAGE_SIZE) as u64;
+                for (i, frame) in chunk.iter().enumerate() {
+                    let entry = opcode::Write::new(
+                        types::Fixed(FIXED_FILE_INDEX),
+                        frame.as_slice().as_ptr(),
+                        PAGE_SIZE as u32,
+                    )
+                    .offset(chunk_offset + (i * PAGE_SIZE) as u64)
+                    .build()
+                    .user_data(self.next_user_data());
+                    // SAFETY: the frame borrows outlive this call, and every
+                    // queued entry is either fully submitted-and-reaped below
+                    // or the handle is poisoned so the ring is never touched
+                    // again.
+                    unsafe { self.push_entry(&entry)? };
+                }
+                self.submit_and_wait_all(chunk.len())?;
+                self.drain_completions(chunk.len(), PAGE_SIZE)?;
+            }
+            Ok(())
+        }
+
         fn read_page(&mut self, page_offset: u64) -> io::Result<()> {
             let user_data = self.next_user_data();
             let buf_ptr = {
@@ -264,26 +399,106 @@ mod imp {
         }
 
         fn submit(&mut self, entry: io_uring::squeue::Entry) -> io::Result<usize> {
-            {
-                let mut submission = self.ring.submission();
-                unsafe {
-                    submission
-                        .push(&entry)
-                        .map_err(|_| io::Error::other("io_uring submission queue full"))?;
-                }
-            }
+            self.check_usable()?;
+            // SAFETY: the entry's buffer is either an internal scratch buffer
+            // owned by self or a caller frame that outlives the call; the
+            // entry is submitted and reaped (or the handle poisoned) below.
+            unsafe { self.push_entry(&entry)? };
+            self.submit_and_wait_all(1)?;
 
-            self.ring
-                .submit_and_wait(1)
-                .map_err(annotate_io_uring_error)?;
-            let mut completion = self.ring.completion();
-            let cqe = completion
-                .next()
-                .ok_or_else(|| io::Error::other("io_uring completion queue empty"))?;
+            let cqe = match self.ring.completion().next() {
+                Some(cqe) => cqe,
+                None => {
+                    self.poisoned = true;
+                    return Err(io::Error::other("io_uring completion queue empty"));
+                }
+            };
             if cqe.result() < 0 {
                 return Err(io::Error::from_raw_os_error(-cqe.result()));
             }
             Ok(cqe.result() as usize)
+        }
+
+        fn check_usable(&self) -> io::Result<()> {
+            if self.poisoned {
+                return Err(io::Error::other(
+                    "direct file disabled after an io_uring failure (operations may still be in flight); refusing to acknowledge further I/O",
+                ));
+            }
+            Ok(())
+        }
+
+        /// Queues one SQE. On failure the handle is poisoned: earlier entries
+        /// of the same batch may already sit unsubmitted in the queue, and
+        /// they must never reach the kernel once their buffers are gone.
+        ///
+        /// # Safety
+        /// The buffers referenced by `entry` must stay live until the
+        /// matching completion is reaped, or the handle is poisoned.
+        unsafe fn push_entry(&mut self, entry: &io_uring::squeue::Entry) -> io::Result<()> {
+            let pushed = unsafe { self.ring.submission().push(entry) };
+            if pushed.is_err() {
+                self.poisoned = true;
+                return Err(io::Error::other("io_uring submission queue full"));
+            }
+            Ok(())
+        }
+
+        /// Submits queued SQEs and waits for `want` completions, retrying
+        /// interrupted waits. Any other failure poisons the handle:
+        /// operations may be in flight against buffers we no longer control.
+        fn submit_and_wait_all(&mut self, want: usize) -> io::Result<()> {
+            loop {
+                match self.ring.submit_and_wait(want) {
+                    Ok(_) => return Ok(()),
+                    Err(err) if err.kind() == io::ErrorKind::Interrupted => continue,
+                    Err(err) => {
+                        self.poisoned = true;
+                        return Err(annotate_io_uring_error(err));
+                    }
+                }
+            }
+        }
+
+        /// Reaps exactly `count` completions, even after one reports an
+        /// error — an unreaped CQE would be mis-attributed to a later
+        /// operation (e.g. an fsync acknowledging a failed write). Returns
+        /// the first error encountered.
+        fn drain_completions(&mut self, count: usize, expected_len: usize) -> io::Result<()> {
+            let mut first_error: Option<io::Error> = None;
+            let mut missing = false;
+            {
+                let mut completion = self.ring.completion();
+                for _ in 0..count {
+                    let Some(cqe) = completion.next() else {
+                        missing = true;
+                        break;
+                    };
+                    if cqe.result() < 0 {
+                        first_error
+                            .get_or_insert_with(|| io::Error::from_raw_os_error(-cqe.result()));
+                    } else if cqe.result() as usize != expected_len {
+                        first_error.get_or_insert_with(|| {
+                            io::Error::new(
+                                io::ErrorKind::WriteZero,
+                                format!(
+                                    "short direct write: expected {expected_len}, got {}",
+                                    cqe.result()
+                                ),
+                            )
+                        });
+                    }
+                }
+            }
+            if missing {
+                self.poisoned = true;
+                return Err(first_error
+                    .unwrap_or_else(|| io::Error::other("io_uring completion queue empty")));
+            }
+            match first_error {
+                Some(err) => Err(err),
+                None => Ok(()),
+            }
         }
 
         fn next_user_data(&mut self) -> u64 {
@@ -294,6 +509,16 @@ mod imp {
     }
 
     unsafe impl Send for DirectFile {}
+
+    fn ensure_page_aligned(offset: u64) -> io::Result<()> {
+        if !offset.is_multiple_of(PAGE_SIZE as u64) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("offset {offset} is not page-aligned"),
+            ));
+        }
+        Ok(())
+    }
 
     fn annotate_io_uring_error(err: io::Error) -> io::Error {
         match err.raw_os_error() {
@@ -344,6 +569,30 @@ mod imp {
         }
 
         pub fn sync_data(&mut self) -> io::Result<()> {
+            Err(io::Error::other("truthdb storage requires Linux io_uring"))
+        }
+
+        pub fn read_page_into(
+            &mut self,
+            _page_offset: u64,
+            _frame: &mut super::AlignedPageBuf,
+        ) -> io::Result<()> {
+            Err(io::Error::other("truthdb storage requires Linux io_uring"))
+        }
+
+        pub fn write_page_from(
+            &mut self,
+            _page_offset: u64,
+            _frame: &super::AlignedPageBuf,
+        ) -> io::Result<()> {
+            Err(io::Error::other("truthdb storage requires Linux io_uring"))
+        }
+
+        pub fn write_pages_from(
+            &mut self,
+            _page_offset: u64,
+            _frames: &[&super::AlignedPageBuf],
+        ) -> io::Result<()> {
             Err(io::Error::other("truthdb storage requires Linux io_uring"))
         }
     }

--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -30,9 +30,7 @@ impl Engine {
 
         // Try to load a snapshot first
         if let Some(snapshot) = engine.storage.load_snapshot()? {
-            let state: EngineState = bincode::deserialize(&snapshot.data)
-                .map_err(|err| EngineError::Replay(format!("failed to decode snapshot: {err}")))?;
-            engine.state = state;
+            engine.state = decode_snapshot(&snapshot.data)?;
             engine.next_seq_no = snapshot.next_seq_no;
             engine.next_doc_id = snapshot.next_doc_id;
             // Rebuild postings (not serialized)
@@ -41,9 +39,18 @@ impl Engine {
             }
         }
 
-        // Replay any WAL entries after the snapshot
+        // Replay any WAL entries after the snapshot. The ring is shared with
+        // other subsystems (relational records use different entry types);
+        // only search events are ours to apply. Records the snapshot already
+        // covers (seq_no below its next_seq_no) are skipped: a crash between
+        // the snapshot descriptor becoming durable and the WAL head
+        // advancing legitimately leaves them in the ring, and re-applying
+        // them would fail (duplicate index/document errors).
         let records = engine.storage.replay_wal_entries()?;
         for record in records {
+            if record.entry_type != ENGINE_WAL_ENTRY_TYPE || record.seq_no < engine.next_seq_no {
+                continue;
+            }
             let event: WalEvent = serde_json::from_slice(&record.payload)
                 .map_err(|err| EngineError::Replay(format!("failed to decode wal event: {err}")))?;
             engine.apply_event(&event)?;
@@ -103,7 +110,10 @@ impl Engine {
     }
 
     pub fn checkpoint(&mut self) -> Result<(), EngineError> {
-        let data = bincode::serialize(&self.state)
+        // JSON, not bincode: documents hold serde_json::Value, which bincode
+        // can serialize but never deserialize (`deserialize_any`), so bincode
+        // snapshots with documents could not be loaded back.
+        let data = serde_json::to_vec(&self.state)
             .map_err(|err| EngineError::Replay(format!("failed to serialize state: {err}")))?;
         let checkpoint_seq = self.next_seq_no.saturating_sub(1);
         self.storage
@@ -129,7 +139,6 @@ impl Engine {
         self.storage.append_wal_entry(
             ENGINE_WAL_ENTRY_TYPE,
             ENGINE_WAL_ENTRY_VERSION,
-            seq_no,
             seq_no,
             &payload,
         )?;
@@ -819,6 +828,21 @@ fn render_json(value: &Value) -> Result<String, EngineError> {
         .map_err(|err| EngineError::Replay(format!("failed to render json response: {err}")))
 }
 
+/// Decodes a snapshot payload: JSON (current format), falling back to
+/// bincode for snapshots written by older versions. Legacy bincode snapshots
+/// can only have been document-free (bincode cannot deserialize
+/// `serde_json::Value`, so document-bearing ones were never loadable).
+fn decode_snapshot(data: &[u8]) -> Result<EngineState, EngineError> {
+    match serde_json::from_slice(data) {
+        Ok(state) => Ok(state),
+        Err(json_err) => bincode::deserialize(data).map_err(|bincode_err| {
+            EngineError::Replay(format!(
+                "failed to decode snapshot: as json: {json_err}; as legacy bincode: {bincode_err}"
+            ))
+        }),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
@@ -950,6 +974,150 @@ mod tests {
             response["hits"]["hits"][0]["_source"]["name"].as_str(),
             Some("Red Running Shoes")
         );
+
+        let _ = std::fs::remove_file(path);
+    }
+
+    /// Regression (review finding, pre-existing): snapshots holding
+    /// documents could never be decoded again (bincode cannot deserialize
+    /// serde_json::Value). Round-trip a checkpoint with real documents plus
+    /// a post-checkpoint WAL event.
+    #[test]
+    fn checkpoint_with_documents_survives_restart() {
+        let path = unique_temp_path("checkpoint-roundtrip");
+        let storage =
+            Storage::create(path.clone(), test_storage_options()).expect("storage create");
+        let mut engine = Engine::new(storage).expect("engine create");
+        engine
+            .execute(
+                r#"
+                create index notes {
+                  "mappings": { "properties": { "body": { "type": "text" } } }
+                }
+                "#,
+            )
+            .expect("create index");
+        engine
+            .execute(r#"insert document notes { "body": "first snapshot doc" }"#)
+            .expect("insert 1");
+        engine
+            .execute(r#"insert document notes { "body": "second snapshot doc" }"#)
+            .expect("insert 2");
+        engine.checkpoint().expect("checkpoint with documents");
+        engine
+            .execute(r#"insert document notes { "body": "post checkpoint doc" }"#)
+            .expect("insert 3");
+        drop(engine);
+
+        let storage = Storage::open(path.clone()).expect("reopen");
+        let mut engine = Engine::new(storage).expect("engine restart after checkpoint");
+        let response = engine
+            .execute(r#"search notes { "query": { "match": { "body": "doc" } } }"#)
+            .expect("search");
+        let response: Value = serde_json::from_str(&response).expect("valid json");
+        assert_eq!(
+            response["hits"]["total"].as_u64(),
+            Some(3),
+            "snapshot docs and post-checkpoint doc must all survive"
+        );
+        // Doc-id continuity: the next insert must not collide.
+        engine
+            .execute(r#"insert document notes { "body": "post restart doc" }"#)
+            .expect("insert after restart");
+        let _ = std::fs::remove_file(path);
+    }
+
+    /// Regression (review finding): a crash between the snapshot descriptor
+    /// becoming durable and the WAL head advancing leaves snapshot-covered
+    /// events in the ring; replay must skip them instead of failing on
+    /// duplicate applies.
+    #[test]
+    fn replay_skips_events_already_covered_by_snapshot() {
+        let path = unique_temp_path("covered-replay");
+        let mut storage =
+            Storage::create(path.clone(), test_storage_options()).expect("storage create");
+
+        // Snapshot state: index "notes" with one document, next_seq_no = 3.
+        let mut mappings = BTreeMap::new();
+        mappings.insert("body".to_string(), FieldType::Text);
+        let create_event = WalEvent::CreateIndex {
+            name: "notes".to_string(),
+            mappings: mappings.clone(),
+        };
+        let mut doc = Document::new();
+        doc.insert("body".to_string(), Value::String("covered".to_string()));
+        let insert_event = WalEvent::InsertDocument {
+            index: "notes".to_string(),
+            id: "1".to_string(),
+            document: doc,
+        };
+        let mut state = EngineState::default();
+        let mut index = IndexState::new(mappings);
+        if let WalEvent::InsertDocument { id, document, .. } = &insert_event {
+            index.insert_document(id, document).expect("apply insert");
+        }
+        state.indices.insert("notes".to_string(), index);
+        let snapshot = serde_json::to_vec(&state).expect("encode state");
+        storage
+            .write_checkpoint(&snapshot, 2, 3, 2)
+            .expect("checkpoint");
+
+        // The crash window: events 1 and 2 (already in the snapshot) sit in
+        // the ring after the checkpoint.
+        for (seq, event) in [(1u64, &create_event), (2u64, &insert_event)] {
+            let payload = serde_json::to_vec(event).expect("encode event");
+            storage
+                .append_wal_entry(
+                    ENGINE_WAL_ENTRY_TYPE,
+                    ENGINE_WAL_ENTRY_VERSION,
+                    seq,
+                    &payload,
+                )
+                .expect("append covered event");
+        }
+        drop(storage);
+
+        let storage = Storage::open(path.clone()).expect("reopen");
+        let mut engine = Engine::new(storage).expect("open must skip covered events");
+        let response = engine
+            .execute(r#"search notes { "query": { "match": { "body": "covered" } } }"#)
+            .expect("search");
+        let response: Value = serde_json::from_str(&response).expect("valid json");
+        assert_eq!(response["hits"]["total"].as_u64(), Some(1));
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn engine_replay_ignores_relational_wal_records() {
+        let path = unique_temp_path("rel-coexistence");
+        let mut storage =
+            Storage::create(path.clone(), test_storage_options()).expect("storage create");
+        // Relational records land in the same ring before and between search
+        // events; search replay must skip them.
+        let extent = storage.allocate_extent(false).expect("extent");
+        let mut engine = Engine::new(storage).expect("engine create");
+        engine
+            .execute(
+                r#"
+                create index notes {
+                  "mappings": { "properties": { "body": { "type": "text" } } }
+                }
+                "#,
+            )
+            .expect("create index");
+        engine
+            .execute(r#"insert document notes { "body": "relational coexistence" }"#)
+            .expect("insert");
+        drop(engine);
+
+        let storage = Storage::open(path.clone()).expect("reopen");
+        let mut engine = Engine::new(storage).expect("engine replay with rel records");
+        let response = engine
+            .execute(r#"search notes { "query": { "match": { "body": "coexistence" } } }"#)
+            .expect("search after replay");
+        let response: Value = serde_json::from_str(&response).expect("valid json");
+        assert_eq!(response["hits"]["total"].as_u64(), Some(1));
+        let _ = extent;
 
         let _ = std::fs::remove_file(path);
     }

--- a/crates/truthdb-core/src/lib.rs
+++ b/crates/truthdb-core/src/lib.rs
@@ -3,5 +3,7 @@ pub mod client_listener;
 mod direct_io;
 pub mod dispatcher;
 pub mod engine;
+pub mod relstore;
 pub mod storage;
 mod storage_layout;
+pub mod wal;

--- a/crates/truthdb-core/src/relstore/buffer_pool.rs
+++ b/crates/truthdb-core/src/relstore/buffer_pool.rs
@@ -1,0 +1,511 @@
+//! Buffer pool: fixed set of page frames with clock eviction.
+//!
+//! Steal is allowed — a dirty page may be evicted before its transaction
+//! commits — with WAL-before-data as the only flush constraint: before a
+//! dirty page goes to disk, the WAL must be flushed up to that page's
+//! `page_lsn`. The pool enforces this through the [`PoolBackend`] it is
+//! given.
+
+use std::collections::HashMap;
+
+use crate::direct_io::AlignedPageBuf;
+use crate::relstore::page;
+use crate::storage::StorageError;
+use crate::storage_layout::PAGE_SIZE;
+
+pub const DEFAULT_CAPACITY_BYTES: u64 = 64 * crate::storage_layout::MIB;
+
+/// The backing services a buffer pool needs: page I/O over the data region
+/// and the WAL flush watermark for the WAL-before-data rule.
+pub trait PoolBackend {
+    fn read_page(&mut self, page_no: u64, frame: &mut AlignedPageBuf) -> Result<(), StorageError>;
+    fn write_page(&mut self, page_no: u64, frame: &AlignedPageBuf) -> Result<(), StorageError>;
+    /// Highest LSN durably flushed to the WAL.
+    fn flushed_lsn(&self) -> u64;
+    /// Makes the WAL durable at least up to `lsn`.
+    fn flush_wal_to(&mut self, lsn: u64) -> Result<(), StorageError>;
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FrameId(usize);
+
+struct Frame {
+    buf: AlignedPageBuf,
+    page_no: u64,
+    pin_count: u32,
+    dirty: bool,
+    referenced: bool,
+    valid: bool,
+}
+
+pub struct BufferPool {
+    frames: Vec<Frame>,
+    table: HashMap<u64, usize>,
+    clock_hand: usize,
+    /// Indices of frames not holding a page (never used, or vacated by a
+    /// failed fetch), so misses don't scan the whole frame array.
+    free: Vec<usize>,
+}
+
+impl BufferPool {
+    /// Creates a pool with `capacity_bytes` of frames (default 64 MiB; at
+    /// least one frame).
+    pub fn new(capacity_bytes: u64) -> Self {
+        let frame_count = (capacity_bytes / PAGE_SIZE as u64).max(1) as usize;
+        let frames = (0..frame_count)
+            .map(|_| Frame {
+                buf: AlignedPageBuf::new(),
+                page_no: 0,
+                pin_count: 0,
+                dirty: false,
+                referenced: false,
+                valid: false,
+            })
+            .collect();
+        BufferPool {
+            free: (0..frame_count).rev().collect(),
+            frames,
+            table: HashMap::new(),
+            clock_hand: 0,
+        }
+    }
+
+    pub fn capacity(&self) -> usize {
+        self.frames.len()
+    }
+
+    pub fn cached_pages(&self) -> usize {
+        self.table.len()
+    }
+
+    /// Fetches and pins a page, reading it from the backend on a miss.
+    /// Verifies the page checksum on read (all-zero pages — fresh
+    /// allocations — are accepted).
+    pub fn fetch(
+        &mut self,
+        page_no: u64,
+        backend: &mut impl PoolBackend,
+    ) -> Result<FrameId, StorageError> {
+        if let Some(&index) = self.table.get(&page_no) {
+            let frame = &mut self.frames[index];
+            frame.pin_count += 1;
+            frame.referenced = true;
+            return Ok(FrameId(index));
+        }
+
+        let index = self.claim_victim(backend)?;
+        if let Err(err) = self.read_and_verify(index, page_no, backend) {
+            // Return the frame to the free list so a later fetch reuses it.
+            self.free.push(index);
+            return Err(err);
+        }
+        self.install(index, page_no);
+        Ok(FrameId(index))
+    }
+
+    /// Reads a page into a frame and validates it: checksum plus the page
+    /// header's self-identity (`page_no`), which catches misdirected
+    /// reads/writes. All-zero pages (fresh allocations) are accepted.
+    fn read_and_verify(
+        &mut self,
+        index: usize,
+        page_no: u64,
+        backend: &mut impl PoolBackend,
+    ) -> Result<(), StorageError> {
+        backend.read_page(page_no, &mut self.frames[index].buf)?;
+        let content = self.frames[index].buf.as_slice();
+        if page::is_zero_page(content) {
+            return Ok(());
+        }
+        if !page::verify_checksum(content) {
+            return Err(StorageError::InvalidFile(format!(
+                "page {page_no} checksum mismatch"
+            )));
+        }
+        let header = page::read_header(content);
+        if header.page_no != page_no {
+            return Err(StorageError::InvalidFile(format!(
+                "page {page_no} identity mismatch: header claims page {}",
+                header.page_no
+            )));
+        }
+        Ok(())
+    }
+
+    /// Pins a frame for a brand-new page without reading from disk: the
+    /// frame starts zeroed and dirty.
+    pub fn fetch_zeroed(
+        &mut self,
+        page_no: u64,
+        backend: &mut impl PoolBackend,
+    ) -> Result<FrameId, StorageError> {
+        if let Some(&index) = self.table.get(&page_no) {
+            let frame = &mut self.frames[index];
+            frame.pin_count += 1;
+            frame.referenced = true;
+            frame.dirty = true;
+            frame.buf.zero();
+            return Ok(FrameId(index));
+        }
+        let index = self.claim_victim(backend)?;
+        self.frames[index].buf.zero();
+        self.install(index, page_no);
+        self.frames[index].dirty = true;
+        Ok(FrameId(index))
+    }
+
+    pub fn page(&self, id: FrameId) -> &[u8] {
+        debug_assert!(self.frames[id.0].valid && self.frames[id.0].pin_count > 0);
+        self.frames[id.0].buf.as_slice()
+    }
+
+    /// Mutable access marks the frame dirty. The caller maintains
+    /// `page_lsn` in the page header; the pool reads it back at flush time
+    /// to enforce WAL-before-data.
+    pub fn page_mut(&mut self, id: FrameId) -> &mut [u8] {
+        let frame = &mut self.frames[id.0];
+        debug_assert!(frame.valid && frame.pin_count > 0);
+        frame.dirty = true;
+        frame.buf.as_mut_slice()
+    }
+
+    pub fn unpin(&mut self, id: FrameId) {
+        let frame = &mut self.frames[id.0];
+        debug_assert!(frame.pin_count > 0, "unpin of unpinned frame");
+        frame.pin_count = frame.pin_count.saturating_sub(1);
+    }
+
+    /// Writes every dirty page back (checkpoint support). Pinned pages are
+    /// flushed too — they stay cached and pinned, just clean.
+    pub fn flush_all(&mut self, backend: &mut impl PoolBackend) -> Result<(), StorageError> {
+        for index in 0..self.frames.len() {
+            if self.frames[index].valid && self.frames[index].dirty {
+                self.write_back(index, backend)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Whether a page is currently cached (test hook).
+    #[cfg(test)]
+    pub fn contains(&self, page_no: u64) -> bool {
+        self.table.contains_key(&page_no)
+    }
+
+    fn install(&mut self, index: usize, page_no: u64) {
+        let frame = &mut self.frames[index];
+        frame.page_no = page_no;
+        frame.pin_count = 1;
+        frame.dirty = false;
+        frame.referenced = true;
+        frame.valid = true;
+        self.table.insert(page_no, index);
+    }
+
+    /// Finds a frame to (re)use: a free frame if any, otherwise a clock
+    /// sweep over unpinned frames, evicting the victim (flushing WAL first
+    /// for dirty pages — steal). Errors when every frame is pinned.
+    fn claim_victim(&mut self, backend: &mut impl PoolBackend) -> Result<usize, StorageError> {
+        if let Some(index) = self.free.pop() {
+            return Ok(index);
+        }
+        // Clock: each frame gets its reference bit cleared once before it can
+        // be chosen, so two full sweeps guarantee a victim if one exists.
+        let mut remaining = self.frames.len() * 2;
+        while remaining > 0 {
+            let index = self.clock_hand;
+            self.clock_hand = (self.clock_hand + 1) % self.frames.len();
+            remaining -= 1;
+            let frame = &mut self.frames[index];
+            if frame.pin_count > 0 {
+                continue;
+            }
+            if frame.referenced {
+                frame.referenced = false;
+                continue;
+            }
+            if frame.dirty {
+                self.write_back(index, backend)?;
+            }
+            self.table.remove(&self.frames[index].page_no);
+            self.frames[index].valid = false;
+            return Ok(index);
+        }
+        Err(StorageError::InvalidConfig(
+            "buffer pool exhausted: all frames pinned".to_string(),
+        ))
+    }
+
+    /// WAL-before-data write-back: flush the WAL to the page's LSN, stamp
+    /// the page checksum, write the page.
+    fn write_back(
+        &mut self,
+        index: usize,
+        backend: &mut impl PoolBackend,
+    ) -> Result<(), StorageError> {
+        let lsn = page::page_lsn(self.frames[index].buf.as_slice());
+        if lsn > backend.flushed_lsn() {
+            backend.flush_wal_to(lsn)?;
+        }
+        page::stamp_checksum(self.frames[index].buf.as_mut_slice());
+        backend.write_page(self.frames[index].page_no, &self.frames[index].buf)?;
+        self.frames[index].dirty = false;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::relstore::page::{PAGE_HEADER_SIZE, PageHeader};
+
+    /// In-memory backend that panics if the pool violates WAL-before-data.
+    struct MockBackend {
+        pages: HashMap<u64, Vec<u8>>,
+        flushed_lsn: u64,
+        wal_flush_calls: usize,
+        reads: usize,
+        writes: usize,
+    }
+
+    impl MockBackend {
+        fn new() -> Self {
+            MockBackend {
+                pages: HashMap::new(),
+                flushed_lsn: 0,
+                wal_flush_calls: 0,
+                reads: 0,
+                writes: 0,
+            }
+        }
+    }
+
+    impl PoolBackend for MockBackend {
+        fn read_page(
+            &mut self,
+            page_no: u64,
+            frame: &mut AlignedPageBuf,
+        ) -> Result<(), StorageError> {
+            self.reads += 1;
+            match self.pages.get(&page_no) {
+                Some(content) => frame.as_mut_slice().copy_from_slice(content),
+                None => frame.zero(),
+            }
+            Ok(())
+        }
+
+        fn write_page(&mut self, page_no: u64, frame: &AlignedPageBuf) -> Result<(), StorageError> {
+            self.writes += 1;
+            let lsn = page::page_lsn(frame.as_slice());
+            assert!(
+                lsn <= self.flushed_lsn,
+                "WAL-before-data violated: page {page_no} with lsn {lsn} written while flushed_lsn is {}",
+                self.flushed_lsn
+            );
+            assert!(
+                page::verify_checksum(frame.as_slice()),
+                "page {page_no} written without a valid checksum"
+            );
+            self.pages.insert(page_no, frame.as_slice().to_vec());
+            Ok(())
+        }
+
+        fn flushed_lsn(&self) -> u64 {
+            self.flushed_lsn
+        }
+
+        fn flush_wal_to(&mut self, lsn: u64) -> Result<(), StorageError> {
+            self.wal_flush_calls += 1;
+            self.flushed_lsn = self.flushed_lsn.max(lsn);
+            Ok(())
+        }
+    }
+
+    fn write_page_payload(pool: &mut BufferPool, id: FrameId, page_no: u64, lsn: u64, marker: u8) {
+        let content = pool.page_mut(id);
+        page::write_header(
+            content,
+            &PageHeader {
+                page_lsn: lsn,
+                page_no,
+                ..PageHeader::default()
+            },
+        );
+        content[PAGE_HEADER_SIZE] = marker;
+    }
+
+    /// Deterministic xorshift PRNG so the property test needs no new deps.
+    struct Rng(u64);
+
+    impl Rng {
+        fn next(&mut self) -> u64 {
+            let mut x = self.0;
+            x ^= x << 13;
+            x ^= x >> 7;
+            x ^= x << 17;
+            self.0 = x;
+            x
+        }
+    }
+
+    #[test]
+    fn fetch_caches_and_pins() {
+        let mut backend = MockBackend::new();
+        let mut pool = BufferPool::new(4 * PAGE_SIZE as u64);
+        let a = pool.fetch(1, &mut backend).expect("fetch");
+        assert_eq!(backend.reads, 1);
+        pool.unpin(a);
+        let b = pool.fetch(1, &mut backend).expect("refetch");
+        assert_eq!(backend.reads, 1, "second fetch must hit the cache");
+        pool.unpin(b);
+    }
+
+    #[test]
+    fn pinned_pages_are_never_evicted() {
+        let mut backend = MockBackend::new();
+        let mut pool = BufferPool::new(2 * PAGE_SIZE as u64);
+        let pinned = pool.fetch(1, &mut backend).expect("pin page 1");
+        for page_no in 2..10 {
+            let id = pool.fetch(page_no, &mut backend).expect("fetch");
+            pool.unpin(id);
+        }
+        assert!(pool.contains(1), "pinned page must stay cached");
+        assert_eq!(&pool.page(pinned)[..8], &[0u8; 8]);
+        pool.unpin(pinned);
+    }
+
+    #[test]
+    fn all_frames_pinned_errors() {
+        let mut backend = MockBackend::new();
+        let mut pool = BufferPool::new(2 * PAGE_SIZE as u64);
+        let _a = pool.fetch(1, &mut backend).expect("a");
+        let _b = pool.fetch(2, &mut backend).expect("b");
+        assert!(pool.fetch(3, &mut backend).is_err());
+    }
+
+    #[test]
+    fn dirty_eviction_flushes_wal_first_steal() {
+        let mut backend = MockBackend::new();
+        let mut pool = BufferPool::new(PAGE_SIZE as u64); // single frame
+        let id = pool.fetch_zeroed(1, &mut backend).expect("new page");
+        write_page_payload(&mut pool, id, 1, 500, 0xAB);
+        pool.unpin(id);
+
+        // Fetching another page forces eviction of the dirty page: the mock
+        // asserts the WAL was flushed to lsn 500 before the write.
+        let other = pool.fetch(2, &mut backend).expect("force eviction");
+        pool.unpin(other);
+        assert_eq!(backend.wal_flush_calls, 1);
+        assert!(backend.flushed_lsn >= 500);
+        assert_eq!(backend.pages.get(&1).unwrap()[PAGE_HEADER_SIZE], 0xAB);
+    }
+
+    #[test]
+    fn checksum_mismatch_is_detected_on_fetch() {
+        let mut backend = MockBackend::new();
+        let mut corrupt = vec![0u8; PAGE_SIZE];
+        corrupt[100] = 0xFF; // non-zero page without a valid checksum
+        backend.pages.insert(7, corrupt);
+        let mut pool = BufferPool::new(4 * PAGE_SIZE as u64);
+        assert!(pool.fetch(7, &mut backend).is_err());
+        // The failed fetch must not leak its frame: the pool still has full
+        // capacity for other pages.
+        for page_no in 0..4u64 {
+            let id = pool.fetch(100 + page_no, &mut backend).expect("fetch");
+            pool.unpin(id);
+        }
+    }
+
+    #[test]
+    fn page_identity_mismatch_is_detected_on_fetch() {
+        let mut backend = MockBackend::new();
+        // A checksummed page whose header claims a different page number
+        // (misdirected write).
+        let mut misdirected = vec![0u8; PAGE_SIZE];
+        page::write_header(
+            &mut misdirected,
+            &PageHeader {
+                page_no: 9,
+                ..PageHeader::default()
+            },
+        );
+        page::stamp_checksum(&mut misdirected);
+        backend.pages.insert(3, misdirected);
+        let mut pool = BufferPool::new(4 * PAGE_SIZE as u64);
+        assert!(pool.fetch(3, &mut backend).is_err());
+    }
+
+    #[test]
+    fn flush_all_persists_dirty_pages() {
+        let mut backend = MockBackend::new();
+        let mut pool = BufferPool::new(8 * PAGE_SIZE as u64);
+        for page_no in 0..4u64 {
+            let id = pool.fetch_zeroed(page_no, &mut backend).expect("new");
+            write_page_payload(&mut pool, id, page_no, 100 + page_no, page_no as u8);
+            pool.unpin(id);
+        }
+        pool.flush_all(&mut backend).expect("flush_all");
+        assert_eq!(backend.writes, 4);
+        for page_no in 0..4u64 {
+            assert_eq!(
+                backend.pages.get(&page_no).unwrap()[PAGE_HEADER_SIZE],
+                page_no as u8
+            );
+        }
+    }
+
+    /// Property test: a random workload of fetches, writes, unpins and
+    /// flushes against an oracle of expected page contents. Invariants:
+    /// - a fetched page always shows the last content written to it;
+    /// - WAL-before-data holds on every backend write (mock asserts);
+    /// - the pool never caches more pages than its capacity.
+    #[test]
+    fn random_workload_matches_oracle() {
+        let mut rng = Rng(0x9E3779B97F4A7C15);
+        for round in 0..8 {
+            let capacity_frames = 2 + (rng.next() % 6) as usize;
+            let mut backend = MockBackend::new();
+            let mut pool = BufferPool::new((capacity_frames * PAGE_SIZE) as u64);
+            let mut oracle: HashMap<u64, u8> = HashMap::new();
+            let mut next_lsn = 1u64;
+            let page_universe = 1 + (rng.next() % 16);
+
+            for _step in 0..2000 {
+                let page_no = rng.next() % page_universe;
+                let id = match pool.fetch(page_no, &mut backend) {
+                    Ok(id) => id,
+                    Err(err) => panic!("round {round}: fetch failed: {err}"),
+                };
+                let expected = oracle.get(&page_no).copied().unwrap_or(0);
+                assert_eq!(
+                    pool.page(id)[PAGE_HEADER_SIZE],
+                    expected,
+                    "round {round}: page {page_no} content diverged from oracle"
+                );
+
+                if rng.next() % 2 == 0 {
+                    let marker = (rng.next() % 255) as u8 + 1;
+                    write_page_payload(&mut pool, id, page_no, next_lsn, marker);
+                    oracle.insert(page_no, marker);
+                    next_lsn += 1;
+                }
+                pool.unpin(id);
+
+                if rng.next() % 64 == 0 {
+                    pool.flush_all(&mut backend).expect("flush_all");
+                }
+                assert!(pool.cached_pages() <= pool.capacity());
+            }
+
+            // Final flush: backend must now hold exactly the oracle state.
+            pool.flush_all(&mut backend).expect("final flush");
+            for (page_no, marker) in &oracle {
+                assert_eq!(
+                    backend.pages.get(page_no).unwrap()[PAGE_HEADER_SIZE],
+                    *marker,
+                    "round {round}: backend diverged for page {page_no}"
+                );
+            }
+        }
+    }
+}

--- a/crates/truthdb-core/src/relstore/mod.rs
+++ b/crates/truthdb-core/src/relstore/mod.rs
@@ -1,0 +1,8 @@
+//! Relational on-disk structures (Stage 1: page format and buffer pool).
+//!
+//! Slotted pages, B+ trees and heaps arrive in Stage 2; this module currently
+//! provides the shared page header/checksum format and the buffer pool that
+//! all relational structures will sit on.
+
+pub mod buffer_pool;
+pub mod page;

--- a/crates/truthdb-core/src/relstore/page.rs
+++ b/crates/truthdb-core/src/relstore/page.rs
@@ -1,0 +1,114 @@
+//! Shared 32-byte page header for all relational pages.
+//!
+//! ```text
+//! offset  0: checksum   u64   xxh64 of the whole page with this field zeroed
+//! offset  8: page_lsn   u64   LSN of the last WAL record that touched the page
+//! offset 16: page_type  u16
+//! offset 18: flags      u16
+//! offset 20: object_id  u32   owning table/index (self-identity)
+//! offset 24: page_no    u64   this page's number in the data region (self-identity)
+//! ```
+//!
+//! The self-identity fields let recovery and consistency checks detect
+//! misdirected writes: a page read from slot N must claim `page_no == N`.
+
+use xxhash_rust::xxh64::xxh64;
+
+use crate::storage_layout::PAGE_SIZE;
+
+pub const PAGE_HEADER_SIZE: usize = 32;
+
+pub const PAGE_TYPE_FREE: u16 = 0;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct PageHeader {
+    pub page_lsn: u64,
+    pub page_type: u16,
+    pub flags: u16,
+    pub object_id: u32,
+    pub page_no: u64,
+}
+
+pub fn read_header(page: &[u8]) -> PageHeader {
+    assert_eq!(page.len(), PAGE_SIZE);
+    PageHeader {
+        page_lsn: u64::from_le_bytes(page[8..16].try_into().unwrap()),
+        page_type: u16::from_le_bytes(page[16..18].try_into().unwrap()),
+        flags: u16::from_le_bytes(page[18..20].try_into().unwrap()),
+        object_id: u32::from_le_bytes(page[20..24].try_into().unwrap()),
+        page_no: u64::from_le_bytes(page[24..32].try_into().unwrap()),
+    }
+}
+
+/// Writes the header fields; the checksum field is left untouched (it is
+/// stamped just before the page goes to disk).
+pub fn write_header(page: &mut [u8], header: &PageHeader) {
+    assert_eq!(page.len(), PAGE_SIZE);
+    page[8..16].copy_from_slice(&header.page_lsn.to_le_bytes());
+    page[16..18].copy_from_slice(&header.page_type.to_le_bytes());
+    page[18..20].copy_from_slice(&header.flags.to_le_bytes());
+    page[20..24].copy_from_slice(&header.object_id.to_le_bytes());
+    page[24..32].copy_from_slice(&header.page_no.to_le_bytes());
+}
+
+pub fn page_lsn(page: &[u8]) -> u64 {
+    u64::from_le_bytes(page[8..16].try_into().unwrap())
+}
+
+pub fn stamp_checksum(page: &mut [u8]) {
+    assert_eq!(page.len(), PAGE_SIZE);
+    page[0..8].copy_from_slice(&0u64.to_le_bytes());
+    let checksum = xxh64(page, 0);
+    page[0..8].copy_from_slice(&checksum.to_le_bytes());
+}
+
+pub fn verify_checksum(page: &[u8]) -> bool {
+    assert_eq!(page.len(), PAGE_SIZE);
+    let stored = u64::from_le_bytes(page[0..8].try_into().unwrap());
+    let mut copy = page.to_vec();
+    copy[0..8].copy_from_slice(&0u64.to_le_bytes());
+    xxh64(&copy, 0) == stored
+}
+
+/// A page that has never been written (fresh allocation) is all zeros.
+pub fn is_zero_page(page: &[u8]) -> bool {
+    page.iter().all(|b| *b == 0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn header_round_trip() {
+        let mut page = vec![0u8; PAGE_SIZE];
+        let header = PageHeader {
+            page_lsn: 0xDEAD_BEEF,
+            page_type: 7,
+            flags: 3,
+            object_id: 42,
+            page_no: 1234,
+        };
+        write_header(&mut page, &header);
+        assert_eq!(read_header(&page), header);
+        assert_eq!(page_lsn(&page), 0xDEAD_BEEF);
+    }
+
+    #[test]
+    fn checksum_round_trip_and_corruption_detection() {
+        let mut page = vec![0u8; PAGE_SIZE];
+        page[100] = 0xAA;
+        stamp_checksum(&mut page);
+        assert!(verify_checksum(&page));
+        page[200] ^= 1;
+        assert!(!verify_checksum(&page));
+    }
+
+    #[test]
+    fn zero_page_detection() {
+        let mut page = vec![0u8; PAGE_SIZE];
+        assert!(is_zero_page(&page));
+        page[0] = 1;
+        assert!(!is_zero_page(&page));
+    }
+}

--- a/crates/truthdb-core/src/storage.rs
+++ b/crates/truthdb-core/src/storage.rs
@@ -3,14 +3,21 @@ use std::path::{Path, PathBuf};
 use thiserror::Error;
 use xxhash_rust::xxh64::xxh64;
 
-use crate::allocator::PageAllocator;
-use crate::direct_io::DirectFile;
+use crate::allocator::{EXTENT_PAGES, PageAllocator};
+use crate::direct_io::{AlignedPageBuf, DirectFile};
 use crate::storage_layout::{
     FileHeader, PAGE_SIZE, SNAPSHOT_DESCRIPTOR_SIZE, SUPERBLOCK_ACTIVE_A, SUPERBLOCK_ACTIVE_B,
-    SnapshotDescriptor, Superblock, WAL_ENTRY_FOOTER_SIZE, WAL_ENTRY_HEADER_SIZE,
-    WAL_ENTRY_TYPE_COMMIT, WAL_ENTRY_TYPE_RECORD, WAL_MAX_BYTES, WAL_MIN_BYTES, WalEntryFooter,
-    WalEntryHeader, align_down, assert_layout_invariants, wal_entry_padded_len, wal_payload_crc,
+    SnapshotDescriptor, Superblock, WAL_ENTRY_TYPE_REL, WAL_MAX_BYTES, WAL_MIN_BYTES, align_down,
+    assert_layout_invariants,
 };
+use crate::wal::records::{REL_KIND_ALLOC_EXTENT, REL_KIND_FREE_EXTENT, RelRecord};
+use crate::wal::{WalWriter, scan_ring};
+
+pub use crate::wal::WalRecord;
+
+/// Version stamped in REL wal entries (entry-level, distinct from the record
+/// kinds inside).
+const REL_WAL_ENTRY_VERSION: u16 = 1;
 
 #[derive(Debug, Clone, Copy)]
 pub struct StorageOptions {
@@ -93,9 +100,20 @@ impl Storage {
     }
 
     pub fn create(path: PathBuf, opts: StorageOptions) -> Result<Self, StorageError> {
+        Self::create_with_wal_bounds(path, opts, WAL_MIN_BYTES, WAL_MAX_BYTES)
+    }
+
+    /// Test hook: create with custom WAL ring bounds so ring-wrap paths can
+    /// be exercised without writing hundreds of MiB.
+    pub(crate) fn create_with_wal_bounds(
+        path: PathBuf,
+        opts: StorageOptions,
+        wal_min_bytes: u64,
+        wal_max_bytes: u64,
+    ) -> Result<Self, StorageError> {
         assert_layout_invariants();
         opts.validate()?;
-        let file = StorageFile::create_new(path, opts)?;
+        let file = StorageFile::create_new(path, opts, wal_min_bytes, wal_max_bytes)?;
         Ok(Storage { file })
     }
 
@@ -103,28 +121,24 @@ impl Storage {
         &self.file.path
     }
 
+    /// Appends one WAL entry, durably, and returns its LSN (unwrapped log
+    /// position). The entry's `logical_ts` is stamped with the LSN by the
+    /// writer.
     pub fn append_wal_entry(
         &mut self,
         entry_type: u16,
         entry_version: u16,
         seq_no: u64,
-        logical_ts: u64,
         payload: &[u8],
     ) -> Result<u64, StorageError> {
         self.file
-            .append_wal_entry(entry_type, entry_version, seq_no, logical_ts, payload)
+            .append_wal_entry(entry_type, entry_version, seq_no, payload)
     }
 
-    pub fn verify_wal_entry_at(&mut self, position: u64) -> Result<bool, StorageError> {
-        self.file.verify_wal_entry_at(position)
-    }
-
-    pub fn recover_wal(&mut self) -> Result<RecoveryState, StorageError> {
-        self.file.recover_wal()
-    }
-
+    /// Returns the WAL records recovered at open (head..tail order). Drains
+    /// the recovery cache; subsequent calls return an empty vec.
     pub fn replay_wal_entries(&mut self) -> Result<Vec<WalRecord>, StorageError> {
-        self.file.replay_wal_entries()
+        Ok(std::mem::take(&mut self.file.replay_cache))
     }
 
     pub fn write_checkpoint(
@@ -143,7 +157,26 @@ impl Storage {
     }
 
     pub fn wal_usage_ratio(&self) -> f64 {
-        self.file.wal_usage_ratio()
+        self.file.wal.usage_ratio()
+    }
+
+    /// Allocates one 64-page extent in the data region and returns its first
+    /// page number. Durable extents are WAL-logged (replayed on recovery);
+    /// temporary extents are not logged and vanish on restart.
+    pub fn allocate_extent(&mut self, temp: bool) -> Result<u64, StorageError> {
+        self.file.allocate_extent(temp)
+    }
+
+    /// Frees a 64-page extent previously returned by
+    /// [`Storage::allocate_extent`]. WAL-logged.
+    pub fn free_extent(&mut self, start_page: u64) -> Result<(), StorageError> {
+        self.file.free_extent(start_page)
+    }
+
+    /// Whether a data-region page is currently allocated (test/diagnostic
+    /// hook).
+    pub fn is_page_allocated(&self, page: u64) -> bool {
+        self.file.allocator.is_allocated(page)
     }
 }
 
@@ -156,13 +189,18 @@ pub struct SnapshotData {
 
 struct StorageFile {
     path: PathBuf,
+    /// Handle for data-region, superblock and descriptor I/O.
     file: DirectFile,
+    /// WAL writer with its own dedicated file handle, so log writes do not
+    /// serialize behind page flushes.
+    wal: WalWriter,
     layout: StorageLayout,
-    header: FileHeader,
     superblock_a: Superblock,
     superblock_b: Superblock,
     active_superblock: ActiveSuperblock,
-    wal_state: WalRingState,
+    allocator: PageAllocator,
+    /// WAL records recovered at open, waiting for the engine to replay them.
+    replay_cache: Vec<WalRecord>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -194,31 +232,32 @@ impl StorageFile {
         let mut header_bytes = [0u8; crate::storage_layout::FILE_HEADER_SIZE];
         file.read_exact_at(0, &mut header_bytes)?;
         let header = FileHeader::from_le_bytes(&header_bytes);
-        let expected_header_checksum = header.compute_checksum();
 
         if header.magic != crate::storage_layout::FILE_MAGIC {
             return Err(StorageError::InvalidFile("bad magic".to_string()));
         }
-        if header.version != crate::storage_layout::FILE_VERSION {
-            return Err(StorageError::InvalidFile("unsupported version".to_string()));
-        }
         if header.page_size as usize != crate::storage_layout::PAGE_SIZE {
             return Err(StorageError::InvalidFile("page size mismatch".to_string()));
         }
-        if header.header_checksum != expected_header_checksum {
+        if header.header_checksum != header.compute_checksum() {
             return Err(StorageError::InvalidFile(
                 "header checksum mismatch".to_string(),
             ));
         }
+        // Validate the layout before any destructive step (the v1 upgrade
+        // mutates the file; a file we cannot operate must be rejected while
+        // it is still untouched v1).
+        let layout = layout_from_header(&header, file.len());
+        validate_allocator_region(&layout)?;
 
         let mut sb_a_bytes = [0u8; crate::storage_layout::SUPERBLOCK_SIZE];
         file.read_exact_at(header.superblock_a_offset, &mut sb_a_bytes)?;
-        let superblock_a = Superblock::from_le_bytes(&sb_a_bytes);
+        let mut superblock_a = Superblock::from_le_bytes(&sb_a_bytes);
         let sb_a_valid = superblock_a.checksum == superblock_a.compute_checksum();
 
         let mut sb_b_bytes = [0u8; crate::storage_layout::SUPERBLOCK_SIZE];
         file.read_exact_at(header.superblock_b_offset, &mut sb_b_bytes)?;
-        let superblock_b = Superblock::from_le_bytes(&sb_b_bytes);
+        let mut superblock_b = Superblock::from_le_bytes(&sb_b_bytes);
         let sb_b_valid = superblock_b.checksum == superblock_b.compute_checksum();
 
         if !sb_a_valid && !sb_b_valid {
@@ -227,59 +266,86 @@ impl StorageFile {
             ));
         }
 
-        let active_superblock = ActiveSuperblock::from_superblocks(
+        let mut active_superblock = ActiveSuperblock::from_superblocks(
             &superblock_a,
             &superblock_b,
             sb_a_valid,
             sb_b_valid,
         );
 
-        let layout = StorageLayout {
-            total_size: file.len(),
-            header_offset: 0,
-            superblock_a_offset: header.superblock_a_offset,
-            superblock_b_offset: header.superblock_b_offset,
-            wal_offset: header.wal_offset,
-            wal_size: header.wal_size,
-            data_offset: header.data_offset,
-            data_size: header.data_size,
-            metadata_offset: header.metadata_offset,
-            metadata_size: header.metadata_size,
-            allocator_offset: header.allocator_offset,
-            allocator_size: header.allocator_size,
-            snapshot_offset: header.snapshot_offset,
-            snapshot_size: header.snapshot_size,
-            reserved_offset: header.reserved_offset,
-            reserved_size: header.reserved_size,
-        };
-
+        if header.version == crate::storage_layout::FILE_VERSION_V1 {
+            let active_sb = match active_superblock {
+                ActiveSuperblock::A => superblock_a,
+                ActiveSuperblock::B => superblock_b,
+            };
+            (superblock_a, superblock_b) =
+                upgrade_v1_to_v2(&mut file, header, &layout, &active_sb)?;
+            active_superblock = ActiveSuperblock::A;
+        }
         let active_sb = match active_superblock {
             ActiveSuperblock::A => &superblock_a,
             ActiveSuperblock::B => &superblock_b,
         };
-        let wal_state = WalRingState {
-            head: active_sb.wal_head,
-            tail: active_sb.wal_tail,
-            offset: header.wal_offset,
-            size: header.wal_size,
-        };
 
-        let file = StorageFile {
+        // Recover the true WAL tail: trust the superblock's tail as a lower
+        // bound and scan forward (CRC + LSN self-identity) past it.
+        let mut log_file = DirectFile::open_existing(path.clone())?;
+        let scan = scan_ring(
+            &mut log_file,
+            layout.wal_offset,
+            layout.wal_size,
+            active_sb.wal_head,
+            active_sb.wal_tail,
+        )?;
+        let wal = WalWriter::open(
+            log_file,
+            layout.wal_offset,
+            layout.wal_size,
+            active_sb.wal_head,
+            scan.tail,
+        )?;
+        let recorded_tail = active_sb.wal_tail;
+
+        let mut storage = StorageFile {
             path,
             file,
+            wal,
             layout,
-            header,
             superblock_a,
             superblock_b,
             active_superblock,
-            wal_state,
+            allocator: PageAllocator::new(layout.data_size),
+            replay_cache: scan.records,
         };
-        file.touch();
-        Ok(file)
+        storage.recover_allocator()?;
+
+        // A tail below the superblock's recorded one means part of the
+        // trusted region was lost (media corruption, or a v1 file whose
+        // superblock ran ahead of durability). Persist the corrected tail
+        // now: otherwise entries appended at it could crash-recover with the
+        // old superblock and stale entries beyond them would be replayed as
+        // trusted.
+        if scan.tail < recorded_tail {
+            let last_seq = storage
+                .replay_cache
+                .iter()
+                .map(|r| r.seq_no)
+                .max()
+                .unwrap_or(0);
+            storage.write_active_superblock(last_seq)?;
+            storage.file.sync_data()?;
+        }
+        Ok(storage)
     }
 
-    fn create_new(path: PathBuf, opts: StorageOptions) -> Result<Self, StorageError> {
-        let layout = compute_layout(opts)?;
+    fn create_new(
+        path: PathBuf,
+        opts: StorageOptions,
+        wal_min_bytes: u64,
+        wal_max_bytes: u64,
+    ) -> Result<Self, StorageError> {
+        let layout = compute_layout(opts, wal_min_bytes, wal_max_bytes)?;
+        validate_allocator_region(&layout)?;
         let mut header = FileHeader::default();
         header.superblock_a_offset = layout.superblock_a_offset;
         header.superblock_b_offset = layout.superblock_b_offset;
@@ -300,11 +366,10 @@ impl StorageFile {
         let mut superblock_a = Superblock::default();
         superblock_a.checksum = superblock_a.compute_checksum();
         let mut superblock_b = Superblock::default();
-        superblock_b.active = crate::storage_layout::SUPERBLOCK_ACTIVE_B;
+        superblock_b.active = SUPERBLOCK_ACTIVE_B;
         superblock_b.checksum = superblock_b.compute_checksum();
 
         let mut file = DirectFile::create_new(path.clone(), layout.total_size)?;
-
         file.write_all_at(layout.header_offset, &header.to_le_bytes_with_checksum())?;
         file.write_all_at(
             layout.superblock_a_offset,
@@ -316,32 +381,94 @@ impl StorageFile {
         )?;
         file.sync_data()?;
 
-        let wal_state = WalRingState {
-            head: superblock_a.wal_head,
-            tail: superblock_a.wal_tail,
-            offset: layout.wal_offset,
-            size: layout.wal_size,
-        };
+        let log_file = DirectFile::open_existing(path.clone())?;
+        let wal = WalWriter::open(log_file, layout.wal_offset, layout.wal_size, 0, 0)?;
 
-        let file = StorageFile {
+        Ok(StorageFile {
             path,
             file,
+            wal,
             layout,
-            header,
             superblock_a,
             superblock_b,
             active_superblock: ActiveSuperblock::A,
-            wal_state,
-        };
-        file.touch();
-        Ok(file)
+            allocator: PageAllocator::new(layout.data_size),
+            replay_cache: Vec::new(),
+        })
     }
 
-    fn touch(&self) {
-        let _ = self.layout.total_size;
-        let _ = self.header.magic;
-        let _ = self.superblock_a.generation;
-        let _ = self.superblock_b.generation;
+    /// Rebuilds the live allocator: persisted bitmap, then reconciliation
+    /// with the snapshot descriptors and the WAL.
+    ///
+    /// Order matters:
+    /// 1. free the stale snapshot descriptor's extent — logically this free
+    ///    belongs to the checkpoint that superseded it, which precedes every
+    ///    replayed WAL record;
+    /// 2. replay logged alloc/free extents (all idempotent bit operations);
+    /// 3. mark the live snapshot's extent allocated last, healing the crash
+    ///    window where the descriptor was written but the bitmap was not.
+    fn recover_allocator(&mut self) -> Result<(), StorageError> {
+        let bitmap_len = (self.layout.data_size / PAGE_SIZE as u64).div_ceil(8) as usize;
+        let mut bitmap = vec![0u8; bitmap_len];
+        self.file
+            .read_exact_at(self.layout.allocator_offset, &mut bitmap)?;
+        self.allocator = PageAllocator::from_bitmap(bitmap, self.layout.data_size);
+
+        let descriptors = self.read_snapshot_descriptors()?;
+        let live_slot = live_descriptor_slot(&descriptors);
+        for (slot, desc) in descriptors.iter().enumerate() {
+            let Some(desc) = desc else { continue };
+            if Some(slot) != live_slot {
+                let (start, pages) = self.descriptor_page_range(desc)?;
+                self.allocator.free(start, pages);
+            }
+        }
+
+        let rel_records: Vec<RelRecord> = self
+            .replay_cache
+            .iter()
+            .filter(|record| record.entry_type == WAL_ENTRY_TYPE_REL)
+            .map(|record| RelRecord::decode(&record.payload))
+            .collect::<Result<_, _>>()?;
+        for record in rel_records {
+            match record.kind {
+                REL_KIND_ALLOC_EXTENT => {
+                    let (start, pages) = record.decode_extent_redo()?;
+                    self.allocator.mark_used(start, pages);
+                }
+                REL_KIND_FREE_EXTENT => {
+                    let (start, pages) = record.decode_extent_redo()?;
+                    self.allocator.free(start, pages);
+                }
+                other => {
+                    return Err(StorageError::InvalidFile(format!(
+                        "unknown rel wal record kind {other}"
+                    )));
+                }
+            }
+        }
+
+        if let Some(live) = live_slot.and_then(|slot| descriptors[slot]) {
+            let (start, pages) = self.descriptor_page_range(&live)?;
+            self.allocator.mark_used(start, pages);
+        }
+        Ok(())
+    }
+
+    /// Converts a snapshot descriptor's byte extent into data-region pages.
+    fn descriptor_page_range(&self, desc: &SnapshotDescriptor) -> Result<(u64, u64), StorageError> {
+        let page = PAGE_SIZE as u64;
+        if desc.data_offset < self.layout.data_offset
+            || !desc.data_offset.is_multiple_of(page)
+            || desc.data_offset + desc.data_len > self.layout.data_offset + self.layout.data_size
+        {
+            return Err(StorageError::InvalidFile(
+                "snapshot descriptor extent outside data region".to_string(),
+            ));
+        }
+        let start = (desc.data_offset - self.layout.data_offset) / page;
+        let pages = desc.data_len.div_ceil(page);
+        Ok((start, pages))
     }
 
     fn append_wal_entry(
@@ -349,298 +476,83 @@ impl StorageFile {
         entry_type: u16,
         entry_version: u16,
         seq_no: u64,
-        logical_ts: u64,
         payload: &[u8],
     ) -> Result<u64, StorageError> {
-        if self.wal_state.size == 0 {
-            return Err(StorageError::InvalidFile(
-                "wal region size is zero".to_string(),
-            ));
+        let lsn = self
+            .wal
+            .append_entry(entry_type, entry_version, seq_no, payload)?;
+        if self.wal.take_superblock_due() {
+            // Best-effort hint: the entry is already durable, so a failed
+            // superblock rewrite must not fail the append (callers would
+            // roll back state whose WAL record is durable). Recovery only
+            // scans a little further.
+            let _ = self.write_active_superblock(seq_no);
         }
-        let payload_len = payload.len();
-        let entry_len = wal_entry_padded_len(payload_len);
-        if entry_len as u64 > self.wal_state.size {
-            return Err(StorageError::WalFull(
-                "entry larger than wal ring".to_string(),
-            ));
-        }
-
-        let used = self.wal_state.tail.saturating_sub(self.wal_state.head);
-        let free = self.wal_state.size.saturating_sub(used);
-
-        let tail_offset = (self.wal_state.tail % self.wal_state.size) as usize;
-        let bytes_to_end = self.wal_state.size as usize - tail_offset;
-        let needs_wrap = entry_len > bytes_to_end;
-        let required = if needs_wrap {
-            bytes_to_end + entry_len
-        } else {
-            entry_len
-        };
-
-        if required as u64 > free {
-            return Err(StorageError::WalFull("wal ring full".to_string()));
-        }
-
-        if needs_wrap && bytes_to_end > 0 {
-            let write_pos = self.wal_state.offset + tail_offset as u64;
-            let zeroes = vec![0u8; bytes_to_end];
-            self.file.write_all_at(write_pos, &zeroes)?;
-            self.wal_state.tail = self.wal_state.tail.saturating_add(bytes_to_end as u64);
-        }
-
-        let write_pos = self.wal_state.offset + (self.wal_state.tail % self.wal_state.size);
-
-        let payload_crc = wal_payload_crc(payload);
-        let header = WalEntryHeader::new(
-            entry_type,
-            entry_version,
-            payload_len as u32,
-            seq_no,
-            logical_ts,
-            payload_crc,
-        );
-
-        let footer = WalEntryFooter {
-            payload_len: payload_len as u32,
-            payload_crc,
-        };
-        let mut entry_bytes = Vec::with_capacity(entry_len);
-        entry_bytes.extend_from_slice(&header.to_le_bytes());
-        entry_bytes.extend_from_slice(payload);
-        entry_bytes.extend_from_slice(&footer.to_le_bytes());
-        entry_bytes.resize(entry_len, 0);
-
-        self.file.write_all_at(write_pos, &entry_bytes)?;
-
-        self.wal_state.tail = self.wal_state.tail.saturating_add(entry_len as u64);
-        self.sync_active_superblock(seq_no)?;
-        self.file.sync_data()?;
-
-        debug_assert!(self.verify_wal_entry_at(write_pos).unwrap_or(false));
-
-        Ok(write_pos)
+        Ok(lsn)
     }
 
-    fn verify_wal_entry_at(&mut self, position: u64) -> Result<bool, StorageError> {
-        let mut header_bytes = [0u8; WAL_ENTRY_HEADER_SIZE];
-        self.file.read_exact_at(position, &mut header_bytes)?;
-        let header = WalEntryHeader::from_le_bytes(&header_bytes);
-        if !header.verify_header_crc() {
-            return Ok(false);
-        }
-
-        let payload_len = header.payload_len as usize;
-        let mut payload = vec![0u8; payload_len];
-        self.file
-            .read_exact_at(position + WAL_ENTRY_HEADER_SIZE as u64, &mut payload)?;
-        let payload_crc = wal_payload_crc(&payload);
-        if payload_crc != header.payload_crc {
-            return Ok(false);
-        }
-
-        let mut footer_bytes = [0u8; WAL_ENTRY_FOOTER_SIZE];
-        self.file.read_exact_at(
-            position + WAL_ENTRY_HEADER_SIZE as u64 + payload_len as u64,
-            &mut footer_bytes,
-        )?;
-        let footer = WalEntryFooter::from_le_bytes(&footer_bytes);
-        if footer.payload_len != header.payload_len || footer.payload_crc != header.payload_crc {
-            return Ok(false);
-        }
-
-        Ok(true)
-    }
-
-    fn recover_wal(&mut self) -> Result<RecoveryState, StorageError> {
-        let wal_offset = self.layout.wal_offset;
-        let wal_size = self.layout.wal_size;
-        let mut cursor = self.wal_state.head;
-        let tail = self.wal_state.tail;
-
-        if wal_size == 0 || tail <= cursor {
-            return Ok(RecoveryState::default());
-        }
-
-        let mut last_valid_seq = None;
-        let mut last_committed_seq = None;
-        let mut bytes_scanned = 0u64;
-        let _ = WAL_ENTRY_TYPE_RECORD;
-
-        while cursor < tail {
-            let ring_pos = cursor % wal_size;
-            let bytes_to_end = wal_size - ring_pos;
-
-            if bytes_to_end < WAL_ENTRY_HEADER_SIZE as u64 {
-                cursor = cursor.saturating_add(bytes_to_end);
-                bytes_scanned = bytes_scanned.saturating_add(bytes_to_end);
-                continue;
-            }
-
-            let file_pos = wal_offset + ring_pos;
-
-            let mut header_bytes = [0u8; WAL_ENTRY_HEADER_SIZE];
-            self.file.read_exact_at(file_pos, &mut header_bytes)?;
-            if header_bytes.iter().all(|b| *b == 0) {
-                cursor = cursor.saturating_add(bytes_to_end);
-                bytes_scanned = bytes_scanned.saturating_add(bytes_to_end);
-                continue;
-            }
-
-            let header = WalEntryHeader::from_le_bytes(&header_bytes);
-            if !header.verify_header_crc() {
-                break;
-            }
-
-            let payload_len = header.payload_len as usize;
-            let entry_len = wal_entry_padded_len(payload_len) as u64;
-            if entry_len > wal_size {
-                break;
-            }
-
-            let total_len = (WAL_ENTRY_HEADER_SIZE + payload_len + WAL_ENTRY_FOOTER_SIZE) as u64;
-            if total_len > bytes_to_end {
-                break;
-            }
-
-            let mut payload = vec![0u8; payload_len];
-            self.file
-                .read_exact_at(file_pos + WAL_ENTRY_HEADER_SIZE as u64, &mut payload)?;
-            let payload_crc = wal_payload_crc(&payload);
-            if payload_crc != header.payload_crc {
-                break;
-            }
-
-            let mut footer_bytes = [0u8; WAL_ENTRY_FOOTER_SIZE];
-            self.file.read_exact_at(
-                file_pos + WAL_ENTRY_HEADER_SIZE as u64 + payload_len as u64,
-                &mut footer_bytes,
-            )?;
-            let footer = WalEntryFooter::from_le_bytes(&footer_bytes);
-            if footer.payload_len != header.payload_len || footer.payload_crc != header.payload_crc
-            {
-                break;
-            }
-
-            if header.entry_type == WAL_ENTRY_TYPE_COMMIT && payload_len >= 18 {
-                let commit_seq = u64::from_le_bytes(payload[8..16].try_into().unwrap());
-                last_committed_seq = Some(commit_seq);
-            }
-
-            last_valid_seq = Some(header.seq_no);
-
-            cursor = cursor.saturating_add(entry_len);
-            bytes_scanned = bytes_scanned.saturating_add(entry_len);
-        }
-
-        Ok(RecoveryState {
-            last_valid_seq,
-            last_committed_seq,
-            bytes_scanned,
-        })
-    }
-
-    fn replay_wal_entries(&mut self) -> Result<Vec<WalRecord>, StorageError> {
-        let wal_offset = self.layout.wal_offset;
-        let wal_size = self.layout.wal_size;
-        let mut cursor = self.wal_state.head;
-        let tail = self.wal_state.tail;
-        let mut entries = Vec::new();
-
-        if wal_size == 0 || tail <= cursor {
-            return Ok(entries);
-        }
-
-        while cursor < tail {
-            let ring_pos = cursor % wal_size;
-            let bytes_to_end = wal_size - ring_pos;
-
-            if bytes_to_end < WAL_ENTRY_HEADER_SIZE as u64 {
-                cursor = cursor.saturating_add(bytes_to_end);
-                continue;
-            }
-
-            let file_pos = wal_offset + ring_pos;
-
-            let mut header_bytes = [0u8; WAL_ENTRY_HEADER_SIZE];
-            self.file.read_exact_at(file_pos, &mut header_bytes)?;
-            if header_bytes.iter().all(|b| *b == 0) {
-                cursor = cursor.saturating_add(bytes_to_end);
-                continue;
-            }
-
-            let header = WalEntryHeader::from_le_bytes(&header_bytes);
-            if !header.verify_header_crc() {
-                break;
-            }
-
-            let payload_len = header.payload_len as usize;
-            let entry_len = wal_entry_padded_len(payload_len) as u64;
-            if entry_len > wal_size {
-                break;
-            }
-
-            let total_len = (WAL_ENTRY_HEADER_SIZE + payload_len + WAL_ENTRY_FOOTER_SIZE) as u64;
-            if total_len > bytes_to_end {
-                break;
-            }
-
-            let mut payload = vec![0u8; payload_len];
-            self.file
-                .read_exact_at(file_pos + WAL_ENTRY_HEADER_SIZE as u64, &mut payload)?;
-            let payload_crc = wal_payload_crc(&payload);
-            if payload_crc != header.payload_crc {
-                break;
-            }
-
-            let mut footer_bytes = [0u8; WAL_ENTRY_FOOTER_SIZE];
-            self.file.read_exact_at(
-                file_pos + WAL_ENTRY_HEADER_SIZE as u64 + payload_len as u64,
-                &mut footer_bytes,
-            )?;
-            let footer = WalEntryFooter::from_le_bytes(&footer_bytes);
-            if footer.payload_len != header.payload_len || footer.payload_crc != header.payload_crc
-            {
-                break;
-            }
-
-            entries.push(WalRecord {
-                entry_type: header.entry_type,
-                entry_version: header.entry_version,
-                seq_no: header.seq_no,
-                logical_ts: header.logical_ts,
-                payload,
+    fn allocate_extent(&mut self, temp: bool) -> Result<u64, StorageError> {
+        if temp {
+            return self.allocator.allocate_temp_extent().ok_or_else(|| {
+                StorageError::InvalidConfig("data region full: cannot allocate extent".to_string())
             });
-
-            cursor = cursor.saturating_add(entry_len);
         }
-
-        Ok(entries)
+        let start = self.allocator.allocate_extent().ok_or_else(|| {
+            StorageError::InvalidConfig("data region full: cannot allocate extent".to_string())
+        })?;
+        let record = RelRecord::alloc_extent(start, EXTENT_PAGES);
+        if let Err(err) = self.append_wal_entry(
+            WAL_ENTRY_TYPE_REL,
+            REL_WAL_ENTRY_VERSION,
+            0,
+            &record.encode(),
+        ) {
+            self.allocator.free(start, EXTENT_PAGES);
+            return Err(err);
+        }
+        Ok(start)
     }
 
-    fn sync_active_superblock(&mut self, last_committed_seq: u64) -> Result<(), StorageError> {
+    fn free_extent(&mut self, start_page: u64) -> Result<(), StorageError> {
+        // Log first, then mutate: a free whose record never became durable
+        // must not leave the pages reusable in memory.
+        let record = RelRecord::free_extent(start_page, EXTENT_PAGES);
+        self.append_wal_entry(
+            WAL_ENTRY_TYPE_REL,
+            REL_WAL_ENTRY_VERSION,
+            0,
+            &record.encode(),
+        )?;
+        self.allocator.free(start_page, EXTENT_PAGES);
+        Ok(())
+    }
+
+    /// Lazily rewrites the active superblock in place (no fsync: it is a
+    /// recovery-scan optimization, not a durability point; a torn write
+    /// falls back to the other superblock).
+    fn write_active_superblock(&mut self, last_committed_seq: u64) -> Result<(), StorageError> {
         let generation = self
             .superblock_a
             .generation
             .max(self.superblock_b.generation)
             .saturating_add(1);
 
+        let (head, tail) = (self.wal.head(), self.wal.tail());
         let (sb, offset) = match self.active_superblock {
             ActiveSuperblock::A => (&mut self.superblock_a, self.layout.superblock_a_offset),
             ActiveSuperblock::B => (&mut self.superblock_b, self.layout.superblock_b_offset),
         };
-
         sb.generation = generation;
         sb.active = match self.active_superblock {
             ActiveSuperblock::A => SUPERBLOCK_ACTIVE_A,
             ActiveSuperblock::B => SUPERBLOCK_ACTIVE_B,
         };
-        sb.wal_head = self.wal_state.head;
-        sb.wal_tail = self.wal_state.tail;
+        sb.wal_head = head;
+        sb.wal_tail = tail;
         sb.last_committed_seq = last_committed_seq;
         sb.checksum = sb.compute_checksum();
-
-        self.file
-            .write_all_at(offset, &sb.to_le_bytes_with_checksum())?;
+        let bytes = sb.to_le_bytes_with_checksum();
+        self.wal.file_mut().write_all_at(offset, &bytes)?;
         Ok(())
     }
 
@@ -651,125 +563,192 @@ impl StorageFile {
         next_seq_no: u64,
         next_doc_id: u64,
     ) -> Result<(), StorageError> {
-        let page_size = PAGE_SIZE as u64;
-        let num_pages = (data.len() as u64).div_ceil(page_size);
-        let padded_len = num_pages * page_size;
-
-        if padded_len > self.layout.data_size {
+        if data.is_empty() {
+            // An empty snapshot would produce a descriptor that
+            // SnapshotDescriptor::is_valid rejects while the WAL head still
+            // advances — silently reviving the previous snapshot on reopen.
             return Err(StorageError::InvalidConfig(
-                "checkpoint data exceeds data region size".to_string(),
+                "checkpoint data must not be empty".to_string(),
             ));
         }
+        let page = PAGE_SIZE as u64;
+        let num_pages = (data.len() as u64).div_ceil(page);
 
-        let mut allocator = self.load_allocator()?;
-
-        let current_snapshot = self.load_active_snapshot_descriptor()?;
-        let target_slot: u8 = if let Some(ref desc) = current_snapshot {
-            if desc.slot == 0 { 1 } else { 0 }
-        } else {
-            0
-        };
-
-        // Two-slot A/B strategy: slot 0 = first half of data region, slot 1 = second half.
-        let half_pages = self.layout.data_size / page_size / 2;
-        let slot_start_page = if target_slot == 0 { 0 } else { half_pages };
-
-        if num_pages > half_pages {
-            return Err(StorageError::InvalidConfig(
-                "checkpoint data exceeds half of data region (slot capacity)".to_string(),
-            ));
-        }
-
-        // Free the target slot region and reallocate
-        allocator.free(slot_start_page, half_pages);
-        let alloc_start = allocator.allocate(num_pages).ok_or_else(|| {
-            StorageError::InvalidConfig("cannot allocate pages for checkpoint".to_string())
-        })?;
-
-        let data_write_offset = self.layout.data_offset + alloc_start * page_size;
-
-        // Write the data (padded to page alignment)
-        let mut padded_data = data.to_vec();
-        padded_data.resize(padded_len as usize, 0);
-        self.file.write_all_at(data_write_offset, &padded_data)?;
-        self.file.sync_data()?;
-
-        // Write allocator bitmap
-        self.save_allocator(&allocator)?;
-        self.file.sync_data()?;
-
-        // Write snapshot descriptor
-        let data_checksum = xxh64(data, 0);
+        // Mint the generation above everything durable: both superblocks AND
+        // both descriptors. A crash between descriptor fsync and superblock
+        // publish leaves a descriptor generation ahead of the superblocks;
+        // minting from superblocks alone could then duplicate a live
+        // descriptor generation.
+        let descriptors = self.read_snapshot_descriptors()?;
+        let previous = live_descriptor_slot(&descriptors).and_then(|slot| descriptors[slot]);
         let generation = self
             .superblock_a
             .generation
             .max(self.superblock_b.generation)
+            .max(
+                descriptors
+                    .iter()
+                    .flatten()
+                    .map(|d| d.generation)
+                    .max()
+                    .unwrap_or(0),
+            )
             .saturating_add(1);
 
+        // The snapshot is an ordinary allocator extent now; the old snapshot
+        // stays allocated (and readable) until the new one is durable.
+        let alloc_start = self.allocator.allocate(num_pages).ok_or_else(|| {
+            StorageError::InvalidConfig(
+                "cannot allocate contiguous pages for checkpoint".to_string(),
+            )
+        })?;
+        let data_write_offset = self.layout.data_offset + alloc_start * page;
+
+        // Phase 1a — snapshot pages + fsync. A failure here may roll the
+        // allocation back: nothing references the extent yet.
+        let write_data = self
+            .write_data_pages(data_write_offset, data)
+            .and_then(|()| self.file.sync_data().map_err(StorageError::from));
+        if let Err(err) = write_data {
+            self.allocator.free(alloc_start, num_pages);
+            return Err(err);
+        }
+
+        // Phase 1b — descriptor write + fsync. From the moment the write is
+        // *issued* the descriptor may be durable regardless of any error we
+        // observe, so from here on there is no rollback: a failure leaves the
+        // extent allocated (worst case a leak until the next successful
+        // checkpoint) and recovery reconciles from whichever descriptor won.
+        let desc_offset = self.write_snapshot_descriptor(
+            data,
+            data_write_offset,
+            &previous,
+            generation,
+            checkpoint_seq,
+            next_seq_no,
+            next_doc_id,
+        )?;
+
+        // Phase 2 — the new snapshot is authoritative from here on. A crash
+        // or error leaves state that `recover_allocator` reconciles on the
+        // next open.
+        self.finish_checkpoint(
+            previous,
+            generation,
+            checkpoint_seq,
+            desc_offset,
+            data_write_offset,
+        )
+    }
+
+    /// Writes the new snapshot descriptor into the slot not currently live
+    /// and fsyncs it. Once durable, its higher generation makes the new
+    /// snapshot authoritative.
+    #[allow(clippy::too_many_arguments)]
+    fn write_snapshot_descriptor(
+        &mut self,
+        data: &[u8],
+        data_write_offset: u64,
+        previous: &Option<SnapshotDescriptor>,
+        generation: u64,
+        checkpoint_seq: u64,
+        next_seq_no: u64,
+        next_doc_id: u64,
+    ) -> Result<u64, StorageError> {
+        let target_slot: u8 = match previous {
+            Some(desc) if desc.slot == 0 => 1,
+            Some(_) => 0,
+            None => 0,
+        };
         let mut desc = SnapshotDescriptor::default();
         desc.generation = generation;
         desc.slot = target_slot;
         desc.checkpoint_seq = checkpoint_seq;
         desc.data_offset = data_write_offset;
         desc.data_len = data.len() as u64;
-        desc.data_checksum = data_checksum;
+        desc.data_checksum = xxh64(data, 0);
         desc.next_seq_no = next_seq_no;
         desc.next_doc_id = next_doc_id;
         desc.checksum = desc.compute_checksum();
-
         let desc_offset =
             self.layout.snapshot_offset + (target_slot as u64) * SNAPSHOT_DESCRIPTOR_SIZE as u64;
         self.file
             .write_all_at(desc_offset, &desc.to_le_bytes_with_checksum())?;
         self.file.sync_data()?;
+        Ok(desc_offset)
+    }
 
-        // Advance wal_head to reclaim entries covered by this checkpoint
-        self.wal_state.head = self.wal_state.tail;
+    /// Checkpoint phase 2: reclaim the previous snapshot, persist the
+    /// allocator bitmap, advance the WAL head and publish both superblocks.
+    fn finish_checkpoint(
+        &mut self,
+        previous: Option<SnapshotDescriptor>,
+        generation: u64,
+        checkpoint_seq: u64,
+        desc_offset: u64,
+        data_write_offset: u64,
+    ) -> Result<(), StorageError> {
+        // Free the previous snapshot's extent now that the new one is
+        //    durable, and persist the allocator bitmap (temp extents
+        //    excluded). The bitmap must be durable before the WAL head
+        //    advances, otherwise logged alloc/free records could be
+        //    reclaimed before their effects are persisted anywhere.
+        if let Some(prev) = &previous {
+            let (start, pages) = self.descriptor_page_range(prev)?;
+            self.allocator.free(start, pages);
+        }
+        let bitmap = self.allocator.persistable_bitmap();
+        if bitmap.len() as u64 > self.layout.allocator_size {
+            return Err(StorageError::InvalidFile(
+                "allocator bitmap exceeds allocator region".to_string(),
+            ));
+        }
+        self.file
+            .write_all_at(self.layout.allocator_offset, &bitmap)?;
+        self.file.sync_data()?;
 
-        // Flip to the inactive superblock and write it with the new state
+        // 4. Advance the WAL head and publish both superblocks (new active
+        //    first).
+        self.wal.set_head(self.wal.tail());
         let new_active = match self.active_superblock {
             ActiveSuperblock::A => ActiveSuperblock::B,
             ActiveSuperblock::B => ActiveSuperblock::A,
         };
         self.active_superblock = new_active;
 
-        // Build the new superblock state for both
+        let (head, tail) = (self.wal.head(), self.wal.tail());
         let new_sb = |active_flag: u8| -> Superblock {
             let mut sb = Superblock::default();
             sb.generation = generation;
             sb.active = active_flag;
-            sb.wal_head = self.wal_state.head;
-            sb.wal_tail = self.wal_state.tail;
+            sb.wal_head = head;
+            sb.wal_tail = tail;
             sb.last_committed_seq = checkpoint_seq;
             sb.snapshot_root = desc_offset;
             sb.data_root = data_write_offset;
             sb.checksum = sb.compute_checksum();
             sb
         };
-
         self.superblock_a = new_sb(SUPERBLOCK_ACTIVE_A);
         self.superblock_b = new_sb(SUPERBLOCK_ACTIVE_B);
 
-        // Write primary (new active) first, then backup
         let (primary_offset, primary_sb, backup_offset, backup_sb) = match new_active {
             ActiveSuperblock::A => (
                 self.layout.superblock_a_offset,
-                &self.superblock_a,
+                self.superblock_a,
                 self.layout.superblock_b_offset,
-                &self.superblock_b,
+                self.superblock_b,
             ),
             ActiveSuperblock::B => (
                 self.layout.superblock_b_offset,
-                &self.superblock_b,
+                self.superblock_b,
                 self.layout.superblock_a_offset,
-                &self.superblock_a,
+                self.superblock_a,
             ),
         };
-
         self.file
             .write_all_at(primary_offset, &primary_sb.to_le_bytes_with_checksum())?;
         self.file.sync_data()?;
-
         self.file
             .write_all_at(backup_offset, &backup_sb.to_le_bytes_with_checksum())?;
         self.file.sync_data()?;
@@ -777,15 +756,41 @@ impl StorageFile {
         Ok(())
     }
 
-    fn load_active_snapshot_descriptor(
-        &mut self,
-    ) -> Result<Option<SnapshotDescriptor>, StorageError> {
-        // Try slot 0 and slot 1, return the one with higher generation
-        let mut best: Option<SnapshotDescriptor> = None;
+    /// Writes `data` (zero-padded to whole pages) at a page-aligned offset
+    /// using batched page writes.
+    fn write_data_pages(&mut self, offset: u64, data: &[u8]) -> Result<(), StorageError> {
+        const BATCH_FRAMES: usize = 64;
+        let mut frames: Vec<AlignedPageBuf> = Vec::with_capacity(BATCH_FRAMES);
+        let mut batch_start = offset;
+        let mut cursor = 0usize;
+        let total_pages = data.len().div_ceil(PAGE_SIZE);
+        for _ in 0..total_pages {
+            let mut frame = AlignedPageBuf::new();
+            let len = (data.len() - cursor).min(PAGE_SIZE);
+            frame.as_mut_slice()[..len].copy_from_slice(&data[cursor..cursor + len]);
+            cursor += len;
+            frames.push(frame);
+            if frames.len() == BATCH_FRAMES {
+                let refs: Vec<&AlignedPageBuf> = frames.iter().collect();
+                self.file.write_pages_from(batch_start, &refs)?;
+                batch_start += (BATCH_FRAMES * PAGE_SIZE) as u64;
+                frames.clear();
+            }
+        }
+        if !frames.is_empty() {
+            let refs: Vec<&AlignedPageBuf> = frames.iter().collect();
+            self.file.write_pages_from(batch_start, &refs)?;
+        }
+        Ok(())
+    }
 
-        for slot in 0..2u8 {
+    fn read_snapshot_descriptors(
+        &mut self,
+    ) -> Result<[Option<SnapshotDescriptor>; 2], StorageError> {
+        let mut out = [None, None];
+        for (slot, entry) in out.iter_mut().enumerate() {
             let desc_offset =
-                self.layout.snapshot_offset + (slot as u64) * SNAPSHOT_DESCRIPTOR_SIZE as u64;
+                self.layout.snapshot_offset + slot as u64 * SNAPSHOT_DESCRIPTOR_SIZE as u64;
             if desc_offset + SNAPSHOT_DESCRIPTOR_SIZE as u64
                 > self.layout.snapshot_offset + self.layout.snapshot_size
             {
@@ -794,12 +799,18 @@ impl StorageFile {
             let mut desc_bytes = [0u8; SNAPSHOT_DESCRIPTOR_SIZE];
             self.file.read_exact_at(desc_offset, &mut desc_bytes)?;
             let desc = SnapshotDescriptor::from_le_bytes(&desc_bytes);
-            if desc.is_valid() && best.as_ref().is_none_or(|b| desc.generation > b.generation) {
-                best = Some(desc);
+            if desc.is_valid() {
+                *entry = Some(desc);
             }
         }
+        Ok(out)
+    }
 
-        Ok(best)
+    fn load_active_snapshot_descriptor(
+        &mut self,
+    ) -> Result<Option<SnapshotDescriptor>, StorageError> {
+        let descriptors = self.read_snapshot_descriptors()?;
+        Ok(live_descriptor_slot(&descriptors).and_then(|slot| descriptors[slot]))
     }
 
     fn load_snapshot(&mut self) -> Result<Option<SnapshotData>, StorageError> {
@@ -825,61 +836,122 @@ impl StorageFile {
             next_doc_id: desc.next_doc_id,
         }))
     }
+}
 
-    fn load_allocator(&mut self) -> Result<PageAllocator, StorageError> {
-        if self.layout.allocator_size == 0 {
-            return Ok(PageAllocator::new(self.layout.data_size));
+/// In-place v1 -> v2 upgrade:
+/// 1. zero the allocator bitmap (v1's half-slot bookkeeping is meaningless
+///    in v2 — `recover_allocator` re-marks the live snapshot extent);
+/// 2. rewrite BOTH superblocks from the active one — v1's backup superblock
+///    may be arbitrarily stale, and any later fallback to it would silently
+///    drop fsync-acknowledged v1 WAL entries (v1 entries beyond a stale tail
+///    cannot pass the v2 forward scan);
+/// 3. stamp the new version.
+///
+/// Each step is fsync-fenced; a crash before step 3 leaves a v1 file and the
+/// upgrade re-runs idempotently.
+fn upgrade_v1_to_v2(
+    file: &mut DirectFile,
+    mut header: FileHeader,
+    layout: &StorageLayout,
+    active_sb: &Superblock,
+) -> Result<(Superblock, Superblock), StorageError> {
+    let zero_page = AlignedPageBuf::new();
+    let mut offset = header.allocator_offset;
+    let end = header.allocator_offset + header.allocator_size;
+    while offset < end {
+        file.write_page_from(offset, &zero_page)?;
+        offset += PAGE_SIZE as u64;
+    }
+    file.sync_data()?;
+
+    let generation = active_sb.generation.saturating_add(1);
+    let new_sb = |active_flag: u8| -> Superblock {
+        let mut sb = *active_sb;
+        sb.generation = generation;
+        sb.active = active_flag;
+        sb.checksum = sb.compute_checksum();
+        sb
+    };
+    let superblock_a = new_sb(SUPERBLOCK_ACTIVE_A);
+    let superblock_b = new_sb(SUPERBLOCK_ACTIVE_B);
+    file.write_all_at(
+        layout.superblock_a_offset,
+        &superblock_a.to_le_bytes_with_checksum(),
+    )?;
+    file.sync_data()?;
+    file.write_all_at(
+        layout.superblock_b_offset,
+        &superblock_b.to_le_bytes_with_checksum(),
+    )?;
+    file.sync_data()?;
+
+    header.version = crate::storage_layout::FILE_VERSION;
+    header.header_checksum = header.compute_checksum();
+    file.write_all_at(0, &header.to_le_bytes_with_checksum())?;
+    file.sync_data()?;
+    Ok((superblock_a, superblock_b))
+}
+
+/// Picks the live snapshot descriptor slot by the highest
+/// `(generation, slot index)` — one total order shared by every consumer
+/// (allocator recovery and snapshot loading), so they can never disagree on
+/// which descriptor is authoritative, even in the face of legacy duplicate
+/// generations.
+fn live_descriptor_slot(descriptors: &[Option<SnapshotDescriptor>; 2]) -> Option<usize> {
+    let mut best: Option<usize> = None;
+    for (slot, desc) in descriptors.iter().enumerate() {
+        let Some(desc) = desc else { continue };
+        let better = match best {
+            None => true,
+            Some(b) => {
+                let current = descriptors[b].as_ref().expect("best slot is valid");
+                (desc.generation, slot) > (current.generation, b)
+            }
+        };
+        if better {
+            best = Some(slot);
         }
-        let bitmap_len = (self.layout.data_size / PAGE_SIZE as u64).div_ceil(8) as usize;
-        let read_len = bitmap_len.min(self.layout.allocator_size as usize);
-        let mut bitmap = vec![0u8; bitmap_len];
-        self.file
-            .read_exact_at(self.layout.allocator_offset, &mut bitmap[..read_len])?;
-        Ok(PageAllocator::from_bitmap(bitmap, self.layout.data_size))
     }
+    best
+}
 
-    fn save_allocator(&mut self, allocator: &PageAllocator) -> Result<(), StorageError> {
-        let bitmap = allocator.bitmap();
-        let write_len = bitmap.len().min(self.layout.allocator_size as usize);
-        self.file
-            .write_all_at(self.layout.allocator_offset, &bitmap[..write_len])?;
-        Ok(())
+fn layout_from_header(header: &FileHeader, total_size: u64) -> StorageLayout {
+    StorageLayout {
+        total_size,
+        header_offset: 0,
+        superblock_a_offset: header.superblock_a_offset,
+        superblock_b_offset: header.superblock_b_offset,
+        wal_offset: header.wal_offset,
+        wal_size: header.wal_size,
+        data_offset: header.data_offset,
+        data_size: header.data_size,
+        metadata_offset: header.metadata_offset,
+        metadata_size: header.metadata_size,
+        allocator_offset: header.allocator_offset,
+        allocator_size: header.allocator_size,
+        snapshot_offset: header.snapshot_offset,
+        snapshot_size: header.snapshot_size,
+        reserved_offset: header.reserved_offset,
+        reserved_size: header.reserved_size,
     }
+}
 
-    fn wal_usage_ratio(&self) -> f64 {
-        if self.wal_state.size == 0 {
-            return 1.0;
-        }
-        let used = self.wal_state.tail.saturating_sub(self.wal_state.head);
-        used as f64 / self.wal_state.size as f64
+fn validate_allocator_region(layout: &StorageLayout) -> Result<(), StorageError> {
+    let bitmap_len = (layout.data_size / PAGE_SIZE as u64).div_ceil(8);
+    if bitmap_len > layout.allocator_size {
+        return Err(StorageError::InvalidConfig(format!(
+            "allocator region ({} bytes) too small for data-region bitmap ({bitmap_len} bytes)",
+            layout.allocator_size
+        )));
     }
+    Ok(())
 }
 
-#[derive(Debug, Clone, Copy)]
-struct WalRingState {
-    head: u64,
-    tail: u64,
-    offset: u64,
-    size: u64,
-}
-
-#[derive(Debug, Default, Clone, Copy)]
-pub struct RecoveryState {
-    pub last_valid_seq: Option<u64>,
-    pub last_committed_seq: Option<u64>,
-    pub bytes_scanned: u64,
-}
-
-#[derive(Debug, Clone)]
-pub struct WalRecord {
-    pub entry_type: u16,
-    pub entry_version: u16,
-    pub seq_no: u64,
-    pub logical_ts: u64,
-    pub payload: Vec<u8>,
-}
-
-fn compute_layout(opts: StorageOptions) -> Result<StorageLayout, StorageError> {
+fn compute_layout(
+    opts: StorageOptions,
+    wal_min_bytes: u64,
+    wal_max_bytes: u64,
+) -> Result<StorageLayout, StorageError> {
     let total_size = opts
         .size_gib
         .checked_mul(crate::storage_layout::GIB)
@@ -894,7 +966,7 @@ fn compute_layout(opts: StorageOptions) -> Result<StorageLayout, StorageError> {
     }
 
     let wal_raw = (total_size as f64 * opts.wal_ratio) as u64;
-    let wal_clamped = wal_raw.clamp(WAL_MIN_BYTES, WAL_MAX_BYTES);
+    let wal_clamped = wal_raw.clamp(wal_min_bytes, wal_max_bytes);
     let wal_size = align_down(wal_clamped, page);
 
     let metadata_size = align_down((total_size as f64 * opts.metadata_ratio) as u64, page);
@@ -954,4 +1026,814 @@ fn compute_layout(opts: StorageOptions) -> Result<StorageLayout, StorageError> {
         reserved_offset,
         reserved_size,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{Read, Seek, SeekFrom, Write};
+    use std::path::{Path, PathBuf};
+
+    use super::*;
+    use crate::storage_layout::{
+        FILE_HEADER_SIZE, FILE_VERSION, FILE_VERSION_V1, SUPERBLOCK_SIZE, WAL_ENTRY_TYPE_RECORD,
+        WalEntryFooter, WalEntryHeader, wal_entry_padded_len, wal_payload_crc,
+    };
+
+    /// Small ring so wrap/full paths are cheap to reach.
+    const TEST_WAL_BYTES: u64 = 64 * 1024;
+
+    fn test_storage_options() -> StorageOptions {
+        StorageOptions {
+            size_gib: 1,
+            wal_ratio: 0.05,
+            metadata_ratio: 0.08,
+            snapshot_ratio: 0.02,
+            allocator_ratio: 0.02,
+            reserved_ratio: 0.17,
+        }
+    }
+
+    fn unique_temp_path(label: &str) -> PathBuf {
+        let mut path = std::env::temp_dir();
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system time before unix epoch")
+            .as_nanos();
+        path.push(format!("truthdb-storage-{label}-{nanos}.db"));
+        path
+    }
+
+    fn create_small(path: &Path) -> Storage {
+        Storage::create_with_wal_bounds(
+            path.to_path_buf(),
+            test_storage_options(),
+            TEST_WAL_BYTES,
+            TEST_WAL_BYTES,
+        )
+        .expect("create storage")
+    }
+
+    /// Buffered write into the file (test-side corruption / fixtures). The
+    /// sync makes it visible to subsequent O_DIRECT reads.
+    fn overwrite_bytes(path: &Path, offset: u64, bytes: &[u8]) {
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .open(path)
+            .expect("open for corruption");
+        file.seek(SeekFrom::Start(offset)).expect("seek");
+        file.write_all(bytes).expect("write");
+        file.sync_all().expect("sync");
+    }
+
+    fn read_bytes(path: &Path, offset: u64, len: usize) -> Vec<u8> {
+        let mut file = std::fs::File::open(path).expect("open for read");
+        file.seek(SeekFrom::Start(offset)).expect("seek");
+        let mut buf = vec![0u8; len];
+        file.read_exact(&mut buf).expect("read");
+        buf
+    }
+
+    fn append_search_entry(storage: &mut Storage, seq_no: u64, payload: &[u8]) -> u64 {
+        storage
+            .append_wal_entry(WAL_ENTRY_TYPE_RECORD, 1, seq_no, payload)
+            .expect("append wal entry")
+    }
+
+    /// Reads both superblocks from disk and returns the active (highest
+    /// valid generation) one.
+    fn read_active_superblock(path: &Path, layout: &StorageLayout) -> Superblock {
+        let read_sb = |offset: u64| -> Option<Superblock> {
+            let bytes = read_bytes(path, offset, SUPERBLOCK_SIZE);
+            let sb = Superblock::from_le_bytes(bytes.as_slice().try_into().unwrap());
+            (sb.checksum == sb.compute_checksum()).then_some(sb)
+        };
+        let a = read_sb(layout.superblock_a_offset);
+        let b = read_sb(layout.superblock_b_offset);
+        match (a, b) {
+            (Some(a), Some(b)) => {
+                if b.generation > a.generation {
+                    b
+                } else {
+                    a
+                }
+            }
+            (Some(a), None) => a,
+            (None, Some(b)) => b,
+            (None, None) => panic!("no valid superblock"),
+        }
+    }
+
+    fn test_layout() -> StorageLayout {
+        compute_layout(test_storage_options(), TEST_WAL_BYTES, TEST_WAL_BYTES).expect("layout")
+    }
+
+    /// Writes a v1-format file: v1 header, superblocks, optional snapshot in
+    /// half-slot 0, WAL entries with v1 stamping (`logical_ts = seq_no`) and
+    /// garbage in the allocator bitmap (v1 half-slot bookkeeping the upgrade
+    /// must discard).
+    fn write_v1_fixture(
+        path: &Path,
+        wal_events: &[(u64, Vec<u8>)],
+        snapshot: Option<(&[u8], u64, u64, u64)>,
+    ) -> StorageLayout {
+        let layout = test_layout();
+        let file = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(path)
+            .expect("create fixture");
+        file.set_len(layout.total_size).expect("set_len");
+        drop(file);
+
+        let mut header = FileHeader::default();
+        header.version = FILE_VERSION_V1;
+        header.superblock_a_offset = layout.superblock_a_offset;
+        header.superblock_b_offset = layout.superblock_b_offset;
+        header.wal_offset = layout.wal_offset;
+        header.wal_size = layout.wal_size;
+        header.data_offset = layout.data_offset;
+        header.data_size = layout.data_size;
+        header.metadata_offset = layout.metadata_offset;
+        header.metadata_size = layout.metadata_size;
+        header.allocator_offset = layout.allocator_offset;
+        header.allocator_size = layout.allocator_size;
+        header.snapshot_offset = layout.snapshot_offset;
+        header.snapshot_size = layout.snapshot_size;
+        header.reserved_offset = layout.reserved_offset;
+        header.reserved_size = layout.reserved_size;
+        header.header_checksum = header.compute_checksum();
+        overwrite_bytes(path, 0, &header.to_le_bytes_with_checksum());
+
+        // WAL entries, sequentially from ring position 0, v1 stamping.
+        let mut tail = 0u64;
+        let mut last_seq = 0u64;
+        for (seq_no, payload) in wal_events {
+            let padded = wal_entry_padded_len(payload.len());
+            let crc = wal_payload_crc(payload);
+            let entry_header = WalEntryHeader::new(
+                WAL_ENTRY_TYPE_RECORD,
+                1,
+                payload.len() as u32,
+                *seq_no,
+                *seq_no, // v1: logical_ts carried the engine seq
+                crc,
+            );
+            let footer = WalEntryFooter {
+                payload_len: payload.len() as u32,
+                payload_crc: crc,
+            };
+            let mut bytes = Vec::with_capacity(padded);
+            bytes.extend_from_slice(&entry_header.to_le_bytes());
+            bytes.extend_from_slice(payload);
+            bytes.extend_from_slice(&footer.to_le_bytes());
+            bytes.resize(padded, 0);
+            overwrite_bytes(path, layout.wal_offset + tail, &bytes);
+            tail += padded as u64;
+            last_seq = *seq_no;
+        }
+
+        // Snapshot in v1 half-slot 0 (start of the data region).
+        if let Some((data, checkpoint_seq, next_seq_no, next_doc_id)) = snapshot {
+            overwrite_bytes(path, layout.data_offset, data);
+            let mut desc = SnapshotDescriptor::default();
+            desc.generation = 1;
+            desc.slot = 0;
+            desc.checkpoint_seq = checkpoint_seq;
+            desc.data_offset = layout.data_offset;
+            desc.data_len = data.len() as u64;
+            desc.data_checksum = xxh64(data, 0);
+            desc.next_seq_no = next_seq_no;
+            desc.next_doc_id = next_doc_id;
+            desc.checksum = desc.compute_checksum();
+            overwrite_bytes(
+                path,
+                layout.snapshot_offset,
+                &desc.to_le_bytes_with_checksum(),
+            );
+        }
+
+        // v1 half-slot allocator garbage the upgrade must wipe.
+        overwrite_bytes(path, layout.allocator_offset, &[0xFF; 512]);
+
+        let mut sb_a = Superblock::default();
+        sb_a.generation = 2;
+        sb_a.active = SUPERBLOCK_ACTIVE_A;
+        sb_a.wal_tail = tail;
+        sb_a.last_committed_seq = last_seq;
+        sb_a.checksum = sb_a.compute_checksum();
+        overwrite_bytes(
+            path,
+            layout.superblock_a_offset,
+            &sb_a.to_le_bytes_with_checksum(),
+        );
+        let mut sb_b = Superblock::default();
+        sb_b.active = SUPERBLOCK_ACTIVE_B;
+        sb_b.checksum = sb_b.compute_checksum();
+        overwrite_bytes(
+            path,
+            layout.superblock_b_offset,
+            &sb_b.to_le_bytes_with_checksum(),
+        );
+        layout
+    }
+
+    #[test]
+    fn v1_fixture_upgrades_in_place_and_preserves_state() {
+        let path = unique_temp_path("v1-upgrade");
+        let snapshot_data = b"v1-snapshot-payload".as_slice();
+        let events = vec![(6u64, vec![1u8; 100]), (7u64, vec![2u8; 50])];
+        write_v1_fixture(&path, &events, Some((snapshot_data, 5, 8, 3)));
+
+        let mut storage = Storage::open(path.clone()).expect("open v1 file");
+
+        // Snapshot survives the upgrade.
+        let snapshot = storage
+            .load_snapshot()
+            .expect("load snapshot")
+            .expect("snapshot present");
+        assert_eq!(snapshot.data, snapshot_data);
+        assert_eq!(snapshot.checkpoint_seq, 5);
+        assert_eq!(snapshot.next_seq_no, 8);
+        assert_eq!(snapshot.next_doc_id, 3);
+
+        // WAL entries survive and replay in order.
+        let records = storage.replay_wal_entries().expect("replay");
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[0].seq_no, 6);
+        assert_eq!(records[0].payload, vec![1u8; 100]);
+        assert_eq!(records[1].seq_no, 7);
+        assert_eq!(records[1].payload, vec![2u8; 50]);
+
+        // The allocator was rebuilt: only the live snapshot extent is
+        // allocated; the v1 half-slot garbage is gone.
+        assert!(storage.is_page_allocated(0), "snapshot extent must be live");
+        assert!(
+            !storage.is_page_allocated(1),
+            "pages past the snapshot extent must be free"
+        );
+        assert!(
+            !storage.is_page_allocated(100),
+            "v1 bitmap garbage must have been wiped"
+        );
+
+        // New work post-upgrade: append + checkpoint + reopen.
+        append_search_entry(&mut storage, 8, b"post-upgrade");
+        storage
+            .write_checkpoint(b"v2-snapshot", 8, 9, 4)
+            .expect("checkpoint");
+        drop(storage);
+
+        // On-disk version is now v2; upgraded file opens cleanly.
+        let header_bytes = read_bytes(&path, 0, FILE_HEADER_SIZE);
+        let header = FileHeader::from_le_bytes(header_bytes.as_slice().try_into().unwrap());
+        assert_eq!(header.version, FILE_VERSION);
+        assert_eq!(header.header_checksum, header.compute_checksum());
+
+        let mut storage = Storage::open(path.clone()).expect("reopen upgraded");
+        let snapshot = storage
+            .load_snapshot()
+            .expect("load")
+            .expect("second snapshot");
+        assert_eq!(snapshot.data, b"v2-snapshot");
+        assert!(
+            storage.replay_wal_entries().expect("replay").is_empty(),
+            "checkpoint reclaimed the wal"
+        );
+        // The upgraded snapshot's extent was freed once the v2 one became
+        // durable; page 0 belonged to the v1 snapshot.
+        assert!(!storage.is_page_allocated(0));
+        drop(storage);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn torn_tail_is_stopped_at_and_healed_by_whole_page_flush() {
+        let path = unique_temp_path("torn-tail");
+        let layout = test_layout();
+        let mut storage = create_small(&path);
+        let payload_a = vec![0xAAu8; 100];
+        append_search_entry(&mut storage, 1, &payload_a);
+        drop(storage); // crash: superblock still says tail = 0
+
+        // Simulate a torn write of a follow-up entry: garbage on the tail
+        // page right after entry A.
+        let entry_a_len = wal_entry_padded_len(payload_a.len()) as u64;
+        overwrite_bytes(&path, layout.wal_offset + entry_a_len, &[0x5Au8; 200]);
+
+        // Recovery must stop at the garbage and keep A.
+        let mut storage = Storage::open(path.clone()).expect("reopen after tear");
+        let records = storage.replay_wal_entries().expect("replay");
+        assert_eq!(records.len(), 1, "only entry A must survive the torn tail");
+        assert_eq!(records[0].payload, payload_a);
+
+        // The next append rewrites the whole tail page from memory, healing
+        // the torn bytes: B lands exactly where the garbage was.
+        let payload_b = vec![0xBBu8; 60];
+        append_search_entry(&mut storage, 2, &payload_b);
+        drop(storage);
+
+        let mut storage = Storage::open(path.clone()).expect("reopen after heal");
+        let records = storage.replay_wal_entries().expect("replay");
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[0].payload, payload_a);
+        assert_eq!(records[1].payload, payload_b);
+        drop(storage);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn superblock_is_lazy_and_forward_scan_recovers_past_it() {
+        let path = unique_temp_path("lazy-superblock");
+        let layout = test_layout();
+        let mut storage = create_small(&path);
+        storage.file.wal.set_superblock_interval(400);
+
+        // 152 bytes per entry: the cadence write fires once, on entry 3
+        // (456 bytes appended), and entry 4 stays past the recorded tail.
+        let payloads: Vec<Vec<u8>> = (0..4u8).map(|i| vec![i + 1; 100]).collect();
+        let mut lsns = Vec::new();
+        for (i, payload) in payloads.iter().enumerate() {
+            lsns.push(append_search_entry(&mut storage, i as u64 + 1, payload));
+        }
+        drop(storage); // crash without checkpoint
+
+        // The on-disk superblock lags the true tail (laziness) but is not 0
+        // (the cadence rewrite fired).
+        let sb = read_active_superblock(&path, &layout);
+        let true_tail = lsns[3] + wal_entry_padded_len(payloads[3].len()) as u64;
+        assert!(sb.wal_tail > 0, "cadence superblock write must have fired");
+        assert!(
+            sb.wal_tail < true_tail,
+            "superblock tail {} must lag the true tail {true_tail}",
+            sb.wal_tail
+        );
+
+        // Recovery scans forward past the stale superblock tail and finds
+        // every entry.
+        let mut storage = Storage::open(path.clone()).expect("reopen");
+        let records = storage.replay_wal_entries().expect("replay");
+        assert_eq!(records.len(), 4, "forward scan must recover all entries");
+        for (record, payload) in records.iter().zip(&payloads) {
+            assert_eq!(&record.payload, payload);
+        }
+        // LSN self-identity stamping.
+        for (record, lsn) in records.iter().zip(&lsns) {
+            assert_eq!(record.logical_ts, *lsn);
+        }
+        drop(storage);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn wal_wraps_after_checkpoint_and_recovers_across_the_lap() {
+        let path = unique_temp_path("wal-wrap");
+        let mut storage = create_small(&path);
+
+        // Fill ~60% of the 64 KiB ring, then reclaim it via checkpoint.
+        for seq in 1..=5u64 {
+            append_search_entry(&mut storage, seq, &vec![seq as u8; 8000]);
+        }
+        storage
+            .write_checkpoint(b"state-at-5", 5, 6, 1)
+            .expect("checkpoint");
+
+        // These cross the lap boundary (one entry forces a wrap gap).
+        let post: Vec<Vec<u8>> = (6..=9u64).map(|seq| vec![seq as u8; 8000]).collect();
+        for (i, payload) in post.iter().enumerate() {
+            append_search_entry(&mut storage, 6 + i as u64, payload);
+        }
+        drop(storage); // crash
+
+        let mut storage = Storage::open(path.clone()).expect("reopen");
+        let snapshot = storage
+            .load_snapshot()
+            .expect("load")
+            .expect("snapshot present");
+        assert_eq!(snapshot.data, b"state-at-5");
+        let records = storage.replay_wal_entries().expect("replay");
+        assert_eq!(
+            records.len(),
+            4,
+            "exactly the post-checkpoint entries replay"
+        );
+        for (record, payload) in records.iter().zip(&post) {
+            assert_eq!(&record.payload, payload);
+        }
+        // The ring stays usable after recovery on the wrapped lap.
+        append_search_entry(&mut storage, 10, b"after-recovery");
+        drop(storage);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn wal_full_errors_and_checkpoint_reclaims() {
+        let path = unique_temp_path("wal-full");
+        let mut storage = create_small(&path);
+        let payload = vec![7u8; 8000];
+        let mut appended = 0;
+        let err = loop {
+            match storage.append_wal_entry(WAL_ENTRY_TYPE_RECORD, 1, appended + 1, &payload) {
+                Ok(_) => appended += 1,
+                Err(err) => break err,
+            }
+            assert!(appended < 100, "ring must fill up");
+        };
+        assert!(matches!(err, StorageError::WalFull(_)), "got: {err}");
+
+        storage
+            .write_checkpoint(b"reclaim", appended, appended + 1, 1)
+            .expect("checkpoint");
+        append_search_entry(&mut storage, appended + 1, &payload);
+        drop(storage);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn extent_alloc_free_replays_from_wal() {
+        let path = unique_temp_path("extent-replay");
+        let mut storage = create_small(&path);
+        let durable = storage.allocate_extent(false).expect("durable extent");
+        let temp = storage.allocate_extent(true).expect("temp extent");
+        assert_ne!(durable, temp);
+        drop(storage); // crash: bitmap never persisted, only the WAL knows
+
+        let mut storage = Storage::open(path.clone()).expect("reopen");
+        assert!(
+            storage.is_page_allocated(durable),
+            "logged alloc must replay"
+        );
+        assert!(
+            !storage.is_page_allocated(temp),
+            "temp extents must vanish on restart"
+        );
+
+        storage.free_extent(durable).expect("free extent");
+        drop(storage); // crash again
+
+        let mut storage = Storage::open(path.clone()).expect("reopen after free");
+        assert!(
+            !storage.is_page_allocated(durable),
+            "logged free must replay"
+        );
+
+        // Alloc + checkpoint: the bitmap carries the state once the WAL is
+        // reclaimed.
+        let kept = storage.allocate_extent(false).expect("extent");
+        storage
+            .write_checkpoint(b"with-extent", 1, 2, 1)
+            .expect("checkpoint");
+        drop(storage);
+
+        let mut storage = Storage::open(path.clone()).expect("reopen after checkpoint");
+        assert!(
+            storage.replay_wal_entries().expect("replay").is_empty(),
+            "wal reclaimed"
+        );
+        assert!(
+            storage.is_page_allocated(kept),
+            "bitmap must carry extents across checkpoints"
+        );
+        drop(storage);
+        let _ = std::fs::remove_file(path);
+    }
+
+    /// Regression (review finding): the whole-tail-page flush must never
+    /// let the page's zero suffix alias onto live entries at the head. With
+    /// a mid-page head and a nearly-full ring, the append that would have
+    /// clobbered the head must instead report WalFull, and every previously
+    /// acknowledged entry must survive a crash.
+    #[test]
+    fn tail_page_flush_never_overwrites_live_head_entries() {
+        let path = unique_temp_path("tail-page-alias");
+        let mut storage = create_small(&path);
+
+        // Head becomes mid-page: one 5056-byte entry, then checkpoint.
+        append_search_entry(&mut storage, 1, &vec![1u8; 5000]);
+        storage
+            .write_checkpoint(b"cp", 1, 2, 1)
+            .expect("checkpoint");
+
+        // Fill the ring almost entirely (the 15th entry wraps).
+        let mut acked = Vec::new();
+        for i in 0..15u64 {
+            let payload = vec![(i + 2) as u8; 4000];
+            append_search_entry(&mut storage, i + 2, &payload);
+            acked.push(payload);
+        }
+
+        // This append fits the naive byte count but its tail-page zero
+        // suffix would overwrite the oldest live entries; it must be
+        // rejected.
+        let err = storage
+            .append_wal_entry(WAL_ENTRY_TYPE_RECORD, 1, 17, &vec![9u8; 900])
+            .expect_err("append aliasing the head must fail");
+        assert!(matches!(err, StorageError::WalFull(_)), "got: {err}");
+        drop(storage); // crash
+
+        let mut storage = Storage::open(path.clone()).expect("reopen");
+        let records = storage.replay_wal_entries().expect("replay");
+        assert_eq!(records.len(), 15, "every acked entry must survive");
+        for (record, payload) in records.iter().zip(&acked) {
+            assert_eq!(&record.payload, payload);
+        }
+        drop(storage);
+        let _ = std::fs::remove_file(path);
+    }
+
+    /// Regression (review finding): a crash between descriptor fsync and
+    /// superblock publish leaves descriptor generations ahead of the
+    /// superblocks. The next checkpoint must mint a strictly higher
+    /// generation (no duplicates), and later opens must agree on the live
+    /// snapshot.
+    #[test]
+    fn checkpoint_after_superblock_publish_crash_mints_higher_generation() {
+        let path = unique_temp_path("gen-minting");
+        let layout = test_layout();
+        let mut storage = create_small(&path);
+        storage.write_checkpoint(b"one", 1, 2, 1).expect("cp 1");
+        drop(storage);
+
+        // Save the checkpoint-1-era superblocks.
+        let sb_a = read_bytes(&path, layout.superblock_a_offset, SUPERBLOCK_SIZE);
+        let sb_b = read_bytes(&path, layout.superblock_b_offset, SUPERBLOCK_SIZE);
+
+        let mut storage = Storage::open(path.clone()).expect("reopen");
+        storage.write_checkpoint(b"two", 2, 3, 1).expect("cp 2");
+        drop(storage);
+
+        // Simulate the crash window: descriptor of checkpoint 2 durable,
+        // superblocks rolled back to checkpoint 1.
+        overwrite_bytes(&path, layout.superblock_a_offset, &sb_a);
+        overwrite_bytes(&path, layout.superblock_b_offset, &sb_b);
+
+        let mut storage = Storage::open(path.clone()).expect("reopen in crash window");
+        let snapshot = storage.load_snapshot().expect("load").expect("snapshot");
+        assert_eq!(snapshot.data, b"two", "newest descriptor must win");
+
+        // The next checkpoint must not duplicate checkpoint 2's generation.
+        storage.write_checkpoint(b"three", 3, 4, 1).expect("cp 3");
+        drop(storage);
+
+        let mut storage = Storage::open(path.clone()).expect("final reopen");
+        let snapshot = storage.load_snapshot().expect("load").expect("snapshot");
+        assert_eq!(snapshot.data, b"three");
+        // Allocator agrees with the snapshot choice: the live extent is
+        // allocated and loadable, and further checkpoints keep working.
+        storage.write_checkpoint(b"four", 4, 5, 1).expect("cp 4");
+        let snapshot = storage.load_snapshot().expect("load").expect("snapshot");
+        assert_eq!(snapshot.data, b"four");
+        drop(storage);
+        let _ = std::fs::remove_file(path);
+    }
+
+    /// Review finding: a durable wrap gap whose next-lap entry never made it
+    /// to disk must rewind the recovered tail to the gap start.
+    #[test]
+    fn wrap_gap_without_next_lap_entry_rewinds_tail() {
+        let path = unique_temp_path("gap-rewind");
+        let layout = test_layout();
+        let mut storage = create_small(&path);
+        for seq in 1..=5u64 {
+            append_search_entry(&mut storage, seq, &vec![seq as u8; 8000]);
+        }
+        storage
+            .write_checkpoint(b"cp", 5, 6, 1)
+            .expect("checkpoint");
+        let post: Vec<Vec<u8>> = (6..=9u64).map(|seq| vec![seq as u8; 8000]).collect();
+        for (i, payload) in post.iter().enumerate() {
+            append_search_entry(&mut storage, 6 + i as u64, payload);
+        }
+        drop(storage);
+
+        // Entry 9 wrapped to the ring start. Erase its lap-2 pages as if the
+        // gap reached disk but the entry itself never did.
+        let entry_len = wal_entry_padded_len(8000);
+        overwrite_bytes(&path, layout.wal_offset, &vec![0u8; entry_len]);
+
+        let mut storage = Storage::open(path.clone()).expect("reopen");
+        let records = storage.replay_wal_entries().expect("replay");
+        assert_eq!(records.len(), 3, "the lost wrap entry must not replay");
+        for (record, payload) in records.iter().zip(&post[..3]) {
+            assert_eq!(&record.payload, payload);
+        }
+
+        // The rewound tail must be usable: a new append re-wraps and
+        // survives another crash.
+        append_search_entry(&mut storage, 9, b"after-rewind");
+        drop(storage);
+        let mut storage = Storage::open(path.clone()).expect("second reopen");
+        let records = storage.replay_wal_entries().expect("replay");
+        assert_eq!(records.len(), 4);
+        assert_eq!(records[3].payload, b"after-rewind");
+        drop(storage);
+        let _ = std::fs::remove_file(path);
+    }
+
+    /// Review finding: the in-place lazy superblock rewrite stakes its
+    /// safety on falling back to the other superblock plus the forward
+    /// scan. Exercise exactly that: corrupt the active superblock and
+    /// recover everything through the stale one.
+    #[test]
+    fn torn_active_superblock_falls_back_and_forward_scan_recovers() {
+        let path = unique_temp_path("torn-superblock");
+        let layout = test_layout();
+        let mut storage = create_small(&path);
+        storage.file.wal.set_superblock_interval(400);
+        let payloads: Vec<Vec<u8>> = (0..4u8).map(|i| vec![i + 1; 100]).collect();
+        for (i, payload) in payloads.iter().enumerate() {
+            append_search_entry(&mut storage, i as u64 + 1, payload);
+        }
+        drop(storage);
+
+        // The lazy writes all went to the active superblock (A). Tear it.
+        overwrite_bytes(
+            &path,
+            layout.superblock_a_offset,
+            &[0xEEu8; SUPERBLOCK_SIZE],
+        );
+
+        let mut storage = Storage::open(path.clone()).expect("reopen on backup superblock");
+        let records = storage.replay_wal_entries().expect("replay");
+        assert_eq!(records.len(), 4, "forward scan from the stale superblock");
+        for (record, payload) in records.iter().zip(&payloads) {
+            assert_eq!(&record.payload, payload);
+        }
+        drop(storage);
+        let _ = std::fs::remove_file(path);
+    }
+
+    /// Corruption inside the trusted region truncates the log there; the
+    /// corrected tail must be persisted at open so stale entries beyond it
+    /// can never re-enter a future trusted region.
+    #[test]
+    fn trusted_region_corruption_truncates_and_persists_corrected_tail() {
+        let path = unique_temp_path("trusted-corruption");
+        let layout = test_layout();
+        let mut storage = create_small(&path);
+        storage.file.wal.set_superblock_interval(400);
+        for seq in 1..=4u64 {
+            append_search_entry(&mut storage, seq, &vec![seq as u8; 100]);
+        }
+        drop(storage);
+        let entry_len = wal_entry_padded_len(100) as u64;
+
+        // Corrupt entry 2, inside the superblock-trusted region.
+        overwrite_bytes(&path, layout.wal_offset + entry_len + 8, &[0xDDu8; 32]);
+
+        let mut storage = Storage::open(path.clone()).expect("reopen after corruption");
+        let records = storage.replay_wal_entries().expect("replay");
+        assert_eq!(records.len(), 1, "log truncates at the corrupt entry");
+        assert_eq!(records[0].payload, vec![1u8; 100]);
+        drop(storage);
+
+        // The corrected (smaller) tail must now be on disk.
+        let sb = read_active_superblock(&path, &layout);
+        assert_eq!(
+            sb.wal_tail, entry_len,
+            "open must persist the corrected tail"
+        );
+
+        // New history: append a differently-sized entry and crash. Recovery
+        // must see [entry 1, new entry] and never resurrect old entries 3/4.
+        let mut storage = Storage::open(path.clone()).expect("reopen");
+        storage.replay_wal_entries().expect("drain");
+        append_search_entry(&mut storage, 2, &vec![9u8; 60]);
+        drop(storage);
+        let mut storage = Storage::open(path.clone()).expect("final reopen");
+        let records = storage.replay_wal_entries().expect("replay");
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[0].payload, vec![1u8; 100]);
+        assert_eq!(records[1].payload, vec![9u8; 60]);
+        drop(storage);
+        let _ = std::fs::remove_file(path);
+    }
+
+    /// Review finding: allocate_extent's rollback when the WAL append fails
+    /// must leave the allocator exactly as before.
+    #[test]
+    fn allocate_extent_rolls_back_when_wal_is_full() {
+        let path = unique_temp_path("extent-rollback");
+        let mut storage = create_small(&path);
+        // Fill the ring for large and small entries alike.
+        let mut seq = 1u64;
+        for payload_len in [8000usize, 1000, 100, 8] {
+            loop {
+                match storage.append_wal_entry(
+                    WAL_ENTRY_TYPE_RECORD,
+                    1,
+                    seq,
+                    &vec![7u8; payload_len],
+                ) {
+                    Ok(_) => seq += 1,
+                    Err(_) => break,
+                }
+                assert!(seq < 1000, "ring must fill up");
+            }
+        }
+
+        let err = storage
+            .allocate_extent(false)
+            .expect_err("extent alloc must fail when its record cannot be logged");
+        assert!(matches!(err, StorageError::WalFull(_)), "got: {err}");
+        for page in 0..EXTENT_PAGES {
+            assert!(
+                !storage.is_page_allocated(page),
+                "rolled-back extent must leave page {page} free"
+            );
+        }
+
+        // After reclaiming the ring, extent allocation works again and the
+        // rolled-back range stays free (the next-fit cursor moved past it,
+        // so it is not the range reused here).
+        storage
+            .write_checkpoint(b"reclaim", seq, seq + 1, 1)
+            .expect("checkpoint");
+        let start = storage.allocate_extent(false).expect("extent");
+        for page in 0..EXTENT_PAGES {
+            assert!(!storage.is_page_allocated(page));
+        }
+        assert!(storage.is_page_allocated(start));
+        drop(storage);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn empty_checkpoint_data_is_rejected() {
+        let path = unique_temp_path("empty-checkpoint");
+        let mut storage = create_small(&path);
+        storage.write_checkpoint(b"valid", 1, 2, 1).expect("cp");
+        let err = storage
+            .write_checkpoint(b"", 2, 3, 1)
+            .expect_err("empty checkpoint must be rejected");
+        assert!(matches!(err, StorageError::InvalidConfig(_)), "got: {err}");
+        // The previous snapshot is untouched.
+        let snapshot = storage.load_snapshot().expect("load").expect("snapshot");
+        assert_eq!(snapshot.data, b"valid");
+        drop(storage);
+        let _ = std::fs::remove_file(path);
+    }
+
+    /// Review finding: the v1 upgrade must refresh BOTH superblocks — a v1
+    /// backup superblock is arbitrarily stale, and a later fallback to it
+    /// would lose every v1 WAL entry (they cannot pass the v2 forward scan).
+    #[test]
+    fn upgraded_v1_file_survives_active_superblock_loss() {
+        let path = unique_temp_path("v1-superblock-refresh");
+        let events = vec![(1u64, vec![5u8; 80]), (2u64, vec![6u8; 40])];
+        let layout = write_v1_fixture(&path, &events, None);
+
+        // First open performs the upgrade.
+        let mut storage = Storage::open(path.clone()).expect("upgrade open");
+        assert_eq!(storage.replay_wal_entries().expect("replay").len(), 2);
+        drop(storage);
+
+        // Lose the active superblock; the refreshed backup must carry the
+        // v1 tail so the trusted scan still finds the v1-stamped entries.
+        overwrite_bytes(
+            &path,
+            layout.superblock_a_offset,
+            &[0xEEu8; SUPERBLOCK_SIZE],
+        );
+        let mut storage = Storage::open(path.clone()).expect("reopen on backup");
+        let records = storage.replay_wal_entries().expect("replay");
+        assert_eq!(records.len(), 2, "v1 entries must survive the fallback");
+        assert_eq!(records[0].payload, vec![5u8; 80]);
+        drop(storage);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn successive_checkpoints_recycle_snapshot_extents() {
+        let path = unique_temp_path("snapshot-recycle");
+        let mut storage = create_small(&path);
+        storage.write_checkpoint(b"first", 1, 2, 1).expect("cp 1");
+        let first_desc = storage
+            .file
+            .load_active_snapshot_descriptor()
+            .expect("desc")
+            .expect("present");
+        let (first_start, first_pages) = storage
+            .file
+            .descriptor_page_range(&first_desc)
+            .expect("range");
+        assert!(storage.is_page_allocated(first_start));
+
+        storage
+            .write_checkpoint(b"second-snapshot", 2, 3, 1)
+            .expect("cp 2");
+        for page in first_start..first_start + first_pages {
+            assert!(
+                !storage.is_page_allocated(page),
+                "first snapshot extent must be freed after the second checkpoint"
+            );
+        }
+        drop(storage);
+
+        let mut storage = Storage::open(path.clone()).expect("reopen");
+        let snapshot = storage.load_snapshot().expect("load").expect("snapshot");
+        assert_eq!(snapshot.data, b"second-snapshot");
+        assert!(!storage.is_page_allocated(first_start));
+        drop(storage);
+        let _ = std::fs::remove_file(path);
+    }
 }

--- a/crates/truthdb-core/src/storage_layout.rs
+++ b/crates/truthdb-core/src/storage_layout.rs
@@ -3,7 +3,8 @@ use xxhash_rust::xxh64::xxh64;
 
 pub const PAGE_SIZE: usize = 4096;
 pub const FILE_MAGIC: [u8; 8] = *b"TRUTHDB\0";
-pub const FILE_VERSION: u32 = 1;
+pub const FILE_VERSION_V1: u32 = 1;
+pub const FILE_VERSION: u32 = 2;
 
 pub const FILE_HEADER_SIZE: usize = PAGE_SIZE;
 pub const SUPERBLOCK_SIZE: usize = PAGE_SIZE;
@@ -19,6 +20,7 @@ pub const WAL_ENTRY_HEADER_SIZE: usize = 40;
 pub const WAL_ENTRY_FOOTER_SIZE: usize = 12;
 pub const WAL_ENTRY_TYPE_RECORD: u16 = 1;
 pub const WAL_ENTRY_TYPE_COMMIT: u16 = 2;
+pub const WAL_ENTRY_TYPE_REL: u16 = 3;
 
 pub const SUPERBLOCK_ACTIVE_A: u8 = 0;
 pub const SUPERBLOCK_ACTIVE_B: u8 = 1;
@@ -540,10 +542,14 @@ pub(crate) fn assert_layout_invariants() {
     use core::mem::size_of;
 
     debug_assert_eq!(FILE_MAGIC, *b"TRUTHDB\0");
-    debug_assert_eq!(FILE_VERSION, 1);
+    debug_assert_eq!(FILE_VERSION_V1, 1);
+    debug_assert_eq!(FILE_VERSION, 2);
     debug_assert_eq!(PAGE_SIZE, 4096);
     debug_assert_eq!(WAL_ENTRY_ALIGNMENT, 8);
     debug_assert_eq!(WAL_ENTRY_FOOTER_SIZE, 12);
+    debug_assert_eq!(WAL_ENTRY_TYPE_RECORD, 1);
+    debug_assert_eq!(WAL_ENTRY_TYPE_COMMIT, 2);
+    debug_assert_eq!(WAL_ENTRY_TYPE_REL, 3);
     debug_assert_eq!(SUPERBLOCK_ACTIVE_A, 0);
     debug_assert_eq!(SUPERBLOCK_ACTIVE_B, 1);
 

--- a/crates/truthdb-core/src/wal/log_buffer.rs
+++ b/crates/truthdb-core/src/wal/log_buffer.rs
@@ -1,0 +1,209 @@
+//! In-memory tail-page log buffer.
+//!
+//! The WAL tail page is kept as a whole-page image in memory. Appends copy
+//! into the image; flushing always writes whole pages from memory and never
+//! reads the tail page back from disk. This fixes the torn-tail
+//! read-modify-write hazard of the v1 WAL: bytes that were already fsynced on
+//! the shared tail page are always rewritten from the same in-memory image,
+//! so (under sector-atomic writes) a torn page rewrite cannot destroy them,
+//! and latent on-disk corruption beyond the tail is healed rather than
+//! immortalized.
+//!
+//! Positions here are *unwrapped* log positions (monotonic u64 byte offsets,
+//! the LSN space). Mapping to ring/file offsets is the caller's job. The ring
+//! size is a page multiple, so a page never straddles a ring wrap.
+
+use crate::direct_io::AlignedPageBuf;
+use crate::storage_layout::PAGE_SIZE;
+
+pub(crate) struct LogBuffer {
+    /// Unwrapped position of the first byte of `tail_page`.
+    page_start: u64,
+    /// Unwrapped position of the next byte to append (the log tail).
+    tail: u64,
+    /// Image of the page containing `tail`; zeroed beyond `tail`.
+    tail_page: AlignedPageBuf,
+}
+
+impl LogBuffer {
+    /// Creates a buffer positioned at `tail`. The image starts zeroed; if
+    /// `tail` is mid-page the caller must seed the on-disk prefix with
+    /// [`LogBuffer::seed_prefix`].
+    pub fn new_at(tail: u64) -> Self {
+        let page_size = PAGE_SIZE as u64;
+        LogBuffer {
+            page_start: tail - (tail % page_size),
+            tail,
+            tail_page: AlignedPageBuf::new(),
+        }
+    }
+
+    /// Seeds the image bytes in `[page_start, tail)` from an on-disk copy of
+    /// the tail page. Bytes at and beyond `tail` remain zero regardless of
+    /// what the disk holds, so the next flush heals any torn suffix.
+    pub fn seed_prefix(&mut self, disk_page: &AlignedPageBuf) {
+        let prefix_len = (self.tail - self.page_start) as usize;
+        self.tail_page.as_mut_slice()[..prefix_len]
+            .copy_from_slice(&disk_page.as_slice()[..prefix_len]);
+    }
+
+    pub fn tail(&self) -> u64 {
+        self.tail
+    }
+
+    /// Appends `bytes` at the tail. Returns completed whole-page images
+    /// (unwrapped page position, image); the still-partial tail page is kept
+    /// internal and available via [`LogBuffer::current_page`].
+    pub fn append(&mut self, bytes: &[u8]) -> Vec<(u64, AlignedPageBuf)> {
+        let mut completed = Vec::new();
+        let mut written = 0usize;
+        while written < bytes.len() {
+            let offset_in_page = (self.tail - self.page_start) as usize;
+            let space = PAGE_SIZE - offset_in_page;
+            let copy_len = space.min(bytes.len() - written);
+            self.tail_page.as_mut_slice()[offset_in_page..offset_in_page + copy_len]
+                .copy_from_slice(&bytes[written..written + copy_len]);
+            self.tail += copy_len as u64;
+            written += copy_len;
+            if self.tail - self.page_start == PAGE_SIZE as u64 {
+                self.complete_page(&mut completed);
+            }
+        }
+        completed
+    }
+
+    /// Advances the tail to `new_tail` with zero bytes (ring-wrap gap fill).
+    /// Returns completed whole-page images exactly like [`LogBuffer::append`];
+    /// the skipped range is all zeros in the images.
+    pub fn skip_zero_to(&mut self, new_tail: u64) -> Vec<(u64, AlignedPageBuf)> {
+        debug_assert!(new_tail >= self.tail);
+        let mut completed = Vec::new();
+        while self.tail < new_tail {
+            let offset_in_page = self.tail - self.page_start;
+            let space = PAGE_SIZE as u64 - offset_in_page;
+            let advance = space.min(new_tail - self.tail);
+            // Image bytes beyond the previous tail are already zero.
+            self.tail += advance;
+            if self.tail - self.page_start == PAGE_SIZE as u64 {
+                self.complete_page(&mut completed);
+            }
+        }
+        completed
+    }
+
+    /// The current (possibly partial) tail page: unwrapped page position and
+    /// whole-page image, zero-padded beyond the tail.
+    pub fn current_page(&self) -> (u64, &AlignedPageBuf) {
+        (self.page_start, &self.tail_page)
+    }
+
+    /// True when the tail sits exactly on a page boundary, i.e. the current
+    /// page image holds no bytes and does not need to be flushed.
+    pub fn current_page_is_empty(&self) -> bool {
+        self.tail == self.page_start
+    }
+
+    fn complete_page(&mut self, completed: &mut Vec<(u64, AlignedPageBuf)>) {
+        let full = std::mem::take(&mut self.tail_page);
+        completed.push((self.page_start, full));
+        self.page_start += PAGE_SIZE as u64;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn concat(buffer: &mut LogBuffer, pages: &mut Vec<(u64, AlignedPageBuf)>, bytes: &[u8]) {
+        pages.extend(buffer.append(bytes));
+    }
+
+    fn reconstruct(pages: &[(u64, AlignedPageBuf)], buffer: &LogBuffer, up_to: u64) -> Vec<u8> {
+        let mut out = vec![0u8; up_to as usize];
+        for (pos, page) in pages {
+            let start = *pos as usize;
+            let end = (start + PAGE_SIZE).min(out.len());
+            if start < out.len() {
+                out[start..end].copy_from_slice(&page.as_slice()[..end - start]);
+            }
+        }
+        let (pos, page) = buffer.current_page();
+        let start = pos as usize;
+        if start < out.len() {
+            let end = (start + PAGE_SIZE).min(out.len());
+            out[start..end].copy_from_slice(&page.as_slice()[..end - start]);
+        }
+        out
+    }
+
+    #[test]
+    fn append_within_one_page_completes_nothing() {
+        let mut buffer = LogBuffer::new_at(0);
+        let pages = buffer.append(&[7u8; 100]);
+        assert!(pages.is_empty());
+        assert_eq!(buffer.tail(), 100);
+        assert_eq!(&buffer.current_page().1.as_slice()[..100], &[7u8; 100]);
+        assert!(
+            buffer.current_page().1.as_slice()[100..]
+                .iter()
+                .all(|b| *b == 0)
+        );
+    }
+
+    #[test]
+    fn append_across_pages_emits_full_page_images() {
+        let mut buffer = LogBuffer::new_at(0);
+        let mut pages = Vec::new();
+        let data: Vec<u8> = (0..PAGE_SIZE + 100).map(|i| (i % 251) as u8).collect();
+        concat(&mut buffer, &mut pages, &data);
+        assert_eq!(pages.len(), 1);
+        assert_eq!(pages[0].0, 0);
+        assert_eq!(buffer.tail(), (PAGE_SIZE + 100) as u64);
+        let reconstructed = reconstruct(&pages, &buffer, buffer.tail());
+        assert_eq!(reconstructed, data);
+    }
+
+    #[test]
+    fn exact_page_fill_leaves_empty_current_page() {
+        let mut buffer = LogBuffer::new_at(0);
+        let pages = buffer.append(&vec![1u8; PAGE_SIZE]);
+        assert_eq!(pages.len(), 1);
+        assert!(buffer.current_page_is_empty());
+        assert_eq!(buffer.current_page().0, PAGE_SIZE as u64);
+    }
+
+    #[test]
+    fn skip_zero_advances_and_zero_fills() {
+        let mut buffer = LogBuffer::new_at(0);
+        let mut pages = buffer.append(&[9u8; 10]);
+        pages.extend(buffer.skip_zero_to(2 * PAGE_SIZE as u64));
+        assert_eq!(pages.len(), 2);
+        assert!(buffer.current_page_is_empty());
+        let reconstructed = reconstruct(&pages, &buffer, 2 * PAGE_SIZE as u64);
+        assert_eq!(&reconstructed[..10], &[9u8; 10]);
+        assert!(reconstructed[10..].iter().all(|b| *b == 0));
+    }
+
+    #[test]
+    fn seed_prefix_keeps_suffix_zero() {
+        let mut disk = AlignedPageBuf::new();
+        disk.as_mut_slice().fill(0xAB);
+        let mut buffer = LogBuffer::new_at(100);
+        buffer.seed_prefix(&disk);
+        let (pos, page) = buffer.current_page();
+        assert_eq!(pos, 0);
+        assert!(page.as_slice()[..100].iter().all(|b| *b == 0xAB));
+        assert!(page.as_slice()[100..].iter().all(|b| *b == 0));
+    }
+
+    #[test]
+    fn mid_page_start_positions_correctly() {
+        let start = PAGE_SIZE as u64 * 3 + 500;
+        let mut buffer = LogBuffer::new_at(start);
+        assert_eq!(buffer.current_page().0, PAGE_SIZE as u64 * 3);
+        let pages = buffer.append(&[5u8; 4000]);
+        assert_eq!(pages.len(), 1);
+        assert_eq!(pages[0].0, PAGE_SIZE as u64 * 3);
+        assert_eq!(buffer.tail(), start + 4000);
+    }
+}

--- a/crates/truthdb-core/src/wal/mod.rs
+++ b/crates/truthdb-core/src/wal/mod.rs
@@ -1,0 +1,347 @@
+//! WAL ring writer and recovery scan.
+//!
+//! v2 WAL semantics:
+//! - Positions are unwrapped u64 byte offsets into the log stream (the LSN
+//!   space); ring/file offsets are derived as `offset + pos % size`.
+//! - Appends go through an in-memory tail-page image ([`LogBuffer`]); flushes
+//!   write whole pages from memory and never read the tail back from disk.
+//! - Every entry's `logical_ts` header field is stamped with the entry's own
+//!   LSN. Recovery trusts the superblock's `wal_tail` only as a lower bound
+//!   and scans forward past it, accepting entries while their CRCs verify and
+//!   `logical_ts` equals the scan position (which also rejects stale
+//!   entries from earlier ring laps).
+//! - The superblock is written lazily: on checkpoint and roughly every
+//!   [`SUPERBLOCK_REWRITE_INTERVAL`] bytes of appended log.
+
+pub mod log_buffer;
+pub mod records;
+
+use crate::direct_io::{AlignedPageBuf, DirectFile};
+use crate::storage::StorageError;
+use crate::storage_layout::{
+    MIB, PAGE_SIZE, WAL_ENTRY_FOOTER_SIZE, WAL_ENTRY_HEADER_SIZE, WalEntryFooter, WalEntryHeader,
+    align_down, wal_entry_padded_len, wal_payload_crc,
+};
+use log_buffer::LogBuffer;
+
+/// Rewrite the active superblock after this many appended bytes, so the
+/// recovery forward scan stays short without paying a superblock write per
+/// append.
+pub(crate) const SUPERBLOCK_REWRITE_INTERVAL: u64 = 16 * MIB;
+
+#[derive(Debug, Clone)]
+pub struct WalRecord {
+    pub entry_type: u16,
+    pub entry_version: u16,
+    pub seq_no: u64,
+    pub logical_ts: u64,
+    pub payload: Vec<u8>,
+}
+
+pub(crate) struct WalWriter {
+    file: DirectFile,
+    ring_offset: u64,
+    ring_size: u64,
+    head: u64,
+    buffer: LogBuffer,
+    bytes_since_superblock: u64,
+    superblock_interval: u64,
+}
+
+impl WalWriter {
+    /// Opens a writer positioned at a recovered `(head, tail)`. Seeds the
+    /// in-memory tail page from disk (prefix only; the suffix stays zero so
+    /// the next flush heals any torn bytes past the tail).
+    pub fn open(
+        mut file: DirectFile,
+        ring_offset: u64,
+        ring_size: u64,
+        head: u64,
+        tail: u64,
+    ) -> Result<Self, StorageError> {
+        let mut buffer = LogBuffer::new_at(tail);
+        if !buffer.current_page_is_empty() {
+            let (page_start, _) = buffer.current_page();
+            let file_offset = ring_offset + page_start % ring_size;
+            let mut disk_page = AlignedPageBuf::new();
+            file.read_page_into(file_offset, &mut disk_page)?;
+            buffer.seed_prefix(&disk_page);
+        }
+        Ok(WalWriter {
+            file,
+            ring_offset,
+            ring_size,
+            head,
+            buffer,
+            bytes_since_superblock: 0,
+            superblock_interval: SUPERBLOCK_REWRITE_INTERVAL,
+        })
+    }
+
+    /// Test hook: shrink the lazy-superblock cadence so it can be exercised
+    /// without appending tens of MiB.
+    #[cfg(test)]
+    pub fn set_superblock_interval(&mut self, bytes: u64) {
+        self.superblock_interval = bytes;
+    }
+
+    pub fn head(&self) -> u64 {
+        self.head
+    }
+
+    pub fn tail(&self) -> u64 {
+        self.buffer.tail()
+    }
+
+    /// Advances the head (checkpoint reclamation).
+    pub fn set_head(&mut self, head: u64) {
+        debug_assert!(head >= self.head && head <= self.tail());
+        self.head = head;
+    }
+
+    pub fn usage_ratio(&self) -> f64 {
+        if self.ring_size == 0 {
+            return 1.0;
+        }
+        let used = self.tail().saturating_sub(self.head);
+        used as f64 / self.ring_size as f64
+    }
+
+    /// The log's dedicated file handle (also used for lazy superblock writes
+    /// so they ride the log path rather than serializing behind data flushes).
+    pub fn file_mut(&mut self) -> &mut DirectFile {
+        &mut self.file
+    }
+
+    /// True once enough bytes have been appended since the last superblock
+    /// write; calling this resets the counter.
+    pub fn take_superblock_due(&mut self) -> bool {
+        if self.bytes_since_superblock >= self.superblock_interval {
+            self.bytes_since_superblock = 0;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Appends one entry, makes it durable (whole-page flush + fsync) and
+    /// returns its LSN.
+    pub fn append_entry(
+        &mut self,
+        entry_type: u16,
+        entry_version: u16,
+        seq_no: u64,
+        payload: &[u8],
+    ) -> Result<u64, StorageError> {
+        if self.ring_size == 0 {
+            return Err(StorageError::InvalidFile(
+                "wal region size is zero".to_string(),
+            ));
+        }
+        let entry_len = wal_entry_padded_len(payload.len());
+        if entry_len as u64 > self.ring_size {
+            return Err(StorageError::WalFull(
+                "entry larger than wal ring".to_string(),
+            ));
+        }
+
+        let tail = self.tail();
+        let bytes_to_lap_end = self.ring_size - (tail % self.ring_size);
+        let gap = if (entry_len as u64) > bytes_to_lap_end {
+            bytes_to_lap_end
+        } else {
+            0
+        };
+        // Free-space guard over the *flushed* range, not just the entry: the
+        // tail page is always written as a whole-page image, so its zero
+        // suffix beyond the new tail must also fit inside the ring window
+        // [head, head + ring_size) — otherwise the suffix would alias onto
+        // (and zero out) the oldest live entries at the head.
+        let new_tail = tail + gap + entry_len as u64;
+        let page = PAGE_SIZE as u64;
+        let flush_end = if new_tail.is_multiple_of(page) {
+            new_tail
+        } else {
+            align_down(new_tail, page) + page
+        };
+        if flush_end.saturating_sub(self.head) > self.ring_size {
+            return Err(StorageError::WalFull("wal ring full".to_string()));
+        }
+
+        let mut completed = Vec::new();
+        if gap > 0 {
+            completed.extend(self.buffer.skip_zero_to(tail + gap));
+        }
+        let lsn = self.buffer.tail();
+
+        let payload_crc = wal_payload_crc(payload);
+        let header = WalEntryHeader::new(
+            entry_type,
+            entry_version,
+            payload.len() as u32,
+            seq_no,
+            lsn,
+            payload_crc,
+        );
+        let footer = WalEntryFooter {
+            payload_len: payload.len() as u32,
+            payload_crc,
+        };
+        let mut entry_bytes = Vec::with_capacity(entry_len);
+        entry_bytes.extend_from_slice(&header.to_le_bytes());
+        entry_bytes.extend_from_slice(payload);
+        entry_bytes.extend_from_slice(&footer.to_le_bytes());
+        entry_bytes.resize(entry_len, 0);
+
+        completed.extend(self.buffer.append(&entry_bytes));
+        self.write_pages(&completed)?;
+        if !self.buffer.current_page_is_empty() {
+            let (page_start, page) = self.buffer.current_page();
+            let file_offset = self.ring_offset + page_start % self.ring_size;
+            self.file.write_page_from(file_offset, page)?;
+        }
+        self.file.sync_data()?;
+
+        self.bytes_since_superblock += gap + entry_len as u64;
+        Ok(lsn)
+    }
+
+    /// Writes completed page images, batching runs that are contiguous in
+    /// file space (runs break at ring-lap boundaries).
+    fn write_pages(&mut self, pages: &[(u64, AlignedPageBuf)]) -> Result<(), StorageError> {
+        let mut index = 0;
+        while index < pages.len() {
+            let run_start = index;
+            // Pages are consecutive in unwrapped space; a run breaks where the
+            // next page wraps to the start of the ring.
+            while index + 1 < pages.len() && !pages[index + 1].0.is_multiple_of(self.ring_size) {
+                index += 1;
+            }
+            let run = &pages[run_start..=index];
+            let frames: Vec<&AlignedPageBuf> = run.iter().map(|(_, page)| page).collect();
+            let file_offset = self.ring_offset + run[0].0 % self.ring_size;
+            self.file.write_pages_from(file_offset, &frames)?;
+            index += 1;
+        }
+        Ok(())
+    }
+}
+
+pub(crate) struct ScanResult {
+    pub records: Vec<WalRecord>,
+    /// Discovered end of the valid log (unwrapped).
+    pub tail: u64,
+}
+
+/// Scans the ring from `head`, collecting valid entries.
+///
+/// Entries starting before `trusted_tail` (the superblock's recorded tail)
+/// are validated by CRC alone. Past it, the scan continues while entries
+/// verify **and** carry `logical_ts == position`, which both detects torn
+/// tails and rejects stale entries from earlier ring laps. A run of zero
+/// bytes is interpreted as a ring-wrap gap: the scan skips to the next lap
+/// and continues if a valid entry sits there, otherwise the log ends before
+/// the gap.
+///
+/// Residual hazard (accepted): if media corruption destroys an entry inside
+/// the trusted region, the log is truncated there and new entries overwrite
+/// the old suffix. An old-history entry that sits at exactly the position
+/// the new history reaches passes the LSN self-identity check and would be
+/// resurrected — distinguishing histories at the same position would need
+/// timeline identifiers (out of scope for Stage 1; this only follows an
+/// already-violated durability assumption).
+pub(crate) fn scan_ring(
+    file: &mut DirectFile,
+    ring_offset: u64,
+    ring_size: u64,
+    head: u64,
+    trusted_tail: u64,
+) -> Result<ScanResult, StorageError> {
+    let mut records = Vec::new();
+    let mut cursor = head;
+    let hard_end = head.saturating_add(ring_size);
+    // When the scan skips a wrap gap beyond the trusted region, the gap only
+    // counts if a valid entry follows; otherwise the log ends where the gap
+    // began.
+    let mut pending_gap_start: Option<u64> = None;
+
+    if ring_size == 0 {
+        return Ok(ScanResult {
+            records,
+            tail: head,
+        });
+    }
+
+    loop {
+        if cursor >= hard_end {
+            break;
+        }
+        let ring_pos = cursor % ring_size;
+        let bytes_to_lap_end = ring_size - ring_pos;
+        let trusted = cursor < trusted_tail;
+
+        if bytes_to_lap_end < WAL_ENTRY_HEADER_SIZE as u64 {
+            // Too small for a header: implicit wrap gap.
+            if !trusted {
+                pending_gap_start.get_or_insert(cursor);
+            }
+            cursor += bytes_to_lap_end;
+            continue;
+        }
+
+        let file_pos = ring_offset + ring_pos;
+        let mut header_bytes = [0u8; WAL_ENTRY_HEADER_SIZE];
+        file.read_exact_at(file_pos, &mut header_bytes)?;
+        if header_bytes.iter().all(|b| *b == 0) {
+            // Wrap gap: writer zero-fills to the lap end before wrapping.
+            if !trusted {
+                pending_gap_start.get_or_insert(cursor);
+            }
+            cursor += bytes_to_lap_end;
+            continue;
+        }
+
+        let header = WalEntryHeader::from_le_bytes(&header_bytes);
+        if !header.verify_header_crc() {
+            break;
+        }
+        let payload_len = header.payload_len as usize;
+        let entry_len = wal_entry_padded_len(payload_len) as u64;
+        let total_len = (WAL_ENTRY_HEADER_SIZE + payload_len + WAL_ENTRY_FOOTER_SIZE) as u64;
+        if total_len > bytes_to_lap_end {
+            // Entries never straddle a lap boundary.
+            break;
+        }
+        if !trusted && header.logical_ts != cursor {
+            break;
+        }
+
+        let mut payload = vec![0u8; payload_len];
+        file.read_exact_at(file_pos + WAL_ENTRY_HEADER_SIZE as u64, &mut payload)?;
+        if wal_payload_crc(&payload) != header.payload_crc {
+            break;
+        }
+        let mut footer_bytes = [0u8; WAL_ENTRY_FOOTER_SIZE];
+        file.read_exact_at(
+            file_pos + (WAL_ENTRY_HEADER_SIZE + payload_len) as u64,
+            &mut footer_bytes,
+        )?;
+        let footer = WalEntryFooter::from_le_bytes(&footer_bytes);
+        if footer.payload_len != header.payload_len || footer.payload_crc != header.payload_crc {
+            break;
+        }
+
+        records.push(WalRecord {
+            entry_type: header.entry_type,
+            entry_version: header.entry_version,
+            seq_no: header.seq_no,
+            logical_ts: header.logical_ts,
+            payload,
+        });
+        pending_gap_start = None;
+        cursor += entry_len;
+    }
+
+    let tail = pending_gap_start.unwrap_or(cursor);
+    Ok(ScanResult { records, tail })
+}

--- a/crates/truthdb-core/src/wal/records.rs
+++ b/crates/truthdb-core/src/wal/records.rs
@@ -1,0 +1,171 @@
+//! ARIES-style relational WAL record framing.
+//!
+//! These records ride inside the existing WAL entry framing
+//! (`WalEntryHeader` + payload + `WalEntryFooter`) under
+//! `WAL_ENTRY_TYPE_REL`. The entry-level CRCs cover the whole record, so this
+//! layer only defines the payload layout:
+//!
+//! ```text
+//! prev_lsn u64 | txn_id u64 | kind u16 | flags u16 | redo_len u32 | undo_len u32 | redo | undo
+//! ```
+//!
+//! The record's own LSN is implied by its position in the ring (unwrapped
+//! byte position, stamped in the entry header's `logical_ts`). `prev_lsn`
+//! chains records of one transaction for undo; `txn_id = 0` marks
+//! non-transactional records (e.g. allocator state changes).
+
+use crate::storage::StorageError;
+
+pub const REL_RECORD_HEADER_SIZE: usize = 8 + 8 + 2 + 2 + 4 + 4;
+
+pub const REL_KIND_ALLOC_EXTENT: u16 = 1;
+pub const REL_KIND_FREE_EXTENT: u16 = 2;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RelRecord {
+    /// Previous LSN of the same transaction (0 = none).
+    pub prev_lsn: u64,
+    /// Owning transaction (0 = non-transactional).
+    pub txn_id: u64,
+    pub kind: u16,
+    pub flags: u16,
+    pub redo: Vec<u8>,
+    pub undo: Vec<u8>,
+}
+
+impl RelRecord {
+    pub fn alloc_extent(start_page: u64, num_pages: u64) -> Self {
+        RelRecord {
+            prev_lsn: 0,
+            txn_id: 0,
+            kind: REL_KIND_ALLOC_EXTENT,
+            flags: 0,
+            redo: extent_payload(start_page, num_pages),
+            undo: Vec::new(),
+        }
+    }
+
+    pub fn free_extent(start_page: u64, num_pages: u64) -> Self {
+        RelRecord {
+            prev_lsn: 0,
+            txn_id: 0,
+            kind: REL_KIND_FREE_EXTENT,
+            flags: 0,
+            redo: extent_payload(start_page, num_pages),
+            undo: Vec::new(),
+        }
+    }
+
+    pub fn encode(&self) -> Vec<u8> {
+        let mut out =
+            Vec::with_capacity(REL_RECORD_HEADER_SIZE + self.redo.len() + self.undo.len());
+        out.extend_from_slice(&self.prev_lsn.to_le_bytes());
+        out.extend_from_slice(&self.txn_id.to_le_bytes());
+        out.extend_from_slice(&self.kind.to_le_bytes());
+        out.extend_from_slice(&self.flags.to_le_bytes());
+        out.extend_from_slice(&(self.redo.len() as u32).to_le_bytes());
+        out.extend_from_slice(&(self.undo.len() as u32).to_le_bytes());
+        out.extend_from_slice(&self.redo);
+        out.extend_from_slice(&self.undo);
+        out
+    }
+
+    pub fn decode(payload: &[u8]) -> Result<Self, StorageError> {
+        if payload.len() < REL_RECORD_HEADER_SIZE {
+            return Err(StorageError::InvalidFile(
+                "rel wal record shorter than header".to_string(),
+            ));
+        }
+        let prev_lsn = u64::from_le_bytes(payload[0..8].try_into().unwrap());
+        let txn_id = u64::from_le_bytes(payload[8..16].try_into().unwrap());
+        let kind = u16::from_le_bytes(payload[16..18].try_into().unwrap());
+        let flags = u16::from_le_bytes(payload[18..20].try_into().unwrap());
+        let redo_len = u32::from_le_bytes(payload[20..24].try_into().unwrap()) as usize;
+        let undo_len = u32::from_le_bytes(payload[24..28].try_into().unwrap()) as usize;
+        let expected = REL_RECORD_HEADER_SIZE
+            .checked_add(redo_len)
+            .and_then(|len| len.checked_add(undo_len))
+            .ok_or_else(|| {
+                StorageError::InvalidFile("rel wal record length overflow".to_string())
+            })?;
+        if payload.len() != expected {
+            return Err(StorageError::InvalidFile(format!(
+                "rel wal record length mismatch: payload {} vs declared {expected}",
+                payload.len()
+            )));
+        }
+        let redo = payload[REL_RECORD_HEADER_SIZE..REL_RECORD_HEADER_SIZE + redo_len].to_vec();
+        let undo = payload[REL_RECORD_HEADER_SIZE + redo_len..].to_vec();
+        Ok(RelRecord {
+            prev_lsn,
+            txn_id,
+            kind,
+            flags,
+            redo,
+            undo,
+        })
+    }
+
+    /// Decodes the `(start_page, num_pages)` redo payload of an
+    /// alloc-extent/free-extent record.
+    pub fn decode_extent_redo(&self) -> Result<(u64, u64), StorageError> {
+        if self.redo.len() != 16 {
+            return Err(StorageError::InvalidFile(
+                "extent wal record redo payload must be 16 bytes".to_string(),
+            ));
+        }
+        let start_page = u64::from_le_bytes(self.redo[0..8].try_into().unwrap());
+        let num_pages = u64::from_le_bytes(self.redo[8..16].try_into().unwrap());
+        Ok((start_page, num_pages))
+    }
+}
+
+fn extent_payload(start_page: u64, num_pages: u64) -> Vec<u8> {
+    let mut out = Vec::with_capacity(16);
+    out.extend_from_slice(&start_page.to_le_bytes());
+    out.extend_from_slice(&num_pages.to_le_bytes());
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rel_record_round_trip() {
+        let record = RelRecord {
+            prev_lsn: 42,
+            txn_id: 7,
+            kind: REL_KIND_ALLOC_EXTENT,
+            flags: 0,
+            redo: vec![1, 2, 3],
+            undo: vec![4, 5],
+        };
+        let decoded = RelRecord::decode(&record.encode()).expect("decode");
+        assert_eq!(decoded, record);
+    }
+
+    #[test]
+    fn extent_records_round_trip() {
+        let record = RelRecord::alloc_extent(128, 64);
+        let decoded = RelRecord::decode(&record.encode()).expect("decode");
+        assert_eq!(decoded.decode_extent_redo().expect("redo"), (128, 64));
+        assert_eq!(decoded.kind, REL_KIND_ALLOC_EXTENT);
+
+        let record = RelRecord::free_extent(4096, 64);
+        let decoded = RelRecord::decode(&record.encode()).expect("decode");
+        assert_eq!(decoded.decode_extent_redo().expect("redo"), (4096, 64));
+        assert_eq!(decoded.kind, REL_KIND_FREE_EXTENT);
+    }
+
+    #[test]
+    fn decode_rejects_truncated_and_mismatched() {
+        let record = RelRecord::alloc_extent(1, 2);
+        let bytes = record.encode();
+        assert!(RelRecord::decode(&bytes[..REL_RECORD_HEADER_SIZE - 1]).is_err());
+        assert!(RelRecord::decode(&bytes[..bytes.len() - 1]).is_err());
+        let mut extended = bytes.clone();
+        extended.push(0);
+        assert!(RelRecord::decode(&extended).is_err());
+    }
+}

--- a/scripts/search_smoke.sh
+++ b/scripts/search_smoke.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Search-path smoke test (Stage 1 exit criterion): create/insert/search,
+# restart the server, search again. Runs the real server + CLI binaries
+# against a throwaway state directory.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+cargo build -p truthdb -p truthdb-cli
+
+STATE_DIR=$(mktemp -d)
+SERVER_PID=""
+cleanup() {
+    [ -n "$SERVER_PID" ] && kill "$SERVER_PID" 2>/dev/null || true
+    rm -rf "$STATE_DIR"
+}
+trap cleanup EXIT
+
+start_server() {
+    STATE_DIRECTORY="$STATE_DIR" ./target/debug/truthdb >>"$STATE_DIR/server.log" 2>&1 &
+    SERVER_PID=$!
+    for _ in $(seq 1 50); do
+        if ./target/debug/truthdb-cli </dev/null >/dev/null 2>&1; then
+            return
+        fi
+        sleep 0.2
+    done
+    echo "FAIL: server did not become ready" >&2
+    cat "$STATE_DIR/server.log" >&2
+    exit 1
+}
+
+stop_server() {
+    kill -TERM "$SERVER_PID"
+    wait "$SERVER_PID" 2>/dev/null || true
+    SERVER_PID=""
+}
+
+run_cli() {
+    ./target/debug/truthdb-cli 2>/dev/null
+}
+
+expect() {
+    local file=$1 pattern=$2
+    if ! grep -qF "$pattern" "$file"; then
+        echo "FAIL: expected '$pattern' in $file:" >&2
+        cat "$file" >&2
+        exit 1
+    fi
+}
+
+start_server
+
+printf '%s\n' \
+    'create index products { "mappings": { "properties": { "name": { "type": "text" }, "category": { "type": "keyword" } } } }' \
+    'insert document products { "name": "Red Running Shoes", "category": "shoes" }' \
+    'insert document products { "name": "Blue Hiking Boots", "category": "boots" }' \
+    'search products { "query": { "match": { "name": "running" } } }' \
+    '\q' | run_cli >"$STATE_DIR/phase1.out"
+expect "$STATE_DIR/phase1.out" '"acknowledged": true'
+expect "$STATE_DIR/phase1.out" '"result": "created"'
+expect "$STATE_DIR/phase1.out" '"Red Running Shoes"'
+expect "$STATE_DIR/phase1.out" '"total": 1'
+
+stop_server
+start_server
+
+printf '%s\n' \
+    'search products { "query": { "bool": { "must": [ { "match": { "name": "running" } } ], "filter": [ { "term": { "category": "shoes" } } ] } } }' \
+    '\q' | run_cli >"$STATE_DIR/phase2.out"
+expect "$STATE_DIR/phase2.out" '"Red Running Shoes"'
+expect "$STATE_DIR/phase2.out" '"total": 1'
+
+echo "search smoke: OK"


### PR DESCRIPTION
Stage 1 of `docs/RELATIONAL_DB_PLAN.md` (storage substrate v2): rework the storage layer so relational data can land on it in later stages, while the existing search functionality keeps working byte-for-byte on the wire.

## What changed

### WAL v2 (`wal/`)
- Positions are unwrapped u64 byte offsets — the LSN space (`LSN = WAL byte position` per the plan).
- Appends go through an in-memory tail-page image; flushes write **whole-page images from memory** and never read the tail back from disk. This fixes the v1 torn-tail read-modify-write hazard and heals latent on-disk corruption past the tail.
- **Lazy superblock**: rewritten on checkpoint + every 16 MiB of appended log instead of per append (v1 wrote it on every append). Recovery treats `superblock.wal_tail` as a lower bound and forward-scans past it, accepting entries while CRCs verify **and** `logical_ts == position` (LSN self-identity — also rejects stale entries from earlier ring laps).
- ARIES record framing (`prev_lsn` / `txn_id` / redo / undo payloads) under new WAL entry type 3; search events keep type 1 unchanged.

### File format v2
- `FILE_VERSION = 2`, in-place v1→v2 upgrade: fsync-fenced, idempotent under crash; zeroes the v1 half-slot allocator bitmap and refreshes **both** superblocks (a stale v1 backup superblock would otherwise lose all v1 WAL on fallback).
- Snapshot **half-slot scheme deleted**: search snapshots are ordinary allocator extents. Checkpoint order: data+fsync → descriptor+fsync → free old extent + persist bitmap+fsync → advance head + publish superblocks. Every crash window is healed by open-time reconciliation (free stale descriptor extent → replay REL WAL records → mark live descriptor extent).

### Allocator v2
- Live in-memory instance, next-fit cursor, 64-page `allocate_extent()`, temp-extent flag (excluded from the persisted bitmap, vanish on restart), WAL-logged alloc/free replayed at open.

### DirectFile
- Caller-owned aligned page frames: `read_page_into` / `write_page_from` / batched `write_pages_from`; second file handle dedicated to log writes.
- io_uring hardening: completions always fully drained (an unreaped CQE could let a later fsync acknowledge a failed write), EINTR retry, handle poisons itself on unrecoverable submission failures.

### relstore/ (Stage 2 groundwork)
- 32-byte self-identifying page header (`page_lsn`, xxh64 checksum, type, `object_id`, `page_no`).
- Buffer pool: clock eviction, pinning, **steal** with WAL-before-data enforced through a `PoolBackend` trait. Standalone with property tests; wired up in Stage 2.

### Engine (search)
- Snapshots now encode as JSON with bincode kept as a read fallback — fixes a pre-existing bug where any document-bearing snapshot could never be decoded again (bincode cannot deserialize `serde_json::Value`), i.e. a checkpointed database failed to reopen.
- Replay skips foreign WAL entry types and snapshot-covered records (`seq_no < next_seq_no`), closing the crash window between descriptor fsync and superblock publish.

## Verification

- 57 tests green, `cargo fmt --check` and `clippy --all-targets -D warnings` clean.
- Stage 1 exit criteria all covered: v1-fixture upgrade test, torn-tail crash test, WAL-wrap/lazy-superblock reconstruction tests, buffer-pool property tests, and `scripts/search_smoke.sh` (create/insert/search → server restart → search against the real binaries).
- Crash-matrix regression tests from an adversarial review pass: tail-page/head aliasing guard, checkpoint generation minting after superblock-publish crashes, wrap-gap tail rewind, torn-active-superblock fallback, trusted-region corruption truncation, extent alloc rollback on full ring.

Documented residual (out of Stage 1 scope, in `scan_ring` docs): distinguishing same-position entries from a pre-corruption history would require timeline IDs; it only arises after physical media corruption of fsynced data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)