### PR TITLE
feat(relstore): relational storage core — B+ trees, heaps, row/key codecs, full ARIES restart (Stage 2)

### DIFF
--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -4,6 +4,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value, json};
 use thiserror::Error;
 
+use crate::relstore::row::{Column, Schema};
+use crate::relstore::types::{ColumnType, Datum};
 use crate::storage::{Storage, StorageError};
 
 const ENGINE_WAL_ENTRY_VERSION: u16 = 1;
@@ -106,7 +108,68 @@ impl Engine {
                     }
                 }))
             }
+            Command::Table(table_command) => self.execute_table(table_command),
         }
+    }
+
+    /// Temporary Stage 2 debug surface over the relational store; replaced
+    /// by SQL in Stage 3.
+    fn execute_table(&mut self, command: TableCommand) -> Result<String, EngineError> {
+        match command {
+            TableCommand::Create { name, body } => {
+                let (columns, key_names) = parse_table_create_body(&body)?;
+                self.storage.rel_create_table(&name, columns, &key_names)?;
+                self.maybe_checkpoint()?;
+                render_json(&json!({ "acknowledged": true, "table": name }))
+            }
+            TableCommand::Insert { name, body } => {
+                let schema = self.table_schema(&name)?;
+                let values = parse_row_values(&schema, &body)?;
+                self.storage.rel_insert(&name, values)?;
+                self.maybe_checkpoint()?;
+                render_json(&json!({ "rows_affected": 1 }))
+            }
+            TableCommand::Scan { name } => {
+                let schema = self.table_schema(&name)?;
+                let rows = self.storage.rel_scan(&name)?;
+                let rendered: Vec<Value> = rows
+                    .iter()
+                    .map(|row| {
+                        let mut object = Map::new();
+                        for (column, value) in schema.columns.iter().zip(row) {
+                            object.insert(column.name.clone(), value.to_json(&column.column_type));
+                        }
+                        Value::Object(object)
+                    })
+                    .collect();
+                render_json(&json!({ "count": rendered.len(), "rows": rendered }))
+            }
+            TableCommand::Update { name, body } => {
+                let schema = self.table_schema(&name)?;
+                let (column, value) = parse_where(&schema, &body)?;
+                let assignments = parse_set(&schema, &body)?;
+                let count = self
+                    .storage
+                    .rel_update_where(&name, &column, &value, &assignments)?;
+                self.maybe_checkpoint()?;
+                render_json(&json!({ "rows_affected": count }))
+            }
+            TableCommand::Delete { name, body } => {
+                let schema = self.table_schema(&name)?;
+                let (column, value) = parse_where(&schema, &body)?;
+                let count = self.storage.rel_delete_where(&name, &column, &value)?;
+                self.maybe_checkpoint()?;
+                render_json(&json!({ "rows_affected": count }))
+            }
+        }
+    }
+
+    fn table_schema(&self, name: &str) -> Result<Schema, EngineError> {
+        let def = self
+            .storage
+            .rel_table(name)
+            .ok_or_else(|| CommandError::InvalidCommand(format!("unknown table '{name}'")))?;
+        Ok(def.schema()?)
     }
 
     pub fn checkpoint(&mut self) -> Result<(), EngineError> {
@@ -447,6 +510,17 @@ enum Command {
         index: String,
         query: SearchQuery,
     },
+    Table(TableCommand),
+}
+
+/// Temporary Stage 2 debug commands over the relational store.
+#[derive(Debug, Clone)]
+enum TableCommand {
+    Create { name: String, body: Document },
+    Insert { name: String, body: Document },
+    Scan { name: String },
+    Update { name: String, body: Document },
+    Delete { name: String, body: Document },
 }
 
 #[derive(Debug, Clone)]
@@ -599,8 +673,39 @@ fn parse_command(input: &str) -> Result<Command, CommandError> {
         return Ok(Command::Search { index, query });
     }
 
+    if let Some((header, body)) = split_command(trimmed, "table create")? {
+        let name = parse_single_name(header, "table create")?;
+        let body = parse_document_body(body)?;
+        return Ok(Command::Table(TableCommand::Create { name, body }));
+    }
+    if let Some((header, body)) = split_command(trimmed, "table insert")? {
+        let name = parse_single_name(header, "table insert")?;
+        let body = parse_document_body(body)?;
+        return Ok(Command::Table(TableCommand::Insert { name, body }));
+    }
+    if let Some((header, body)) = split_command(trimmed, "table update")? {
+        let name = parse_single_name(header, "table update")?;
+        let body = parse_document_body(body)?;
+        return Ok(Command::Table(TableCommand::Update { name, body }));
+    }
+    if let Some((header, body)) = split_command(trimmed, "table delete")? {
+        let name = parse_single_name(header, "table delete")?;
+        let body = parse_document_body(body)?;
+        return Ok(Command::Table(TableCommand::Delete { name, body }));
+    }
+    if let Some((header, _body)) = split_command(trimmed, "table scan")? {
+        let name = parse_single_name(header, "table scan")?;
+        return Ok(Command::Table(TableCommand::Scan { name }));
+    }
+    // `table scan` takes no body, so also accept the bodyless form (every
+    // other route requires a `{`, which split_command enforces).
+    if trimmed.to_ascii_lowercase().starts_with("table scan") {
+        let name = parse_single_name(trimmed, "table scan")?;
+        return Ok(Command::Table(TableCommand::Scan { name }));
+    }
+
     Err(CommandError::InvalidCommand(
-        "expected one of: create index, insert document, search".to_string(),
+        "expected one of: create index, insert document, search, table create/insert/scan/update/delete".to_string(),
     ))
 }
 
@@ -678,6 +783,120 @@ fn parse_document_body(body: &str) -> Result<Document, CommandError> {
     let value = parse_json(body)?;
     let object = as_object(&value, "document body")?;
     Ok(object.clone())
+}
+
+/// Parses `{"columns": [{"name","type","nullable"?}...], "primary_key": [..]?}`.
+fn parse_table_create_body(body: &Document) -> Result<(Vec<Column>, Vec<String>), EngineError> {
+    let bad = |msg: &str| EngineError::Command(CommandError::InvalidCommand(msg.to_string()));
+    let columns_value = body
+        .get("columns")
+        .and_then(Value::as_array)
+        .ok_or_else(|| bad("table create requires a 'columns' array"))?;
+    let mut columns = Vec::with_capacity(columns_value.len());
+    for column_value in columns_value {
+        let object = column_value
+            .as_object()
+            .ok_or_else(|| bad("each column must be an object"))?;
+        let name = object
+            .get("name")
+            .and_then(Value::as_str)
+            .ok_or_else(|| bad("column missing 'name'"))?;
+        let type_spec = object
+            .get("type")
+            .and_then(Value::as_str)
+            .ok_or_else(|| bad("column missing 'type'"))?;
+        let nullable = object
+            .get("nullable")
+            .map(|v| v.as_bool().ok_or_else(|| bad("'nullable' must be a bool")))
+            .transpose()?
+            .unwrap_or(true);
+        let column_type = ColumnType::parse(type_spec)
+            .map_err(|err| EngineError::Command(CommandError::InvalidCommand(err.0)))?;
+        columns.push(Column {
+            name: name.to_string(),
+            column_type,
+            nullable,
+        });
+    }
+    let key_names = match body.get("primary_key") {
+        None => Vec::new(),
+        Some(value) => value
+            .as_array()
+            .ok_or_else(|| bad("'primary_key' must be an array"))?
+            .iter()
+            .map(|v| {
+                v.as_str()
+                    .map(str::to_string)
+                    .ok_or_else(|| bad("'primary_key' entries must be strings"))
+            })
+            .collect::<Result<Vec<_>, _>>()?,
+    };
+    Ok((columns, key_names))
+}
+
+/// Converts an insert body (column -> JSON value) into a full row in schema
+/// order; absent columns become NULL.
+fn parse_row_values(schema: &Schema, body: &Document) -> Result<Vec<Datum>, EngineError> {
+    for field in body.keys() {
+        if !schema.columns.iter().any(|c| &c.name == field) {
+            return Err(CommandError::InvalidCommand(format!("unknown column '{field}'")).into());
+        }
+    }
+    schema
+        .columns
+        .iter()
+        .map(|column| {
+            let value = body.get(&column.name).unwrap_or(&Value::Null);
+            Datum::from_json(&column.column_type, value)
+                .map_err(|err| CommandError::InvalidCommand(err.0).into())
+        })
+        .collect()
+}
+
+/// Parses `{"where": {"col": value}}` into a typed equality predicate.
+fn parse_where(schema: &Schema, body: &Document) -> Result<(String, Datum), EngineError> {
+    let bad = |msg: &str| EngineError::Command(CommandError::InvalidCommand(msg.to_string()));
+    let object = body
+        .get("where")
+        .and_then(Value::as_object)
+        .ok_or_else(|| bad("expected a 'where' object with exactly one column"))?;
+    if object.len() != 1 {
+        return Err(bad("'where' must contain exactly one column"));
+    }
+    let (name, value) = object.iter().next().expect("one entry");
+    let column = schema
+        .columns
+        .iter()
+        .find(|c| &c.name == name)
+        .ok_or_else(|| bad(&format!("unknown column '{name}'")))?;
+    let datum = Datum::from_json(&column.column_type, value)
+        .map_err(|err| EngineError::Command(CommandError::InvalidCommand(err.0)))?;
+    Ok((name.clone(), datum))
+}
+
+/// Parses `{"set": {"col": value, ...}}` into typed assignments.
+fn parse_set(schema: &Schema, body: &Document) -> Result<Vec<(String, Datum)>, EngineError> {
+    let bad = |msg: &str| EngineError::Command(CommandError::InvalidCommand(msg.to_string()));
+    let object = body
+        .get("set")
+        .and_then(Value::as_object)
+        .ok_or_else(|| bad("expected a 'set' object"))?;
+    if object.is_empty() {
+        return Err(bad("'set' must assign at least one column"));
+    }
+    object
+        .iter()
+        .map(|(name, value)| {
+            let column = schema
+                .columns
+                .iter()
+                .find(|c| &c.name == name)
+                .ok_or_else(|| bad(&format!("unknown column '{name}'")))?;
+            let datum = Datum::from_json(&column.column_type, value)
+                .map_err(|err| EngineError::Command(CommandError::InvalidCommand(err.0)))?;
+            Ok((name.clone(), datum))
+        })
+        .collect()
 }
 
 fn parse_search_body(body: &str) -> Result<SearchQuery, CommandError> {
@@ -1084,6 +1303,95 @@ mod tests {
             .expect("search");
         let response: Value = serde_json::from_str(&response).expect("valid json");
         assert_eq!(response["hits"]["total"].as_u64(), Some(1));
+        let _ = std::fs::remove_file(path);
+    }
+
+    /// Stage 2 exit criterion: search events and relational records share
+    /// one WAL ring; a crash must recover both, each through its own
+    /// mechanism, regardless of interleaving.
+    #[test]
+    fn mixed_search_and_relational_wal_replays_in_order() {
+        let path = unique_temp_path("mixed-wal");
+        let storage =
+            Storage::create(path.clone(), test_storage_options()).expect("storage create");
+        let mut engine = Engine::new(storage).expect("engine create");
+
+        engine
+            .execute(
+                r#"create index docs { "mappings": { "properties": { "body": { "type": "text" } } } }"#,
+            )
+            .expect("create index");
+        engine
+            .execute(
+                r#"table create items { "columns": [ {"name":"id","type":"int","nullable":false}, {"name":"label","type":"nvarchar(50)"} ], "primary_key": ["id"] }"#,
+            )
+            .expect("create table");
+        // Interleave the two subsystems in one ring.
+        for i in 0..10 {
+            engine
+                .execute(&format!(
+                    r#"insert document docs {{ "body": "search event {i}" }}"#
+                ))
+                .expect("insert doc");
+            engine
+                .execute(&format!(
+                    r#"table insert items {{ "id": {i}, "label": "row {i}" }}"#
+                ))
+                .expect("insert row");
+        }
+        engine
+            .execute(r#"table delete items { "where": { "id": 3 } }"#)
+            .expect("delete row");
+        drop(engine); // crash: everything lives in the shared WAL only
+
+        let storage = Storage::open(path.clone()).expect("reopen");
+        let mut engine = Engine::new(storage).expect("recover both subsystems");
+
+        let response = engine
+            .execute(r#"search docs { "query": { "match": { "body": "search" } } }"#)
+            .expect("search");
+        let response: Value = serde_json::from_str(&response).expect("json");
+        assert_eq!(response["hits"]["total"].as_u64(), Some(10));
+
+        let response = engine.execute(r#"table scan items {}"#).expect("scan");
+        let response: Value = serde_json::from_str(&response).expect("json");
+        assert_eq!(response["count"].as_u64(), Some(9));
+        let ids: Vec<i64> = response["rows"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|r| r["id"].as_i64().unwrap())
+            .collect();
+        assert_eq!(ids, vec![0, 1, 2, 4, 5, 6, 7, 8, 9], "key order, id 3 gone");
+
+        // Both surfaces stay writable after recovery.
+        engine
+            .execute(
+                r#"table update items { "where": { "id": 4 }, "set": { "label": "updated" } }"#,
+            )
+            .expect("update after recovery");
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn table_scan_accepts_bodyless_form() {
+        let path = unique_temp_path("scan-bodyless");
+        let storage =
+            Storage::create(path.clone(), test_storage_options()).expect("storage create");
+        let mut engine = Engine::new(storage).expect("engine create");
+        engine
+            .execute(
+                r#"table create t { "columns": [ {"name":"id","type":"int","nullable":false} ], "primary_key": ["id"] }"#,
+            )
+            .expect("create table");
+        engine
+            .execute(r#"table insert t { "id": 1 }"#)
+            .expect("insert");
+        for command in ["table scan t", "table scan t {}"] {
+            let response = engine.execute(command).expect("scan");
+            let response: Value = serde_json::from_str(&response).expect("json");
+            assert_eq!(response["count"].as_u64(), Some(1), "for '{command}'");
+        }
         let _ = std::fs::remove_file(path);
     }
 

--- a/crates/truthdb-core/src/relstore/btree.rs
+++ b/crates/truthdb-core/src/relstore/btree.rs
@@ -1,0 +1,669 @@
+//! Clustered B+ tree: leaves hold full rows, internal nodes hold separator
+//! keys; leaves are sibling-linked for scans. The root page number is
+//! stable for the table's lifetime (root splits copy the root's content into
+//! a new child), so catalog entries and undo records can always re-descend
+//! from the same page.
+//!
+//! Cell formats:
+//! - leaf: `[key_len u16][key][row]`
+//! - internal: `[key_len u16][key][child u64]`; entry 0 always carries the
+//!   empty sentinel key (covers keys below every separator)
+//!
+//! Logging: the user-visible op (one leaf insert/remove/update) goes through
+//! [`RelCtx::apply_op`] with a *logical* undo (the row may move across pages
+//! through later splits, so undo re-descends by key). Splits are structural:
+//! performed in memory, then logged as full-page images of every touched
+//! page (redo is idempotent by page LSN), never undone.
+
+use crate::relstore::ctx::{OpMode, RelCtx};
+use crate::relstore::page::PAGE_TYPE_TREE;
+use crate::relstore::slotted::{NO_PAGE, SlottedPage, SlottedRead};
+use crate::storage::StorageError;
+use crate::storage_layout::PAGE_SIZE;
+use crate::wal::records::{PageOpRedo, PageOpUndo};
+
+/// Maximum tree cell size: two cells (plus slots) must fit in a page or
+/// splits could fail to make progress. Heap rows keep the larger in-row cap;
+/// tree rows are bounded by this until overflow pages (Stage 14).
+pub const TREE_MAX_CELL: usize = (PAGE_SIZE - crate::relstore::slotted::STRUCT_HEADER_END) / 2 - 4;
+
+/// A `(key bytes, row bytes)` pair from a scan.
+pub type KeyRow = (Vec<u8>, Vec<u8>);
+
+pub(crate) struct BTree {
+    pub object_id: u32,
+    pub root: u64,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct PathNode {
+    page: u64,
+    /// Index of the entry in the *parent* that routed here (unused for the
+    /// root).
+    parent_index: usize,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum TreeInsert {
+    Inserted,
+    DuplicateKey,
+}
+
+fn leaf_cell(key: &[u8], row: &[u8]) -> Vec<u8> {
+    let mut cell = Vec::with_capacity(2 + key.len() + row.len());
+    cell.extend_from_slice(&(key.len() as u16).to_le_bytes());
+    cell.extend_from_slice(key);
+    cell.extend_from_slice(row);
+    cell
+}
+
+fn internal_cell(key: &[u8], child: u64) -> Vec<u8> {
+    let mut cell = Vec::with_capacity(2 + key.len() + 8);
+    cell.extend_from_slice(&(key.len() as u16).to_le_bytes());
+    cell.extend_from_slice(key);
+    cell.extend_from_slice(&child.to_le_bytes());
+    cell
+}
+
+fn cell_key(cell: &[u8]) -> &[u8] {
+    let key_len = u16::from_le_bytes([cell[0], cell[1]]) as usize;
+    &cell[2..2 + key_len]
+}
+
+fn leaf_cell_row(cell: &[u8]) -> &[u8] {
+    let key_len = u16::from_le_bytes([cell[0], cell[1]]) as usize;
+    &cell[2 + key_len..]
+}
+
+fn internal_cell_child(cell: &[u8]) -> u64 {
+    let key_len = u16::from_le_bytes([cell[0], cell[1]]) as usize;
+    u64::from_le_bytes(cell[2 + key_len..2 + key_len + 8].try_into().unwrap())
+}
+
+/// Binary search in a leaf: Ok(index) on exact match, Err(insertion point)
+/// otherwise.
+fn leaf_search(page: &SlottedRead<'_>, key: &[u8]) -> Result<usize, usize> {
+    let mut low = 0usize;
+    let mut high = page.slot_count();
+    while low < high {
+        let mid = (low + high) / 2;
+        let cell = page.get(mid).expect("tree pages have no tombstones");
+        match cell_key(cell).cmp(key) {
+            std::cmp::Ordering::Less => low = mid + 1,
+            std::cmp::Ordering::Greater => high = mid,
+            std::cmp::Ordering::Equal => return Ok(mid),
+        }
+    }
+    Err(low)
+}
+
+/// Routing in an internal node: index of the rightmost entry whose key is
+/// `<= key` (entry 0's sentinel empty key matches everything).
+fn internal_route(page: &SlottedRead<'_>, key: &[u8]) -> usize {
+    let mut low = 0usize;
+    let mut high = page.slot_count();
+    while low < high {
+        let mid = (low + high) / 2;
+        let cell = page.get(mid).expect("tree pages have no tombstones");
+        if cell_key(cell) <= key {
+            low = mid + 1;
+        } else {
+            high = mid;
+        }
+    }
+    debug_assert!(low > 0, "sentinel entry must match");
+    low - 1
+}
+
+impl BTree {
+    /// Creates a single-leaf tree (logged as a system image).
+    pub fn create(ctx: &mut RelCtx<'_>, object_id: u32) -> Result<BTree, StorageError> {
+        let root = ctx.allocate_page(0)?;
+        let frame = ctx.format_page(root, PAGE_TYPE_TREE, object_id, 0)?;
+        ctx.pool.unpin(frame);
+        ctx.log_system_image(root)?;
+        Ok(BTree { object_id, root })
+    }
+
+    /// Descends to the leaf responsible for `key`, recording the path.
+    fn descend(&self, ctx: &mut RelCtx<'_>, key: &[u8]) -> Result<Vec<PathNode>, StorageError> {
+        let mut path = vec![PathNode {
+            page: self.root,
+            parent_index: 0,
+        }];
+        loop {
+            let node = *path.last().expect("path non-empty");
+            let frame = ctx.fetch(node.page)?;
+            let page = SlottedRead::new(ctx.pool.page(frame));
+            if page.level() == 0 {
+                ctx.pool.unpin(frame);
+                return Ok(path);
+            }
+            let index = internal_route(&page, key);
+            let child = internal_cell_child(page.get(index).expect("routed entry"));
+            ctx.pool.unpin(frame);
+            path.push(PathNode {
+                page: child,
+                parent_index: index,
+            });
+        }
+    }
+
+    pub fn get(&self, ctx: &mut RelCtx<'_>, key: &[u8]) -> Result<Option<Vec<u8>>, StorageError> {
+        let path = self.descend(ctx, key)?;
+        let leaf = path.last().expect("path has a leaf").page;
+        let frame = ctx.fetch(leaf)?;
+        let page = SlottedRead::new(ctx.pool.page(frame));
+        let row = leaf_search(&page, key)
+            .ok()
+            .map(|index| leaf_cell_row(page.get(index).expect("found cell")).to_vec());
+        ctx.pool.unpin(frame);
+        Ok(row)
+    }
+
+    /// Inserts a unique key. Splits happen structurally (system images)
+    /// before the insert is logged with a logical delete-key undo.
+    pub fn insert_unique(
+        &self,
+        ctx: &mut RelCtx<'_>,
+        mode: &mut OpMode<'_>,
+        key: &[u8],
+        row: &[u8],
+    ) -> Result<TreeInsert, StorageError> {
+        let cell = leaf_cell(key, row);
+        if cell.len() > TREE_MAX_CELL {
+            return Err(StorageError::InvalidConfig(format!(
+                "tree row of {} bytes exceeds the per-cell cap of {TREE_MAX_CELL}",
+                cell.len()
+            )));
+        }
+        loop {
+            let path = self.descend(ctx, key)?;
+            let leaf = path.last().expect("leaf").page;
+            let frame = ctx.fetch(leaf)?;
+            let page = SlottedRead::new(ctx.pool.page(frame));
+            let position = match leaf_search(&page, key) {
+                Ok(_) => {
+                    ctx.pool.unpin(frame);
+                    return Ok(TreeInsert::DuplicateKey);
+                }
+                Err(position) => position,
+            };
+            let fits = page.total_free() >= cell.len() + 4;
+            ctx.pool.unpin(frame);
+
+            if fits {
+                ctx.apply_op(
+                    mode.log_mode(PageOpUndo::TreeDeleteKey {
+                        object_id: self.object_id,
+                        key: key.to_vec(),
+                    }),
+                    PageOpRedo::InsertAt {
+                        page: leaf,
+                        index: position as u16,
+                        bytes: cell.clone(),
+                    },
+                )?;
+                return Ok(TreeInsert::Inserted);
+            }
+            self.split_one(ctx, &path)?;
+            // Re-descend: the split may have moved the target range.
+        }
+    }
+
+    /// Deletes `key`, returning the removed row. No rebalancing (deletes
+    /// leave pages sparse, SQL Server-style).
+    pub fn delete(
+        &self,
+        ctx: &mut RelCtx<'_>,
+        mode: &mut OpMode<'_>,
+        key: &[u8],
+    ) -> Result<Option<Vec<u8>>, StorageError> {
+        let path = self.descend(ctx, key)?;
+        let leaf = path.last().expect("leaf").page;
+        let frame = ctx.fetch(leaf)?;
+        let page = SlottedRead::new(ctx.pool.page(frame));
+        let found = leaf_search(&page, key).ok().map(|index| {
+            (
+                index,
+                leaf_cell_row(page.get(index).expect("cell")).to_vec(),
+            )
+        });
+        ctx.pool.unpin(frame);
+        let Some((index, row)) = found else {
+            return Ok(None);
+        };
+        ctx.apply_op(
+            mode.log_mode(PageOpUndo::TreeInsertRow {
+                object_id: self.object_id,
+                key: key.to_vec(),
+                row: row.clone(),
+            }),
+            PageOpRedo::RemoveAt {
+                page: leaf,
+                index: index as u16,
+            },
+        )?;
+        Ok(Some(row))
+    }
+
+    /// Replaces the row stored under `key` (the key itself is immutable).
+    /// Returns the previous row, or None if the key is absent.
+    pub fn update(
+        &self,
+        ctx: &mut RelCtx<'_>,
+        mode: &mut OpMode<'_>,
+        key: &[u8],
+        new_row: &[u8],
+    ) -> Result<Option<Vec<u8>>, StorageError> {
+        let cell = leaf_cell(key, new_row);
+        if cell.len() > TREE_MAX_CELL {
+            return Err(StorageError::InvalidConfig(format!(
+                "tree row of {} bytes exceeds the per-cell cap of {TREE_MAX_CELL}",
+                cell.len()
+            )));
+        }
+        let path = self.descend(ctx, key)?;
+        let leaf = path.last().expect("leaf").page;
+        let frame = ctx.fetch(leaf)?;
+        let page = SlottedRead::new(ctx.pool.page(frame));
+        let found = leaf_search(&page, key).ok().map(|index| {
+            let old_cell = page.get(index).expect("cell");
+            (
+                index,
+                leaf_cell_row(old_cell).to_vec(),
+                page.total_free() + old_cell.len() >= cell.len(),
+            )
+        });
+        ctx.pool.unpin(frame);
+        let Some((index, old_row, fits_in_place)) = found else {
+            return Ok(None);
+        };
+
+        if fits_in_place {
+            ctx.apply_op(
+                mode.log_mode(PageOpUndo::TreeUpdateRow {
+                    object_id: self.object_id,
+                    key: key.to_vec(),
+                    row: old_row.clone(),
+                }),
+                PageOpRedo::UpdateAt {
+                    page: leaf,
+                    index: index as u16,
+                    bytes: cell,
+                },
+            )?;
+            return Ok(Some(old_row));
+        }
+
+        // Grown row that no longer fits: remove + re-insert (with splits).
+        // The undo pair restores the old row: undo(insert) deletes the key,
+        // then undo(remove) re-inserts the old row.
+        ctx.apply_op(
+            mode.log_mode(PageOpUndo::TreeInsertRow {
+                object_id: self.object_id,
+                key: key.to_vec(),
+                row: old_row.clone(),
+            }),
+            PageOpRedo::RemoveAt {
+                page: leaf,
+                index: index as u16,
+            },
+        )?;
+        match self.insert_unique(ctx, mode, key, new_row)? {
+            TreeInsert::Inserted => Ok(Some(old_row)),
+            TreeInsert::DuplicateKey => Err(StorageError::InvalidFile(
+                "key reappeared during tree update".to_string(),
+            )),
+        }
+    }
+
+    /// Full scan in key order via the leaf chain: (key, row) pairs.
+    pub fn scan(&self, ctx: &mut RelCtx<'_>) -> Result<Vec<KeyRow>, StorageError> {
+        // Find the leftmost leaf.
+        let mut page_no = self.root;
+        loop {
+            let frame = ctx.fetch(page_no)?;
+            let page = SlottedRead::new(ctx.pool.page(frame));
+            if page.level() == 0 {
+                ctx.pool.unpin(frame);
+                break;
+            }
+            let child = internal_cell_child(page.get(0).expect("sentinel entry"));
+            ctx.pool.unpin(frame);
+            page_no = child;
+        }
+        let mut out = Vec::new();
+        while page_no != NO_PAGE {
+            let frame = ctx.fetch(page_no)?;
+            let page = SlottedRead::new(ctx.pool.page(frame));
+            for index in 0..page.slot_count() {
+                let cell = page.get(index).expect("tree pages have no tombstones");
+                out.push((cell_key(cell).to_vec(), leaf_cell_row(cell).to_vec()));
+            }
+            let next = page.next_page();
+            ctx.pool.unpin(frame);
+            page_no = next;
+        }
+        Ok(out)
+    }
+
+    /// Splits exactly one node: the deepest node on `path` whose parent can
+    /// absorb the separator (ancestors that cannot are split instead; the
+    /// caller re-descends after each split).
+    fn split_one(&self, ctx: &mut RelCtx<'_>, path: &[PathNode]) -> Result<(), StorageError> {
+        let mut depth = path.len() - 1;
+        loop {
+            let (split_at, sep_len) = self.split_plan(ctx, path[depth].page)?;
+            if depth == 0 {
+                return self.split_root(ctx, split_at);
+            }
+            // Parent must fit an internal cell of (2 + sep_len + 8) bytes.
+            let parent = path[depth - 1].page;
+            let frame = ctx.fetch(parent)?;
+            let parent_free = SlottedRead::new(ctx.pool.page(frame)).total_free();
+            ctx.pool.unpin(frame);
+            if parent_free >= 2 + sep_len + 8 + 4 {
+                return self.split_child(
+                    ctx,
+                    path[depth].page,
+                    parent,
+                    path[depth].parent_index,
+                    split_at,
+                );
+            }
+            depth -= 1;
+        }
+    }
+
+    /// Read-only split plan: (index to split at, separator key length).
+    fn split_plan(
+        &self,
+        ctx: &mut RelCtx<'_>,
+        page_no: u64,
+    ) -> Result<(usize, usize), StorageError> {
+        let frame = ctx.fetch(page_no)?;
+        let page = SlottedRead::new(ctx.pool.page(frame));
+        let count = page.slot_count();
+        debug_assert!(count >= 2, "splitting a page with < 2 cells");
+        let split_at = count / 2;
+        let sep_len = cell_key(page.get(split_at).expect("cell")).len();
+        ctx.pool.unpin(frame);
+        Ok((split_at, sep_len))
+    }
+
+    /// Splits a non-root node: upper half moves to a fresh right sibling,
+    /// separator goes into the parent.
+    ///
+    /// Crash-atomicity protocol: every touched frame stays PINNED from its
+    /// first mutation until the single atomic image-group record is
+    /// appended (so no buffer-pool steal can write unlogged state), and
+    /// pre-images restore the in-memory pages if the append fails.
+    fn split_child(
+        &self,
+        ctx: &mut RelCtx<'_>,
+        page_no: u64,
+        parent: u64,
+        parent_index: usize,
+        split_at: usize,
+    ) -> Result<(), StorageError> {
+        let right = ctx.allocate_page(0)?;
+
+        // Pin the left node for the whole operation; read the upper half.
+        let left_frame = ctx.fetch(page_no)?;
+        let left_pre_image = ctx.pool.page(left_frame).to_vec();
+        let (level, count, moved, old_next) = {
+            let page = SlottedRead::new(ctx.pool.page(left_frame));
+            let count = page.slot_count();
+            let moved: Vec<Vec<u8>> = (split_at..count)
+                .map(|i| page.get(i).expect("cell").to_vec())
+                .collect();
+            (page.level(), count, moved, page.next_page())
+        };
+        let separator = cell_key(&moved[0]).to_vec();
+
+        // Build the right sibling (fresh page: no pre-image needed — on any
+        // failure it stays an unreferenced orphan).
+        let right_frame = match ctx.format_page(right, PAGE_TYPE_TREE, self.object_id, level) {
+            Ok(frame) => frame,
+            Err(err) => {
+                ctx.pool.unpin(left_frame);
+                return Err(err);
+            }
+        };
+        let build_failed = {
+            let mut right_page = SlottedPage::new(ctx.pool.page_mut(right_frame));
+            let mut failed = false;
+            for (i, cell) in moved.iter().enumerate() {
+                let cell = if level > 0 && i == 0 {
+                    // Promote the first key to the parent; the right node's
+                    // first entry becomes the sentinel.
+                    internal_cell(&[], internal_cell_child(cell))
+                } else {
+                    cell.clone()
+                };
+                if right_page.insert_at(i, &cell).is_err() {
+                    failed = true;
+                    break;
+                }
+            }
+            if !failed && level == 0 {
+                right_page.set_next_page(old_next);
+            }
+            failed
+        };
+        if build_failed {
+            ctx.pool.unpin(left_frame);
+            ctx.pool.unpin(right_frame);
+            return Err(split_overflow());
+        }
+
+        // Shrink the left node.
+        {
+            let mut left_page = SlottedPage::new(ctx.pool.page_mut(left_frame));
+            for i in (split_at..count).rev() {
+                left_page.remove_at(i);
+            }
+            if level == 0 {
+                left_page.set_next_page(right);
+            }
+        }
+
+        // Insert the separator into the parent (fit checked by caller), then
+        // log the whole split as ONE atomic record.
+        let result = (|| -> Result<crate::relstore::buffer_pool::FrameId, StorageError> {
+            let parent_frame = ctx.fetch(parent)?;
+            let parent_pre_image = ctx.pool.page(parent_frame).to_vec();
+            if SlottedPage::new(ctx.pool.page_mut(parent_frame))
+                .insert_at(parent_index + 1, &internal_cell(&separator, right))
+                .is_err()
+            {
+                ctx.pool.unpin(parent_frame);
+                return Err(split_overflow());
+            }
+            match ctx.log_system_images(&[
+                (page_no, left_frame),
+                (right, right_frame),
+                (parent, parent_frame),
+            ]) {
+                Ok(_) => Ok(parent_frame),
+                Err(err) => {
+                    ctx.pool
+                        .page_mut(parent_frame)
+                        .copy_from_slice(&parent_pre_image);
+                    ctx.pool.unpin(parent_frame);
+                    Err(err)
+                }
+            }
+        })();
+        match result {
+            Ok(parent_frame) => {
+                ctx.pool.unpin(left_frame);
+                ctx.pool.unpin(right_frame);
+                ctx.pool.unpin(parent_frame);
+                Ok(())
+            }
+            Err(err) => {
+                // Restore the left node; the orphan right page is harmless.
+                ctx.pool
+                    .page_mut(left_frame)
+                    .copy_from_slice(&left_pre_image);
+                ctx.pool.unpin(left_frame);
+                ctx.pool.unpin(right_frame);
+                Err(err)
+            }
+        }
+    }
+
+    /// Splits the root while keeping its page number: contents move into a
+    /// fresh left child, the root becomes (or stays) internal with two
+    /// entries. Same pin-until-logged atomic protocol as `split_child`.
+    fn split_root(&self, ctx: &mut RelCtx<'_>, split_at: usize) -> Result<(), StorageError> {
+        let left = ctx.allocate_page(0)?;
+        let right = ctx.allocate_page(0)?;
+
+        let root_frame = ctx.fetch(self.root)?;
+        let root_pre_image = ctx.pool.page(root_frame).to_vec();
+        let (level, cells) = {
+            let page = SlottedRead::new(ctx.pool.page(root_frame));
+            let cells: Vec<Vec<u8>> = (0..page.slot_count())
+                .map(|i| page.get(i).expect("cell").to_vec())
+                .collect();
+            (page.level(), cells)
+        };
+        let separator = cell_key(&cells[split_at]).to_vec();
+
+        let result = (|| -> Result<
+            (
+                crate::relstore::buffer_pool::FrameId,
+                crate::relstore::buffer_pool::FrameId,
+            ),
+            StorageError,
+        > {
+            let left_frame = ctx.format_page(left, PAGE_TYPE_TREE, self.object_id, level)?;
+            let build_failed = {
+                let mut left_page = SlottedPage::new(ctx.pool.page_mut(left_frame));
+                let mut failed = false;
+                for (i, cell) in cells[..split_at].iter().enumerate() {
+                    if left_page.insert_at(i, cell).is_err() {
+                        failed = true;
+                        break;
+                    }
+                }
+                if !failed && level == 0 {
+                    left_page.set_next_page(right);
+                }
+                failed
+            };
+            if build_failed {
+                ctx.pool.unpin(left_frame);
+                return Err(split_overflow());
+            }
+            let right_frame = match ctx.format_page(right, PAGE_TYPE_TREE, self.object_id, level)
+            {
+                Ok(frame) => frame,
+                Err(err) => {
+                    ctx.pool.unpin(left_frame);
+                    return Err(err);
+                }
+            };
+            // The root was the only (or rightmost) node at its level, so
+            // the right child terminates the chain at leaf level.
+            let build_failed = {
+                let mut right_page = SlottedPage::new(ctx.pool.page_mut(right_frame));
+                let mut failed = false;
+                for (i, cell) in cells[split_at..].iter().enumerate() {
+                    let cell = if level > 0 && i == 0 {
+                        internal_cell(&[], internal_cell_child(cell))
+                    } else {
+                        cell.clone()
+                    };
+                    if right_page.insert_at(i, &cell).is_err() {
+                        failed = true;
+                        break;
+                    }
+                }
+                failed
+            };
+            if build_failed {
+                ctx.pool.unpin(left_frame);
+                ctx.pool.unpin(right_frame);
+                return Err(split_overflow());
+            }
+
+            let rebuild_failed = {
+                let mut root_page = SlottedPage::format(ctx.pool.page_mut(root_frame), level + 1);
+                root_page
+                    .insert_at(0, &internal_cell(&[], left))
+                    .and_then(|()| root_page.insert_at(1, &internal_cell(&separator, right)))
+                    .is_err()
+            };
+            if rebuild_failed {
+                ctx.pool.unpin(left_frame);
+                ctx.pool.unpin(right_frame);
+                return Err(split_overflow());
+            }
+            match ctx.log_system_images(&[
+                (left, left_frame),
+                (right, right_frame),
+                (self.root, root_frame),
+            ]) {
+                Ok(_) => Ok((left_frame, right_frame)),
+                Err(err) => {
+                    ctx.pool.unpin(left_frame);
+                    ctx.pool.unpin(right_frame);
+                    Err(err)
+                }
+            }
+        })();
+        match result {
+            Ok((left_frame, right_frame)) => {
+                ctx.pool.unpin(root_frame);
+                ctx.pool.unpin(left_frame);
+                ctx.pool.unpin(right_frame);
+                Ok(())
+            }
+            Err(err) => {
+                ctx.pool
+                    .page_mut(root_frame)
+                    .copy_from_slice(&root_pre_image);
+                ctx.pool.unpin(root_frame);
+                Err(err)
+            }
+        }
+    }
+}
+
+fn split_overflow() -> StorageError {
+    StorageError::InvalidFile("page overflow during split (cell size invariant broken)".to_string())
+}
+
+/// Applies a logical tree undo as compensation. Ops are tolerant of partial
+/// prior application (a crash between the CLRs of one undone record replays
+/// the whole undo, so each piece must be a no-op when already done).
+pub(crate) fn apply_tree_undo(
+    ctx: &mut RelCtx<'_>,
+    mode: &mut OpMode<'_>,
+    tree: &BTree,
+    undo: &PageOpUndo,
+) -> Result<(), StorageError> {
+    match undo {
+        PageOpUndo::TreeDeleteKey { key, .. } => {
+            // Undo of an insert: delete if present.
+            let _ = tree.delete(ctx, mode, key)?;
+        }
+        PageOpUndo::TreeInsertRow { key, row, .. } => {
+            // Undo of a delete: re-insert if absent.
+            let _ = tree.insert_unique(ctx, mode, key, row)?;
+        }
+        PageOpUndo::TreeUpdateRow { key, row, .. } => {
+            // Undo of an update: restore the old row (insert if the new row
+            // vanished mid-undo).
+            if tree.update(ctx, mode, key, row)?.is_none() {
+                let _ = tree.insert_unique(ctx, mode, key, row)?;
+            }
+        }
+        _ => unreachable!("not a tree undo"),
+    }
+    Ok(())
+}

--- a/crates/truthdb-core/src/relstore/buffer_pool.rs
+++ b/crates/truthdb-core/src/relstore/buffer_pool.rs
@@ -237,14 +237,16 @@ impl BufferPool {
     }
 
     /// WAL-before-data write-back: flush the WAL to the page's LSN, stamp
-    /// the page checksum, write the page.
+    /// the page checksum, write the page. The flushed watermark counts
+    /// covered bytes, so a record STARTING at the watermark is not durable
+    /// yet — hence `>=`.
     fn write_back(
         &mut self,
         index: usize,
         backend: &mut impl PoolBackend,
     ) -> Result<(), StorageError> {
         let lsn = page::page_lsn(self.frames[index].buf.as_slice());
-        if lsn > backend.flushed_lsn() {
+        if lsn >= backend.flushed_lsn() && lsn > 0 {
             backend.flush_wal_to(lsn)?;
         }
         page::stamp_checksum(self.frames[index].buf.as_mut_slice());

--- a/crates/truthdb-core/src/relstore/catalog.rs
+++ b/crates/truthdb-core/src/relstore/catalog.rs
@@ -1,0 +1,109 @@
+//! Catalog storage: table definitions live as rows in a clustered B+ tree
+//! (object id 1, keyed by object id, value = JSON-encoded [`TableDef`]).
+//! The catalog root page is recorded in the superblock's `metadata_root`
+//! (as an absolute file offset; 0 = none) and re-announced through
+//! SET_CATALOG_ROOT WAL records so a pre-checkpoint crash can rediscover it.
+
+use serde::{Deserialize, Serialize};
+
+use crate::relstore::btree::{BTree, TreeInsert};
+use crate::relstore::ctx::{OpMode, RelCtx};
+use crate::relstore::key::encode_datum;
+use crate::relstore::row::{Column, Schema};
+use crate::relstore::types::{ColumnType, Datum};
+use crate::storage::StorageError;
+use crate::wal::records::RelRecord;
+
+/// Object id of the catalog tree itself.
+pub const CATALOG_OBJECT_ID: u32 = 1;
+/// First object id handed to user tables.
+pub const FIRST_USER_OBJECT_ID: u32 = 2;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TableDef {
+    pub object_id: u32,
+    pub name: String,
+    /// (column name, parseable type spec, nullable).
+    pub columns: Vec<(String, String, bool)>,
+    /// Schema indices of the primary-key columns; empty = heap table.
+    pub key_columns: Vec<usize>,
+    /// Tree root page or heap first page.
+    pub root_page: u64,
+}
+
+impl TableDef {
+    pub fn schema(&self) -> Result<Schema, StorageError> {
+        let columns = self
+            .columns
+            .iter()
+            .map(|(name, spec, nullable)| {
+                Ok(Column {
+                    name: name.clone(),
+                    column_type: ColumnType::parse(spec)
+                        .map_err(|err| StorageError::InvalidFile(err.to_string()))?,
+                    nullable: *nullable,
+                })
+            })
+            .collect::<Result<Vec<_>, StorageError>>()?;
+        Ok(Schema { columns })
+    }
+
+    pub fn is_tree(&self) -> bool {
+        !self.key_columns.is_empty()
+    }
+}
+
+fn catalog_tree(root: u64) -> BTree {
+    BTree {
+        object_id: CATALOG_OBJECT_ID,
+        root,
+    }
+}
+
+fn catalog_key(object_id: u32) -> Vec<u8> {
+    let mut key = Vec::new();
+    encode_datum(&Datum::Int(object_id as i32), &mut key).expect("int key encodes");
+    key
+}
+
+/// Creates the catalog tree (system records) and announces its root.
+pub(crate) fn create_catalog(ctx: &mut RelCtx<'_>) -> Result<u64, StorageError> {
+    let tree = BTree::create(ctx, CATALOG_OBJECT_ID)?;
+    ctx.append(&RelRecord::set_catalog_root(tree.root), false)?;
+    Ok(tree.root)
+}
+
+/// Loads every table definition from the catalog tree.
+pub(crate) fn load_tables(
+    ctx: &mut RelCtx<'_>,
+    catalog_root: u64,
+) -> Result<Vec<TableDef>, StorageError> {
+    let tree = catalog_tree(catalog_root);
+    tree.scan(ctx)?
+        .into_iter()
+        .map(|(_, row)| {
+            serde_json::from_slice(&row)
+                .map_err(|err| StorageError::InvalidFile(format!("corrupt catalog row: {err}")))
+        })
+        .collect()
+}
+
+/// Inserts a table definition (undoable: part of the creating statement's
+/// transaction).
+pub(crate) fn insert_table(
+    ctx: &mut RelCtx<'_>,
+    mode: &mut OpMode<'_>,
+    catalog_root: u64,
+    def: &TableDef,
+) -> Result<(), StorageError> {
+    let row = serde_json::to_vec(def)
+        .map_err(|err| StorageError::InvalidFile(format!("encode catalog row: {err}")))?;
+    let tree = catalog_tree(catalog_root);
+    match tree.insert_unique(ctx, mode, &catalog_key(def.object_id), &row)? {
+        TreeInsert::Inserted => Ok(()),
+        TreeInsert::DuplicateKey => Err(StorageError::InvalidFile(format!(
+            "duplicate object id {} in catalog",
+            def.object_id
+        ))),
+    }
+}

--- a/crates/truthdb-core/src/relstore/ctx.rs
+++ b/crates/truthdb-core/src/relstore/ctx.rs
@@ -1,0 +1,388 @@
+//! Execution context for relational page operations.
+//!
+//! Every mutation flows through [`RelCtx::apply_op`]: the physiological redo
+//! op is applied to the page by the same code recovery uses
+//! ([`apply_redo_to_page`]), then logged. The first modification of a page
+//! since the last checkpoint is logged as a full page image instead
+//! (torn-page repair); the record still carries the operation's undo.
+//!
+//! Write-ahead ordering: records are appended (page-written but not
+//! necessarily fsynced) before the buffer frame is marked dirty with the
+//! record's LSN; the buffer pool fsyncs the log up to a page's LSN before
+//! stealing it, and commit forces the log.
+
+use std::collections::HashMap;
+
+use crate::allocator::PageAllocator;
+use crate::direct_io::{AlignedPageBuf, DirectFile};
+use crate::relstore::buffer_pool::{BufferPool, FrameId, PoolBackend};
+use crate::relstore::page::{self, PageHeader};
+use crate::relstore::slotted::SlottedPage;
+use crate::storage::StorageError;
+use crate::storage_layout::{PAGE_SIZE, WAL_ENTRY_TYPE_REL};
+use crate::wal::WalWriter;
+use crate::wal::records::{PageOpRedo, PageOpUndo, RelRecord};
+
+const REL_WAL_ENTRY_VERSION: u16 = 1;
+
+/// Raw page I/O + WAL watermark for the buffer pool, over the data region.
+pub(crate) struct PoolIo<'a> {
+    pub file: &'a mut DirectFile,
+    pub wal: &'a mut WalWriter,
+    pub data_offset: u64,
+    pub data_pages: u64,
+}
+
+impl PoolIo<'_> {
+    fn offset_of(&self, page_no: u64) -> Result<u64, StorageError> {
+        if page_no >= self.data_pages {
+            return Err(StorageError::InvalidFile(format!(
+                "page {page_no} outside the data region"
+            )));
+        }
+        Ok(self.data_offset + page_no * PAGE_SIZE as u64)
+    }
+}
+
+impl PoolBackend for PoolIo<'_> {
+    fn read_page(&mut self, page_no: u64, frame: &mut AlignedPageBuf) -> Result<(), StorageError> {
+        let offset = self.offset_of(page_no)?;
+        self.file.read_page_into(offset, frame)?;
+        Ok(())
+    }
+
+    fn write_page(&mut self, page_no: u64, frame: &AlignedPageBuf) -> Result<(), StorageError> {
+        let offset = self.offset_of(page_no)?;
+        self.file.write_page_from(offset, frame)?;
+        Ok(())
+    }
+
+    fn flushed_lsn(&self) -> u64 {
+        self.wal.flushed_lsn()
+    }
+
+    fn flush_wal_to(&mut self, lsn: u64) -> Result<(), StorageError> {
+        self.wal.sync_to(lsn)
+    }
+}
+
+/// An active (statement-scoped, autocommit) transaction: the WAL chain tail
+/// and an in-memory undo log so statement rollback never re-reads the ring.
+pub(crate) struct TxnLink {
+    pub txn_id: u64,
+    pub last_lsn: u64,
+    pub undo_log: Vec<(u64, PageOpUndo)>,
+}
+
+/// How an access-method operation logs its user-visible page op: as a
+/// forward transaction record (with undo) or as a compensation record
+/// during rollback/recovery-undo. Structural changes (splits, new pages)
+/// are always system records regardless.
+pub(crate) enum OpMode<'t> {
+    Txn(&'t mut TxnLink),
+    Clr {
+        txn: &'t mut TxnLink,
+        undo_next: u64,
+    },
+}
+
+impl OpMode<'_> {
+    /// Builds the [`LogMode`] for one page op: forward mode attaches the
+    /// undo, CLR mode drops it (CLRs are never undone).
+    pub fn log_mode(&mut self, undo: PageOpUndo) -> LogMode<'_> {
+        match self {
+            OpMode::Txn(txn) => LogMode::Txn(txn, undo),
+            OpMode::Clr { txn, undo_next } => LogMode::Clr {
+                txn,
+                undo_next: *undo_next,
+            },
+        }
+    }
+}
+
+/// How a page mutation is logged.
+pub(crate) enum LogMode<'t> {
+    /// User-transaction record with an undo action.
+    Txn(&'t mut TxnLink, PageOpUndo),
+    /// Compensation record during rollback/recovery-undo: `undo_next` points
+    /// at the next record to undo.
+    Clr {
+        txn: &'t mut TxnLink,
+        undo_next: u64,
+    },
+    /// System change (splits, page formats, chain links): redo-only,
+    /// txn 0, never undone.
+    System,
+}
+
+#[cfg(test)]
+thread_local! {
+    /// Test fault injection: `Some(n)` makes the (n+1)-th apply_op fail
+    /// after syncing the log — prior appends stay durable, simulating a
+    /// crash at that exact point (including inside recovery undo).
+    pub(crate) static FAIL_APPLY_OPS_AFTER: std::cell::Cell<Option<u32>> =
+        const { std::cell::Cell::new(None) };
+}
+
+pub(crate) struct RelCtx<'a> {
+    pub pool: &'a mut BufferPool,
+    pub io: PoolIo<'a>,
+    pub allocator: &'a mut PageAllocator,
+    /// Pages dirtied since the last checkpoint -> LSN of their first change
+    /// (the FPI). Drives FPI-on-first-touch.
+    pub dpt: &'a mut HashMap<u64, u64>,
+    /// True on undo paths (rollback, recovery): appends may use the WAL's
+    /// compensation reserve, which forward statements must not touch.
+    pub use_reserve: bool,
+}
+
+impl RelCtx<'_> {
+    pub fn fetch(&mut self, page_no: u64) -> Result<FrameId, StorageError> {
+        self.pool.fetch(page_no, &mut self.io)
+    }
+
+    pub fn fetch_zeroed(&mut self, page_no: u64) -> Result<FrameId, StorageError> {
+        self.pool.fetch_zeroed(page_no, &mut self.io)
+    }
+
+    /// Allocates one page in the data region, WAL-logged (redo-idempotent).
+    pub fn allocate_page(&mut self, txn_id: u64) -> Result<u64, StorageError> {
+        let page_no = self
+            .allocator
+            .allocate(1)
+            .ok_or_else(|| StorageError::InvalidConfig("data region full".to_string()))?;
+        let record = RelRecord::alloc_extent(page_no, 1);
+        if let Err(err) = self.append(&record, false) {
+            self.allocator.free(page_no, 1);
+            return Err(err);
+        }
+        let _ = txn_id;
+        Ok(page_no)
+    }
+
+    pub fn append(&mut self, record: &RelRecord, sync: bool) -> Result<u64, StorageError> {
+        self.io.wal.append_entry_reserve(
+            WAL_ENTRY_TYPE_REL,
+            REL_WAL_ENTRY_VERSION,
+            0,
+            &record.encode(),
+            sync,
+            self.use_reserve,
+        )
+    }
+
+    pub fn begin(&mut self, txn_id: u64) -> Result<TxnLink, StorageError> {
+        let lsn = self.append(&RelRecord::txn_begin(txn_id), false)?;
+        Ok(TxnLink {
+            txn_id,
+            last_lsn: lsn,
+            undo_log: Vec::new(),
+        })
+    }
+
+    /// Commit = force the log at the commit record, then an end record. The
+    /// end record is an ATT-cleanup optimization (analysis already treats
+    /// COMMIT as terminal), so its failure must not fail a durable commit.
+    pub fn commit(&mut self, txn: TxnLink) -> Result<(), StorageError> {
+        let commit_lsn = self.append(&RelRecord::txn_commit(txn.txn_id, txn.last_lsn), true)?;
+        let _ = self.append(&RelRecord::txn_end(txn.txn_id, commit_lsn), false);
+        Ok(())
+    }
+
+    /// Applies a physiological op to its page and logs it. Callers must have
+    /// verified the op fits (page splits happen before this). If the log
+    /// append fails, the in-memory page is restored from its pre-image: a
+    /// mutation without a durable record must never survive in the pool.
+    pub fn apply_op(&mut self, mode: LogMode<'_>, redo: PageOpRedo) -> Result<u64, StorageError> {
+        #[cfg(test)]
+        {
+            let fire = FAIL_APPLY_OPS_AFTER.with(|c| match c.get() {
+                Some(0) => {
+                    c.set(None);
+                    true
+                }
+                Some(n) => {
+                    c.set(Some(n - 1));
+                    false
+                }
+                None => false,
+            });
+            if fire {
+                self.io.wal.sync_all()?;
+                return Err(StorageError::InvalidConfig(
+                    "test fault injection".to_string(),
+                ));
+            }
+        }
+
+        let page_no = redo.page();
+        let frame = self.fetch(page_no)?;
+        let pre_image: Vec<u8> = self.pool.page(frame).to_vec();
+        if let Err(err) = apply_redo_to_page(self.pool.page_mut(frame), &redo) {
+            self.pool.page_mut(frame).copy_from_slice(&pre_image);
+            self.pool.unpin(frame);
+            return Err(err);
+        }
+
+        let first_touch = !self.dpt.contains_key(&page_no);
+        let record = match &mode {
+            LogMode::Txn(txn, undo) => {
+                if first_touch {
+                    RelRecord::page_image(
+                        txn.txn_id,
+                        txn.last_lsn,
+                        page_no,
+                        self.pool.page(frame),
+                        undo,
+                    )
+                } else {
+                    RelRecord::page_op(txn.txn_id, txn.last_lsn, &redo, undo)
+                }
+            }
+            // CLRs compensate ops that already forced an FPI for this page
+            // after the checkpoint, so they never need an image themselves.
+            LogMode::Clr { txn, undo_next } => {
+                RelRecord::clr(txn.txn_id, txn.last_lsn, *undo_next, &redo)
+            }
+            LogMode::System => {
+                if first_touch {
+                    RelRecord::page_image(0, 0, page_no, self.pool.page(frame), &PageOpUndo::None)
+                } else {
+                    RelRecord::page_op(0, 0, &redo, &PageOpUndo::None)
+                }
+            }
+        };
+        let lsn = match self.append(&record, false) {
+            Ok(lsn) => lsn,
+            Err(err) => {
+                // No durable record: the mutation must not survive either.
+                self.pool.page_mut(frame).copy_from_slice(&pre_image);
+                self.pool.unpin(frame);
+                return Err(err);
+            }
+        };
+        match mode {
+            LogMode::Txn(txn, undo) => {
+                txn.last_lsn = lsn;
+                txn.undo_log.push((lsn, undo));
+            }
+            LogMode::Clr { txn, .. } => {
+                txn.last_lsn = lsn;
+            }
+            LogMode::System => {}
+        }
+        self.dpt.entry(page_no).or_insert(lsn);
+        set_frame_lsn(self.pool.page_mut(frame), lsn);
+        self.pool.unpin(frame);
+        Ok(lsn)
+    }
+
+    /// Logs the current full image of a page as a system record (used for
+    /// freshly formatted pages whose creation would not be idempotent as
+    /// per-op records). On append failure the page stays an orphan (never
+    /// referenced), which is safe.
+    pub fn log_system_image(&mut self, page_no: u64) -> Result<u64, StorageError> {
+        let frame = self.fetch(page_no)?;
+        let record = RelRecord::page_image(0, 0, page_no, self.pool.page(frame), &PageOpUndo::None);
+        let lsn = match self.append(&record, false) {
+            Ok(lsn) => lsn,
+            Err(err) => {
+                self.pool.unpin(frame);
+                return Err(err);
+            }
+        };
+        self.dpt.entry(page_no).or_insert(lsn);
+        set_frame_lsn(self.pool.page_mut(frame), lsn);
+        self.pool.unpin(frame);
+        Ok(lsn)
+    }
+
+    /// Logs one ATOMIC record holding the full images of every page of a
+    /// structure change (B+ tree split). The caller keeps all frames pinned
+    /// from the first mutation until this returns, so no steal can write
+    /// unlogged state; a crash either recovers the whole change (one WAL
+    /// entry) or none of it. Frames stay pinned on return (caller unpins).
+    pub fn log_system_images(&mut self, pages: &[(u64, FrameId)]) -> Result<u64, StorageError> {
+        let record = {
+            let images: Vec<(u64, &[u8])> = pages
+                .iter()
+                .map(|(page_no, frame)| (*page_no, self.pool.page(*frame)))
+                .collect();
+            RelRecord::page_images(&images)
+        };
+        let lsn = self.append(&record, false)?;
+        for (page_no, frame) in pages {
+            self.dpt.entry(*page_no).or_insert(lsn);
+            set_frame_lsn(self.pool.page_mut(*frame), lsn);
+        }
+        Ok(lsn)
+    }
+
+    /// Formats a brand-new page (tree or heap) in the pool; the caller logs
+    /// it via [`RelCtx::log_system_image`] once its content is complete.
+    pub fn format_page(
+        &mut self,
+        page_no: u64,
+        page_type: u16,
+        object_id: u32,
+        level: u16,
+    ) -> Result<FrameId, StorageError> {
+        let frame = self.fetch_zeroed(page_no)?;
+        let bytes = self.pool.page_mut(frame);
+        SlottedPage::format(bytes, level);
+        page::write_header(
+            bytes,
+            &PageHeader {
+                page_lsn: 0,
+                page_type,
+                flags: 0,
+                object_id,
+                page_no,
+            },
+        );
+        Ok(frame)
+    }
+}
+
+fn set_frame_lsn(page_bytes: &mut [u8], lsn: u64) {
+    let mut header = page::read_header(page_bytes);
+    header.page_lsn = lsn;
+    page::write_header(page_bytes, &header);
+}
+
+/// Applies a physiological redo op to a page. Used identically by normal
+/// operation and recovery redo, which is what makes redo exact replay.
+pub(crate) fn apply_redo_to_page(
+    page_bytes: &mut [u8],
+    redo: &PageOpRedo,
+) -> Result<(), StorageError> {
+    let full =
+        |what: &str| StorageError::InvalidFile(format!("page full applying {what} (logging bug)"));
+    let mut page = SlottedPage::new(page_bytes);
+    match redo {
+        PageOpRedo::InsertAt { index, bytes, .. } => page
+            .insert_at(*index as usize, bytes)
+            .map_err(|_| full("InsertAt")),
+        PageOpRedo::RemoveAt { index, .. } => {
+            page.remove_at(*index as usize);
+            Ok(())
+        }
+        PageOpRedo::UpdateAt { index, bytes, .. } => page
+            .update_at(*index as usize, bytes)
+            .map_err(|_| full("UpdateAt")),
+        PageOpRedo::HeapInsert { slot, bytes, .. } => page
+            .insert_stable_at(*slot as usize, bytes)
+            .map_err(|_| full("HeapInsert")),
+        PageOpRedo::HeapDelete { slot, .. } => {
+            page.delete_stable(*slot as usize);
+            Ok(())
+        }
+        PageOpRedo::HeapUpdate { slot, bytes, .. } => page
+            .update_stable(*slot as usize, bytes)
+            .map_err(|_| full("HeapUpdate")),
+        PageOpRedo::SetNextPage { next, .. } => {
+            page.set_next_page(*next);
+            Ok(())
+        }
+    }
+}

--- a/crates/truthdb-core/src/relstore/heap.rs
+++ b/crates/truthdb-core/src/relstore/heap.rs
@@ -1,0 +1,381 @@
+//! Heap table: unordered rows addressed by stable RIDs (page, slot), pages
+//! linked into a chain. Updates that no longer fit in place move the row and
+//! leave a forwarding stub at the home slot, so RIDs stay valid.
+//!
+//! Cell format (1-byte tag prefix):
+//! - `0` home row: `[0][row bytes]`
+//! - `1` forwarding stub: `[1][target page u64][target slot u16]`
+//! - `2` moved row: `[2][home page u64][home slot u16][row bytes]` — the
+//!   back-pointer lets deletes and moves keep the home stub consistent.
+//!
+//! All mutations are physical slot operations logged with physical undos
+//! (RIDs are stable, so physical undo is exact).
+
+use crate::relstore::ctx::{LogMode, RelCtx, TxnLink};
+use crate::relstore::page::PAGE_TYPE_HEAP;
+use crate::relstore::slotted::{NO_PAGE, STRUCT_HEADER_END, SlottedRead};
+use crate::storage::StorageError;
+use crate::storage_layout::PAGE_SIZE;
+use crate::wal::records::{PageOpRedo, PageOpUndo};
+
+const TAG_ROW: u8 = 0;
+const TAG_STUB: u8 = 1;
+const TAG_MOVED: u8 = 2;
+
+const STUB_LEN: usize = 1 + 8 + 2;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Rid {
+    pub page: u64,
+    pub slot: u16,
+}
+
+pub(crate) struct Heap {
+    pub object_id: u32,
+    pub first_page: u64,
+}
+
+fn row_cell(row: &[u8]) -> Vec<u8> {
+    let mut cell = Vec::with_capacity(1 + row.len());
+    cell.push(TAG_ROW);
+    cell.extend_from_slice(row);
+    cell
+}
+
+fn stub_cell(target: Rid) -> Vec<u8> {
+    let mut cell = Vec::with_capacity(STUB_LEN);
+    cell.push(TAG_STUB);
+    cell.extend_from_slice(&target.page.to_le_bytes());
+    cell.extend_from_slice(&target.slot.to_le_bytes());
+    cell
+}
+
+fn moved_cell(home: Rid, row: &[u8]) -> Vec<u8> {
+    let mut cell = Vec::with_capacity(11 + row.len());
+    cell.push(TAG_MOVED);
+    cell.extend_from_slice(&home.page.to_le_bytes());
+    cell.extend_from_slice(&home.slot.to_le_bytes());
+    cell.extend_from_slice(row);
+    cell
+}
+
+fn parse_rid(bytes: &[u8]) -> Rid {
+    Rid {
+        page: u64::from_le_bytes(bytes[0..8].try_into().unwrap()),
+        slot: u16::from_le_bytes(bytes[8..10].try_into().unwrap()),
+    }
+}
+
+impl Heap {
+    /// Creates the heap's first page (logged as a system image).
+    pub fn create(ctx: &mut RelCtx<'_>, object_id: u32) -> Result<Heap, StorageError> {
+        let first_page = ctx.allocate_page(0)?;
+        let frame = ctx.format_page(first_page, PAGE_TYPE_HEAP, object_id, 0)?;
+        ctx.pool.unpin(frame);
+        ctx.log_system_image(first_page)?;
+        Ok(Heap {
+            object_id,
+            first_page,
+        })
+    }
+
+    /// Inserts a row, returning its RID.
+    pub fn insert(
+        &self,
+        ctx: &mut RelCtx<'_>,
+        txn: &mut TxnLink,
+        row: &[u8],
+    ) -> Result<Rid, StorageError> {
+        let cell = row_cell(row);
+        let (page_no, slot) = self.place_cell(ctx, txn, &cell)?;
+        Ok(Rid {
+            page: page_no,
+            slot,
+        })
+    }
+
+    /// Finds (or allocates) a page with room for `cell` and inserts it,
+    /// logging the insert with an undo. Returns (page, slot).
+    fn place_cell(
+        &self,
+        ctx: &mut RelCtx<'_>,
+        txn: &mut TxnLink,
+        cell: &[u8],
+    ) -> Result<(u64, u16), StorageError> {
+        if cell.len() + 4 > PAGE_SIZE - STRUCT_HEADER_END {
+            return Err(StorageError::InvalidConfig(
+                "row too large for a heap page".to_string(),
+            ));
+        }
+        let mut page_no = self.first_page;
+        loop {
+            let frame = ctx.fetch(page_no)?;
+            let page = SlottedRead::new(ctx.pool.page(frame));
+            // Choose the slot without mutating: the actual mutation goes
+            // through apply_op so it is logged.
+            let slot = if page.total_free() >= cell.len() + 4 {
+                Some(next_stable_slot(&page))
+            } else {
+                None
+            };
+            let next = page.next_page();
+            ctx.pool.unpin(frame);
+
+            if let Some(slot) = slot {
+                ctx.apply_op(
+                    LogMode::Txn(
+                        txn,
+                        PageOpUndo::HeapDeleteSlot {
+                            page: page_no,
+                            slot: slot as u16,
+                        },
+                    ),
+                    PageOpRedo::HeapInsert {
+                        page: page_no,
+                        slot: slot as u16,
+                        bytes: cell.to_vec(),
+                    },
+                )?;
+                return Ok((page_no, slot as u16));
+            }
+            if next == NO_PAGE {
+                // Grow the chain: new page (system image), then link it.
+                let new_page = ctx.allocate_page(txn.txn_id)?;
+                let frame = ctx.format_page(new_page, PAGE_TYPE_HEAP, self.object_id, 0)?;
+                ctx.pool.unpin(frame);
+                ctx.log_system_image(new_page)?;
+                ctx.apply_op(
+                    LogMode::System,
+                    PageOpRedo::SetNextPage {
+                        page: page_no,
+                        next: new_page,
+                    },
+                )?;
+                page_no = new_page;
+            } else {
+                page_no = next;
+            }
+        }
+    }
+
+    fn read_cell(&self, ctx: &mut RelCtx<'_>, rid: Rid) -> Result<Option<Vec<u8>>, StorageError> {
+        let frame = ctx.fetch(rid.page)?;
+        let page = SlottedRead::new(ctx.pool.page(frame));
+        let copy = if (rid.slot as usize) < page.slot_count() {
+            page.get(rid.slot as usize).map(|c| c.to_vec())
+        } else {
+            None
+        };
+        ctx.pool.unpin(frame);
+        Ok(copy)
+    }
+
+    /// Deletes the row at `rid` (home slot), including a moved copy.
+    /// Returns false if already gone.
+    pub fn delete(
+        &self,
+        ctx: &mut RelCtx<'_>,
+        txn: &mut TxnLink,
+        rid: Rid,
+    ) -> Result<bool, StorageError> {
+        let Some(cell) = self.read_cell(ctx, rid)? else {
+            return Ok(false);
+        };
+        match cell[0] {
+            TAG_ROW | TAG_MOVED => {
+                self.delete_cell(ctx, txn, rid, &cell)?;
+                Ok(true)
+            }
+            TAG_STUB => {
+                let target = parse_rid(&cell[1..]);
+                if let Some(target_cell) = self.read_cell(ctx, target)? {
+                    self.delete_cell(ctx, txn, target, &target_cell)?;
+                }
+                self.delete_cell(ctx, txn, rid, &cell)?;
+                Ok(true)
+            }
+            other => Err(StorageError::InvalidFile(format!(
+                "unknown heap cell tag {other}"
+            ))),
+        }
+    }
+
+    fn delete_cell(
+        &self,
+        ctx: &mut RelCtx<'_>,
+        txn: &mut TxnLink,
+        rid: Rid,
+        old_cell: &[u8],
+    ) -> Result<(), StorageError> {
+        ctx.apply_op(
+            LogMode::Txn(
+                txn,
+                PageOpUndo::HeapInsertRow {
+                    page: rid.page,
+                    slot: rid.slot,
+                    bytes: old_cell.to_vec(),
+                },
+            ),
+            PageOpRedo::HeapDelete {
+                page: rid.page,
+                slot: rid.slot,
+            },
+        )?;
+        Ok(())
+    }
+
+    /// Updates the row at `rid` in place when possible, otherwise moves it
+    /// and leaves/updates the forwarding stub. Returns false if the row is
+    /// gone.
+    pub fn update(
+        &self,
+        ctx: &mut RelCtx<'_>,
+        txn: &mut TxnLink,
+        rid: Rid,
+        new_row: &[u8],
+    ) -> Result<bool, StorageError> {
+        let Some(cell) = self.read_cell(ctx, rid)? else {
+            return Ok(false);
+        };
+        match cell[0] {
+            TAG_ROW => {
+                let new_cell = row_cell(new_row);
+                if self.update_fits(ctx, rid, new_cell.len())? {
+                    self.update_cell(ctx, txn, rid, &cell, &new_cell)?;
+                } else {
+                    // Move: place a moved-cell elsewhere, shrink home to a
+                    // stub. A stub can be BIGGER than a tiny home cell on a
+                    // full page — check before mutating anything so the
+                    // statement fails cleanly instead of half-applied.
+                    if !self.update_fits(ctx, rid, STUB_LEN)? {
+                        return Err(StorageError::Constraint(format!(
+                            "row cannot grow: page {} is too full to hold a forwarding stub",
+                            rid.page
+                        )));
+                    }
+                    let moved = moved_cell(rid, new_row);
+                    let (page, slot) = self.place_cell(ctx, txn, &moved)?;
+                    let stub = stub_cell(Rid { page, slot });
+                    self.update_cell(ctx, txn, rid, &cell, &stub)?;
+                }
+                Ok(true)
+            }
+            TAG_MOVED => {
+                let home = parse_rid(&cell[1..]);
+                let new_cell = moved_cell(home, new_row);
+                if self.update_fits(ctx, rid, new_cell.len())? {
+                    self.update_cell(ctx, txn, rid, &cell, &new_cell)?;
+                } else {
+                    let (page, slot) = self.place_cell(ctx, txn, &new_cell)?;
+                    // Repoint the home stub, then drop the old copy.
+                    let home_cell = self.read_cell(ctx, home)?.ok_or_else(|| {
+                        StorageError::InvalidFile("moved row without home stub".to_string())
+                    })?;
+                    self.update_cell(ctx, txn, home, &home_cell, &stub_cell(Rid { page, slot }))?;
+                    self.delete_cell(ctx, txn, rid, &cell)?;
+                }
+                Ok(true)
+            }
+            TAG_STUB => {
+                let target = parse_rid(&cell[1..]);
+                if self.read_cell(ctx, target)?.is_none() {
+                    return Ok(false);
+                }
+                self.update(ctx, txn, target, new_row)
+            }
+            other => Err(StorageError::InvalidFile(format!(
+                "unknown heap cell tag {other}"
+            ))),
+        }
+    }
+
+    fn update_fits(
+        &self,
+        ctx: &mut RelCtx<'_>,
+        rid: Rid,
+        new_len: usize,
+    ) -> Result<bool, StorageError> {
+        let frame = ctx.fetch(rid.page)?;
+        let page = SlottedRead::new(ctx.pool.page(frame));
+        let old_len = page.get(rid.slot as usize).map(|c| c.len()).unwrap_or(0);
+        let fits = new_len <= old_len || page.total_free() + old_len >= new_len;
+        ctx.pool.unpin(frame);
+        Ok(fits)
+    }
+
+    fn update_cell(
+        &self,
+        ctx: &mut RelCtx<'_>,
+        txn: &mut TxnLink,
+        rid: Rid,
+        old_cell: &[u8],
+        new_cell: &[u8],
+    ) -> Result<(), StorageError> {
+        ctx.apply_op(
+            LogMode::Txn(
+                txn,
+                PageOpUndo::HeapUpdateRow {
+                    page: rid.page,
+                    slot: rid.slot,
+                    bytes: old_cell.to_vec(),
+                },
+            ),
+            PageOpRedo::HeapUpdate {
+                page: rid.page,
+                slot: rid.slot,
+                bytes: new_cell.to_vec(),
+            },
+        )?;
+        Ok(())
+    }
+
+    /// Scans all rows: (home RID, row bytes). Moved rows report their home
+    /// RID; stubs and tombstones are skipped.
+    pub fn scan(&self, ctx: &mut RelCtx<'_>) -> Result<Vec<(Rid, Vec<u8>)>, StorageError> {
+        let mut out = Vec::new();
+        let mut page_no = self.first_page;
+        while page_no != NO_PAGE {
+            let frame = ctx.fetch(page_no)?;
+            let page = SlottedRead::new(ctx.pool.page(frame));
+            let next = page.next_page();
+            let mut bad_tag = None;
+            for slot in 0..page.slot_count() {
+                let Some(cell) = page.get(slot) else { continue };
+                match cell[0] {
+                    TAG_ROW => out.push((
+                        Rid {
+                            page: page_no,
+                            slot: slot as u16,
+                        },
+                        cell[1..].to_vec(),
+                    )),
+                    TAG_MOVED => out.push((parse_rid(&cell[1..]), cell[11..].to_vec())),
+                    TAG_STUB => {}
+                    other => {
+                        bad_tag = Some(other);
+                        break;
+                    }
+                }
+            }
+            ctx.pool.unpin(frame);
+            if let Some(tag) = bad_tag {
+                return Err(StorageError::InvalidFile(format!(
+                    "unknown heap cell tag {tag}"
+                )));
+            }
+            page_no = next;
+        }
+        Ok(out)
+    }
+}
+
+/// Picks the slot a stable insert will use without mutating the page
+/// (mirrors `SlottedPage::insert_stable`).
+fn next_stable_slot(page: &SlottedRead<'_>) -> usize {
+    for i in 0..page.slot_count() {
+        if page.get(i).is_none() {
+            return i;
+        }
+    }
+    page.slot_count()
+}

--- a/crates/truthdb-core/src/relstore/key.rs
+++ b/crates/truthdb-core/src/relstore/key.rs
@@ -1,0 +1,307 @@
+//! Order-preserving key encoding: encoded keys compare with `memcmp` in the
+//! same order as their typed values.
+//!
+//! Per key column: a NULL sorts first as a single `0x00` byte; non-NULL
+//! values are `0x01` followed by a type-specific payload:
+//! - integers/decimals: big-endian with the sign bit flipped
+//! - floats: IEEE-754 total-order transform, big-endian
+//! - date/time/datetime2: their tick counts, big-endian (date-major)
+//! - uniqueidentifier: bytes permuted into SQL Server comparison order
+//! - strings/binary: raw bytes with `0x00 -> 0x00 0xFF` escaping and a
+//!   `0x00 0x00` terminator so composite keys stay order-preserving
+//!   (NVARCHAR uses UTF-16BE code units — binary collation until Stage 5;
+//!   collation sort keys replace these payloads then).
+//!
+//! Keys are compared, never decoded: B+ tree leaves carry the full row, so
+//! values are always recoverable without reversing this encoding.
+
+use crate::relstore::row::Schema;
+use crate::relstore::types::{Datum, TypeError};
+
+const NULL_MARKER: u8 = 0x00;
+const VALUE_MARKER: u8 = 0x01;
+
+/// SQL Server's uniqueidentifier comparison evaluates bytes in this
+/// significance order (most significant first).
+const GUID_COMPARE_ORDER: [usize; 16] = [10, 11, 12, 13, 14, 15, 8, 9, 7, 6, 5, 4, 3, 2, 1, 0];
+
+/// Encodes the key columns (by schema index) of a row.
+pub fn encode_key(
+    schema: &Schema,
+    key_columns: &[usize],
+    values: &[Datum],
+) -> Result<Vec<u8>, TypeError> {
+    let mut out = Vec::new();
+    for &index in key_columns {
+        let column = schema
+            .columns
+            .get(index)
+            .ok_or_else(|| TypeError(format!("key column index {index} out of range")))?;
+        let value = values
+            .get(index)
+            .ok_or_else(|| TypeError(format!("row has no value for key column {index}")))?;
+        let _ = column;
+        encode_datum(value, &mut out)?;
+    }
+    Ok(out)
+}
+
+pub fn encode_datum(value: &Datum, out: &mut Vec<u8>) -> Result<(), TypeError> {
+    if value.is_null() {
+        out.push(NULL_MARKER);
+        return Ok(());
+    }
+    out.push(VALUE_MARKER);
+    match value {
+        Datum::TinyInt(v) => out.push(*v),
+        Datum::SmallInt(v) => out.extend_from_slice(&((*v as u16) ^ 0x8000).to_be_bytes()),
+        Datum::Int(v) => out.extend_from_slice(&((*v as u32) ^ 0x8000_0000).to_be_bytes()),
+        Datum::BigInt(v) => {
+            out.extend_from_slice(&((*v as u64) ^ 0x8000_0000_0000_0000).to_be_bytes())
+        }
+        Datum::Bit(v) => out.push(*v as u8),
+        Datum::Real(v) => out.extend_from_slice(&total_order_f32(*v).to_be_bytes()),
+        Datum::Float(v) => out.extend_from_slice(&total_order_f64(*v).to_be_bytes()),
+        Datum::Decimal(v) => out.extend_from_slice(&((*v as u128) ^ (1u128 << 127)).to_be_bytes()),
+        Datum::Date(days) => out.extend_from_slice(&days.to_be_bytes()),
+        Datum::Time(ticks) => out.extend_from_slice(&ticks.to_be_bytes()),
+        Datum::DateTime2(days, ticks) => {
+            out.extend_from_slice(&days.to_be_bytes());
+            out.extend_from_slice(&ticks.to_be_bytes());
+        }
+        Datum::UniqueIdentifier(bytes) => {
+            for &position in &GUID_COMPARE_ORDER {
+                out.push(bytes[position]);
+            }
+        }
+        Datum::VarChar(s) => encode_escaped(s.as_bytes(), out),
+        Datum::NVarChar(s) => {
+            let units: Vec<u8> = s.encode_utf16().flat_map(|u| u.to_be_bytes()).collect();
+            encode_escaped(&units, out);
+        }
+        Datum::VarBinary(b) => encode_escaped(b, out),
+        Datum::Null => unreachable!(),
+    }
+    Ok(())
+}
+
+/// Escapes 0x00 bytes so a terminator can mark the end of the value without
+/// breaking ordering: `0x00` becomes `0x00 0xFF`, and the value ends with
+/// `0x00 0x00`. A shorter prefix therefore always sorts before any
+/// continuation.
+fn encode_escaped(bytes: &[u8], out: &mut Vec<u8>) {
+    for &b in bytes {
+        if b == 0x00 {
+            out.push(0x00);
+            out.push(0xFF);
+        } else {
+            out.push(b);
+        }
+    }
+    out.push(0x00);
+    out.push(0x00);
+}
+
+/// IEEE-754 total-order transform: the resulting unsigned integers compare
+/// like the floats (with -0.0 < 0.0 and NaN ordered after +inf).
+fn total_order_f64(v: f64) -> u64 {
+    let bits = v.to_bits();
+    if bits & 0x8000_0000_0000_0000 != 0 {
+        !bits
+    } else {
+        bits ^ 0x8000_0000_0000_0000
+    }
+}
+
+fn total_order_f32(v: f32) -> u32 {
+    let bits = v.to_bits();
+    if bits & 0x8000_0000 != 0 {
+        !bits
+    } else {
+        bits ^ 0x8000_0000
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cmp::Ordering;
+
+    fn encoded(value: &Datum) -> Vec<u8> {
+        let mut out = Vec::new();
+        encode_datum(value, &mut out).expect("encode");
+        out
+    }
+
+    fn assert_order(a: &Datum, b: &Datum, expected: Ordering) {
+        assert_eq!(
+            encoded(a).cmp(&encoded(b)),
+            expected,
+            "key order mismatch for {a:?} vs {b:?}"
+        );
+    }
+
+    /// Deterministic xorshift so the property tests need no new deps.
+    struct Rng(u64);
+    impl Rng {
+        fn next(&mut self) -> u64 {
+            let mut x = self.0;
+            x ^= x << 13;
+            x ^= x >> 7;
+            x ^= x << 17;
+            self.0 = x;
+            x
+        }
+    }
+
+    #[test]
+    fn null_sorts_first() {
+        for value in [
+            Datum::Int(i32::MIN),
+            Datum::BigInt(i64::MIN),
+            Datum::Float(f64::NEG_INFINITY),
+            Datum::VarChar(String::new()),
+        ] {
+            assert_order(&Datum::Null, &value, Ordering::Less);
+        }
+    }
+
+    #[test]
+    fn integer_order_is_preserved() {
+        let mut rng = Rng(0xDEADBEEF12345678);
+        for _ in 0..2000 {
+            let a = rng.next() as i64;
+            let b = rng.next() as i64;
+            assert_order(&Datum::BigInt(a), &Datum::BigInt(b), a.cmp(&b));
+            let (a, b) = (a as i32, b as i32);
+            assert_order(&Datum::Int(a), &Datum::Int(b), a.cmp(&b));
+            let (a, b) = (a as i16, b as i16);
+            assert_order(&Datum::SmallInt(a), &Datum::SmallInt(b), a.cmp(&b));
+        }
+    }
+
+    #[test]
+    fn float_order_is_preserved() {
+        let interesting = [
+            f64::NEG_INFINITY,
+            -1e300,
+            -1.5,
+            -0.0,
+            0.0,
+            f64::MIN_POSITIVE,
+            1.5,
+            1e300,
+            f64::INFINITY,
+        ];
+        for (i, a) in interesting.iter().enumerate() {
+            for (j, b) in interesting.iter().enumerate() {
+                let expected = if i == j {
+                    // -0.0 and 0.0 encode distinctly (total order) but any
+                    // consistent order is fine; only test distinct indices.
+                    continue;
+                } else {
+                    i.cmp(&j)
+                };
+                assert_order(&Datum::Float(*a), &Datum::Float(*b), expected);
+            }
+        }
+    }
+
+    #[test]
+    fn decimal_order_is_preserved() {
+        let mut rng = Rng(0xC0FFEE);
+        for _ in 0..2000 {
+            let a = (rng.next() as i128) * (rng.next() as i64 as i128);
+            let b = (rng.next() as i128) * (rng.next() as i64 as i128);
+            assert_order(&Datum::Decimal(a), &Datum::Decimal(b), a.cmp(&b));
+        }
+    }
+
+    #[test]
+    fn string_order_and_embedded_zero_safety() {
+        assert_order(
+            &Datum::VarChar("a".to_string()),
+            &Datum::VarChar("b".to_string()),
+            Ordering::Less,
+        );
+        assert_order(
+            &Datum::VarChar("a".to_string()),
+            &Datum::VarChar("ab".to_string()),
+            Ordering::Less,
+        );
+        // Embedded NUL must not terminate the key early.
+        assert_order(
+            &Datum::VarBinary(vec![0x61]),
+            &Datum::VarBinary(vec![0x61, 0x00]),
+            Ordering::Less,
+        );
+        assert_order(
+            &Datum::VarBinary(vec![0x61, 0x00]),
+            &Datum::VarBinary(vec![0x61, 0x00, 0x00]),
+            Ordering::Less,
+        );
+        assert_order(
+            &Datum::VarBinary(vec![0x61, 0x00, 0xFF]),
+            &Datum::VarBinary(vec![0x61, 0x01]),
+            Ordering::Less,
+        );
+    }
+
+    #[test]
+    fn composite_keys_compare_column_major() {
+        use crate::relstore::row::Column;
+        use crate::relstore::types::ColumnType;
+        let schema = Schema {
+            columns: vec![
+                Column {
+                    name: "a".to_string(),
+                    column_type: ColumnType::VarChar { max_len: 10 },
+                    nullable: true,
+                },
+                Column {
+                    name: "b".to_string(),
+                    column_type: ColumnType::Int,
+                    nullable: true,
+                },
+            ],
+        };
+        let key = |s: &str, n: i32| {
+            encode_key(
+                &schema,
+                &[0, 1],
+                &[Datum::VarChar(s.to_string()), Datum::Int(n)],
+            )
+            .expect("key")
+        };
+        // First column dominates; the terminator keeps "ab" < "b" even
+        // though 'b' bytes follow in the second key.
+        assert!(key("ab", 999) < key("b", 0));
+        assert!(key("a", 2) < key("a", 10));
+        assert!(key("a", 10) < key("ab", 0));
+    }
+
+    #[test]
+    fn temporal_order_is_chronological() {
+        assert_order(&Datum::Date(100), &Datum::Date(101), Ordering::Less);
+        assert_order(&Datum::Time(5), &Datum::Time(6), Ordering::Less);
+        assert_order(
+            &Datum::DateTime2(100, u64::MAX >> 24),
+            &Datum::DateTime2(101, 0),
+            Ordering::Less,
+        );
+    }
+
+    #[test]
+    fn guid_order_matches_sql_server_byte_groups() {
+        // Differ only in byte 15 (most significant group) vs byte 0 (least).
+        let mut low = [0u8; 16];
+        let mut high = [0u8; 16];
+        low[0] = 0xFF; // least significant position
+        high[15] = 0x01; // part of the most significant group
+        assert_order(
+            &Datum::UniqueIdentifier(low),
+            &Datum::UniqueIdentifier(high),
+            Ordering::Less,
+        );
+    }
+}

--- a/crates/truthdb-core/src/relstore/mod.rs
+++ b/crates/truthdb-core/src/relstore/mod.rs
@@ -1,8 +1,70 @@
-//! Relational on-disk structures (Stage 1: page format and buffer pool).
-//!
-//! Slotted pages, B+ trees and heaps arrive in Stage 2; this module currently
-//! provides the shared page header/checksum format and the buffer pool that
-//! all relational structures will sit on.
+//! Relational on-disk structures: page format, buffer pool, row/key codecs,
+//! slotted pages, clustered B+ trees, heaps, catalog storage and ARIES
+//! restart. Stage 2 exposes them through `Storage`'s `rel_*` methods and
+//! temporary debug commands; the SQL layer (Stage 3+) replaces the command
+//! surface, not the storage.
 
+pub mod btree;
 pub mod buffer_pool;
+pub mod catalog;
+pub(crate) mod ctx;
+pub mod heap;
+pub mod key;
 pub mod page;
+pub mod recovery;
+pub mod row;
+pub mod slotted;
+#[cfg(test)]
+mod tests;
+pub mod types;
+
+use std::collections::HashMap;
+
+use buffer_pool::BufferPool;
+use catalog::{CATALOG_OBJECT_ID, FIRST_USER_OBJECT_ID, TableDef};
+
+/// In-memory relational state owned by the storage file.
+pub(crate) struct RelState {
+    pub pool: BufferPool,
+    /// Set when a commit or rollback could not be logged: the pool may hold
+    /// state the WAL cannot explain, so all relational work — and above all
+    /// checkpoints, which would make that state durable and unrecoverable —
+    /// is refused until a restart replays the log.
+    pub wedged: bool,
+    /// Pages dirtied since the last checkpoint -> LSN of their first change.
+    pub dpt: HashMap<u64, u64>,
+    pub catalog_root: Option<u64>,
+    /// Catalog cache: table name -> definition.
+    pub tables: HashMap<String, TableDef>,
+    pub next_txn_id: u64,
+    pub next_object_id: u32,
+}
+
+impl RelState {
+    pub fn new(pool_capacity_bytes: u64) -> Self {
+        RelState {
+            pool: BufferPool::new(pool_capacity_bytes),
+            wedged: false,
+            dpt: HashMap::new(),
+            catalog_root: None,
+            tables: HashMap::new(),
+            next_txn_id: 1,
+            next_object_id: FIRST_USER_OBJECT_ID,
+        }
+    }
+
+    /// Stable root pages by object id (for logical tree undos), including
+    /// the catalog tree itself.
+    pub fn tree_roots(&self) -> HashMap<u32, u64> {
+        let mut roots = HashMap::new();
+        if let Some(root) = self.catalog_root {
+            roots.insert(CATALOG_OBJECT_ID, root);
+        }
+        for def in self.tables.values() {
+            if def.is_tree() {
+                roots.insert(def.object_id, def.root_page);
+            }
+        }
+        roots
+    }
+}

--- a/crates/truthdb-core/src/relstore/page.rs
+++ b/crates/truthdb-core/src/relstore/page.rs
@@ -19,6 +19,10 @@ use crate::storage_layout::PAGE_SIZE;
 pub const PAGE_HEADER_SIZE: usize = 32;
 
 pub const PAGE_TYPE_FREE: u16 = 0;
+/// B+ tree page (leaf vs internal distinguished by the structure header's
+/// level field).
+pub const PAGE_TYPE_TREE: u16 = 1;
+pub const PAGE_TYPE_HEAP: u16 = 2;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct PageHeader {

--- a/crates/truthdb-core/src/relstore/recovery.rs
+++ b/crates/truthdb-core/src/relstore/recovery.rs
@@ -1,0 +1,327 @@
+//! ARIES restart for the relational store: analysis, LSN-gated redo
+//! (repeating history, including CLRs), and undo of loser transactions with
+//! compensation logging.
+//!
+//! The WAL head is the recovery horizon: checkpoints flush every dirty
+//! relational page and only advance the head past records no crash could
+//! still need (no active transactions can span a checkpoint while the engine
+//! is single-threaded), so analysis simply scans everything from the head.
+//!
+//! Undo of one record may need several page ops (logical tree undos can
+//! split pages). Every CLR of that group carries `undo_next = record.lsn`
+//! (re-run the whole group on a crash — the ops are written to tolerate
+//! partial prior application), and a final no-op CLR with
+//! `undo_next = record.prev_lsn` seals the group.
+
+use std::collections::HashMap;
+
+use crate::relstore::btree::{BTree, apply_tree_undo};
+use crate::relstore::ctx::{OpMode, RelCtx, TxnLink, apply_redo_to_page};
+use crate::relstore::page;
+use crate::relstore::slotted::SlottedRead;
+use crate::storage::StorageError;
+use crate::wal::records::{
+    PageOpRedo, PageOpUndo, REL_KIND_ALLOC_EXTENT, REL_KIND_CLR, REL_KIND_FREE_EXTENT,
+    REL_KIND_PAGE_IMAGE, REL_KIND_PAGE_IMAGES, REL_KIND_PAGE_OP, REL_KIND_SET_CATALOG_ROOT,
+    REL_KIND_TXN_BEGIN, REL_KIND_TXN_COMMIT, REL_KIND_TXN_END, RelRecord,
+};
+
+pub(crate) struct AnalysisRedoOutcome {
+    /// Loser transactions: id -> last LSN of their chain.
+    pub losers: HashMap<u64, u64>,
+    /// Catalog root from the newest SET_CATALOG_ROOT record, if any.
+    pub catalog_root: Option<u64>,
+    /// Highest transaction id seen (0 when none).
+    pub max_txn_id: u64,
+}
+
+/// Analysis + redo over the recovered records (`(lsn, record)`, log order).
+pub(crate) fn analyze_and_redo(
+    ctx: &mut RelCtx<'_>,
+    records: &[(u64, RelRecord)],
+) -> Result<AnalysisRedoOutcome, StorageError> {
+    // Analysis: rebuild the active-transaction table.
+    let mut att: HashMap<u64, u64> = HashMap::new();
+    let mut catalog_root = None;
+    let mut max_txn_id = 0u64;
+    for (lsn, record) in records {
+        max_txn_id = max_txn_id.max(record.txn_id);
+        match record.kind {
+            REL_KIND_TXN_BEGIN => {
+                att.insert(record.txn_id, *lsn);
+            }
+            REL_KIND_TXN_COMMIT | REL_KIND_TXN_END => {
+                att.remove(&record.txn_id);
+            }
+            REL_KIND_PAGE_OP | REL_KIND_PAGE_IMAGE | REL_KIND_PAGE_IMAGES | REL_KIND_CLR => {
+                if record.txn_id != 0 {
+                    att.insert(record.txn_id, *lsn);
+                }
+            }
+            REL_KIND_SET_CATALOG_ROOT => {
+                catalog_root = Some(record.decode_catalog_root()?);
+            }
+            REL_KIND_ALLOC_EXTENT | REL_KIND_FREE_EXTENT => {}
+            other => {
+                return Err(StorageError::InvalidFile(format!(
+                    "unknown rel record kind {other} during analysis"
+                )));
+            }
+        }
+    }
+
+    // Redo: repeat history in log order, gated by each page's LSN.
+    for (lsn, record) in records {
+        match record.kind {
+            REL_KIND_PAGE_IMAGE => {
+                let (page_no, image) = record.decode_page_image()?;
+                redo_page_image(ctx, *lsn, page_no, image)?;
+            }
+            REL_KIND_PAGE_IMAGES => {
+                for (page_no, image) in record.decode_page_images()? {
+                    redo_page_image(ctx, *lsn, page_no, image)?;
+                }
+            }
+            REL_KIND_PAGE_OP => {
+                let redo = record.decode_page_op_redo()?;
+                redo_page_op(ctx, *lsn, &redo)?;
+            }
+            REL_KIND_CLR => {
+                let (_, redo) = record.decode_clr()?;
+                if let Some(redo) = redo {
+                    redo_page_op(ctx, *lsn, &redo)?;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    Ok(AnalysisRedoOutcome {
+        losers: att,
+        catalog_root,
+        max_txn_id,
+    })
+}
+
+/// Full-image redo: replaces the page wholesale when its LSN is older —
+/// including pages whose on-disk state is torn (checksum-invalid), which is
+/// exactly what the image is there to repair.
+fn redo_page_image(
+    ctx: &mut RelCtx<'_>,
+    lsn: u64,
+    page_no: u64,
+    image: &[u8],
+) -> Result<(), StorageError> {
+    let frame = match ctx.fetch(page_no) {
+        Ok(frame) => {
+            if page::page_lsn(ctx.pool.page(frame)) >= lsn {
+                ctx.pool.unpin(frame);
+                return Ok(());
+            }
+            frame
+        }
+        // Torn page: take a zeroed frame and repair from the image.
+        Err(_) => ctx.fetch_zeroed(page_no)?,
+    };
+    let bytes = ctx.pool.page_mut(frame);
+    bytes.copy_from_slice(image);
+    let mut header = page::read_header(bytes);
+    header.page_lsn = lsn;
+    page::write_header(bytes, &header);
+    ctx.pool.unpin(frame);
+    ctx.dpt.entry(page_no).or_insert(lsn);
+    Ok(())
+}
+
+fn redo_page_op(ctx: &mut RelCtx<'_>, lsn: u64, redo: &PageOpRedo) -> Result<(), StorageError> {
+    let page_no = redo.page();
+    let frame = ctx.fetch(page_no)?;
+    let bytes = ctx.pool.page(frame);
+    if page::page_lsn(bytes) >= lsn {
+        ctx.pool.unpin(frame);
+        return Ok(());
+    }
+    let bytes = ctx.pool.page_mut(frame);
+    let applied = apply_redo_to_page(bytes, redo);
+    if applied.is_ok() {
+        let mut header = page::read_header(bytes);
+        header.page_lsn = lsn;
+        page::write_header(bytes, &header);
+    }
+    ctx.pool.unpin(frame);
+    applied?;
+    ctx.dpt.entry(page_no).or_insert(lsn);
+    Ok(())
+}
+
+/// Undoes every loser transaction, logging CLRs, ending each with a TXN_END.
+/// `tree_roots` maps object ids to their (stable) root pages for logical
+/// tree undos.
+pub(crate) fn undo_losers(
+    ctx: &mut RelCtx<'_>,
+    records: &[(u64, RelRecord)],
+    losers: &HashMap<u64, u64>,
+    tree_roots: &HashMap<u32, u64>,
+) -> Result<(), StorageError> {
+    // Undo may append CLRs into a ring that a forward statement filled:
+    // compensation records are allowed into the WAL's reserve.
+    ctx.use_reserve = true;
+    let by_lsn: HashMap<u64, &RelRecord> =
+        records.iter().map(|(lsn, record)| (*lsn, record)).collect();
+
+    // cursor = next record to undo; link = the CLR chain tail.
+    let mut active: HashMap<u64, (u64, TxnLink)> = losers
+        .iter()
+        .map(|(&txn_id, &last_lsn)| {
+            (
+                txn_id,
+                (
+                    last_lsn,
+                    TxnLink {
+                        txn_id,
+                        last_lsn,
+                        undo_log: Vec::new(),
+                    },
+                ),
+            )
+        })
+        .collect();
+
+    // Single backward sweep: always continue with the globally largest
+    // cursor (ARIES multi-transaction undo).
+    loop {
+        let Some((txn_id, cursor)) = active
+            .iter()
+            .map(|(&txn_id, &(cursor, _))| (txn_id, cursor))
+            .max_by_key(|&(_, cursor)| cursor)
+        else {
+            break;
+        };
+        let record = *by_lsn.get(&cursor).ok_or_else(|| {
+            StorageError::InvalidFile(format!(
+                "undo needs record at lsn {cursor}, which is no longer in the wal"
+            ))
+        })?;
+        let next_cursor = match record.kind {
+            REL_KIND_CLR => record.decode_clr()?.0,
+            REL_KIND_PAGE_OP | REL_KIND_PAGE_IMAGE => {
+                let undo = record.decode_page_op_undo()?;
+                let (_, link) = active.get_mut(&txn_id).expect("active loser");
+                undo_one(ctx, link, &undo, cursor, record.prev_lsn, tree_roots)?;
+                record.prev_lsn
+            }
+            REL_KIND_TXN_BEGIN => 0,
+            _ => record.prev_lsn,
+        };
+        if next_cursor == 0 {
+            let (_, link) = active.remove(&txn_id).expect("active loser");
+            ctx.append(&RelRecord::txn_end(txn_id, link.last_lsn), false)?;
+        } else {
+            active.get_mut(&txn_id).expect("active loser").0 = next_cursor;
+        }
+    }
+    Ok(())
+}
+
+/// Undoes one record as a CLR group: the compensating ops (tolerant of
+/// partial prior application), then a sealing no-op CLR that moves the undo
+/// cursor past the record.
+pub(crate) fn undo_one(
+    ctx: &mut RelCtx<'_>,
+    link: &mut TxnLink,
+    undo: &PageOpUndo,
+    record_lsn: u64,
+    record_prev: u64,
+    tree_roots: &HashMap<u32, u64>,
+) -> Result<(), StorageError> {
+    {
+        let mut mode = OpMode::Clr {
+            txn: link,
+            undo_next: record_lsn,
+        };
+        match undo {
+            PageOpUndo::None => {}
+            PageOpUndo::TreeDeleteKey { object_id, .. }
+            | PageOpUndo::TreeInsertRow { object_id, .. }
+            | PageOpUndo::TreeUpdateRow { object_id, .. } => {
+                let root = *tree_roots.get(object_id).ok_or_else(|| {
+                    StorageError::InvalidFile(format!(
+                        "undo references unknown tree object {object_id}"
+                    ))
+                })?;
+                let tree = BTree {
+                    object_id: *object_id,
+                    root,
+                };
+                apply_tree_undo(ctx, &mut mode, &tree, undo)?;
+            }
+            PageOpUndo::HeapDeleteSlot { page, slot } => {
+                if heap_slot_occupied(ctx, *page, *slot)? {
+                    ctx.apply_op(
+                        mode.log_mode(PageOpUndo::None),
+                        PageOpRedo::HeapDelete {
+                            page: *page,
+                            slot: *slot,
+                        },
+                    )?;
+                }
+            }
+            PageOpUndo::HeapInsertRow { page, slot, bytes } => {
+                if !heap_slot_occupied(ctx, *page, *slot)? {
+                    ctx.apply_op(
+                        mode.log_mode(PageOpUndo::None),
+                        PageOpRedo::HeapInsert {
+                            page: *page,
+                            slot: *slot,
+                            bytes: bytes.clone(),
+                        },
+                    )?;
+                }
+            }
+            PageOpUndo::HeapUpdateRow { page, slot, bytes } => {
+                ctx.apply_op(
+                    mode.log_mode(PageOpUndo::None),
+                    PageOpRedo::HeapUpdate {
+                        page: *page,
+                        slot: *slot,
+                        bytes: bytes.clone(),
+                    },
+                )?;
+            }
+        }
+    }
+    // Seal the group: the undo cursor may now move past the record.
+    let seal = RelRecord::clr_noop(link.txn_id, link.last_lsn, record_prev);
+    link.last_lsn = ctx.append(&seal, false)?;
+    Ok(())
+}
+
+/// Rolls back a live transaction (statement failure) using its in-memory
+/// undo log; same CLR discipline as recovery undo.
+pub(crate) fn rollback(
+    ctx: &mut RelCtx<'_>,
+    mut txn: TxnLink,
+    tree_roots: &HashMap<u32, u64>,
+) -> Result<(), StorageError> {
+    ctx.use_reserve = true;
+    let entries: Vec<(u64, PageOpUndo)> = std::mem::take(&mut txn.undo_log);
+    let begin_prev = 0u64;
+    for (index, (lsn, undo)) in entries.iter().enumerate().rev() {
+        let prev = if index == 0 {
+            begin_prev
+        } else {
+            entries[index - 1].0
+        };
+        undo_one(ctx, &mut txn, undo, *lsn, prev, tree_roots)?;
+    }
+    ctx.append(&RelRecord::txn_end(txn.txn_id, txn.last_lsn), false)?;
+    Ok(())
+}
+
+fn heap_slot_occupied(ctx: &mut RelCtx<'_>, page_no: u64, slot: u16) -> Result<bool, StorageError> {
+    let frame = ctx.fetch(page_no)?;
+    let page = SlottedRead::new(ctx.pool.page(frame));
+    let occupied = (slot as usize) < page.slot_count() && page.get(slot as usize).is_some();
+    ctx.pool.unpin(frame);
+    Ok(occupied)
+}

--- a/crates/truthdb-core/src/relstore/row.rs
+++ b/crates/truthdb-core/src/relstore/row.rs
@@ -1,0 +1,304 @@
+//! Row codec: `null bitmap | fixed section | var end-offsets | var data`.
+//!
+//! Fixed-width columns occupy their slot in schema order whether or not they
+//! are NULL (zeroed when NULL); variable-width columns store u16 end offsets
+//! relative to the start of the var-data section, so value `i` spans
+//! `[end[i-1], end[i])`. Rows are capped at [`MAX_ROW_BYTES`] until overflow
+//! pages arrive (Stage 14).
+
+use crate::relstore::types::{ColumnType, Datum, TypeError};
+
+/// In-row size cap (bytes), leaving page-header/slot overhead inside a 4 KiB
+/// page.
+pub const MAX_ROW_BYTES: usize = 3900;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Column {
+    pub name: String,
+    pub column_type: ColumnType,
+    pub nullable: bool,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Schema {
+    pub columns: Vec<Column>,
+}
+
+impl Schema {
+    fn null_bitmap_len(&self) -> usize {
+        self.columns.len().div_ceil(8)
+    }
+
+    fn fixed_section_len(&self) -> usize {
+        self.columns
+            .iter()
+            .filter_map(|c| c.column_type.fixed_size())
+            .sum()
+    }
+
+    fn var_column_count(&self) -> usize {
+        self.columns
+            .iter()
+            .filter(|c| c.column_type.fixed_size().is_none())
+            .count()
+    }
+}
+
+/// Checks that a datum's variant matches the column type (or is NULL).
+fn datum_matches(column_type: &ColumnType, datum: &Datum) -> bool {
+    matches!(
+        (column_type, datum),
+        (_, Datum::Null)
+            | (ColumnType::TinyInt, Datum::TinyInt(_))
+            | (ColumnType::SmallInt, Datum::SmallInt(_))
+            | (ColumnType::Int, Datum::Int(_))
+            | (ColumnType::BigInt, Datum::BigInt(_))
+            | (ColumnType::Bit, Datum::Bit(_))
+            | (ColumnType::Real, Datum::Real(_))
+            | (ColumnType::Float, Datum::Float(_))
+            | (ColumnType::Decimal { .. }, Datum::Decimal(_))
+            | (ColumnType::Date, Datum::Date(_))
+            | (ColumnType::Time, Datum::Time(_))
+            | (ColumnType::DateTime2, Datum::DateTime2(_, _))
+            | (ColumnType::UniqueIdentifier, Datum::UniqueIdentifier(_))
+            | (ColumnType::VarChar { .. }, Datum::VarChar(_))
+            | (ColumnType::NVarChar { .. }, Datum::NVarChar(_))
+            | (ColumnType::VarBinary { .. }, Datum::VarBinary(_))
+    )
+}
+
+pub fn encode_row(schema: &Schema, values: &[Datum]) -> Result<Vec<u8>, TypeError> {
+    if values.len() != schema.columns.len() {
+        return Err(TypeError(format!(
+            "row arity mismatch: {} values for {} columns",
+            values.len(),
+            schema.columns.len()
+        )));
+    }
+    for (column, value) in schema.columns.iter().zip(values) {
+        if !datum_matches(&column.column_type, value) {
+            return Err(TypeError(format!(
+                "type mismatch for column '{}' ({})",
+                column.name,
+                column.column_type.name()
+            )));
+        }
+    }
+
+    let bitmap_len = schema.null_bitmap_len();
+    let fixed_len = schema.fixed_section_len();
+    let var_count = schema.var_column_count();
+    let mut out = vec![0u8; bitmap_len];
+    out.reserve(fixed_len + var_count * 2);
+
+    // Null bitmap: bit set = NULL.
+    for (index, value) in values.iter().enumerate() {
+        if value.is_null() {
+            out[index / 8] |= 1 << (index % 8);
+        }
+    }
+
+    // Fixed section (zeroes for NULL fixed columns).
+    for (column, value) in schema.columns.iter().zip(values) {
+        if let Some(size) = column.column_type.fixed_size() {
+            if value.is_null() {
+                out.extend(std::iter::repeat_n(0u8, size));
+            } else {
+                value.encode_fixed(&mut out);
+            }
+        }
+    }
+
+    // Var end-offsets then var data. NULL var values are zero-length (the
+    // bitmap distinguishes NULL from empty).
+    let mut var_payloads: Vec<Vec<u8>> = Vec::with_capacity(var_count);
+    for (column, value) in schema.columns.iter().zip(values) {
+        if column.column_type.fixed_size().is_none() {
+            var_payloads.push(if value.is_null() {
+                Vec::new()
+            } else {
+                value.encode_var()
+            });
+        }
+    }
+    let mut end = 0usize;
+    for payload in &var_payloads {
+        end += payload.len();
+        if end > u16::MAX as usize {
+            return Err(TypeError("var section exceeds 64 KiB".to_string()));
+        }
+        out.extend_from_slice(&(end as u16).to_le_bytes());
+    }
+    for payload in &var_payloads {
+        out.extend_from_slice(payload);
+    }
+
+    if out.len() > MAX_ROW_BYTES {
+        return Err(TypeError(format!(
+            "row of {} bytes exceeds the in-row cap of {MAX_ROW_BYTES}",
+            out.len()
+        )));
+    }
+    Ok(out)
+}
+
+pub fn decode_row(schema: &Schema, bytes: &[u8]) -> Result<Vec<Datum>, TypeError> {
+    let bitmap_len = schema.null_bitmap_len();
+    let fixed_len = schema.fixed_section_len();
+    let var_count = schema.var_column_count();
+    let header_len = bitmap_len + fixed_len + var_count * 2;
+    if bytes.len() < header_len {
+        return Err(TypeError(format!(
+            "row too short: {} bytes, header needs {header_len}",
+            bytes.len()
+        )));
+    }
+    let bitmap = &bytes[..bitmap_len];
+    let is_null = |index: usize| bitmap[index / 8] & (1 << (index % 8)) != 0;
+
+    let var_offsets_start = bitmap_len + fixed_len;
+    let var_data_start = var_offsets_start + var_count * 2;
+    let var_data = &bytes[var_data_start..];
+    let mut var_ends = Vec::with_capacity(var_count);
+    for i in 0..var_count {
+        let at = var_offsets_start + i * 2;
+        var_ends.push(u16::from_le_bytes([bytes[at], bytes[at + 1]]) as usize);
+    }
+    if let Some(&last) = var_ends.last()
+        && last != var_data.len()
+    {
+        return Err(TypeError("var section length mismatch".to_string()));
+    }
+
+    let mut values = Vec::with_capacity(schema.columns.len());
+    let mut fixed_cursor = bitmap_len;
+    let mut var_index = 0usize;
+    for (index, column) in schema.columns.iter().enumerate() {
+        match column.column_type.fixed_size() {
+            Some(size) => {
+                let raw = &bytes[fixed_cursor..fixed_cursor + size];
+                fixed_cursor += size;
+                values.push(if is_null(index) {
+                    Datum::Null
+                } else {
+                    Datum::decode_fixed(&column.column_type, raw)?
+                });
+            }
+            None => {
+                let start = if var_index == 0 {
+                    0
+                } else {
+                    var_ends[var_index - 1]
+                };
+                let end = var_ends[var_index];
+                var_index += 1;
+                if start > end || end > var_data.len() {
+                    return Err(TypeError("corrupt var offsets".to_string()));
+                }
+                values.push(if is_null(index) {
+                    Datum::Null
+                } else {
+                    Datum::decode_var(&column.column_type, &var_data[start..end])?
+                });
+            }
+        }
+    }
+    Ok(values)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn schema() -> Schema {
+        Schema {
+            columns: vec![
+                Column {
+                    name: "id".to_string(),
+                    column_type: ColumnType::Int,
+                    nullable: false,
+                },
+                Column {
+                    name: "name".to_string(),
+                    column_type: ColumnType::NVarChar { max_len: 50 },
+                    nullable: true,
+                },
+                Column {
+                    name: "price".to_string(),
+                    column_type: ColumnType::Decimal {
+                        precision: 10,
+                        scale: 2,
+                    },
+                    nullable: true,
+                },
+                Column {
+                    name: "blob".to_string(),
+                    column_type: ColumnType::VarBinary { max_len: 100 },
+                    nullable: true,
+                },
+                Column {
+                    name: "flag".to_string(),
+                    column_type: ColumnType::Bit,
+                    nullable: true,
+                },
+            ],
+        }
+    }
+
+    #[test]
+    fn row_round_trip() {
+        let schema = schema();
+        let values = vec![
+            Datum::Int(42),
+            Datum::NVarChar("åäö".to_string()),
+            Datum::Decimal(12345),
+            Datum::VarBinary(vec![1, 2, 3]),
+            Datum::Bit(true),
+        ];
+        let bytes = encode_row(&schema, &values).expect("encode");
+        assert_eq!(decode_row(&schema, &bytes).expect("decode"), values);
+    }
+
+    #[test]
+    fn nulls_round_trip_and_empty_string_is_not_null() {
+        let schema = schema();
+        let values = vec![
+            Datum::Int(1),
+            Datum::Null,
+            Datum::Null,
+            Datum::VarBinary(Vec::new()),
+            Datum::Null,
+        ];
+        let bytes = encode_row(&schema, &values).expect("encode");
+        let decoded = decode_row(&schema, &bytes).expect("decode");
+        assert_eq!(decoded, values);
+        assert_eq!(decoded[3], Datum::VarBinary(Vec::new()), "empty != NULL");
+    }
+
+    #[test]
+    fn arity_and_type_mismatches_error() {
+        let schema = schema();
+        assert!(encode_row(&schema, &[Datum::Int(1)]).is_err());
+        let values = vec![
+            Datum::BigInt(1), // wrong variant for INT column
+            Datum::Null,
+            Datum::Null,
+            Datum::Null,
+            Datum::Null,
+        ];
+        assert!(encode_row(&schema, &values).is_err());
+    }
+
+    #[test]
+    fn oversized_row_is_rejected() {
+        let schema = Schema {
+            columns: vec![Column {
+                name: "big".to_string(),
+                column_type: ColumnType::VarBinary { max_len: u16::MAX },
+                nullable: false,
+            }],
+        };
+        let values = vec![Datum::VarBinary(vec![0u8; MAX_ROW_BYTES + 1])];
+        assert!(encode_row(&schema, &values).is_err());
+    }
+}

--- a/crates/truthdb-core/src/relstore/slotted.rs
+++ b/crates/truthdb-core/src/relstore/slotted.rs
@@ -1,0 +1,406 @@
+//! Slotted page layout shared by B+ tree and heap pages.
+//!
+//! ```text
+//! 0..32    page header (checksum, page_lsn, type, object_id, page_no)
+//! 32..48   structure header: next_page u64 | slot_count u16 |
+//!          data_start u16 | level u16 | pad u16
+//! 48..     slot directory, 4 bytes per slot: offset u16 | len u16
+//! ...      free space
+//! data_start..4096  cell data, packed downward from the page end
+//! ```
+//!
+//! Two slot disciplines share the format:
+//! - *positional* (B+ tree): the directory is kept sorted; inserts shift
+//!   directory entries, so indices are positions, not identities.
+//! - *stable* (heap): a slot index is a row identity (RID); deletes leave a
+//!   tombstone (`offset == 0`) that later inserts may reuse.
+
+use crate::relstore::page::PAGE_HEADER_SIZE;
+use crate::storage_layout::PAGE_SIZE;
+
+pub const STRUCT_HEADER_END: usize = PAGE_HEADER_SIZE + 16;
+const SLOT_SIZE: usize = 4;
+
+const NEXT_PAGE_AT: usize = PAGE_HEADER_SIZE;
+const SLOT_COUNT_AT: usize = PAGE_HEADER_SIZE + 8;
+const DATA_START_AT: usize = PAGE_HEADER_SIZE + 10;
+const LEVEL_AT: usize = PAGE_HEADER_SIZE + 12;
+
+/// No next page (page numbers are data-region relative; 0 is a valid page,
+/// so the sentinel is all-ones).
+pub const NO_PAGE: u64 = u64::MAX;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PageFull;
+
+pub struct SlottedPage<'a> {
+    data: &'a mut [u8],
+}
+
+impl<'a> SlottedPage<'a> {
+    /// Wraps an existing formatted page.
+    pub fn new(data: &'a mut [u8]) -> Self {
+        debug_assert_eq!(data.len(), PAGE_SIZE);
+        SlottedPage { data }
+    }
+
+    /// Formats a fresh page: empty directory, full cell area, no next page.
+    /// The caller sets the page header (type/object/page_no) separately.
+    pub fn format(data: &'a mut [u8], level: u16) -> Self {
+        let mut page = SlottedPage::new(data);
+        page.set_next_page(NO_PAGE);
+        page.set_u16(SLOT_COUNT_AT, 0);
+        page.set_u16(DATA_START_AT, PAGE_SIZE as u16);
+        page.set_u16(LEVEL_AT, level);
+        page
+    }
+
+    pub fn next_page(&self) -> u64 {
+        u64::from_le_bytes(
+            self.data[NEXT_PAGE_AT..NEXT_PAGE_AT + 8]
+                .try_into()
+                .unwrap(),
+        )
+    }
+
+    pub fn set_next_page(&mut self, next: u64) {
+        self.data[NEXT_PAGE_AT..NEXT_PAGE_AT + 8].copy_from_slice(&next.to_le_bytes());
+    }
+
+    pub fn level(&self) -> u16 {
+        self.get_u16(LEVEL_AT)
+    }
+
+    pub fn slot_count(&self) -> usize {
+        self.get_u16(SLOT_COUNT_AT) as usize
+    }
+
+    fn data_start(&self) -> usize {
+        self.get_u16(DATA_START_AT) as usize
+    }
+
+    /// Contiguous free bytes between the directory and the cell area.
+    pub fn contiguous_free(&self) -> usize {
+        self.data_start() - (STRUCT_HEADER_END + self.slot_count() * SLOT_SIZE)
+    }
+
+    /// Total reclaimable free bytes (contiguous + tombstone holes).
+    pub fn total_free(&self) -> usize {
+        let live: usize = (0..self.slot_count())
+            .filter_map(|i| self.slot(i))
+            .map(|(_, len)| len)
+            .sum();
+        PAGE_SIZE - STRUCT_HEADER_END - self.slot_count() * SLOT_SIZE - live
+    }
+
+    fn slot(&self, index: usize) -> Option<(usize, usize)> {
+        let at = STRUCT_HEADER_END + index * SLOT_SIZE;
+        let offset = u16::from_le_bytes([self.data[at], self.data[at + 1]]) as usize;
+        let len = u16::from_le_bytes([self.data[at + 2], self.data[at + 3]]) as usize;
+        if offset == 0 {
+            None
+        } else {
+            Some((offset, len))
+        }
+    }
+
+    fn set_slot(&mut self, index: usize, offset: usize, len: usize) {
+        let at = STRUCT_HEADER_END + index * SLOT_SIZE;
+        self.data[at..at + 2].copy_from_slice(&(offset as u16).to_le_bytes());
+        self.data[at + 2..at + 4].copy_from_slice(&(len as u16).to_le_bytes());
+    }
+
+    /// Cell bytes at a slot; `None` for tombstones.
+    pub fn get(&self, index: usize) -> Option<&[u8]> {
+        debug_assert!(index < self.slot_count());
+        let (offset, len) = self.slot(index)?;
+        Some(&self.data[offset..offset + len])
+    }
+
+    /// Allocates a cell in the data area (compacting if fragmentation is the
+    /// only obstacle) and returns its offset. `extra_slot` reserves room for
+    /// one new directory entry.
+    fn allocate_cell(&mut self, len: usize, extra_slot: bool) -> Result<usize, PageFull> {
+        let slot_overhead = if extra_slot { SLOT_SIZE } else { 0 };
+        if self.contiguous_free() < len + slot_overhead {
+            if self.total_free() < len + slot_overhead {
+                return Err(PageFull);
+            }
+            self.compact();
+            if self.contiguous_free() < len + slot_overhead {
+                return Err(PageFull);
+            }
+        }
+        let offset = self.data_start() - len;
+        self.set_u16(DATA_START_AT, offset as u16);
+        Ok(offset)
+    }
+
+    /// Rewrites the cell area to squeeze out holes; slot indices unchanged.
+    fn compact(&mut self) {
+        let cells: Vec<(usize, Vec<u8>)> = (0..self.slot_count())
+            .filter_map(|i| self.get(i).map(|bytes| (i, bytes.to_vec())))
+            .collect();
+        let mut cursor = PAGE_SIZE;
+        self.set_u16(DATA_START_AT, PAGE_SIZE as u16);
+        for (index, bytes) in cells {
+            cursor -= bytes.len();
+            self.data[cursor..cursor + bytes.len()].copy_from_slice(&bytes);
+            self.set_slot(index, cursor, bytes.len());
+        }
+        self.set_u16(DATA_START_AT, cursor as u16);
+    }
+
+    // ---- positional discipline (B+ tree) -------------------------------
+
+    /// Inserts a cell at directory position `index`, shifting later entries.
+    pub fn insert_at(&mut self, index: usize, bytes: &[u8]) -> Result<(), PageFull> {
+        let count = self.slot_count();
+        debug_assert!(index <= count);
+        let offset = self.allocate_cell(bytes.len(), true)?;
+        self.data[offset..offset + bytes.len()].copy_from_slice(bytes);
+        // Shift directory entries [index..count) one slot right.
+        let src = STRUCT_HEADER_END + index * SLOT_SIZE;
+        let end = STRUCT_HEADER_END + count * SLOT_SIZE;
+        self.data.copy_within(src..end, src + SLOT_SIZE);
+        self.set_slot(index, offset, bytes.len());
+        self.set_u16(SLOT_COUNT_AT, (count + 1) as u16);
+        Ok(())
+    }
+
+    /// Removes the cell at directory position `index`, shifting later
+    /// entries left.
+    pub fn remove_at(&mut self, index: usize) {
+        let count = self.slot_count();
+        debug_assert!(index < count);
+        let src = STRUCT_HEADER_END + (index + 1) * SLOT_SIZE;
+        let end = STRUCT_HEADER_END + count * SLOT_SIZE;
+        self.data.copy_within(src..end, src - SLOT_SIZE);
+        self.set_u16(SLOT_COUNT_AT, (count - 1) as u16);
+    }
+
+    /// Replaces the cell at position `index`.
+    pub fn update_at(&mut self, index: usize, bytes: &[u8]) -> Result<(), PageFull> {
+        let (offset, len) = self.slot(index).expect("update of tombstone");
+        if bytes.len() <= len {
+            self.data[offset..offset + bytes.len()].copy_from_slice(bytes);
+            self.set_slot(index, offset, bytes.len());
+            return Ok(());
+        }
+        // Tombstone the old cell during allocation so compaction can reclaim
+        // it, then restore on failure.
+        self.set_slot(index, 0, 0);
+        match self.allocate_cell(bytes.len(), false) {
+            Ok(new_offset) => {
+                self.data[new_offset..new_offset + bytes.len()].copy_from_slice(bytes);
+                self.set_slot(index, new_offset, bytes.len());
+                Ok(())
+            }
+            Err(PageFull) => {
+                self.set_slot(index, offset, len);
+                Err(PageFull)
+            }
+        }
+    }
+
+    // ---- stable discipline (heap) ---------------------------------------
+
+    /// Inserts a cell into the first tombstone slot (or a new slot) and
+    /// returns the slot index — the row's identity.
+    pub fn insert_stable(&mut self, bytes: &[u8]) -> Result<usize, PageFull> {
+        let reuse = (0..self.slot_count()).find(|&i| self.slot(i).is_none());
+        let index = match reuse {
+            Some(index) => index,
+            None => self.slot_count(),
+        };
+        self.insert_stable_at(index, bytes)?;
+        Ok(index)
+    }
+
+    /// Inserts at an exact slot index (recovery redo and undo need
+    /// determinism). The slot must be a tombstone or the next fresh index.
+    pub fn insert_stable_at(&mut self, index: usize, bytes: &[u8]) -> Result<(), PageFull> {
+        let count = self.slot_count();
+        debug_assert!(
+            index < count && self.slot(index).is_none() || index == count,
+            "stable insert into occupied slot {index}"
+        );
+        let new_slot = index == count;
+        let offset = self.allocate_cell(bytes.len(), new_slot)?;
+        self.data[offset..offset + bytes.len()].copy_from_slice(bytes);
+        if new_slot {
+            self.set_u16(SLOT_COUNT_AT, (count + 1) as u16);
+        }
+        self.set_slot(index, offset, bytes.len());
+        Ok(())
+    }
+
+    /// Tombstones a slot; the index stays valid (RID stability).
+    pub fn delete_stable(&mut self, index: usize) {
+        debug_assert!(index < self.slot_count());
+        self.set_slot(index, 0, 0);
+    }
+
+    /// Replaces the cell at a stable slot.
+    pub fn update_stable(&mut self, index: usize, bytes: &[u8]) -> Result<(), PageFull> {
+        self.update_at(index, bytes)
+    }
+
+    fn get_u16(&self, at: usize) -> u16 {
+        u16::from_le_bytes([self.data[at], self.data[at + 1]])
+    }
+
+    fn set_u16(&mut self, at: usize, value: u16) {
+        self.data[at..at + 2].copy_from_slice(&value.to_le_bytes());
+    }
+}
+
+/// Read-only view of a slotted page over a shared borrow (scans and space
+/// checks; [`SlottedPage`] requires `&mut`).
+pub struct SlottedRead<'a> {
+    data: &'a [u8],
+}
+
+impl<'a> SlottedRead<'a> {
+    pub fn new(data: &'a [u8]) -> Self {
+        debug_assert_eq!(data.len(), PAGE_SIZE);
+        SlottedRead { data }
+    }
+
+    pub fn next_page(&self) -> u64 {
+        u64::from_le_bytes(
+            self.data[NEXT_PAGE_AT..NEXT_PAGE_AT + 8]
+                .try_into()
+                .unwrap(),
+        )
+    }
+
+    pub fn level(&self) -> u16 {
+        u16::from_le_bytes([self.data[LEVEL_AT], self.data[LEVEL_AT + 1]])
+    }
+
+    pub fn slot_count(&self) -> usize {
+        u16::from_le_bytes([self.data[SLOT_COUNT_AT], self.data[SLOT_COUNT_AT + 1]]) as usize
+    }
+
+    pub fn get(&self, index: usize) -> Option<&'a [u8]> {
+        debug_assert!(index < self.slot_count());
+        let at = STRUCT_HEADER_END + index * SLOT_SIZE;
+        let offset = u16::from_le_bytes([self.data[at], self.data[at + 1]]) as usize;
+        let len = u16::from_le_bytes([self.data[at + 2], self.data[at + 3]]) as usize;
+        if offset == 0 {
+            None
+        } else {
+            Some(&self.data[offset..offset + len])
+        }
+    }
+
+    pub fn total_free(&self) -> usize {
+        let live: usize = (0..self.slot_count())
+            .filter_map(|i| self.get(i))
+            .map(|c| c.len())
+            .sum();
+        PAGE_SIZE - STRUCT_HEADER_END - self.slot_count() * SLOT_SIZE - live
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fresh() -> Vec<u8> {
+        vec![0u8; PAGE_SIZE]
+    }
+
+    #[test]
+    fn positional_insert_get_remove() {
+        let mut data = fresh();
+        let mut page = SlottedPage::format(&mut data, 0);
+        page.insert_at(0, b"bb").unwrap();
+        page.insert_at(0, b"aa").unwrap();
+        page.insert_at(2, b"cc").unwrap();
+        assert_eq!(page.get(0), Some(b"aa".as_slice()));
+        assert_eq!(page.get(1), Some(b"bb".as_slice()));
+        assert_eq!(page.get(2), Some(b"cc".as_slice()));
+        page.remove_at(1);
+        assert_eq!(page.slot_count(), 2);
+        assert_eq!(page.get(0), Some(b"aa".as_slice()));
+        assert_eq!(page.get(1), Some(b"cc".as_slice()));
+    }
+
+    #[test]
+    fn update_grows_and_shrinks() {
+        let mut data = fresh();
+        let mut page = SlottedPage::format(&mut data, 0);
+        page.insert_at(0, b"short").unwrap();
+        page.insert_at(1, b"other").unwrap();
+        page.update_at(0, b"a considerably longer cell payload")
+            .unwrap();
+        assert_eq!(
+            page.get(0),
+            Some(b"a considerably longer cell payload".as_slice())
+        );
+        assert_eq!(page.get(1), Some(b"other".as_slice()));
+        page.update_at(0, b"x").unwrap();
+        assert_eq!(page.get(0), Some(b"x".as_slice()));
+    }
+
+    #[test]
+    fn stable_slots_reuse_tombstones_and_keep_identity() {
+        let mut data = fresh();
+        let mut page = SlottedPage::format(&mut data, 0);
+        let a = page.insert_stable(b"aaa").unwrap();
+        let b = page.insert_stable(b"bbb").unwrap();
+        let c = page.insert_stable(b"ccc").unwrap();
+        assert_eq!((a, b, c), (0, 1, 2));
+        page.delete_stable(b);
+        assert_eq!(page.get(b), None);
+        assert_eq!(page.get(c), Some(b"ccc".as_slice()), "identities stable");
+        let reused = page.insert_stable(b"ddd").unwrap();
+        assert_eq!(reused, b, "tombstone slot reused");
+        assert_eq!(page.get(b), Some(b"ddd".as_slice()));
+    }
+
+    #[test]
+    fn fills_up_then_compaction_reclaims_holes() {
+        let mut data = fresh();
+        let mut page = SlottedPage::format(&mut data, 0);
+        let cell = vec![7u8; 100];
+        let mut slots = Vec::new();
+        loop {
+            match page.insert_stable(&cell) {
+                Ok(slot) => slots.push(slot),
+                Err(PageFull) => break,
+            }
+        }
+        assert!(slots.len() >= 35, "expected ~39 cells, got {}", slots.len());
+        // Free every other cell: contiguous space stays tiny, but compaction
+        // must make the holes usable.
+        for &slot in slots.iter().step_by(2) {
+            page.delete_stable(slot);
+        }
+        let big = vec![9u8; 1000];
+        page.insert_stable(&big).expect("compaction reclaims holes");
+    }
+
+    #[test]
+    fn insert_at_exact_slot_for_redo() {
+        let mut data = fresh();
+        let mut page = SlottedPage::format(&mut data, 0);
+        page.insert_stable_at(0, b"row0").unwrap();
+        page.insert_stable_at(1, b"row1").unwrap();
+        page.delete_stable(0);
+        page.insert_stable_at(0, b"row0-again").unwrap();
+        assert_eq!(page.get(0), Some(b"row0-again".as_slice()));
+    }
+
+    #[test]
+    fn next_page_and_level_round_trip() {
+        let mut data = fresh();
+        let mut page = SlottedPage::format(&mut data, 3);
+        assert_eq!(page.next_page(), NO_PAGE);
+        page.set_next_page(12345);
+        assert_eq!(page.next_page(), 12345);
+        assert_eq!(page.level(), 3);
+    }
+}

--- a/crates/truthdb-core/src/relstore/tests.rs
+++ b/crates/truthdb-core/src/relstore/tests.rs
@@ -1,0 +1,608 @@
+//! Stage 2 exit-criteria tests: kill-and-recover matrix, CLR idempotence,
+//! torn-page FPI repair, B+ tree vs BTreeMap oracle, split-crash, heap
+//! forwarding stubs and statement rollback.
+
+use std::collections::BTreeMap;
+use std::io::{Seek, SeekFrom, Write};
+use std::path::{Path, PathBuf};
+
+use crate::relstore::row::Column;
+use crate::relstore::types::{ColumnType, Datum};
+use crate::storage::{Storage, StorageError, StorageOptions};
+
+/// Room for FPIs and split images without checkpoints in most tests.
+const REL_TEST_WAL_BYTES: u64 = 8 * 1024 * 1024;
+
+fn storage_options() -> StorageOptions {
+    StorageOptions {
+        size_gib: 1,
+        wal_ratio: 0.05,
+        metadata_ratio: 0.08,
+        snapshot_ratio: 0.02,
+        allocator_ratio: 0.02,
+        reserved_ratio: 0.17,
+    }
+}
+
+fn unique_temp_path(label: &str) -> PathBuf {
+    let mut path = std::env::temp_dir();
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system time before unix epoch")
+        .as_nanos();
+    path.push(format!("truthdb-rel-{label}-{nanos}.db"));
+    path
+}
+
+fn create_storage(path: &Path) -> Storage {
+    Storage::create_with_wal_bounds(
+        path.to_path_buf(),
+        storage_options(),
+        REL_TEST_WAL_BYTES,
+        REL_TEST_WAL_BYTES,
+    )
+    .expect("create storage")
+}
+
+fn overwrite_bytes(path: &Path, offset: u64, bytes: &[u8]) {
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .open(path)
+        .expect("open for corruption");
+    file.seek(SeekFrom::Start(offset)).expect("seek");
+    file.write_all(bytes).expect("write");
+    file.sync_all().expect("sync");
+}
+
+fn int_column(name: &str, nullable: bool) -> Column {
+    Column {
+        name: name.to_string(),
+        column_type: ColumnType::Int,
+        nullable,
+    }
+}
+
+fn varchar_column(name: &str, max_len: u16) -> Column {
+    Column {
+        name: name.to_string(),
+        column_type: ColumnType::VarChar { max_len },
+        nullable: true,
+    }
+}
+
+fn create_tree_table(storage: &mut Storage, name: &str) {
+    storage
+        .rel_create_table(
+            name,
+            vec![int_column("id", false), varchar_column("payload", 4000)],
+            &["id".to_string()],
+        )
+        .expect("create tree table");
+}
+
+fn create_heap_table(storage: &mut Storage, name: &str) {
+    storage
+        .rel_create_table(
+            name,
+            vec![int_column("id", false), varchar_column("payload", 4000)],
+            &[],
+        )
+        .expect("create heap table");
+}
+
+fn row(id: i32, payload: &str) -> Vec<Datum> {
+    vec![Datum::Int(id), Datum::VarChar(payload.to_string())]
+}
+
+fn scan_ids(storage: &mut Storage, table: &str) -> Vec<i32> {
+    storage
+        .rel_scan(table)
+        .expect("scan")
+        .into_iter()
+        .map(|r| match r[0] {
+            Datum::Int(id) => id,
+            _ => panic!("expected int id"),
+        })
+        .collect()
+}
+
+#[test]
+fn committed_statements_survive_crash_without_checkpoint() {
+    let path = unique_temp_path("committed-durable");
+    let mut storage = create_storage(&path);
+    create_tree_table(&mut storage, "t");
+    create_heap_table(&mut storage, "h");
+    for i in 0..20 {
+        storage
+            .rel_insert("t", row(i, &format!("tree-{i}")))
+            .expect("insert");
+        storage
+            .rel_insert("h", row(i, &format!("heap-{i}")))
+            .expect("insert");
+    }
+    storage
+        .rel_delete_where("t", "id", &Datum::Int(3))
+        .expect("delete");
+    storage
+        .rel_update_where(
+            "t",
+            "id",
+            &Datum::Int(4),
+            &[("payload".to_string(), Datum::VarChar("updated".to_string()))],
+        )
+        .expect("update");
+    drop(storage); // crash: nothing checkpointed, pool never flushed
+
+    let mut storage = Storage::open(path.clone()).expect("reopen");
+    let ids = scan_ids(&mut storage, "t");
+    assert_eq!(ids, (0..20).filter(|i| *i != 3).collect::<Vec<_>>());
+    let updated = storage
+        .rel_get("t", &[Datum::Int(4)])
+        .expect("get")
+        .expect("row 4 exists");
+    assert_eq!(updated[1], Datum::VarChar("updated".to_string()));
+    assert_eq!(scan_ids(&mut storage, "h").len(), 20);
+    drop(storage);
+    let _ = std::fs::remove_file(path);
+}
+
+#[test]
+fn uncommitted_statement_is_undone_and_recovery_rerun_is_clean() {
+    let path = unique_temp_path("loser-undo");
+    let mut storage = create_storage(&path);
+    create_tree_table(&mut storage, "t");
+    create_heap_table(&mut storage, "h");
+    storage
+        .rel_insert("t", row(1, "committed"))
+        .expect("insert");
+    storage
+        .rel_insert("h", row(1, "committed"))
+        .expect("insert");
+    // Crash mid-statement: ops durable, commit record never written.
+    storage
+        .rel_insert_without_commit("t", row(2, "uncommitted"))
+        .expect("uncommitted tree insert");
+    storage
+        .rel_insert_without_commit("h", row(2, "uncommitted"))
+        .expect("uncommitted heap insert");
+    drop(storage);
+
+    // First recovery: losers undone via CLRs.
+    let mut storage = Storage::open(path.clone()).expect("reopen with losers");
+    assert_eq!(scan_ids(&mut storage, "t"), vec![1], "loser insert undone");
+    assert_eq!(scan_ids(&mut storage, "h"), vec![1], "loser insert undone");
+    drop(storage); // crash again before any checkpoint: CLRs replay
+
+    // Second recovery re-runs redo over the CLRs (idempotence) and must not
+    // resurrect or double-undo anything.
+    let mut storage = Storage::open(path.clone()).expect("reopen after recovery crash");
+    assert_eq!(scan_ids(&mut storage, "t"), vec![1]);
+    assert_eq!(scan_ids(&mut storage, "h"), vec![1]);
+    // The store stays fully usable.
+    storage
+        .rel_insert("t", row(2, "fresh"))
+        .expect("insert after recovery");
+    assert_eq!(scan_ids(&mut storage, "t"), vec![1, 2]);
+    drop(storage);
+    let _ = std::fs::remove_file(path);
+}
+
+#[test]
+fn torn_page_is_repaired_from_full_page_image() {
+    let path = unique_temp_path("torn-page-fpi");
+    let mut storage = create_storage(&path);
+    create_tree_table(&mut storage, "t");
+    for i in 0..5 {
+        storage.rel_insert("t", row(i, "payload")).expect("insert");
+    }
+    // Flush dirty pages to disk without advancing the WAL head (the
+    // mid-checkpoint crash window), then tear the table's root page.
+    storage.rel_flush_pool_only().expect("flush");
+    let root_page = storage.rel_table("t").expect("def").root_page;
+    let offset = storage.data_page_offset(root_page);
+    drop(storage);
+    overwrite_bytes(&path, offset + 1000, &[0xDBu8; 2000]);
+
+    let mut storage = Storage::open(path.clone()).expect("reopen after tear");
+    assert_eq!(scan_ids(&mut storage, "t"), vec![0, 1, 2, 3, 4]);
+    drop(storage);
+    let _ = std::fs::remove_file(path);
+}
+
+/// Deterministic xorshift so the oracle test needs no new deps.
+struct Rng(u64);
+impl Rng {
+    fn next(&mut self) -> u64 {
+        let mut x = self.0;
+        x ^= x << 13;
+        x ^= x >> 7;
+        x ^= x << 17;
+        self.0 = x;
+        x
+    }
+}
+
+#[test]
+fn btree_matches_btreemap_oracle_through_splits_and_crash() {
+    let path = unique_temp_path("btree-oracle");
+    let mut storage = create_storage(&path);
+    create_tree_table(&mut storage, "t");
+    let mut oracle: BTreeMap<i32, String> = BTreeMap::new();
+    let mut rng = Rng(0x5EED_5EED_5EED_5EED);
+
+    for step in 0..900 {
+        let id = (rng.next() % 300) as i32;
+        match rng.next() % 4 {
+            // Insert (duplicate key must be rejected and change nothing).
+            0 | 1 => {
+                let payload = format!("{id}-{}", "x".repeat(180 + (rng.next() % 200) as usize));
+                let result = storage.rel_insert("t", row(id, &payload));
+                if oracle.contains_key(&id) {
+                    assert!(
+                        matches!(result, Err(StorageError::Constraint(_))),
+                        "duplicate insert must fail"
+                    );
+                } else {
+                    result.expect("insert");
+                    oracle.insert(id, payload);
+                }
+            }
+            2 => {
+                let expected = oracle.remove(&id).is_some();
+                let count = storage
+                    .rel_delete_where("t", "id", &Datum::Int(id))
+                    .expect("delete");
+                assert_eq!(count == 1, expected, "delete count diverged");
+            }
+            _ => {
+                let payload = format!("{id}-upd-{}", "y".repeat(100 + (rng.next() % 500) as usize));
+                let count = storage
+                    .rel_update_where(
+                        "t",
+                        "id",
+                        &Datum::Int(id),
+                        &[("payload".to_string(), Datum::VarChar(payload.clone()))],
+                    )
+                    .expect("update");
+                if let std::collections::btree_map::Entry::Occupied(mut entry) = oracle.entry(id) {
+                    assert_eq!(count, 1);
+                    entry.insert(payload);
+                } else {
+                    assert_eq!(count, 0);
+                }
+            }
+        }
+        // Periodic point-lookup and checkpoint (fresh FPI epochs).
+        if step % 97 == 0 {
+            let got = storage.rel_get("t", &[Datum::Int(id)]).expect("get");
+            assert_eq!(got.is_some(), oracle.contains_key(&id));
+            storage
+                .write_checkpoint(b"oracle-checkpoint", 1, 2, 1)
+                .expect("checkpoint");
+        }
+    }
+
+    let verify = |storage: &mut Storage, oracle: &BTreeMap<i32, String>| {
+        let rows = storage.rel_scan("t").expect("scan");
+        assert_eq!(rows.len(), oracle.len(), "row count diverged");
+        for (row, (id, payload)) in rows.iter().zip(oracle.iter()) {
+            assert_eq!(row[0], Datum::Int(*id), "scan must be in key order");
+            assert_eq!(row[1], Datum::VarChar(payload.clone()));
+        }
+    };
+    verify(&mut storage, &oracle);
+    drop(storage); // crash without a final checkpoint
+
+    let mut storage = Storage::open(path.clone()).expect("reopen");
+    verify(&mut storage, &oracle);
+    drop(storage);
+    let _ = std::fs::remove_file(path);
+}
+
+#[test]
+fn multi_level_splits_survive_crash() {
+    let path = unique_temp_path("split-crash");
+    let mut storage = create_storage(&path);
+    create_tree_table(&mut storage, "t");
+    // ~400-byte rows: ~9 per leaf; 300 rows forces a multi-level tree.
+    // Insert in descending order to exercise inserts at position 0.
+    for i in (0..300).rev() {
+        let payload = format!("{i}-{}", "z".repeat(380));
+        storage.rel_insert("t", row(i, &payload)).expect("insert");
+    }
+    drop(storage); // crash: splits only exist as WAL images
+
+    let mut storage = Storage::open(path.clone()).expect("reopen");
+    assert_eq!(scan_ids(&mut storage, "t"), (0..300).collect::<Vec<_>>());
+    // The recovered tree keeps working (routing, further splits).
+    for i in 300..340 {
+        let payload = format!("{i}-{}", "z".repeat(380));
+        storage
+            .rel_insert("t", row(i, &payload))
+            .expect("insert after recovery");
+    }
+    assert_eq!(scan_ids(&mut storage, "t"), (0..340).collect::<Vec<_>>());
+    drop(storage);
+    let _ = std::fs::remove_file(path);
+}
+
+#[test]
+fn heap_updates_move_rows_with_forwarding_stubs() {
+    let path = unique_temp_path("heap-stubs");
+    let mut storage = create_storage(&path);
+    create_heap_table(&mut storage, "h");
+    // Fill the first page almost completely.
+    for i in 0..3 {
+        storage
+            .rel_insert("h", row(i, &"a".repeat(1200)))
+            .expect("insert");
+    }
+    // Growing row 0 beyond the page's free space forces a move + stub.
+    let count = storage
+        .rel_update_where(
+            "h",
+            "id",
+            &Datum::Int(0),
+            &[("payload".to_string(), Datum::VarChar("B".repeat(3000)))],
+        )
+        .expect("update");
+    assert_eq!(count, 1);
+    let mut ids = scan_ids(&mut storage, "h");
+    ids.sort_unstable();
+    assert_eq!(ids, vec![0, 1, 2], "moved row appears exactly once");
+    drop(storage); // crash
+
+    let mut storage = Storage::open(path.clone()).expect("reopen");
+    let rows = storage.rel_scan("h").expect("scan");
+    let moved = rows
+        .iter()
+        .find(|r| r[0] == Datum::Int(0))
+        .expect("moved row survives");
+    assert_eq!(moved[1], Datum::VarChar("B".repeat(3000)));
+    // Deleting through the stub removes the row entirely.
+    assert_eq!(
+        storage
+            .rel_delete_where("h", "id", &Datum::Int(0))
+            .expect("delete"),
+        1
+    );
+    let mut ids = scan_ids(&mut storage, "h");
+    ids.sort_unstable();
+    assert_eq!(ids, vec![1, 2]);
+    drop(storage);
+    let _ = std::fs::remove_file(path);
+}
+
+#[test]
+fn failing_statement_rolls_back_all_its_rows() {
+    let path = unique_temp_path("statement-rollback");
+    let mut storage = create_storage(&path);
+    create_tree_table(&mut storage, "t");
+    for i in 0..5 {
+        storage.rel_insert("t", row(i, "small")).expect("insert");
+    }
+    // A multi-row update where the grown rows exceed the tree cell cap: the
+    // first rows update fine, then the statement fails and must roll back.
+    let err = storage
+        .rel_update_where(
+            "t",
+            "payload",
+            &Datum::VarChar("small".to_string()),
+            &[("payload".to_string(), Datum::VarChar("W".repeat(3000)))],
+        )
+        .expect_err("oversized tree rows must fail the statement");
+    assert!(matches!(err, StorageError::InvalidConfig(_)), "got: {err}");
+    let rows = storage.rel_scan("t").expect("scan");
+    assert_eq!(rows.len(), 5);
+    for row in &rows {
+        assert_eq!(
+            row[1],
+            Datum::VarChar("small".to_string()),
+            "no partial update may survive rollback"
+        );
+    }
+    // And the same holds across a crash (the rollback CLRs replay).
+    drop(storage);
+    let mut storage = Storage::open(path.clone()).expect("reopen");
+    let rows = storage.rel_scan("t").expect("scan");
+    assert_eq!(rows.len(), 5);
+    for row in &rows {
+        assert_eq!(row[1], Datum::VarChar("small".to_string()));
+    }
+    drop(storage);
+    let _ = std::fs::remove_file(path);
+}
+
+#[test]
+fn create_table_crash_before_commit_rolls_back_catalog() {
+    let path = unique_temp_path("create-table-loser");
+    let mut storage = create_storage(&path);
+    create_tree_table(&mut storage, "keep");
+    storage.rel_insert("keep", row(1, "x")).expect("insert");
+    drop(storage);
+
+    // Committed table survives; the catalog itself recovered.
+    let mut storage = Storage::open(path.clone()).expect("reopen");
+    assert!(storage.rel_table("keep").is_some());
+    assert_eq!(scan_ids(&mut storage, "keep"), vec![1]);
+
+    // NOT NULL constraint failures roll the whole insert statement back.
+    let err = storage
+        .rel_insert("keep", vec![Datum::Null, Datum::VarChar("x".to_string())])
+        .expect_err("null pk must fail");
+    assert!(matches!(err, StorageError::Constraint(_)), "got: {err}");
+    assert_eq!(scan_ids(&mut storage, "keep"), vec![1]);
+    drop(storage);
+    let _ = std::fs::remove_file(path);
+}
+
+#[test]
+fn checkpoint_persists_relational_pages_and_truncates_wal() {
+    let path = unique_temp_path("rel-checkpoint");
+    let mut storage = create_storage(&path);
+    create_tree_table(&mut storage, "t");
+    for i in 0..50 {
+        storage
+            .rel_insert("t", row(i, &"c".repeat(200)))
+            .expect("insert");
+    }
+    storage
+        .write_checkpoint(b"combined", 1, 2, 1)
+        .expect("checkpoint");
+    // Post-checkpoint work lands in a fresh WAL epoch.
+    for i in 50..60 {
+        storage
+            .rel_insert("t", row(i, &"c".repeat(200)))
+            .expect("insert");
+    }
+    drop(storage);
+
+    let mut storage = Storage::open(path.clone()).expect("reopen");
+    assert_eq!(scan_ids(&mut storage, "t"), (0..60).collect::<Vec<_>>());
+    // The catalog root survived via the superblock (not just the WAL).
+    assert!(storage.rel_table("t").is_some());
+    drop(storage);
+    let _ = std::fs::remove_file(path);
+}
+
+// TEMPORARY VERIFIER REPRO — remove after review verification.
+
+/// Review finding: a statement failing mid-way (after some ops applied)
+/// must roll back every applied op via CLRs — live, and across a crash.
+#[test]
+fn mid_statement_failure_rolls_back_applied_ops() {
+    let path = unique_temp_path("fault-rollback");
+    let mut storage = create_storage(&path);
+    create_tree_table(&mut storage, "t");
+    for i in 0..5 {
+        storage.rel_insert("t", row(i, "original")).expect("insert");
+    }
+    // Let 3 update ops apply, then fail the 4th (simulated WAL failure).
+    crate::relstore::ctx::FAIL_APPLY_OPS_AFTER.with(|c| c.set(Some(3)));
+    let err = storage
+        .rel_update_where(
+            "t",
+            "payload",
+            &Datum::VarChar("original".to_string()),
+            &[("payload".to_string(), Datum::VarChar("changed".to_string()))],
+        )
+        .expect_err("injected fault must fail the statement");
+    crate::relstore::ctx::FAIL_APPLY_OPS_AFTER.with(|c| c.set(None));
+    assert!(matches!(err, StorageError::InvalidConfig(_)), "got: {err}");
+
+    let verify = |storage: &mut Storage| {
+        let rows = storage.rel_scan("t").expect("scan");
+        assert_eq!(rows.len(), 5);
+        for row in &rows {
+            assert_eq!(
+                row[1],
+                Datum::VarChar("original".to_string()),
+                "no partially-applied update may survive"
+            );
+        }
+    };
+    verify(&mut storage);
+    drop(storage); // crash: the rollback CLRs must replay
+    let mut storage = Storage::open(path.clone()).expect("reopen");
+    verify(&mut storage);
+    // Store is not wedged (rollback succeeded) and stays writable.
+    storage
+        .rel_insert("t", row(100, "after"))
+        .expect("insert after rollback");
+    drop(storage);
+    let _ = std::fs::remove_file(path);
+}
+
+/// Exit criterion: a crash DURING recovery undo re-runs cleanly. Two losers
+/// are undone one after the other; the injected fault kills recovery after
+/// the first loser completed (its CLRs and TXN_END durable) and before the
+/// second — the rerun must finish the job exactly once.
+#[test]
+fn crash_during_recovery_undo_reruns_cleanly() {
+    let path = unique_temp_path("crash-mid-undo");
+    let mut storage = create_storage(&path);
+    create_tree_table(&mut storage, "t");
+    storage
+        .rel_insert("t", row(1, "committed"))
+        .expect("insert");
+    storage
+        .rel_insert_without_commit("t", row(2, "loser-a"))
+        .expect("loser a");
+    storage
+        .rel_insert_without_commit("t", row(3, "loser-b"))
+        .expect("loser b");
+    drop(storage); // crash with two losers
+
+    // Recovery undoes the higher-LSN loser first; fail on the second's op.
+    crate::relstore::ctx::FAIL_APPLY_OPS_AFTER.with(|c| c.set(Some(1)));
+    let result = Storage::open(path.clone());
+    crate::relstore::ctx::FAIL_APPLY_OPS_AFTER.with(|c| c.set(None));
+    assert!(
+        result.is_err(),
+        "injected fault must abort recovery mid-undo"
+    );
+    drop(result);
+
+    // Re-run: the first loser's durable CLRs replay (no double-undo), the
+    // second loser is undone now.
+    let mut storage = Storage::open(path.clone()).expect("recovery rerun");
+    assert_eq!(scan_ids(&mut storage, "t"), vec![1], "only committed data");
+    storage
+        .rel_insert("t", row(2, "fresh"))
+        .expect("insert after rerun");
+    assert_eq!(scan_ids(&mut storage, "t"), vec![1, 2]);
+    drop(storage);
+    let _ = std::fs::remove_file(path);
+}
+
+/// Review finding: a growing update of a tiny row on a page too full to
+/// hold a forwarding stub must fail cleanly (constraint error), not with an
+/// internal logging error or partial application.
+#[test]
+fn heap_update_on_stub_starved_page_fails_cleanly() {
+    let path = unique_temp_path("stub-starved");
+    let mut storage = create_storage(&path);
+    storage
+        .rel_create_table(
+            "h",
+            vec![
+                int_column("id", false),
+                Column {
+                    name: "v".to_string(),
+                    column_type: ColumnType::VarBinary { max_len: 200 },
+                    nullable: true,
+                },
+            ],
+            &[],
+        )
+        .expect("create heap");
+    // Fill page 1 to exactly 2 free bytes: 336 null-v rows (12 bytes each
+    // with slot) + one row with a 2-byte value (14 bytes with slot).
+    for i in 0..336 {
+        storage
+            .rel_insert("h", vec![Datum::Int(i), Datum::Null])
+            .expect("filler");
+    }
+    storage
+        .rel_insert("h", vec![Datum::Int(999), Datum::VarBinary(vec![7u8; 2])])
+        .expect("pad row");
+
+    // Row id=0's cell is 8 bytes; a stub needs 11 and the page has 1 free.
+    let err = storage
+        .rel_update_where(
+            "h",
+            "id",
+            &Datum::Int(0),
+            &[("v".to_string(), Datum::VarBinary(vec![9u8; 100]))],
+        )
+        .expect_err("stub-starved page must reject the growing update");
+    assert!(matches!(err, StorageError::Constraint(_)), "got: {err}");
+
+    // Nothing changed and the store keeps working.
+    let rows = storage.rel_scan("h").expect("scan");
+    assert_eq!(rows.len(), 337);
+    let row0 = rows.iter().find(|r| r[0] == Datum::Int(0)).expect("row 0");
+    assert_eq!(row0[1], Datum::Null);
+    drop(storage);
+    let _ = std::fs::remove_file(path);
+}

--- a/crates/truthdb-core/src/relstore/types.rs
+++ b/crates/truthdb-core/src/relstore/types.rs
@@ -1,0 +1,795 @@
+//! Storage-level column types and values with T-SQL on-disk encodings.
+//!
+//! Fixed-width encodings (little-endian unless noted):
+//! - TINYINT 1B (u8), SMALLINT 2B (i16), INT 4B (i32), BIGINT 8B (i64)
+//! - BIT 1B (0/1)
+//! - REAL 4B (f32), FLOAT 8B (f64)
+//! - DECIMAL(p<=38, s) 16B: unscaled value as i128
+//! - DATE 3B: days since 0001-01-01 (proleptic Gregorian)
+//! - TIME 5B: 100ns ticks since midnight (precision 7)
+//! - DATETIME2 8B: TIME(7) ticks (5B) then DATE days (3B)
+//! - UNIQUEIDENTIFIER 16B: RFC 4122 byte order
+//!
+//! Variable-width: VARCHAR(n) as UTF-8 bytes (single-byte collations arrive
+//! in Stage 5), NVARCHAR(n) as UTF-16LE, VARBINARY(n) raw.
+
+use serde_json::Value as Json;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ColumnType {
+    TinyInt,
+    SmallInt,
+    Int,
+    BigInt,
+    Bit,
+    Real,
+    Float,
+    /// precision <= 38, scale <= precision.
+    Decimal {
+        precision: u8,
+        scale: u8,
+    },
+    Date,
+    Time,
+    DateTime2,
+    UniqueIdentifier,
+    /// max length in bytes.
+    VarChar {
+        max_len: u16,
+    },
+    /// max length in characters (stored as UTF-16LE code units).
+    NVarChar {
+        max_len: u16,
+    },
+    VarBinary {
+        max_len: u16,
+    },
+}
+
+impl ColumnType {
+    /// Size of the fixed-width encoding, or None for variable-width types.
+    pub fn fixed_size(&self) -> Option<usize> {
+        match self {
+            ColumnType::TinyInt | ColumnType::Bit => Some(1),
+            ColumnType::SmallInt => Some(2),
+            ColumnType::Int | ColumnType::Real => Some(4),
+            ColumnType::BigInt | ColumnType::Float => Some(8),
+            ColumnType::Decimal { .. } | ColumnType::UniqueIdentifier => Some(16),
+            ColumnType::Date => Some(3),
+            ColumnType::Time => Some(5),
+            ColumnType::DateTime2 => Some(8),
+            ColumnType::VarChar { .. }
+            | ColumnType::NVarChar { .. }
+            | ColumnType::VarBinary { .. } => None,
+        }
+    }
+
+    /// Parses the debug-command type syntax: `int`, `varchar(30)`,
+    /// `decimal(10,2)`, ...
+    pub fn parse(spec: &str) -> Result<Self, TypeError> {
+        let spec = spec.trim().to_ascii_lowercase();
+        let (name, args) = match spec.find('(') {
+            Some(open) => {
+                let close = spec
+                    .rfind(')')
+                    .filter(|close| *close > open)
+                    .ok_or_else(|| TypeError(format!("unbalanced parens in type '{spec}'")))?;
+                let args: Vec<&str> = spec[open + 1..close].split(',').map(str::trim).collect();
+                (&spec[..open], args)
+            }
+            None => (spec.as_str(), Vec::new()),
+        };
+        let one_arg = |args: &[&str]| -> Result<u16, TypeError> {
+            if args.len() != 1 {
+                return Err(TypeError(format!("type '{name}' takes one argument")));
+            }
+            args[0]
+                .parse::<u16>()
+                .map_err(|_| TypeError(format!("bad length in type '{name}'")))
+        };
+        match name.trim() {
+            "tinyint" => Ok(ColumnType::TinyInt),
+            "smallint" => Ok(ColumnType::SmallInt),
+            "int" => Ok(ColumnType::Int),
+            "bigint" => Ok(ColumnType::BigInt),
+            "bit" => Ok(ColumnType::Bit),
+            "real" => Ok(ColumnType::Real),
+            "float" => Ok(ColumnType::Float),
+            "date" => Ok(ColumnType::Date),
+            "time" => Ok(ColumnType::Time),
+            "datetime2" => Ok(ColumnType::DateTime2),
+            "uniqueidentifier" => Ok(ColumnType::UniqueIdentifier),
+            "varchar" => Ok(ColumnType::VarChar {
+                max_len: one_arg(&args)?,
+            }),
+            "nvarchar" => Ok(ColumnType::NVarChar {
+                max_len: one_arg(&args)?,
+            }),
+            "varbinary" => Ok(ColumnType::VarBinary {
+                max_len: one_arg(&args)?,
+            }),
+            "decimal" | "numeric" => {
+                if args.len() != 2 {
+                    return Err(TypeError("decimal takes (precision, scale)".to_string()));
+                }
+                let precision: u8 = args[0]
+                    .parse()
+                    .map_err(|_| TypeError("bad decimal precision".to_string()))?;
+                let scale: u8 = args[1]
+                    .parse()
+                    .map_err(|_| TypeError("bad decimal scale".to_string()))?;
+                if precision == 0 || precision > 38 || scale > precision {
+                    return Err(TypeError(format!(
+                        "decimal({precision},{scale}) out of range (p in 1..=38, s <= p)"
+                    )));
+                }
+                Ok(ColumnType::Decimal { precision, scale })
+            }
+            other => Err(TypeError(format!("unsupported type '{other}'"))),
+        }
+    }
+
+    pub fn name(&self) -> String {
+        match self {
+            ColumnType::TinyInt => "tinyint".to_string(),
+            ColumnType::SmallInt => "smallint".to_string(),
+            ColumnType::Int => "int".to_string(),
+            ColumnType::BigInt => "bigint".to_string(),
+            ColumnType::Bit => "bit".to_string(),
+            ColumnType::Real => "real".to_string(),
+            ColumnType::Float => "float".to_string(),
+            ColumnType::Date => "date".to_string(),
+            ColumnType::Time => "time".to_string(),
+            ColumnType::DateTime2 => "datetime2".to_string(),
+            ColumnType::UniqueIdentifier => "uniqueidentifier".to_string(),
+            ColumnType::Decimal { precision, scale } => format!("decimal({precision},{scale})"),
+            ColumnType::VarChar { max_len } => format!("varchar({max_len})"),
+            ColumnType::NVarChar { max_len } => format!("nvarchar({max_len})"),
+            ColumnType::VarBinary { max_len } => format!("varbinary({max_len})"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct TypeError(pub String);
+
+impl std::fmt::Display for TypeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// A storage-level value. Integer-backed temporal types carry their T-SQL
+/// tick encodings directly.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Datum {
+    Null,
+    TinyInt(u8),
+    SmallInt(i16),
+    Int(i32),
+    BigInt(i64),
+    Bit(bool),
+    Real(f32),
+    Float(f64),
+    /// Unscaled value; scale comes from the column type.
+    Decimal(i128),
+    /// Days since 0001-01-01.
+    Date(u32),
+    /// 100ns ticks since midnight.
+    Time(u64),
+    /// (days since 0001-01-01, 100ns ticks since midnight).
+    DateTime2(u32, u64),
+    UniqueIdentifier([u8; 16]),
+    VarChar(String),
+    NVarChar(String),
+    VarBinary(Vec<u8>),
+}
+
+impl Datum {
+    pub fn is_null(&self) -> bool {
+        matches!(self, Datum::Null)
+    }
+
+    /// Fixed-width on-disk encoding (only valid for fixed-width types).
+    pub fn encode_fixed(&self, out: &mut Vec<u8>) {
+        match self {
+            Datum::TinyInt(v) => out.push(*v),
+            Datum::SmallInt(v) => out.extend_from_slice(&v.to_le_bytes()),
+            Datum::Int(v) => out.extend_from_slice(&v.to_le_bytes()),
+            Datum::BigInt(v) => out.extend_from_slice(&v.to_le_bytes()),
+            Datum::Bit(v) => out.push(*v as u8),
+            Datum::Real(v) => out.extend_from_slice(&v.to_le_bytes()),
+            Datum::Float(v) => out.extend_from_slice(&v.to_le_bytes()),
+            Datum::Decimal(v) => out.extend_from_slice(&v.to_le_bytes()),
+            Datum::Date(days) => out.extend_from_slice(&days.to_le_bytes()[..3]),
+            Datum::Time(ticks) => out.extend_from_slice(&ticks.to_le_bytes()[..5]),
+            Datum::DateTime2(days, ticks) => {
+                out.extend_from_slice(&ticks.to_le_bytes()[..5]);
+                out.extend_from_slice(&days.to_le_bytes()[..3]);
+            }
+            Datum::UniqueIdentifier(bytes) => out.extend_from_slice(bytes),
+            Datum::Null | Datum::VarChar(_) | Datum::NVarChar(_) | Datum::VarBinary(_) => {
+                unreachable!("not a fixed-width datum")
+            }
+        }
+    }
+
+    /// Variable-width on-disk encoding (only valid for var-width types).
+    pub fn encode_var(&self) -> Vec<u8> {
+        match self {
+            Datum::VarChar(s) => s.as_bytes().to_vec(),
+            Datum::NVarChar(s) => s.encode_utf16().flat_map(|u| u.to_le_bytes()).collect(),
+            Datum::VarBinary(b) => b.clone(),
+            _ => unreachable!("not a var-width datum"),
+        }
+    }
+
+    pub fn decode_fixed(column_type: &ColumnType, bytes: &[u8]) -> Result<Datum, TypeError> {
+        let want = column_type.fixed_size().expect("fixed-width type");
+        if bytes.len() != want {
+            return Err(TypeError(format!(
+                "fixed datum length mismatch for {}: {} vs {want}",
+                column_type.name(),
+                bytes.len()
+            )));
+        }
+        Ok(match column_type {
+            ColumnType::TinyInt => Datum::TinyInt(bytes[0]),
+            ColumnType::SmallInt => Datum::SmallInt(i16::from_le_bytes(bytes.try_into().unwrap())),
+            ColumnType::Int => Datum::Int(i32::from_le_bytes(bytes.try_into().unwrap())),
+            ColumnType::BigInt => Datum::BigInt(i64::from_le_bytes(bytes.try_into().unwrap())),
+            ColumnType::Bit => Datum::Bit(bytes[0] != 0),
+            ColumnType::Real => Datum::Real(f32::from_le_bytes(bytes.try_into().unwrap())),
+            ColumnType::Float => Datum::Float(f64::from_le_bytes(bytes.try_into().unwrap())),
+            ColumnType::Decimal { .. } => {
+                Datum::Decimal(i128::from_le_bytes(bytes.try_into().unwrap()))
+            }
+            ColumnType::Date => Datum::Date(u24_le(bytes)),
+            ColumnType::Time => Datum::Time(u40_le(bytes)),
+            ColumnType::DateTime2 => Datum::DateTime2(u24_le(&bytes[5..8]), u40_le(&bytes[0..5])),
+            ColumnType::UniqueIdentifier => {
+                Datum::UniqueIdentifier(bytes.try_into().expect("16 bytes"))
+            }
+            _ => unreachable!("fixed_size returned Some for var type"),
+        })
+    }
+
+    pub fn decode_var(column_type: &ColumnType, bytes: &[u8]) -> Result<Datum, TypeError> {
+        Ok(match column_type {
+            ColumnType::VarChar { .. } => Datum::VarChar(
+                String::from_utf8(bytes.to_vec())
+                    .map_err(|_| TypeError("invalid utf-8 in varchar".to_string()))?,
+            ),
+            ColumnType::NVarChar { .. } => {
+                if !bytes.len().is_multiple_of(2) {
+                    return Err(TypeError("odd nvarchar byte length".to_string()));
+                }
+                let units: Vec<u16> = bytes
+                    .chunks_exact(2)
+                    .map(|c| u16::from_le_bytes([c[0], c[1]]))
+                    .collect();
+                Datum::NVarChar(
+                    String::from_utf16(&units)
+                        .map_err(|_| TypeError("invalid utf-16 in nvarchar".to_string()))?,
+                )
+            }
+            ColumnType::VarBinary { .. } => Datum::VarBinary(bytes.to_vec()),
+            _ => unreachable!("not a var-width type"),
+        })
+    }
+
+    /// Converts a JSON value (debug-command input) into a typed datum,
+    /// validating range and length limits.
+    pub fn from_json(column_type: &ColumnType, value: &Json) -> Result<Datum, TypeError> {
+        if value.is_null() {
+            return Ok(Datum::Null);
+        }
+        let int_in = |min: i64, max: i64| -> Result<i64, TypeError> {
+            let v = value
+                .as_i64()
+                .ok_or_else(|| TypeError(format!("expected integer for {}", column_type.name())))?;
+            if v < min || v > max {
+                return Err(TypeError(format!(
+                    "value {v} out of range for {}",
+                    column_type.name()
+                )));
+            }
+            Ok(v)
+        };
+        let string_in = || -> Result<&str, TypeError> {
+            value
+                .as_str()
+                .ok_or_else(|| TypeError(format!("expected string for {}", column_type.name())))
+        };
+        match column_type {
+            ColumnType::TinyInt => Ok(Datum::TinyInt(int_in(0, u8::MAX as i64)? as u8)),
+            ColumnType::SmallInt => Ok(Datum::SmallInt(
+                int_in(i16::MIN as i64, i16::MAX as i64)? as i16
+            )),
+            ColumnType::Int => Ok(Datum::Int(int_in(i32::MIN as i64, i32::MAX as i64)? as i32)),
+            ColumnType::BigInt => Ok(Datum::BigInt(int_in(i64::MIN, i64::MAX)?)),
+            ColumnType::Bit => match value {
+                Json::Bool(b) => Ok(Datum::Bit(*b)),
+                Json::Number(_) => Ok(Datum::Bit(int_in(0, 1)? != 0)),
+                _ => Err(TypeError("expected bool or 0/1 for bit".to_string())),
+            },
+            ColumnType::Real => {
+                let v = value
+                    .as_f64()
+                    .ok_or_else(|| TypeError("expected number for real".to_string()))?;
+                let narrowed = v as f32;
+                if v.is_finite() && !narrowed.is_finite() {
+                    return Err(TypeError(format!("value {v} out of range for real")));
+                }
+                Ok(Datum::Real(narrowed))
+            }
+            ColumnType::Float => {
+                let v = value
+                    .as_f64()
+                    .ok_or_else(|| TypeError("expected number for float".to_string()))?;
+                Ok(Datum::Float(v))
+            }
+            ColumnType::Decimal { precision, scale } => {
+                let text = match value {
+                    Json::String(s) => s.clone(),
+                    Json::Number(n) => n.to_string(),
+                    _ => {
+                        return Err(TypeError(
+                            "expected number or string for decimal".to_string(),
+                        ));
+                    }
+                };
+                parse_decimal(&text, *precision, *scale).map(Datum::Decimal)
+            }
+            ColumnType::Date => Ok(Datum::Date(parse_date(string_in()?)?)),
+            ColumnType::Time => Ok(Datum::Time(parse_time(string_in()?)?)),
+            ColumnType::DateTime2 => {
+                let raw = string_in()?;
+                let split = raw
+                    .find([' ', 'T'])
+                    .ok_or_else(|| TypeError("expected 'YYYY-MM-DD hh:mm:ss'".to_string()))?;
+                let days = parse_date(&raw[..split])?;
+                let ticks = parse_time(&raw[split + 1..])?;
+                Ok(Datum::DateTime2(days, ticks))
+            }
+            ColumnType::UniqueIdentifier => Ok(Datum::UniqueIdentifier(parse_guid(string_in()?)?)),
+            ColumnType::VarChar { max_len } => {
+                let s = string_in()?;
+                if s.len() > *max_len as usize {
+                    return Err(TypeError(format!(
+                        "string of {} bytes exceeds varchar({max_len})",
+                        s.len()
+                    )));
+                }
+                Ok(Datum::VarChar(s.to_string()))
+            }
+            ColumnType::NVarChar { max_len } => {
+                let s = string_in()?;
+                let units = s.encode_utf16().count();
+                if units > *max_len as usize {
+                    return Err(TypeError(format!(
+                        "string of {units} characters exceeds nvarchar({max_len})"
+                    )));
+                }
+                Ok(Datum::NVarChar(s.to_string()))
+            }
+            ColumnType::VarBinary { max_len } => {
+                let hex = string_in()?;
+                // The 0x prefix is debug-command sugar; GUIDs must not have
+                // one, so parse_hex itself stays strict.
+                let bytes = parse_hex(hex.strip_prefix("0x").unwrap_or(hex))?;
+                if bytes.len() > *max_len as usize {
+                    return Err(TypeError(format!(
+                        "{} bytes exceeds varbinary({max_len})",
+                        bytes.len()
+                    )));
+                }
+                Ok(Datum::VarBinary(bytes))
+            }
+        }
+    }
+
+    /// Renders a datum back to JSON for debug-command output.
+    pub fn to_json(&self, column_type: &ColumnType) -> Json {
+        match self {
+            Datum::Null => Json::Null,
+            Datum::TinyInt(v) => Json::from(*v),
+            Datum::SmallInt(v) => Json::from(*v),
+            Datum::Int(v) => Json::from(*v),
+            Datum::BigInt(v) => Json::from(*v),
+            Datum::Bit(v) => Json::from(*v),
+            Datum::Real(v) => Json::from(*v as f64),
+            Datum::Float(v) => Json::from(*v),
+            Datum::Decimal(unscaled) => {
+                let scale = match column_type {
+                    ColumnType::Decimal { scale, .. } => *scale,
+                    _ => 0,
+                };
+                Json::String(format_decimal(*unscaled, scale))
+            }
+            Datum::Date(days) => Json::String(format_date(*days)),
+            Datum::Time(ticks) => Json::String(format_time(*ticks)),
+            Datum::DateTime2(days, ticks) => {
+                Json::String(format!("{} {}", format_date(*days), format_time(*ticks)))
+            }
+            Datum::UniqueIdentifier(bytes) => Json::String(format_guid(bytes)),
+            Datum::VarChar(s) | Datum::NVarChar(s) => Json::String(s.clone()),
+            Datum::VarBinary(b) => Json::String(format_hex(b)),
+        }
+    }
+}
+
+fn u24_le(bytes: &[u8]) -> u32 {
+    u32::from_le_bytes([bytes[0], bytes[1], bytes[2], 0])
+}
+
+fn u40_le(bytes: &[u8]) -> u64 {
+    u64::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], 0, 0, 0])
+}
+
+/// Days since 0001-01-01 for a proleptic-Gregorian civil date
+/// (Howard Hinnant's days-from-civil, rebased).
+fn days_from_civil(year: i64, month: u32, day: u32) -> i64 {
+    let y = if month <= 2 { year - 1 } else { year };
+    let era = if y >= 0 { y } else { y - 399 } / 400;
+    let yoe = y - era * 400;
+    let mp = (month as i64 + 9) % 12;
+    let doy = (153 * mp + 2) / 5 + day as i64 - 1;
+    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+    era * 146_097 + doe - 719_468 // days since 1970-01-01
+}
+
+const EPOCH_1970_FROM_0001: i64 = 719_162; // days_from_civil(1970,1,1) - days_from_civil(1,1,1)
+
+fn civil_from_days(days_since_0001: u32) -> (i64, u32, u32) {
+    let z = days_since_0001 as i64 - EPOCH_1970_FROM_0001 + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = z - era * 146_097;
+    let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = (doy - (153 * mp + 2) / 5 + 1) as u32;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 } as u32;
+    (if m <= 2 { y + 1 } else { y }, m, d)
+}
+
+fn parse_date(text: &str) -> Result<u32, TypeError> {
+    let bad = || TypeError(format!("bad date '{text}', expected YYYY-MM-DD"));
+    let parts: Vec<&str> = text.trim().split('-').collect();
+    if parts.len() != 3 {
+        return Err(bad());
+    }
+    let year: i64 = parts[0].parse().map_err(|_| bad())?;
+    let month: u32 = parts[1].parse().map_err(|_| bad())?;
+    let day: u32 = parts[2].parse().map_err(|_| bad())?;
+    if !(1..=9999).contains(&year) || !(1..=12).contains(&month) || !(1..=31).contains(&day) {
+        return Err(bad());
+    }
+    let days = days_from_civil(year, month, day) + EPOCH_1970_FROM_0001;
+    // Reject non-existent dates like Feb 30 (round-trip check).
+    if civil_from_days(days as u32) != (year, month, day) {
+        return Err(bad());
+    }
+    Ok(days as u32)
+}
+
+fn format_date(days: u32) -> String {
+    let (y, m, d) = civil_from_days(days);
+    format!("{y:04}-{m:02}-{d:02}")
+}
+
+const TICKS_PER_SECOND: u64 = 10_000_000;
+
+fn parse_time(text: &str) -> Result<u64, TypeError> {
+    let bad = || TypeError(format!("bad time '{text}', expected hh:mm:ss[.fffffff]"));
+    let text = text.trim();
+    let (main, frac) = match text.find('.') {
+        Some(dot) => (&text[..dot], &text[dot + 1..]),
+        None => (text, ""),
+    };
+    let parts: Vec<&str> = main.split(':').collect();
+    if parts.len() < 2 || parts.len() > 3 {
+        return Err(bad());
+    }
+    let hours: u64 = parts[0].parse().map_err(|_| bad())?;
+    let minutes: u64 = parts[1].parse().map_err(|_| bad())?;
+    let seconds: u64 = if parts.len() == 3 {
+        parts[2].parse().map_err(|_| bad())?
+    } else {
+        0
+    };
+    if hours > 23 || minutes > 59 || seconds > 59 {
+        return Err(bad());
+    }
+    if frac.len() > 7 || !frac.chars().all(|c| c.is_ascii_digit()) {
+        return Err(bad());
+    }
+    let mut frac_ticks = 0u64;
+    if !frac.is_empty() {
+        frac_ticks = frac.parse::<u64>().map_err(|_| bad())? * 10u64.pow(7 - frac.len() as u32);
+    }
+    Ok((hours * 3600 + minutes * 60 + seconds) * TICKS_PER_SECOND + frac_ticks)
+}
+
+fn format_time(ticks: u64) -> String {
+    let seconds_total = ticks / TICKS_PER_SECOND;
+    let frac = ticks % TICKS_PER_SECOND;
+    let (h, m, s) = (
+        seconds_total / 3600,
+        (seconds_total / 60) % 60,
+        seconds_total % 60,
+    );
+    if frac == 0 {
+        format!("{h:02}:{m:02}:{s:02}")
+    } else {
+        format!("{h:02}:{m:02}:{s:02}.{frac:07}")
+    }
+}
+
+fn parse_decimal(text: &str, precision: u8, scale: u8) -> Result<i128, TypeError> {
+    let bad = || TypeError(format!("bad decimal '{text}'"));
+    let text = text.trim();
+    let (negative, rest) = match text.strip_prefix('-') {
+        Some(rest) => (true, rest),
+        None => (false, text.strip_prefix('+').unwrap_or(text)),
+    };
+    let (int_part, frac_part) = match rest.find('.') {
+        Some(dot) => (&rest[..dot], &rest[dot + 1..]),
+        None => (rest, ""),
+    };
+    if int_part.is_empty() && frac_part.is_empty() {
+        return Err(bad());
+    }
+    if !int_part.chars().all(|c| c.is_ascii_digit())
+        || !frac_part.chars().all(|c| c.is_ascii_digit())
+    {
+        return Err(bad());
+    }
+    if frac_part.len() > scale as usize {
+        return Err(TypeError(format!(
+            "decimal '{text}' has more than {scale} fractional digits"
+        )));
+    }
+    let mut unscaled: i128 = 0;
+    for c in int_part.chars().chain(frac_part.chars()) {
+        unscaled = unscaled
+            .checked_mul(10)
+            .and_then(|v| v.checked_add((c as u8 - b'0') as i128))
+            .ok_or_else(bad)?;
+    }
+    for _ in frac_part.len()..scale as usize {
+        unscaled = unscaled.checked_mul(10).ok_or_else(bad)?;
+    }
+    let limit = 10i128.checked_pow(precision as u32).ok_or_else(bad)?;
+    if unscaled >= limit {
+        return Err(TypeError(format!(
+            "decimal '{text}' overflows precision {precision}"
+        )));
+    }
+    Ok(if negative { -unscaled } else { unscaled })
+}
+
+fn format_decimal(unscaled: i128, scale: u8) -> String {
+    let negative = unscaled < 0;
+    let magnitude = unscaled.unsigned_abs().to_string();
+    let scale = scale as usize;
+    let digits = if magnitude.len() <= scale {
+        format!("{}{}", "0".repeat(scale + 1 - magnitude.len()), magnitude)
+    } else {
+        magnitude
+    };
+    let split = digits.len() - scale;
+    let mut out = String::new();
+    if negative {
+        out.push('-');
+    }
+    out.push_str(&digits[..split]);
+    if scale > 0 {
+        out.push('.');
+        out.push_str(&digits[split..]);
+    }
+    out
+}
+
+fn parse_guid(text: &str) -> Result<[u8; 16], TypeError> {
+    let bad = || TypeError(format!("bad uniqueidentifier '{text}'"));
+    let hex: String = text.chars().filter(|c| *c != '-').collect();
+    if hex.len() != 32 || text.chars().filter(|c| *c == '-').count() != 4 {
+        return Err(bad());
+    }
+    let bytes = parse_hex(&hex).map_err(|_| bad())?;
+    bytes.try_into().map_err(|_| bad())
+}
+
+fn format_guid(bytes: &[u8; 16]) -> String {
+    let hex = format_hex(bytes);
+    format!(
+        "{}-{}-{}-{}-{}",
+        &hex[0..8],
+        &hex[8..12],
+        &hex[12..16],
+        &hex[16..20],
+        &hex[20..32]
+    )
+}
+
+fn parse_hex(text: &str) -> Result<Vec<u8>, TypeError> {
+    // Byte-wise so multi-byte characters cannot cause slicing panics.
+    let bytes = text.as_bytes();
+    if !bytes.len().is_multiple_of(2) {
+        return Err(TypeError("odd hex length".to_string()));
+    }
+    let nibble = |b: u8| -> Result<u8, TypeError> {
+        match b {
+            b'0'..=b'9' => Ok(b - b'0'),
+            b'a'..=b'f' => Ok(b - b'a' + 10),
+            b'A'..=b'F' => Ok(b - b'A' + 10),
+            _ => Err(TypeError(format!("bad hex '{text}'"))),
+        }
+    };
+    bytes
+        .chunks_exact(2)
+        .map(|pair| Ok(nibble(pair[0])? << 4 | nibble(pair[1])?))
+        .collect()
+}
+
+fn format_hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn round_trip_fixed(column_type: ColumnType, datum: Datum) {
+        let mut bytes = Vec::new();
+        datum.encode_fixed(&mut bytes);
+        assert_eq!(bytes.len(), column_type.fixed_size().unwrap());
+        assert_eq!(Datum::decode_fixed(&column_type, &bytes).unwrap(), datum);
+    }
+
+    #[test]
+    fn fixed_encodings_round_trip() {
+        round_trip_fixed(ColumnType::TinyInt, Datum::TinyInt(255));
+        round_trip_fixed(ColumnType::SmallInt, Datum::SmallInt(-32768));
+        round_trip_fixed(ColumnType::Int, Datum::Int(-2_000_000_000));
+        round_trip_fixed(ColumnType::BigInt, Datum::BigInt(i64::MIN));
+        round_trip_fixed(ColumnType::Bit, Datum::Bit(true));
+        round_trip_fixed(ColumnType::Real, Datum::Real(-1.5));
+        round_trip_fixed(ColumnType::Float, Datum::Float(std::f64::consts::PI));
+        round_trip_fixed(
+            ColumnType::Decimal {
+                precision: 38,
+                scale: 10,
+            },
+            Datum::Decimal(-1234567890123456789012345678901234567i128),
+        );
+        round_trip_fixed(ColumnType::Date, Datum::Date(738_000));
+        round_trip_fixed(ColumnType::Time, Datum::Time(863_999_999_999));
+        round_trip_fixed(
+            ColumnType::DateTime2,
+            Datum::DateTime2(738_000, 123_456_789),
+        );
+        round_trip_fixed(
+            ColumnType::UniqueIdentifier,
+            Datum::UniqueIdentifier([7u8; 16]),
+        );
+    }
+
+    #[test]
+    fn var_encodings_round_trip() {
+        let nvar = ColumnType::NVarChar { max_len: 30 };
+        let datum = Datum::NVarChar("åäö смеш 😀".to_string());
+        let bytes = datum.encode_var();
+        assert_eq!(Datum::decode_var(&nvar, &bytes).unwrap(), datum);
+
+        let var = ColumnType::VarChar { max_len: 30 };
+        let datum = Datum::VarChar("hello".to_string());
+        assert_eq!(Datum::decode_var(&var, &datum.encode_var()).unwrap(), datum);
+    }
+
+    #[test]
+    fn date_time_parsing_and_formatting() {
+        // Known anchors: 0001-01-01 is day 0; 1970-01-01 is day 719162.
+        assert_eq!(parse_date("0001-01-01").unwrap(), 0);
+        assert_eq!(parse_date("1970-01-01").unwrap(), 719_162);
+        assert_eq!(format_date(719_162), "1970-01-01");
+        assert_eq!(parse_date("2026-07-12").unwrap(), 739_808);
+        assert_eq!(format_date(739_808), "2026-07-12");
+        assert!(parse_date("2026-02-30").is_err());
+        assert!(parse_date("2026-13-01").is_err());
+
+        assert_eq!(parse_time("00:00:00").unwrap(), 0);
+        assert_eq!(
+            parse_time("23:59:59.9999999").unwrap(),
+            24 * 3600 * TICKS_PER_SECOND - 1
+        );
+        assert_eq!(
+            parse_time("12:30").unwrap(),
+            (12 * 3600 + 30 * 60) * TICKS_PER_SECOND
+        );
+        assert_eq!(
+            format_time(parse_time("01:02:03.05").unwrap()),
+            "01:02:03.0500000"
+        );
+        assert!(parse_time("24:00:00").is_err());
+    }
+
+    #[test]
+    fn decimal_parsing_scale_and_precision() {
+        assert_eq!(parse_decimal("123.45", 10, 2).unwrap(), 12345);
+        assert_eq!(parse_decimal("-0.5", 10, 2).unwrap(), -50);
+        assert_eq!(parse_decimal("7", 10, 2).unwrap(), 700);
+        assert!(
+            parse_decimal("1.234", 10, 2).is_err(),
+            "too many frac digits"
+        );
+        assert!(
+            parse_decimal("123456789", 10, 2).is_err(),
+            "overflows p=10 s=2"
+        );
+        assert_eq!(format_decimal(12345, 2), "123.45");
+        assert_eq!(format_decimal(-50, 2), "-0.50");
+        assert_eq!(format_decimal(700, 0), "700");
+    }
+
+    #[test]
+    fn guid_round_trip() {
+        let guid = parse_guid("01234567-89ab-cdef-0123-456789abcdef").unwrap();
+        assert_eq!(format_guid(&guid), "01234567-89ab-cdef-0123-456789abcdef");
+        assert!(parse_guid("not-a-guid").is_err());
+        // Review findings: these inputs used to panic.
+        assert!(parse_guid("0x234567-89ab-cdef-0123-456789abcdef").is_err());
+        assert!(parse_hex("åä").is_err());
+        assert!(ColumnType::parse("int)x(").is_err());
+        // REAL overflow must error, not become infinity.
+        assert!(Datum::from_json(&ColumnType::Real, &serde_json::json!(1e300)).is_err());
+    }
+
+    #[test]
+    fn json_conversion_validates_ranges() {
+        let int = ColumnType::Int;
+        assert_eq!(Datum::from_json(&int, &json!(42)).unwrap(), Datum::Int(42));
+        assert!(Datum::from_json(&int, &json!(3_000_000_000i64)).is_err());
+        assert_eq!(Datum::from_json(&int, &Json::Null).unwrap(), Datum::Null);
+
+        let varchar = ColumnType::VarChar { max_len: 3 };
+        assert!(Datum::from_json(&varchar, &json!("toolong")).is_err());
+
+        let bit = ColumnType::Bit;
+        assert_eq!(
+            Datum::from_json(&bit, &json!(true)).unwrap(),
+            Datum::Bit(true)
+        );
+        assert_eq!(
+            Datum::from_json(&bit, &json!(0)).unwrap(),
+            Datum::Bit(false)
+        );
+
+        let varbinary = ColumnType::VarBinary { max_len: 8 };
+        assert_eq!(
+            Datum::from_json(&varbinary, &json!("0xdeadbeef")).unwrap(),
+            Datum::VarBinary(vec![0xde, 0xad, 0xbe, 0xef])
+        );
+    }
+
+    #[test]
+    fn type_spec_parsing() {
+        assert_eq!(ColumnType::parse("INT").unwrap(), ColumnType::Int);
+        assert_eq!(
+            ColumnType::parse("varchar(30)").unwrap(),
+            ColumnType::VarChar { max_len: 30 }
+        );
+        assert_eq!(
+            ColumnType::parse("decimal(10, 2)").unwrap(),
+            ColumnType::Decimal {
+                precision: 10,
+                scale: 2
+            }
+        );
+        assert!(ColumnType::parse("decimal(40,2)").is_err());
+        assert!(ColumnType::parse("blob").is_err());
+    }
+}

--- a/crates/truthdb-core/src/storage.rs
+++ b/crates/truthdb-core/src/storage.rs
@@ -5,6 +5,16 @@ use xxhash_rust::xxh64::xxh64;
 
 use crate::allocator::{EXTENT_PAGES, PageAllocator};
 use crate::direct_io::{AlignedPageBuf, DirectFile};
+use crate::relstore::RelState;
+use crate::relstore::btree::{BTree, TreeInsert};
+use crate::relstore::buffer_pool::DEFAULT_CAPACITY_BYTES;
+use crate::relstore::catalog::{self, FIRST_USER_OBJECT_ID, TableDef};
+use crate::relstore::ctx::{OpMode, PoolIo, RelCtx, TxnLink};
+use crate::relstore::heap::Heap;
+use crate::relstore::key::encode_key;
+use crate::relstore::recovery as rel_recovery;
+use crate::relstore::row::{Column, Schema, decode_row, encode_row};
+use crate::relstore::types::{Datum, TypeError};
 use crate::storage_layout::{
     FileHeader, PAGE_SIZE, SNAPSHOT_DESCRIPTOR_SIZE, SUPERBLOCK_ACTIVE_A, SUPERBLOCK_ACTIVE_B,
     SnapshotDescriptor, Superblock, WAL_ENTRY_TYPE_REL, WAL_MAX_BYTES, WAL_MIN_BYTES, align_down,
@@ -14,6 +24,12 @@ use crate::wal::records::{REL_KIND_ALLOC_EXTENT, REL_KIND_FREE_EXTENT, RelRecord
 use crate::wal::{WalWriter, scan_ring};
 
 pub use crate::wal::WalRecord;
+
+impl From<TypeError> for StorageError {
+    fn from(err: TypeError) -> Self {
+        StorageError::InvalidConfig(err.0)
+    }
+}
 
 /// Version stamped in REL wal entries (entry-level, distinct from the record
 /// kinds inside).
@@ -86,6 +102,9 @@ pub enum StorageError {
 
     #[error("wal ring full: {0}")]
     WalFull(String),
+
+    #[error("constraint violation: {0}")]
+    Constraint(String),
 }
 
 pub struct Storage {
@@ -178,6 +197,437 @@ impl Storage {
     pub fn is_page_allocated(&self, page: u64) -> bool {
         self.file.allocator.is_allocated(page)
     }
+
+    // ---- relational store (Stage 2 surface; SQL replaces this in Stage 3) --
+
+    /// Creates a table: with `key_names` it becomes a clustered B+ tree on
+    /// those columns, without it a heap.
+    pub fn rel_create_table(
+        &mut self,
+        name: &str,
+        columns: Vec<Column>,
+        key_names: &[String],
+    ) -> Result<(), StorageError> {
+        self.file.ensure_rel_usable()?;
+        if self.file.rel.tables.contains_key(name) {
+            return Err(StorageError::Constraint(format!(
+                "table '{name}' already exists"
+            )));
+        }
+        if columns.is_empty() {
+            return Err(StorageError::InvalidConfig(
+                "a table needs at least one column".to_string(),
+            ));
+        }
+        let mut key_columns = Vec::new();
+        for key_name in key_names {
+            let index = columns
+                .iter()
+                .position(|c| &c.name == key_name)
+                .ok_or_else(|| {
+                    StorageError::InvalidConfig(format!("unknown key column '{key_name}'"))
+                })?;
+            if columns[index].nullable {
+                return Err(StorageError::InvalidConfig(format!(
+                    "primary key column '{key_name}' must be NOT NULL"
+                )));
+            }
+            key_columns.push(index);
+        }
+
+        // The catalog tree itself is created outside the statement (system
+        // records, not undoable) so a rolled-back CREATE TABLE still leaves
+        // a valid catalog.
+        if self.file.rel.catalog_root.is_none() {
+            let root = {
+                let mut ctx = self.file.rel_ctx();
+                catalog::create_catalog(&mut ctx)?
+            };
+            self.file.rel.catalog_root = Some(root);
+        }
+        let catalog_root = self.file.rel.catalog_root.expect("catalog exists");
+        let object_id = self.file.rel.next_object_id;
+        let def_columns: Vec<(String, String, bool)> = columns
+            .iter()
+            .map(|c| (c.name.clone(), c.column_type.name(), c.nullable))
+            .collect();
+        let table_name = name.to_string();
+        let is_tree = !key_columns.is_empty();
+
+        let def = self.file.rel_statement(move |ctx, txn| {
+            let root_page = if is_tree {
+                BTree::create(ctx, object_id)?.root
+            } else {
+                Heap::create(ctx, object_id)?.first_page
+            };
+            let def = TableDef {
+                object_id,
+                name: table_name,
+                columns: def_columns,
+                key_columns,
+                root_page,
+            };
+            catalog::insert_table(ctx, &mut OpMode::Txn(txn), catalog_root, &def)?;
+            Ok(def)
+        })?;
+        self.file.rel.next_object_id += 1;
+        self.file.rel.tables.insert(name.to_string(), def);
+        Ok(())
+    }
+
+    /// The table's definition (schema and layout), if it exists.
+    pub fn rel_table(&self, name: &str) -> Option<TableDef> {
+        self.file.rel.tables.get(name).cloned()
+    }
+
+    pub fn rel_insert(&mut self, name: &str, values: Vec<Datum>) -> Result<(), StorageError> {
+        self.file.ensure_rel_usable()?;
+        let (def, schema) = self.rel_def(name)?;
+        validate_not_null(&schema, &values)?;
+        let row = encode_row(&schema, &values)?;
+        if def.is_tree() {
+            let key = encode_key(&schema, &def.key_columns, &values)?;
+            let tree = BTree {
+                object_id: def.object_id,
+                root: def.root_page,
+            };
+            self.file.rel_statement(move |ctx, txn| {
+                match tree.insert_unique(ctx, &mut OpMode::Txn(txn), &key, &row)? {
+                    TreeInsert::Inserted => Ok(()),
+                    TreeInsert::DuplicateKey => Err(StorageError::Constraint(
+                        "duplicate primary key".to_string(),
+                    )),
+                }
+            })
+        } else {
+            let heap = Heap {
+                object_id: def.object_id,
+                first_page: def.root_page,
+            };
+            self.file.rel_statement(move |ctx, txn| {
+                heap.insert(ctx, txn, &row)?;
+                Ok(())
+            })
+        }
+    }
+
+    /// Point lookup by primary key (clustered tables only).
+    pub fn rel_get(
+        &mut self,
+        name: &str,
+        key_values: &[Datum],
+    ) -> Result<Option<Vec<Datum>>, StorageError> {
+        self.file.ensure_rel_usable()?;
+        let (def, schema) = self.rel_def(name)?;
+        if !def.is_tree() {
+            return Err(StorageError::InvalidConfig(format!(
+                "table '{name}' has no primary key"
+            )));
+        }
+        if key_values.len() != def.key_columns.len() {
+            return Err(StorageError::InvalidConfig(
+                "wrong number of key values".to_string(),
+            ));
+        }
+        let mut key = Vec::new();
+        for value in key_values {
+            crate::relstore::key::encode_datum(value, &mut key)?;
+        }
+        let tree = BTree {
+            object_id: def.object_id,
+            root: def.root_page,
+        };
+        let mut ctx = self.file.rel_ctx();
+        match tree.get(&mut ctx, &key)? {
+            Some(row) => Ok(Some(decode_row(&schema, &row)?)),
+            None => Ok(None),
+        }
+    }
+
+    /// Full scan: rows as typed datums (key order for trees, chain order
+    /// for heaps).
+    pub fn rel_scan(&mut self, name: &str) -> Result<Vec<Vec<Datum>>, StorageError> {
+        self.file.ensure_rel_usable()?;
+        let (def, schema) = self.rel_def(name)?;
+        let mut ctx = self.file.rel_ctx();
+        let raw: Vec<Vec<u8>> = if def.is_tree() {
+            let tree = BTree {
+                object_id: def.object_id,
+                root: def.root_page,
+            };
+            tree.scan(&mut ctx)?
+                .into_iter()
+                .map(|(_, row)| row)
+                .collect()
+        } else {
+            let heap = Heap {
+                object_id: def.object_id,
+                first_page: def.root_page,
+            };
+            heap.scan(&mut ctx)?
+                .into_iter()
+                .map(|(_, row)| row)
+                .collect()
+        };
+        raw.into_iter()
+            .map(|row| decode_row(&schema, &row).map_err(StorageError::from))
+            .collect()
+    }
+
+    /// Deletes every row where `column = value`; returns the count. Targets
+    /// are materialized before any mutation (Halloween avoidance).
+    pub fn rel_delete_where(
+        &mut self,
+        name: &str,
+        column: &str,
+        value: &Datum,
+    ) -> Result<usize, StorageError> {
+        self.file.ensure_rel_usable()?;
+        let (def, schema) = self.rel_def(name)?;
+        let column_index = column_index(&schema, column)?;
+        if def.is_tree() {
+            let tree = BTree {
+                object_id: def.object_id,
+                root: def.root_page,
+            };
+            let keys = {
+                let mut ctx = self.file.rel_ctx();
+                let mut keys = Vec::new();
+                for (key, row) in tree.scan(&mut ctx)? {
+                    if decode_row(&schema, &row)?[column_index] == *value {
+                        keys.push(key);
+                    }
+                }
+                keys
+            };
+            let count = keys.len();
+            if count > 0 {
+                self.file.rel_statement(move |ctx, txn| {
+                    for key in &keys {
+                        tree.delete(ctx, &mut OpMode::Txn(txn), key)?;
+                    }
+                    Ok(())
+                })?;
+            }
+            Ok(count)
+        } else {
+            let heap = Heap {
+                object_id: def.object_id,
+                first_page: def.root_page,
+            };
+            let rids = {
+                let mut ctx = self.file.rel_ctx();
+                let mut rids = Vec::new();
+                for (rid, row) in heap.scan(&mut ctx)? {
+                    if decode_row(&schema, &row)?[column_index] == *value {
+                        rids.push(rid);
+                    }
+                }
+                rids
+            };
+            let count = rids.len();
+            if count > 0 {
+                self.file.rel_statement(move |ctx, txn| {
+                    for rid in &rids {
+                        heap.delete(ctx, txn, *rid)?;
+                    }
+                    Ok(())
+                })?;
+            }
+            Ok(count)
+        }
+    }
+
+    /// Updates every row where `column = value` with the given column
+    /// assignments; returns the count. Key columns of clustered tables are
+    /// immutable here (delete + insert to change a key).
+    pub fn rel_update_where(
+        &mut self,
+        name: &str,
+        column: &str,
+        value: &Datum,
+        assignments: &[(String, Datum)],
+    ) -> Result<usize, StorageError> {
+        self.file.ensure_rel_usable()?;
+        let (def, schema) = self.rel_def(name)?;
+        let column_index = column_index(&schema, column)?;
+        let mut set: Vec<(usize, Datum)> = Vec::new();
+        for (set_name, set_value) in assignments {
+            let index = column_index_by(&schema, set_name)?;
+            if def.key_columns.contains(&index) {
+                return Err(StorageError::InvalidConfig(format!(
+                    "cannot update primary key column '{set_name}'"
+                )));
+            }
+            set.push((index, set_value.clone()));
+        }
+
+        let apply_set = |mut values: Vec<Datum>| -> Vec<Datum> {
+            for (index, new_value) in &set {
+                values[*index] = new_value.clone();
+            }
+            values
+        };
+
+        if def.is_tree() {
+            let tree = BTree {
+                object_id: def.object_id,
+                root: def.root_page,
+            };
+            let targets = {
+                let mut ctx = self.file.rel_ctx();
+                let mut targets = Vec::new();
+                for (key, row) in tree.scan(&mut ctx)? {
+                    let values = decode_row(&schema, &row)?;
+                    if values[column_index] == *value {
+                        targets.push((key, values));
+                    }
+                }
+                targets
+            };
+            let count = targets.len();
+            let mut encoded = Vec::with_capacity(count);
+            for (key, values) in targets {
+                let new_values = apply_set(values);
+                validate_not_null(&schema, &new_values)?;
+                encoded.push((key, encode_row(&schema, &new_values)?));
+            }
+            if count > 0 {
+                self.file.rel_statement(move |ctx, txn| {
+                    for (key, row) in &encoded {
+                        tree.update(ctx, &mut OpMode::Txn(txn), key, row)?;
+                    }
+                    Ok(())
+                })?;
+            }
+            Ok(count)
+        } else {
+            let heap = Heap {
+                object_id: def.object_id,
+                first_page: def.root_page,
+            };
+            let targets = {
+                let mut ctx = self.file.rel_ctx();
+                let mut targets = Vec::new();
+                for (rid, row) in heap.scan(&mut ctx)? {
+                    let values = decode_row(&schema, &row)?;
+                    if values[column_index] == *value {
+                        targets.push((rid, values));
+                    }
+                }
+                targets
+            };
+            let count = targets.len();
+            let mut encoded = Vec::with_capacity(count);
+            for (rid, values) in targets {
+                let new_values = apply_set(values);
+                validate_not_null(&schema, &new_values)?;
+                encoded.push((rid, encode_row(&schema, &new_values)?));
+            }
+            if count > 0 {
+                self.file.rel_statement(move |ctx, txn| {
+                    for (rid, row) in &encoded {
+                        heap.update(ctx, txn, *rid, row)?;
+                    }
+                    Ok(())
+                })?;
+            }
+            Ok(count)
+        }
+    }
+
+    /// Test hook: run an insert's ops durably but never commit — the state a
+    /// crash mid-statement leaves behind (loser transaction for recovery).
+    #[cfg(test)]
+    pub(crate) fn rel_insert_without_commit(
+        &mut self,
+        name: &str,
+        values: Vec<Datum>,
+    ) -> Result<(), StorageError> {
+        let (def, schema) = self.rel_def(name)?;
+        let row = encode_row(&schema, &values)?;
+        let txn_id = self.file.rel.next_txn_id;
+        self.file.rel.next_txn_id += 1;
+        let mut ctx = self.file.rel_ctx();
+        let mut txn = ctx.begin(txn_id)?;
+        if def.is_tree() {
+            let key = encode_key(&schema, &def.key_columns, &values)?;
+            let tree = BTree {
+                object_id: def.object_id,
+                root: def.root_page,
+            };
+            tree.insert_unique(&mut ctx, &mut OpMode::Txn(&mut txn), &key, &row)?;
+        } else {
+            let heap = Heap {
+                object_id: def.object_id,
+                first_page: def.root_page,
+            };
+            heap.insert(&mut ctx, &mut txn, &row)?;
+        }
+        // Durable ops, no commit record: exactly the crash window.
+        ctx.io.wal.sync_all()?;
+        Ok(())
+    }
+
+    /// Test hook: flush dirty relational pages to disk WITHOUT advancing the
+    /// WAL head (the mid-checkpoint crash window where torn pages are
+    /// possible but their FPIs are still in the log).
+    #[cfg(test)]
+    pub(crate) fn rel_flush_pool_only(&mut self) -> Result<(), StorageError> {
+        self.file.wal.sync_all()?;
+        let RelState { pool, .. } = &mut self.file.rel;
+        let mut io = PoolIo {
+            file: &mut self.file.file,
+            wal: &mut self.file.wal,
+            data_offset: self.file.layout.data_offset,
+            data_pages: self.file.layout.data_size / PAGE_SIZE as u64,
+        };
+        pool.flush_all(&mut io)?;
+        self.file.file.sync_data()?;
+        Ok(())
+    }
+
+    /// Test hook: the absolute file offset of a data-region page.
+    #[cfg(test)]
+    pub(crate) fn data_page_offset(&self, page: u64) -> u64 {
+        self.file.layout.data_offset + page * PAGE_SIZE as u64
+    }
+
+    fn rel_def(&self, name: &str) -> Result<(TableDef, Schema), StorageError> {
+        let def = self
+            .file
+            .rel
+            .tables
+            .get(name)
+            .cloned()
+            .ok_or_else(|| StorageError::InvalidConfig(format!("unknown table '{name}'")))?;
+        let schema = def.schema()?;
+        Ok((def, schema))
+    }
+}
+
+fn column_index(schema: &Schema, name: &str) -> Result<usize, StorageError> {
+    column_index_by(schema, name)
+}
+
+fn column_index_by(schema: &Schema, name: &str) -> Result<usize, StorageError> {
+    schema
+        .columns
+        .iter()
+        .position(|c| c.name == name)
+        .ok_or_else(|| StorageError::InvalidConfig(format!("unknown column '{name}'")))
+}
+
+fn validate_not_null(schema: &Schema, values: &[Datum]) -> Result<(), StorageError> {
+    for (column, value) in schema.columns.iter().zip(values) {
+        if !column.nullable && value.is_null() {
+            return Err(StorageError::Constraint(format!(
+                "column '{}' does not allow NULL",
+                column.name
+            )));
+        }
+    }
+    Ok(())
 }
 
 pub struct SnapshotData {
@@ -199,6 +649,8 @@ struct StorageFile {
     superblock_b: Superblock,
     active_superblock: ActiveSuperblock,
     allocator: PageAllocator,
+    /// Relational store state (buffer pool, dirty-page table, catalog cache).
+    rel: RelState,
     /// WAL records recovered at open, waiting for the engine to replay them.
     replay_cache: Vec<WalRecord>,
 }
@@ -306,6 +758,20 @@ impl StorageFile {
         )?;
         let recorded_tail = active_sb.wal_tail;
 
+        // The catalog root is stored as an absolute file offset (0 = none).
+        let mut rel = RelState::new(DEFAULT_CAPACITY_BYTES);
+        if active_sb.metadata_root != 0 {
+            if active_sb.metadata_root < layout.data_offset
+                || active_sb.metadata_root >= layout.data_offset + layout.data_size
+            {
+                return Err(StorageError::InvalidFile(
+                    "catalog root outside the data region".to_string(),
+                ));
+            }
+            rel.catalog_root =
+                Some((active_sb.metadata_root - layout.data_offset) / PAGE_SIZE as u64);
+        }
+
         let mut storage = StorageFile {
             path,
             file,
@@ -315,6 +781,7 @@ impl StorageFile {
             superblock_b,
             active_superblock,
             allocator: PageAllocator::new(layout.data_size),
+            rel,
             replay_cache: scan.records,
         };
         storage.recover_allocator()?;
@@ -335,6 +802,10 @@ impl StorageFile {
             storage.write_active_superblock(last_seq)?;
             storage.file.sync_data()?;
         }
+
+        // ARIES restart for the relational store: analysis + redo, catalog
+        // reload, undo of losers with compensation logging.
+        storage.recover_rel()?;
         Ok(storage)
     }
 
@@ -393,8 +864,137 @@ impl StorageFile {
             superblock_b,
             active_superblock: ActiveSuperblock::A,
             allocator: PageAllocator::new(layout.data_size),
+            rel: RelState::new(DEFAULT_CAPACITY_BYTES),
             replay_cache: Vec::new(),
         })
+    }
+
+    /// Builds the relational execution context over this file's parts.
+    fn rel_ctx(&mut self) -> RelCtx<'_> {
+        RelCtx {
+            pool: &mut self.rel.pool,
+            io: PoolIo {
+                file: &mut self.file,
+                wal: &mut self.wal,
+                data_offset: self.layout.data_offset,
+                data_pages: self.layout.data_size / PAGE_SIZE as u64,
+            },
+            allocator: &mut self.allocator,
+            dpt: &mut self.rel.dpt,
+            use_reserve: false,
+        }
+    }
+
+    /// Decodes the relational records (with their LSNs) from the recovery
+    /// scan.
+    fn rel_records(&self) -> Result<Vec<(u64, RelRecord)>, StorageError> {
+        self.replay_cache
+            .iter()
+            .filter(|record| record.entry_type == WAL_ENTRY_TYPE_REL)
+            .map(|record| Ok((record.logical_ts, RelRecord::decode(&record.payload)?)))
+            .collect()
+    }
+
+    /// ARIES restart: analysis + redo (repeating history), then undo of
+    /// loser transactions with CLRs. The catalog is loaded between redo and
+    /// undo (undo needs tree roots) and reloaded after (undo may have
+    /// removed catalog rows).
+    fn recover_rel(&mut self) -> Result<(), StorageError> {
+        let records = self.rel_records()?;
+        if records.is_empty() && self.rel.catalog_root.is_none() {
+            return Ok(());
+        }
+
+        let outcome = {
+            let mut ctx = self.rel_ctx();
+            rel_recovery::analyze_and_redo(&mut ctx, &records)?
+        };
+        if let Some(root) = outcome.catalog_root {
+            self.rel.catalog_root = Some(root);
+        }
+        self.rel.next_txn_id = outcome.max_txn_id + 1;
+
+        self.reload_catalog()?;
+        if !outcome.losers.is_empty() {
+            let roots = self.rel.tree_roots();
+            let mut ctx = self.rel_ctx();
+            rel_recovery::undo_losers(&mut ctx, &records, &outcome.losers, &roots)?;
+            self.reload_catalog()?;
+        }
+        self.rel.next_object_id = self
+            .rel
+            .tables
+            .values()
+            .map(|def| def.object_id + 1)
+            .max()
+            .unwrap_or(FIRST_USER_OBJECT_ID)
+            .max(FIRST_USER_OBJECT_ID);
+        self.wal.sync_all()?;
+        Ok(())
+    }
+
+    fn reload_catalog(&mut self) -> Result<(), StorageError> {
+        let Some(root) = self.rel.catalog_root else {
+            self.rel.tables.clear();
+            return Ok(());
+        };
+        let defs = {
+            let mut ctx = self.rel_ctx();
+            catalog::load_tables(&mut ctx, root)?
+        };
+        self.rel.tables = defs
+            .into_iter()
+            .map(|def| (def.name.clone(), def))
+            .collect();
+        Ok(())
+    }
+
+    /// Runs one autocommit relational statement: begin, ops, commit (force
+    /// log); statement failure rolls back through the in-memory undo log.
+    fn rel_statement<T>(
+        &mut self,
+        f: impl FnOnce(&mut RelCtx<'_>, &mut TxnLink) -> Result<T, StorageError>,
+    ) -> Result<T, StorageError> {
+        let txn_id = self.rel.next_txn_id;
+        self.rel.next_txn_id += 1;
+        let roots = self.rel.tree_roots();
+        let mut ctx = self.rel_ctx();
+        let mut txn = ctx.begin(txn_id)?;
+        let (result, wedged) = match f(&mut ctx, &mut txn) {
+            Ok(value) => match ctx.commit(txn) {
+                Ok(()) => (Ok(value), false),
+                // The commit record may or may not have reached the disk;
+                // writing CLRs now could undo a durable commit. Wedge and
+                // let restart recovery decide (commit durable -> winner,
+                // else -> loser undone).
+                Err(err) => (Err(err), true),
+            },
+            Err(err) => match rel_recovery::rollback(&mut ctx, txn, &roots) {
+                Ok(()) => {
+                    let _ = ctx.io.wal.sync_all();
+                    (Err(err), false)
+                }
+                // Half-rolled-back state in the pool that the WAL cannot
+                // explain: nothing relational may proceed (a checkpoint
+                // would make it permanent).
+                Err(rollback_err) => (Err(rollback_err), true),
+            },
+        };
+        let _ = ctx;
+        if wedged {
+            self.rel.wedged = true;
+        }
+        result
+    }
+
+    fn ensure_rel_usable(&self) -> Result<(), StorageError> {
+        if self.rel.wedged {
+            return Err(StorageError::InvalidFile(
+                "relational store wedged after a failed commit/rollback; restart to recover from the log"
+                    .to_string(),
+            ));
+        }
+        Ok(())
     }
 
     /// Rebuilds the live allocator: persisted bitmap, then reconciliation
@@ -440,11 +1040,9 @@ impl StorageFile {
                     let (start, pages) = record.decode_extent_redo()?;
                     self.allocator.free(start, pages);
                 }
-                other => {
-                    return Err(StorageError::InvalidFile(format!(
-                        "unknown rel wal record kind {other}"
-                    )));
-                }
+                // Transaction/page records are ARIES recovery's business
+                // (recover_rel); the allocator only replays extent state.
+                _ => {}
             }
         }
 
@@ -563,6 +1161,7 @@ impl StorageFile {
         next_seq_no: u64,
         next_doc_id: u64,
     ) -> Result<(), StorageError> {
+        self.ensure_rel_usable()?;
         if data.is_empty() {
             // An empty snapshot would produce a descriptor that
             // SnapshotDescriptor::is_valid rejects while the WAL head still
@@ -688,6 +1287,25 @@ impl StorageFile {
         desc_offset: u64,
         data_write_offset: u64,
     ) -> Result<(), StorageError> {
+        // Flush every dirty relational page (WAL-before-data enforced per
+        // page by the pool) and reset the dirty-page table: the next change
+        // to any page starts a fresh FPI epoch. With the engine single-
+        // threaded, no relational transaction can span a checkpoint, so the
+        // WAL head may advance to the tail below (a future concurrent engine
+        // must clamp it to the oldest active transaction's begin LSN).
+        self.wal.sync_all()?;
+        {
+            let RelState { pool, dpt, .. } = &mut self.rel;
+            let mut io = PoolIo {
+                file: &mut self.file,
+                wal: &mut self.wal,
+                data_offset: self.layout.data_offset,
+                data_pages: self.layout.data_size / PAGE_SIZE as u64,
+            };
+            pool.flush_all(&mut io)?;
+            dpt.clear();
+        }
+
         // Free the previous snapshot's extent now that the new one is
         //    durable, and persist the allocator bitmap (temp extents
         //    excluded). The bitmap must be durable before the WAL head
@@ -717,6 +1335,12 @@ impl StorageFile {
         self.active_superblock = new_active;
 
         let (head, tail) = (self.wal.head(), self.wal.tail());
+        // Catalog root as an absolute file offset (0 = none).
+        let metadata_root = self
+            .rel
+            .catalog_root
+            .map(|page| self.layout.data_offset + page * PAGE_SIZE as u64)
+            .unwrap_or(0);
         let new_sb = |active_flag: u8| -> Superblock {
             let mut sb = Superblock::default();
             sb.generation = generation;
@@ -726,6 +1350,7 @@ impl StorageFile {
             sb.last_committed_seq = checkpoint_seq;
             sb.snapshot_root = desc_offset;
             sb.data_root = data_write_offset;
+            sb.metadata_root = metadata_root;
             sb.checksum = sb.compute_checksum();
             sb
         };

--- a/crates/truthdb-core/src/wal/mod.rs
+++ b/crates/truthdb-core/src/wal/mod.rs
@@ -44,6 +44,16 @@ pub(crate) struct WalWriter {
     ring_size: u64,
     head: u64,
     buffer: LogBuffer,
+    /// Tail position up to which the log is known fsync-durable. Appends
+    /// with `sync = false` advance the tail but not this watermark.
+    flushed: u64,
+    /// Ring bytes reserved for compensation records: forward relational
+    /// appends stop at `ring_size - reserve` so rollback and recovery undo
+    /// always have room to write their CLRs.
+    reserve: u64,
+    /// Set when a page write failed mid-append: the in-memory tail no longer
+    /// matches the disk and no further appends can be trusted.
+    poisoned: bool,
     bytes_since_superblock: u64,
     superblock_interval: u64,
 }
@@ -73,6 +83,9 @@ impl WalWriter {
             ring_size,
             head,
             buffer,
+            flushed: tail,
+            reserve: ring_size / 4,
+            poisoned: false,
             bytes_since_superblock: 0,
             superblock_interval: SUPERBLOCK_REWRITE_INTERVAL,
         })
@@ -124,6 +137,31 @@ impl WalWriter {
         }
     }
 
+    /// The tail position up to which the log is fsync-durable.
+    pub fn flushed_lsn(&self) -> u64 {
+        self.flushed
+    }
+
+    /// Makes the log durable at least up to and including the record that
+    /// STARTS at `lsn` (page writes always happen at append time; this only
+    /// issues the missing fsync). `flushed` counts covered bytes, so a
+    /// record starting exactly at the watermark is not yet durable.
+    pub fn sync_to(&mut self, lsn: u64) -> Result<(), StorageError> {
+        if lsn >= self.flushed {
+            self.sync_all()?;
+        }
+        Ok(())
+    }
+
+    /// Fsyncs everything appended so far.
+    pub fn sync_all(&mut self) -> Result<(), StorageError> {
+        if self.flushed < self.tail() {
+            self.file.sync_data()?;
+            self.flushed = self.tail();
+        }
+        Ok(())
+    }
+
     /// Appends one entry, makes it durable (whole-page flush + fsync) and
     /// returns its LSN.
     pub fn append_entry(
@@ -133,6 +171,40 @@ impl WalWriter {
         seq_no: u64,
         payload: &[u8],
     ) -> Result<u64, StorageError> {
+        self.append_entry_opts(entry_type, entry_version, seq_no, payload, true)
+    }
+
+    /// Appends one entry; page images are written immediately, but the fsync
+    /// is skipped when `sync` is false (force-at-commit: the caller fsyncs
+    /// via [`WalWriter::sync_all`] before acknowledging anything).
+    pub fn append_entry_opts(
+        &mut self,
+        entry_type: u16,
+        entry_version: u16,
+        seq_no: u64,
+        payload: &[u8],
+        sync: bool,
+    ) -> Result<u64, StorageError> {
+        self.append_entry_reserve(entry_type, entry_version, seq_no, payload, sync, true)
+    }
+
+    /// Like [`WalWriter::append_entry_opts`], but with explicit access to the
+    /// compensation reserve: forward relational appends pass
+    /// `allow_reserve = false` so rollback/recovery CLRs always have room.
+    pub fn append_entry_reserve(
+        &mut self,
+        entry_type: u16,
+        entry_version: u16,
+        seq_no: u64,
+        payload: &[u8],
+        sync: bool,
+        allow_reserve: bool,
+    ) -> Result<u64, StorageError> {
+        if self.poisoned {
+            return Err(StorageError::InvalidFile(
+                "wal writer disabled after a failed page write; restart to recover".to_string(),
+            ));
+        }
         if self.ring_size == 0 {
             return Err(StorageError::InvalidFile(
                 "wal region size is zero".to_string(),
@@ -164,7 +236,12 @@ impl WalWriter {
         } else {
             align_down(new_tail, page) + page
         };
-        if flush_end.saturating_sub(self.head) > self.ring_size {
+        let capacity = if allow_reserve {
+            self.ring_size
+        } else {
+            self.ring_size - self.reserve
+        };
+        if flush_end.saturating_sub(self.head) > capacity {
             return Err(StorageError::WalFull("wal ring full".to_string()));
         }
 
@@ -194,13 +271,25 @@ impl WalWriter {
         entry_bytes.resize(entry_len, 0);
 
         completed.extend(self.buffer.append(&entry_bytes));
-        self.write_pages(&completed)?;
+        // A failed page write leaves the in-memory tail ahead of the disk:
+        // nothing appended afterwards could be trusted, so poison the writer
+        // (restart recovers to the last durable prefix).
+        if let Err(err) = self.write_pages(&completed) {
+            self.poisoned = true;
+            return Err(err);
+        }
         if !self.buffer.current_page_is_empty() {
             let (page_start, page) = self.buffer.current_page();
             let file_offset = self.ring_offset + page_start % self.ring_size;
-            self.file.write_page_from(file_offset, page)?;
+            if let Err(err) = self.file.write_page_from(file_offset, page) {
+                self.poisoned = true;
+                return Err(err.into());
+            }
         }
-        self.file.sync_data()?;
+        if sync {
+            self.file.sync_data()?;
+            self.flushed = self.tail();
+        }
 
         self.bytes_since_superblock += gap + entry_len as u64;
         Ok(lsn)

--- a/crates/truthdb-core/src/wal/records.rs
+++ b/crates/truthdb-core/src/wal/records.rs
@@ -15,11 +15,29 @@
 //! non-transactional records (e.g. allocator state changes).
 
 use crate::storage::StorageError;
+use crate::storage_layout::PAGE_SIZE;
 
 pub const REL_RECORD_HEADER_SIZE: usize = 8 + 8 + 2 + 2 + 4 + 4;
 
 pub const REL_KIND_ALLOC_EXTENT: u16 = 1;
 pub const REL_KIND_FREE_EXTENT: u16 = 2;
+pub const REL_KIND_TXN_BEGIN: u16 = 3;
+pub const REL_KIND_TXN_COMMIT: u16 = 4;
+pub const REL_KIND_TXN_END: u16 = 5;
+/// Physiological page operation: redo = [`PageOpRedo`], undo = [`PageOpUndo`].
+pub const REL_KIND_PAGE_OP: u16 = 6;
+/// Full page image (first touch after checkpoint, and structure changes
+/// like splits): redo = page number + whole-page image, undo = [`PageOpUndo`].
+pub const REL_KIND_PAGE_IMAGE: u16 = 7;
+/// Compensation log record: redo = undo_next LSN + [`PageOpRedo`]; never
+/// undone itself.
+pub const REL_KIND_CLR: u16 = 8;
+/// Redo-only: the catalog tree root page (page number in redo payload).
+pub const REL_KIND_SET_CATALOG_ROOT: u16 = 9;
+/// Atomic group of full page images (B+ tree splits): all pages of one
+/// structure change land in ONE WAL entry, so a crash either keeps the whole
+/// change or none of it.
+pub const REL_KIND_PAGE_IMAGES: u16 = 10;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RelRecord {
@@ -31,6 +49,280 @@ pub struct RelRecord {
     pub flags: u16,
     pub redo: Vec<u8>,
     pub undo: Vec<u8>,
+}
+
+/// Physiological redo payload of a page operation. Applying it is
+/// idempotent under the page-LSN gate.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PageOpRedo {
+    /// B+ tree positional insert (directory shifts right).
+    InsertAt {
+        page: u64,
+        index: u16,
+        bytes: Vec<u8>,
+    },
+    /// B+ tree positional remove (directory shifts left).
+    RemoveAt { page: u64, index: u16 },
+    /// B+ tree positional cell replacement.
+    UpdateAt {
+        page: u64,
+        index: u16,
+        bytes: Vec<u8>,
+    },
+    /// Heap insert at an exact stable slot.
+    HeapInsert {
+        page: u64,
+        slot: u16,
+        bytes: Vec<u8>,
+    },
+    /// Heap tombstone.
+    HeapDelete { page: u64, slot: u16 },
+    /// Heap cell replacement at a stable slot.
+    HeapUpdate {
+        page: u64,
+        slot: u16,
+        bytes: Vec<u8>,
+    },
+    /// Heap page chain link.
+    SetNextPage { page: u64, next: u64 },
+}
+
+impl PageOpRedo {
+    pub fn page(&self) -> u64 {
+        match self {
+            PageOpRedo::InsertAt { page, .. }
+            | PageOpRedo::RemoveAt { page, .. }
+            | PageOpRedo::UpdateAt { page, .. }
+            | PageOpRedo::HeapInsert { page, .. }
+            | PageOpRedo::HeapDelete { page, .. }
+            | PageOpRedo::HeapUpdate { page, .. }
+            | PageOpRedo::SetNextPage { page, .. } => *page,
+        }
+    }
+
+    fn encode(&self, out: &mut Vec<u8>) {
+        match self {
+            PageOpRedo::InsertAt { page, index, bytes } => {
+                out.push(1);
+                put_u64(out, *page);
+                put_u16(out, *index);
+                put_bytes(out, bytes);
+            }
+            PageOpRedo::RemoveAt { page, index } => {
+                out.push(2);
+                put_u64(out, *page);
+                put_u16(out, *index);
+            }
+            PageOpRedo::UpdateAt { page, index, bytes } => {
+                out.push(3);
+                put_u64(out, *page);
+                put_u16(out, *index);
+                put_bytes(out, bytes);
+            }
+            PageOpRedo::HeapInsert { page, slot, bytes } => {
+                out.push(4);
+                put_u64(out, *page);
+                put_u16(out, *slot);
+                put_bytes(out, bytes);
+            }
+            PageOpRedo::HeapDelete { page, slot } => {
+                out.push(5);
+                put_u64(out, *page);
+                put_u16(out, *slot);
+            }
+            PageOpRedo::HeapUpdate { page, slot, bytes } => {
+                out.push(6);
+                put_u64(out, *page);
+                put_u16(out, *slot);
+                put_bytes(out, bytes);
+            }
+            PageOpRedo::SetNextPage { page, next } => {
+                out.push(7);
+                put_u64(out, *page);
+                put_u64(out, *next);
+            }
+        }
+    }
+
+    fn decode(cursor: &mut Cursor<'_>) -> Result<Self, StorageError> {
+        Ok(match cursor.u8()? {
+            1 => PageOpRedo::InsertAt {
+                page: cursor.u64()?,
+                index: cursor.u16()?,
+                bytes: cursor.bytes()?,
+            },
+            2 => PageOpRedo::RemoveAt {
+                page: cursor.u64()?,
+                index: cursor.u16()?,
+            },
+            3 => PageOpRedo::UpdateAt {
+                page: cursor.u64()?,
+                index: cursor.u16()?,
+                bytes: cursor.bytes()?,
+            },
+            4 => PageOpRedo::HeapInsert {
+                page: cursor.u64()?,
+                slot: cursor.u16()?,
+                bytes: cursor.bytes()?,
+            },
+            5 => PageOpRedo::HeapDelete {
+                page: cursor.u64()?,
+                slot: cursor.u16()?,
+            },
+            6 => PageOpRedo::HeapUpdate {
+                page: cursor.u64()?,
+                slot: cursor.u16()?,
+                bytes: cursor.bytes()?,
+            },
+            7 => PageOpRedo::SetNextPage {
+                page: cursor.u64()?,
+                next: cursor.u64()?,
+            },
+            other => {
+                return Err(StorageError::InvalidFile(format!(
+                    "unknown page-op redo tag {other}"
+                )));
+            }
+        })
+    }
+}
+
+/// Undo action of a page operation. Tree undos are *logical* (the row may
+/// have moved through splits since); heap undos are physical (RIDs are
+/// stable).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PageOpUndo {
+    None,
+    /// Undo of a tree insert: delete the key wherever it now lives.
+    TreeDeleteKey {
+        object_id: u32,
+        key: Vec<u8>,
+    },
+    /// Undo of a tree delete: re-insert the row.
+    TreeInsertRow {
+        object_id: u32,
+        key: Vec<u8>,
+        row: Vec<u8>,
+    },
+    /// Undo of a tree update: restore the previous row for the key.
+    TreeUpdateRow {
+        object_id: u32,
+        key: Vec<u8>,
+        row: Vec<u8>,
+    },
+    /// Undo of a heap insert.
+    HeapDeleteSlot {
+        page: u64,
+        slot: u16,
+    },
+    /// Undo of a heap delete: restore the exact slot.
+    HeapInsertRow {
+        page: u64,
+        slot: u16,
+        bytes: Vec<u8>,
+    },
+    /// Undo of a heap update: restore the previous cell.
+    HeapUpdateRow {
+        page: u64,
+        slot: u16,
+        bytes: Vec<u8>,
+    },
+}
+
+impl PageOpUndo {
+    fn encode(&self, out: &mut Vec<u8>) {
+        match self {
+            PageOpUndo::None => out.push(0),
+            PageOpUndo::TreeDeleteKey { object_id, key } => {
+                out.push(1);
+                put_u32(out, *object_id);
+                put_bytes(out, key);
+            }
+            PageOpUndo::TreeInsertRow {
+                object_id,
+                key,
+                row,
+            } => {
+                out.push(2);
+                put_u32(out, *object_id);
+                put_bytes(out, key);
+                put_bytes(out, row);
+            }
+            PageOpUndo::TreeUpdateRow {
+                object_id,
+                key,
+                row,
+            } => {
+                out.push(3);
+                put_u32(out, *object_id);
+                put_bytes(out, key);
+                put_bytes(out, row);
+            }
+            PageOpUndo::HeapDeleteSlot { page, slot } => {
+                out.push(4);
+                put_u64(out, *page);
+                put_u16(out, *slot);
+            }
+            PageOpUndo::HeapInsertRow { page, slot, bytes } => {
+                out.push(5);
+                put_u64(out, *page);
+                put_u16(out, *slot);
+                put_bytes(out, bytes);
+            }
+            PageOpUndo::HeapUpdateRow { page, slot, bytes } => {
+                out.push(6);
+                put_u64(out, *page);
+                put_u16(out, *slot);
+                put_bytes(out, bytes);
+            }
+        }
+    }
+
+    fn decode(cursor: &mut Cursor<'_>) -> Result<Self, StorageError> {
+        Ok(match cursor.u8()? {
+            0 => PageOpUndo::None,
+            1 => PageOpUndo::TreeDeleteKey {
+                object_id: cursor.u32()?,
+                key: cursor.bytes()?,
+            },
+            2 => PageOpUndo::TreeInsertRow {
+                object_id: cursor.u32()?,
+                key: cursor.bytes()?,
+                row: cursor.bytes()?,
+            },
+            3 => PageOpUndo::TreeUpdateRow {
+                object_id: cursor.u32()?,
+                key: cursor.bytes()?,
+                row: cursor.bytes()?,
+            },
+            4 => PageOpUndo::HeapDeleteSlot {
+                page: cursor.u64()?,
+                slot: cursor.u16()?,
+            },
+            5 => PageOpUndo::HeapInsertRow {
+                page: cursor.u64()?,
+                slot: cursor.u16()?,
+                bytes: cursor.bytes()?,
+            },
+            6 => PageOpUndo::HeapUpdateRow {
+                page: cursor.u64()?,
+                slot: cursor.u16()?,
+                bytes: cursor.bytes()?,
+            },
+            other => {
+                return Err(StorageError::InvalidFile(format!(
+                    "unknown page-op undo tag {other}"
+                )));
+            }
+        })
+    }
+
+    pub fn decode_from(bytes: &[u8]) -> Result<Self, StorageError> {
+        let mut cursor = Cursor { bytes, at: 0 };
+        let undo = PageOpUndo::decode(&mut cursor)?;
+        cursor.finish()?;
+        Ok(undo)
+    }
 }
 
 impl RelRecord {
@@ -118,6 +410,288 @@ impl RelRecord {
         let num_pages = u64::from_le_bytes(self.redo[8..16].try_into().unwrap());
         Ok((start_page, num_pages))
     }
+
+    pub fn txn_begin(txn_id: u64) -> Self {
+        RelRecord {
+            prev_lsn: 0,
+            txn_id,
+            kind: REL_KIND_TXN_BEGIN,
+            flags: 0,
+            redo: Vec::new(),
+            undo: Vec::new(),
+        }
+    }
+
+    pub fn txn_commit(txn_id: u64, prev_lsn: u64) -> Self {
+        RelRecord {
+            prev_lsn,
+            txn_id,
+            kind: REL_KIND_TXN_COMMIT,
+            flags: 0,
+            redo: Vec::new(),
+            undo: Vec::new(),
+        }
+    }
+
+    pub fn txn_end(txn_id: u64, prev_lsn: u64) -> Self {
+        RelRecord {
+            prev_lsn,
+            txn_id,
+            kind: REL_KIND_TXN_END,
+            flags: 0,
+            redo: Vec::new(),
+            undo: Vec::new(),
+        }
+    }
+
+    pub fn page_op(txn_id: u64, prev_lsn: u64, redo: &PageOpRedo, undo: &PageOpUndo) -> Self {
+        let mut redo_bytes = Vec::new();
+        redo.encode(&mut redo_bytes);
+        let mut undo_bytes = Vec::new();
+        undo.encode(&mut undo_bytes);
+        RelRecord {
+            prev_lsn,
+            txn_id,
+            kind: REL_KIND_PAGE_OP,
+            flags: 0,
+            redo: redo_bytes,
+            undo: undo_bytes,
+        }
+    }
+
+    /// Full page image (first touch since checkpoint or structure change);
+    /// `undo` carries the logical undo of the operation the image subsumes.
+    pub fn page_image(
+        txn_id: u64,
+        prev_lsn: u64,
+        page: u64,
+        image: &[u8],
+        undo: &PageOpUndo,
+    ) -> Self {
+        debug_assert_eq!(image.len(), PAGE_SIZE);
+        let mut redo_bytes = Vec::with_capacity(8 + PAGE_SIZE);
+        put_u64(&mut redo_bytes, page);
+        redo_bytes.extend_from_slice(image);
+        let mut undo_bytes = Vec::new();
+        undo.encode(&mut undo_bytes);
+        RelRecord {
+            prev_lsn,
+            txn_id,
+            kind: REL_KIND_PAGE_IMAGE,
+            flags: 0,
+            redo: redo_bytes,
+            undo: undo_bytes,
+        }
+    }
+
+    /// Compensation record: `undo_next` points at the next record of the
+    /// transaction still to be undone (the undone record's `prev_lsn`).
+    pub fn clr(txn_id: u64, prev_lsn: u64, undo_next: u64, redo: &PageOpRedo) -> Self {
+        let mut redo_bytes = Vec::new();
+        put_u64(&mut redo_bytes, undo_next);
+        redo.encode(&mut redo_bytes);
+        RelRecord {
+            prev_lsn,
+            txn_id,
+            kind: REL_KIND_CLR,
+            flags: 0,
+            redo: redo_bytes,
+            undo: Vec::new(),
+        }
+    }
+
+    /// A CLR that compensates a record without any page effect to redo
+    /// (e.g. the undone row was never physically placed).
+    pub fn clr_noop(txn_id: u64, prev_lsn: u64, undo_next: u64) -> Self {
+        let mut redo_bytes = Vec::new();
+        put_u64(&mut redo_bytes, undo_next);
+        RelRecord {
+            prev_lsn,
+            txn_id,
+            kind: REL_KIND_CLR,
+            flags: 0,
+            redo: redo_bytes,
+            undo: Vec::new(),
+        }
+    }
+
+    /// Atomic multi-page image (system record, never undone).
+    pub fn page_images(pages: &[(u64, &[u8])]) -> Self {
+        let mut redo = Vec::with_capacity(2 + pages.len() * (8 + PAGE_SIZE));
+        put_u16(&mut redo, pages.len() as u16);
+        for (page_no, image) in pages {
+            debug_assert_eq!(image.len(), PAGE_SIZE);
+            put_u64(&mut redo, *page_no);
+            redo.extend_from_slice(image);
+        }
+        RelRecord {
+            prev_lsn: 0,
+            txn_id: 0,
+            kind: REL_KIND_PAGE_IMAGES,
+            flags: 0,
+            redo,
+            undo: Vec::new(),
+        }
+    }
+
+    /// Decodes a PAGE_IMAGES redo into `(page, image)` pairs.
+    pub fn decode_page_images(&self) -> Result<Vec<(u64, &[u8])>, StorageError> {
+        debug_assert_eq!(self.kind, REL_KIND_PAGE_IMAGES);
+        if self.redo.len() < 2 {
+            return Err(StorageError::InvalidFile(
+                "page images record too short".to_string(),
+            ));
+        }
+        let count = u16::from_le_bytes(self.redo[0..2].try_into().unwrap()) as usize;
+        if self.redo.len() != 2 + count * (8 + PAGE_SIZE) {
+            return Err(StorageError::InvalidFile(
+                "page images record has wrong size".to_string(),
+            ));
+        }
+        let mut out = Vec::with_capacity(count);
+        for i in 0..count {
+            let at = 2 + i * (8 + PAGE_SIZE);
+            let page = u64::from_le_bytes(self.redo[at..at + 8].try_into().unwrap());
+            out.push((page, &self.redo[at + 8..at + 8 + PAGE_SIZE]));
+        }
+        Ok(out)
+    }
+
+    pub fn set_catalog_root(page: u64) -> Self {
+        let mut redo = Vec::new();
+        put_u64(&mut redo, page);
+        RelRecord {
+            prev_lsn: 0,
+            txn_id: 0,
+            kind: REL_KIND_SET_CATALOG_ROOT,
+            flags: 0,
+            redo,
+            undo: Vec::new(),
+        }
+    }
+
+    pub fn decode_page_op_redo(&self) -> Result<PageOpRedo, StorageError> {
+        debug_assert_eq!(self.kind, REL_KIND_PAGE_OP);
+        let mut cursor = Cursor {
+            bytes: &self.redo,
+            at: 0,
+        };
+        let redo = PageOpRedo::decode(&mut cursor)?;
+        cursor.finish()?;
+        Ok(redo)
+    }
+
+    pub fn decode_page_op_undo(&self) -> Result<PageOpUndo, StorageError> {
+        PageOpUndo::decode_from(&self.undo)
+    }
+
+    /// Decodes a PAGE_IMAGE redo into `(page, image)`.
+    pub fn decode_page_image(&self) -> Result<(u64, &[u8]), StorageError> {
+        debug_assert_eq!(self.kind, REL_KIND_PAGE_IMAGE);
+        if self.redo.len() != 8 + PAGE_SIZE {
+            return Err(StorageError::InvalidFile(
+                "page image record has wrong size".to_string(),
+            ));
+        }
+        let page = u64::from_le_bytes(self.redo[0..8].try_into().unwrap());
+        Ok((page, &self.redo[8..]))
+    }
+
+    /// Decodes a CLR redo into `(undo_next, optional page op)`.
+    pub fn decode_clr(&self) -> Result<(u64, Option<PageOpRedo>), StorageError> {
+        debug_assert_eq!(self.kind, REL_KIND_CLR);
+        if self.redo.len() < 8 {
+            return Err(StorageError::InvalidFile(
+                "clr record too short".to_string(),
+            ));
+        }
+        let undo_next = u64::from_le_bytes(self.redo[0..8].try_into().unwrap());
+        if self.redo.len() == 8 {
+            return Ok((undo_next, None));
+        }
+        let mut cursor = Cursor {
+            bytes: &self.redo,
+            at: 8,
+        };
+        let redo = PageOpRedo::decode(&mut cursor)?;
+        cursor.finish()?;
+        Ok((undo_next, Some(redo)))
+    }
+
+    pub fn decode_catalog_root(&self) -> Result<u64, StorageError> {
+        debug_assert_eq!(self.kind, REL_KIND_SET_CATALOG_ROOT);
+        if self.redo.len() != 8 {
+            return Err(StorageError::InvalidFile(
+                "catalog root record has wrong size".to_string(),
+            ));
+        }
+        Ok(u64::from_le_bytes(self.redo[0..8].try_into().unwrap()))
+    }
+}
+
+struct Cursor<'a> {
+    bytes: &'a [u8],
+    at: usize,
+}
+
+impl Cursor<'_> {
+    fn take(&mut self, len: usize) -> Result<&[u8], StorageError> {
+        if self.at + len > self.bytes.len() {
+            return Err(StorageError::InvalidFile(
+                "truncated wal record payload".to_string(),
+            ));
+        }
+        let slice = &self.bytes[self.at..self.at + len];
+        self.at += len;
+        Ok(slice)
+    }
+
+    fn u8(&mut self) -> Result<u8, StorageError> {
+        Ok(self.take(1)?[0])
+    }
+
+    fn u16(&mut self) -> Result<u16, StorageError> {
+        Ok(u16::from_le_bytes(self.take(2)?.try_into().unwrap()))
+    }
+
+    fn u32(&mut self) -> Result<u32, StorageError> {
+        Ok(u32::from_le_bytes(self.take(4)?.try_into().unwrap()))
+    }
+
+    fn u64(&mut self) -> Result<u64, StorageError> {
+        Ok(u64::from_le_bytes(self.take(8)?.try_into().unwrap()))
+    }
+
+    fn bytes(&mut self) -> Result<Vec<u8>, StorageError> {
+        let len = self.u32()? as usize;
+        Ok(self.take(len)?.to_vec())
+    }
+
+    fn finish(&self) -> Result<(), StorageError> {
+        if self.at != self.bytes.len() {
+            return Err(StorageError::InvalidFile(
+                "trailing bytes in wal record payload".to_string(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+fn put_u16(out: &mut Vec<u8>, value: u16) {
+    out.extend_from_slice(&value.to_le_bytes());
+}
+
+fn put_u32(out: &mut Vec<u8>, value: u32) {
+    out.extend_from_slice(&value.to_le_bytes());
+}
+
+fn put_u64(out: &mut Vec<u8>, value: u64) {
+    out.extend_from_slice(&value.to_le_bytes());
+}
+
+fn put_bytes(out: &mut Vec<u8>, bytes: &[u8]) {
+    put_u32(out, bytes.len() as u32);
+    out.extend_from_slice(bytes);
 }
 
 fn extent_payload(start_page: u64, num_pages: u64) -> Vec<u8> {
@@ -156,6 +730,91 @@ mod tests {
         let decoded = RelRecord::decode(&record.encode()).expect("decode");
         assert_eq!(decoded.decode_extent_redo().expect("redo"), (4096, 64));
         assert_eq!(decoded.kind, REL_KIND_FREE_EXTENT);
+    }
+
+    #[test]
+    fn page_op_records_round_trip() {
+        let redo = PageOpRedo::InsertAt {
+            page: 42,
+            index: 7,
+            bytes: vec![1, 2, 3],
+        };
+        let undo = PageOpUndo::TreeDeleteKey {
+            object_id: 5,
+            key: vec![9, 9],
+        };
+        let record = RelRecord::page_op(11, 1000, &redo, &undo);
+        let decoded = RelRecord::decode(&record.encode()).expect("decode");
+        assert_eq!(decoded.decode_page_op_redo().expect("redo"), redo);
+        assert_eq!(decoded.decode_page_op_undo().expect("undo"), undo);
+        assert_eq!(decoded.txn_id, 11);
+        assert_eq!(decoded.prev_lsn, 1000);
+
+        for redo in [
+            PageOpRedo::RemoveAt { page: 1, index: 0 },
+            PageOpRedo::HeapInsert {
+                page: 2,
+                slot: 3,
+                bytes: vec![4],
+            },
+            PageOpRedo::HeapDelete { page: 2, slot: 3 },
+            PageOpRedo::HeapUpdate {
+                page: 2,
+                slot: 3,
+                bytes: vec![],
+            },
+            PageOpRedo::SetNextPage { page: 5, next: 6 },
+        ] {
+            let record = RelRecord::page_op(1, 0, &redo, &PageOpUndo::None);
+            let decoded = RelRecord::decode(&record.encode()).expect("decode");
+            assert_eq!(decoded.decode_page_op_redo().expect("redo"), redo);
+            assert_eq!(
+                decoded.decode_page_op_undo().expect("undo"),
+                PageOpUndo::None
+            );
+        }
+    }
+
+    #[test]
+    fn page_image_and_clr_round_trip() {
+        let image = vec![0xABu8; PAGE_SIZE];
+        let undo = PageOpUndo::HeapDeleteSlot { page: 9, slot: 2 };
+        let record = RelRecord::page_image(3, 500, 9, &image, &undo);
+        let decoded = RelRecord::decode(&record.encode()).expect("decode");
+        let (page, decoded_image) = decoded.decode_page_image().expect("image");
+        assert_eq!(page, 9);
+        assert_eq!(decoded_image, image.as_slice());
+        assert_eq!(decoded.decode_page_op_undo().expect("undo"), undo);
+
+        let redo = PageOpRedo::RemoveAt { page: 9, index: 1 };
+        let clr = RelRecord::clr(3, 600, 450, &redo);
+        let decoded = RelRecord::decode(&clr.encode()).expect("decode");
+        let (undo_next, op) = decoded.decode_clr().expect("clr");
+        assert_eq!(undo_next, 450);
+        assert_eq!(op, Some(redo));
+
+        let clr = RelRecord::clr_noop(3, 700, 0);
+        let decoded = RelRecord::decode(&clr.encode()).expect("decode");
+        assert_eq!(decoded.decode_clr().expect("clr"), (0, None));
+    }
+
+    #[test]
+    fn txn_and_catalog_records_round_trip() {
+        for record in [
+            RelRecord::txn_begin(7),
+            RelRecord::txn_commit(7, 123),
+            RelRecord::txn_end(7, 456),
+            RelRecord::set_catalog_root(99),
+        ] {
+            let decoded = RelRecord::decode(&record.encode()).expect("decode");
+            assert_eq!(decoded, record);
+        }
+        assert_eq!(
+            RelRecord::set_catalog_root(99)
+                .decode_catalog_root()
+                .expect("root"),
+            99
+        );
     }
 
     #[test]


### PR DESCRIPTION
Stage 2 of `docs/RELATIONAL_DB_PLAN.md`: the relational storage core on the Stage 1 substrate. No SQL yet — demonstrable through temporary `table create/insert/scan/update/delete` debug commands routed ahead of the frozen ES-search grammar (Stage 3 replaces the command surface, not the storage).

## What's in here (~6,000 lines)

### Access methods
- **Clustered B+ tree** (`relstore/btree.rs`): leaves hold full rows, internal nodes hold separator keys (empty-sentinel first entry), sibling-linked leaves, **stable root page** (root splits copy content into fresh children — catalog entries and logical undo can always re-descend). No merge-on-delete (SQL Server-style lazy).
- **Heap** (`relstore/heap.rs`): chained pages, stable RIDs, forwarding stubs with home back-pointers for grown rows.
- **Slotted pages** (`relstore/slotted.rs`): one format, two disciplines (positional for trees, stable for heaps), hole compaction.

### Codecs
- Row codec `null bitmap | fixed | var offsets | var data` with T-SQL on-disk encodings: INT family, BIT, FLOAT/REAL, DECIMAL(p≤38,s) as i128, DATE/TIME/DATETIME2 tick encodings, UNIQUEIDENTIFIER, [N]VARCHAR/VARBINARY.
- Order-preserving key codec: memcmp order == typed order (sign-flipped BE integers, IEEE-754 total-order floats, NULL-first markers, `0x00`-escaped strings with terminators for composite keys, SQL Server GUID byte-group comparison order). Collation sort keys slot in here in Stage 5.

### ARIES
- **Logging protocol** (`relstore/ctx.rs`): every mutation applies through the *same* physiological-redo function recovery uses, then logs. First page touch per checkpoint epoch logs a full page image (torn-page repair). Records append without fsync; **commit forces the log**; the buffer pool fsyncs to a page's LSN before stealing it. If an append fails, the page's pre-image is restored — the pool never holds state the WAL cannot explain.
- **Splits are crash-atomic**: all pages of a split go into ONE multi-page image record, with every frame pinned from first mutation until the record is appended, so neither a WAL-prefix crash nor a buffer-pool steal can expose a half-split tree.
- **Restart** (`relstore/recovery.rs`): analysis → LSN-gated redo (repeats history, CLRs included, images repair checksum-invalid pages) → max-LSN undo sweep with CLR groups (`undo_next` = record LSN + sealing no-op CLR; undo ops tolerate partial prior application, so a crash mid-undo re-runs cleanly).
- **WAL compensation reserve**: forward relational appends stop at 75% of the ring; rollback/recovery CLRs may use the reserve, so undo always has log space.
- **Wedge protocol**: if a commit or rollback itself fails to log, all relational work — checkpoints above all — is refused until restart recovery, closing the "checkpoint makes an un-undoable loser permanent" window.

### Catalog + integration
- Table definitions live as rows in a clustered tree (object id 1), root announced via WAL records and persisted in `superblock.metadata_root` at checkpoint.
- Combined checkpoint: flushes the relational pool (WAL-before-data per page), resets the FPI epoch, persists the allocator bitmap and catalog root, then advances the WAL head.
- Search engine untouched on the wire; the two subsystems share the ring and recover independently by entry type.

## Adversarial review

A 62-agent review/verify workflow confirmed **27 findings**; all are fixed in this PR (the two criticals were the non-atomic split logging and the steal-before-log window — both closed by the atomic pinned-split protocol) or explicitly accepted and documented (page leaks from rolled-back DDL; fuzzy checkpoint begin/end records deferred to Stage 6 where concurrency makes them meaningful).

## Verification

- 95 tests green, fmt/clippy clean. Stage 2 exit criteria all covered:
  - kill-and-recover matrix: committed durable, uncommitted undone, **crash during recovery re-runs cleanly** (fault-injected crash between two losers' undo)
  - torn-page repair via FPI (page torn on disk mid-checkpoint window, repaired from the log)
  - B+ tree vs BTreeMap oracle: 900 random insert/delete/update/get ops through splits, periodic checkpoints, final crash + recovery, full ordered-scan comparison
  - multi-level split-crash (descending-order inserts, recovery, continued inserts)
  - heap forwarding stubs across restart; statement rollback incl. fault-injected mid-statement failure
  - mixed search+relational WAL replay ordering
- Search smoke script green; relational CLI smoke (create/insert → server restart → scan) green over the wire.

## Known Stage 2 limits (documented in code)

- Tree cells cap at ~2,020 bytes (two cells per 4 KiB page guarantees split progress); heap rows keep the ~3,900-byte cap. Overflow pages arrive in Stage 14.
- Pages allocated by rolled-back statements leak (system allocations are never compensated) — bounded, reclaimable by a future stage.
- The WAL reserve makes undo-out-of-log-space pathological rather than impossible; hard per-transaction log quotas belong to Stage 6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)