### PR TITLE
Add TDS (SQL Server protocol) gateway [Stage 4]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,3 +126,98 @@ jobs:
           name: truthdb
           path: target/release/truthdb
           if-no-files-found: error
+
+  conformance:
+    name: TDS Conformance
+    runs-on: ubuntu-latest
+    container:
+      image: rust:1.92-bookworm
+      # io_uring at runtime needs the seccomp profile relaxed, same as tests.
+      options: --security-opt seccomp=unconfined
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: .cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Cache cargo index
+        uses: actions/cache@v4
+        with:
+          path: .cargo/git
+          key: ${{ runner.os }}-cargo-git-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Cache target directory
+        uses: actions/cache@v4
+        with:
+          path: target
+          key: ${{ runner.os }}-target-conformance-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Build server
+        run: cargo build --release -p truthdb
+
+      - name: Install Python TDS driver (pytds)
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends python3 python3-pip
+          pip install --break-system-packages python-tds==1.17.1
+
+      - name: Install Go
+        run: |
+          curl -fsSL https://go.dev/dl/go1.22.4.linux-amd64.tar.gz | tar -C /usr/local -xz
+          echo "/usr/local/go/bin" >> "$GITHUB_PATH"
+
+      - name: Configure and start server
+        run: |
+          mkdir -p /etc/truthdb /var/lib/truthdb
+          cat > /etc/truthdb/truthdb.toml <<'EOF'
+          [storage]
+          size_gib = 1
+
+          [tds]
+          enabled = true
+          addr = "127.0.0.1"
+          port = 1433
+          database = "truthdb"
+
+          [tds.auth]
+          sa = "secret"
+          EOF
+          STATE_DIRECTORY=/var/lib/truthdb ./target/release/truthdb &
+          echo $! > /tmp/truthdb.pid
+
+      - name: Wait for the TDS port
+        run: |
+          python3 - <<'EOF'
+          import socket, sys, time
+          for _ in range(60):
+              try:
+                  socket.create_connection(("127.0.0.1", 1433), timeout=1).close()
+                  sys.exit(0)
+              except OSError:
+                  time.sleep(0.5)
+          print("TDS port 1433 never opened", file=sys.stderr)
+          sys.exit(1)
+          EOF
+
+      - name: Conformance — pytds (Python)
+        run: python3 scripts/tds_conformance.py 127.0.0.1 1433 sa secret
+
+      - name: Conformance — go-mssqldb (Go)
+        run: |
+          repo="$PWD"
+          work="$(mktemp -d)"
+          cp "$repo/scripts/tds_conformance.go" "$work/main.go"
+          cd "$work"
+          go mod init conf
+          go get github.com/microsoft/go-mssqldb@v1.8.0
+          go run . 127.0.0.1 1433 sa secret
+
+      - name: Stop server
+        if: always()
+        run: |
+          if [ -f /tmp/truthdb.pid ]; then kill "$(cat /tmp/truthdb.pid)" || true; fi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -869,6 +869,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "truthdb-core",
+ "truthdb-tds",
 ]
 
 [[package]]
@@ -936,6 +937,15 @@ dependencies = [
 [[package]]
 name = "truthdb-sql"
 version = "0.1.0"
+
+[[package]]
+name = "truthdb-tds"
+version = "0.1.0"
+dependencies = [
+ "tokio",
+ "tracing",
+ "truthdb-core",
+]
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "crates/truthdb-proto",
     "crates/truthdb-net",
     "crates/truthdb-sql",
+    "crates/truthdb-tds",
 ]
 
 [workspace.dependencies]
@@ -29,12 +30,14 @@ tokio = { version = "1.39.0", features = ["full"] }
 truthdb-proto = { path = "crates/truthdb-proto", version = "0.1.0" }
 truthdb-net = { path = "crates/truthdb-net", version = "0.1.0" }
 truthdb-sql = { path = "crates/truthdb-sql", version = "0.1.0" }
+truthdb-tds = { path = "crates/truthdb-tds", version = "0.1.0" }
 xxhash-rust = { version = "0.8.12", features = ["xxh64"] }
 libc = "0.2"
 io-uring = "0.7"
 
 [dependencies]
 truthdb-core = { path = "crates/truthdb-core", version = "0.1.0" }
+truthdb-tds = { path = "crates/truthdb-tds", version = "0.1.0" }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 serde = { workspace = true }

--- a/config/default.toml
+++ b/config/default.toml
@@ -16,3 +16,14 @@ group_sync_ms = 5
 backpressure_timeout_ms = 50
 snapshot_min_interval_ms = 1000
 snapshot_wal_threshold = 0.7
+
+# TDS (SQL Server protocol) gateway. Disabled by default. When enabled, real
+# SQL Server drivers (pytds, go-mssqldb with encrypt=disable) can connect.
+# [tds]
+# enabled = true
+# addr = "0.0.0.0"
+# port = 1433
+# database = "truthdb"
+#
+# [tds.auth]           # username = password (plaintext; TLS arrives in Stage 9)
+# sa = "change-me"

--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -128,6 +128,16 @@ impl Engine {
         Ok(render_sql_outcome(&outcome))
     }
 
+    /// Runs a SQL batch and returns the typed outcome (result sets +
+    /// optional error). The TDS gateway uses this to emit COLMETADATA / ROW
+    /// / DONE / ERROR token streams; a TDS client only ever speaks SQL, so
+    /// there is no ES routing here.
+    pub fn sql_batch(&mut self, input: &str) -> Result<crate::rel::BatchOutcome, EngineError> {
+        let outcome = crate::rel::execute_batch(&mut self.storage, input);
+        self.maybe_checkpoint()?;
+        Ok(outcome)
+    }
+
     pub fn checkpoint(&mut self) -> Result<(), EngineError> {
         // JSON, not bincode: documents hold serde_json::Value, which bincode
         // can serialize but never deserialize (`deserialize_any`), so bincode
@@ -855,15 +865,19 @@ fn render_sql_outcome(outcome: &crate::rel::BatchOutcome) -> String {
         .iter()
         .map(|result| match result {
             StatementResult::Rows(rowset) => {
+                let columns: Vec<&str> = rowset.columns.iter().map(|c| c.name.as_str()).collect();
                 let rows: Vec<Value> = rowset
                     .rows
                     .iter()
                     .map(|row| {
                         Value::Array(
                             row.iter()
-                                .map(|cell| match cell {
-                                    Some(text) => Value::String(text.clone()),
-                                    None => Value::Null,
+                                .zip(&rowset.columns)
+                                .map(|(datum, column)| {
+                                    match crate::rel::render_cell(datum, &column.column_type) {
+                                        Some(text) => Value::String(text),
+                                        None => Value::Null,
+                                    }
                                 })
                                 .collect(),
                         )
@@ -871,7 +885,7 @@ fn render_sql_outcome(outcome: &crate::rel::BatchOutcome) -> String {
                     .collect();
                 json!({
                     "type": "rows",
-                    "columns": rowset.columns,
+                    "columns": columns,
                     "rows": rows,
                 })
             }
@@ -1388,6 +1402,24 @@ mod tests {
                 vec![Some("8".into()), Some("80".into())],
             ]
         );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn sql_bare_column_alias_is_preserved() {
+        let path = unique_temp_path("sql-alias");
+        let mut engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE nums (n INT NOT NULL PRIMARY KEY)")
+            .expect("create");
+        engine
+            .execute("INSERT INTO nums VALUES (1)")
+            .expect("insert");
+        // A bare column with an alias must report the alias, not the source
+        // column name (regression guard for the typed-projection refactor).
+        let (columns, rows) = sql_rows(&mut engine, "SELECT n AS foo FROM nums");
+        assert_eq!(columns, vec!["foo"]);
+        assert_eq!(rows, vec![vec![Some("1".into())]]);
         let _ = std::fs::remove_file(path);
     }
 

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -19,9 +19,8 @@ use truthdb_sql::{ast, eval};
 
 use crate::relstore::catalog::TableDef;
 use crate::relstore::row::{Column, Schema};
-use crate::relstore::types::ColumnType;
+use crate::relstore::types::{ColumnType, Datum};
 use crate::storage::{Storage, StorageError};
-use value::Cell;
 
 /// Result of one executed statement.
 #[derive(Debug, Clone, PartialEq)]
@@ -32,11 +31,19 @@ pub enum StatementResult {
     Done,
 }
 
+/// A result column: its name and resolved SQL type (drives TDS
+/// COLMETADATA and display rendering alike).
+#[derive(Debug, Clone, PartialEq)]
+pub struct ResultColumn {
+    pub name: String,
+    pub column_type: ColumnType,
+}
+
+/// A typed result set: column metadata plus rows of typed [`Datum`]s.
 #[derive(Debug, Clone, PartialEq)]
 pub struct RowSet {
-    pub columns: Vec<String>,
-    /// Cells; `None` renders as NULL.
-    pub rows: Vec<Vec<Option<String>>>,
+    pub columns: Vec<ResultColumn>,
+    pub rows: Vec<Vec<Datum>>,
 }
 
 /// A batch's outcome: the results of the statements that ran, plus the error
@@ -329,23 +336,34 @@ fn exec_insert(storage: &mut Storage, insert: &Insert) -> Result<StatementResult
 // ---- SELECT -------------------------------------------------------------
 
 struct Source {
-    columns: Vec<String>,
-    rows: Vec<Vec<Cell>>,
+    columns: Vec<ResultColumn>,
+    /// Rows of typed values (real-table Datums; virtual sources build them).
+    rows: Vec<Vec<Datum>>,
+}
+
+impl Source {
+    fn names(&self) -> Vec<String> {
+        self.columns.iter().map(|c| c.name.clone()).collect()
+    }
+}
+
+/// SqlValues of a row, for expression evaluation.
+fn row_values(row: &[Datum]) -> Vec<SqlValue> {
+    row.iter().map(value::datum_to_sql).collect()
 }
 
 fn exec_select(storage: &mut Storage, select: &Select) -> Result<RowSet, SqlError> {
     let source = build_source(storage, select.from.as_ref())?;
-    let resolver = source.columns.clone();
+    let resolver = source.names();
 
     // WHERE. The predicate must be boolean-typed (SQL Server 4145): a bare
     // numeric/string expression is rejected rather than silently coerced.
-    let mut rows: Vec<Vec<Cell>> = Vec::new();
+    let mut rows: Vec<Vec<Datum>> = Vec::new();
     for row in source.rows {
         let keep = match &select.where_clause {
             None => true,
             Some(predicate) => {
-                let values: Vec<SqlValue> = row.iter().map(|c| c.value.clone()).collect();
-                let value = eval::eval(predicate, &values, &resolver)?;
+                let value = eval::eval(predicate, &row_values(&row), &resolver)?;
                 match value {
                     SqlValue::Bool(b) => b,
                     SqlValue::Null => false,
@@ -377,12 +395,11 @@ fn exec_select(storage: &mut Storage, select: &Select) -> Result<RowSet, SqlErro
         rows.truncate(top as usize);
     }
 
-    // Projection.
     project(&select.items, &source.columns, &rows, &resolver)
 }
 
 fn order_rows(
-    rows: &mut [Vec<Cell>],
+    rows: &mut [Vec<Datum>],
     order_by: &[OrderItem],
     resolver: &Vec<String>,
 ) -> Result<(), SqlError> {
@@ -390,7 +407,7 @@ fn order_rows(
     // errors before sorting.
     let mut keyed: Vec<(Vec<SqlValue>, usize)> = Vec::with_capacity(rows.len());
     for (index, row) in rows.iter().enumerate() {
-        let values: Vec<SqlValue> = row.iter().map(|c| c.value.clone()).collect();
+        let values = row_values(row);
         let mut key = Vec::with_capacity(order_by.len());
         for item in order_by {
             key.push(eval::eval(&item.expr, &values, resolver)?);
@@ -408,34 +425,33 @@ fn order_rows(
         ai.cmp(bi) // stable tie-break
     });
     let order: Vec<usize> = keyed.into_iter().map(|(_, i)| i).collect();
-    apply_permutation(rows, &order);
-    Ok(())
-}
-
-fn apply_permutation(rows: &mut [Vec<Cell>], order: &[usize]) {
-    let reordered: Vec<Vec<Cell>> = order.iter().map(|&i| rows[i].clone()).collect();
+    let reordered: Vec<Vec<Datum>> = order.iter().map(|&i| rows[i].clone()).collect();
     rows.clone_from_slice(&reordered);
+    Ok(())
 }
 
 fn project(
     items: &[SelectItem],
-    source_columns: &[String],
-    rows: &[Vec<Cell>],
+    source_columns: &[ResultColumn],
+    rows: &[Vec<Datum>],
     resolver: &Vec<String>,
 ) -> Result<RowSet, SqlError> {
-    // Output column plan: (name, projector).
+    // Output column plan: a source column (typed, pass-through) or a
+    // computed expression (evaluated then typed by inference).
     enum Proj<'a> {
-        SourceColumn(usize),
-        Expr(&'a Expr),
+        SourceColumn { index: usize, name: String },
+        Expr { name: String, expr: &'a Expr },
     }
-    let mut names = Vec::new();
+    let source_names: Vec<String> = source_columns.iter().map(|c| c.name.clone()).collect();
     let mut projs = Vec::new();
     for item in items {
         match item {
             SelectItem::Wildcard => {
-                for (index, name) in source_columns.iter().enumerate() {
-                    names.push(name.clone());
-                    projs.push(Proj::SourceColumn(index));
+                for (index, column) in source_columns.iter().enumerate() {
+                    projs.push(Proj::SourceColumn {
+                        index,
+                        name: column.name.clone(),
+                    });
                 }
             }
             SelectItem::Expr { expr, alias } => {
@@ -444,32 +460,51 @@ fn project(
                     .map(|a| a.value.clone())
                     .or_else(|| bare_column_name(expr))
                     .unwrap_or_default();
-                names.push(name);
-                match bare_column_index(expr, source_columns) {
-                    Some(index) => projs.push(Proj::SourceColumn(index)),
-                    None => projs.push(Proj::Expr(expr)),
+                match bare_column_index(expr, &source_names) {
+                    // A bare column still carries its resolved output name so an
+                    // `AS alias` (or the referenced name's casing) is preserved.
+                    Some(index) => projs.push(Proj::SourceColumn { index, name }),
+                    None => projs.push(Proj::Expr { name, expr }),
                 }
             }
         }
     }
 
-    let mut out_rows = Vec::with_capacity(rows.len());
-    for row in rows {
-        let mut out = Vec::with_capacity(projs.len());
-        for proj in &projs {
-            match proj {
-                Proj::SourceColumn(index) => out.push(row[*index].display.clone()),
-                Proj::Expr(expr) => {
-                    let values: Vec<SqlValue> = row.iter().map(|c| c.value.clone()).collect();
-                    let value = eval::eval(expr, &values, resolver)?;
-                    out.push(Cell::from_sql(value).display);
+    // Precompute all row values once for expression evaluation.
+    let row_sql: Vec<Vec<SqlValue>> = rows.iter().map(|r| row_values(r)).collect();
+
+    let mut columns = Vec::with_capacity(projs.len());
+    let mut out_rows: Vec<Vec<Datum>> = vec![Vec::with_capacity(projs.len()); rows.len()];
+    for proj in &projs {
+        match proj {
+            Proj::SourceColumn { index, name } => {
+                columns.push(ResultColumn {
+                    name: name.clone(),
+                    column_type: source_columns[*index].column_type,
+                });
+                for (out, row) in out_rows.iter_mut().zip(rows) {
+                    out.push(row[*index].clone());
+                }
+            }
+            Proj::Expr { name, expr } => {
+                // Evaluate the column for every row, then infer one type.
+                let mut values = Vec::with_capacity(rows.len());
+                for row in &row_sql {
+                    values.push(eval::eval(expr, row, resolver)?);
+                }
+                let column_type = value::infer_type(&values);
+                columns.push(ResultColumn {
+                    name: name.clone(),
+                    column_type,
+                });
+                for (out, value) in out_rows.iter_mut().zip(&values) {
+                    out.push(value::sql_to_datum_loose(value));
                 }
             }
         }
-        out_rows.push(out);
     }
     Ok(RowSet {
-        columns: names,
+        columns,
         rows: out_rows,
     })
 }
@@ -505,18 +540,15 @@ fn build_source(storage: &mut Storage, from: Option<&Name>) -> Result<Source, Sq
             let def = resolve_table(storage, &from.value)
                 .ok_or_else(|| SqlError::invalid_object(&from.value).at(from.span))?;
             let schema = def.schema().map_err(|e| map_storage_err(e, &def.name))?;
-            let raw = storage
+            let rows = storage
                 .rel_scan(&def.name)
                 .map_err(|err| map_storage_err(err, &def.name))?;
-            let columns: Vec<String> = schema.columns.iter().map(|c| c.name.clone()).collect();
-            let rows = raw
-                .into_iter()
-                .map(|datums| {
-                    datums
-                        .iter()
-                        .zip(&schema.columns)
-                        .map(|(d, c)| Cell::from_datum(d, &c.column_type))
-                        .collect()
+            let columns = schema
+                .columns
+                .iter()
+                .map(|c| ResultColumn {
+                    name: c.name.clone(),
+                    column_type: c.column_type,
                 })
                 .collect();
             Ok(Source { columns, rows })
@@ -526,38 +558,50 @@ fn build_source(storage: &mut Storage, from: Option<&Name>) -> Result<Source, Sq
 
 // ---- sys.* virtual sources ---------------------------------------------
 
+fn nvarchar(name: &str, max_len: u16) -> ResultColumn {
+    ResultColumn {
+        name: name.to_string(),
+        column_type: ColumnType::NVarChar { max_len },
+    }
+}
+
+fn int_col(name: &str) -> ResultColumn {
+    ResultColumn {
+        name: name.to_string(),
+        column_type: ColumnType::Int,
+    }
+}
+
 fn sys_tables(storage: &Storage) -> Source {
-    let columns = vec!["object_id".to_string(), "name".to_string()];
+    let columns = vec![int_col("object_id"), nvarchar("name", 128)];
     let rows = storage
         .rel_tables()
         .into_iter()
-        .map(|def| {
-            vec![
-                Cell::from_sql(SqlValue::Int(def.object_id as i64)),
-                Cell::from_sql(SqlValue::Str(def.name)),
-            ]
-        })
+        .map(|def| vec![Datum::Int(def.object_id as i32), Datum::NVarChar(def.name)])
         .collect();
     Source { columns, rows }
 }
 
 fn sys_columns(storage: &Storage) -> Source {
     let columns = vec![
-        "object_id".to_string(),
-        "name".to_string(),
-        "column_id".to_string(),
-        "type".to_string(),
-        "is_nullable".to_string(),
+        int_col("object_id"),
+        nvarchar("name", 128),
+        int_col("column_id"),
+        nvarchar("type", 128),
+        ResultColumn {
+            name: "is_nullable".to_string(),
+            column_type: ColumnType::Bit,
+        },
     ];
     let mut rows = Vec::new();
     for def in storage.rel_tables() {
         for (index, (name, type_spec, nullable)) in def.columns.iter().enumerate() {
             rows.push(vec![
-                Cell::from_sql(SqlValue::Int(def.object_id as i64)),
-                Cell::from_sql(SqlValue::Str(name.clone())),
-                Cell::from_sql(SqlValue::Int(index as i64 + 1)),
-                Cell::from_sql(SqlValue::Str(type_spec.clone())),
-                Cell::from_sql(SqlValue::Bool(*nullable)),
+                Datum::Int(def.object_id as i32),
+                Datum::NVarChar(name.clone()),
+                Datum::Int(index as i32 + 1),
+                Datum::NVarChar(type_spec.clone()),
+                Datum::Bit(*nullable),
             ]);
         }
     }
@@ -623,3 +667,9 @@ fn map_storage_err(err: StorageError, table: &str) -> SqlError {
 }
 
 pub use ast::Statement as SqlStatement;
+
+/// Renders a result cell to its display string (`None` = NULL). Shared by
+/// the JSON envelope and any text renderer.
+pub fn render_cell(datum: &Datum, column_type: &ColumnType) -> Option<String> {
+    value::display(datum, column_type)
+}

--- a/crates/truthdb-core/src/rel/value.rs
+++ b/crates/truthdb-core/src/rel/value.rs
@@ -6,26 +6,59 @@ use truthdb_sql::error::SqlError;
 
 use crate::relstore::types::{ColumnType, Datum};
 
-/// A projected result cell: the value used for evaluation/ordering and its
-/// rendered form (`None` = SQL NULL).
-#[derive(Debug, Clone)]
-pub struct Cell {
-    pub value: SqlValue,
-    pub display: Option<String>,
-}
-
-impl Cell {
-    pub fn from_datum(datum: &Datum, column_type: &ColumnType) -> Cell {
-        Cell {
-            value: datum_to_sql(datum),
-            display: datum_display(datum, column_type),
+/// Infers a concrete result column type for a projected (computed) column
+/// from its values across all rows: string wins (NVARCHAR sized to the
+/// widest), then float, then integer (BIGINT holds any i64), then bit; an
+/// all-NULL column defaults to INT.
+pub fn infer_type(values: &[SqlValue]) -> ColumnType {
+    let mut has_str = false;
+    let mut has_float = false;
+    let mut has_int = false;
+    let mut has_bool = false;
+    let mut max_len = 1usize;
+    for value in values {
+        match value {
+            SqlValue::Str(s) => {
+                has_str = true;
+                max_len = max_len.max(s.encode_utf16().count().max(1));
+            }
+            SqlValue::Float(_) => has_float = true,
+            SqlValue::Int(_) => has_int = true,
+            SqlValue::Bool(_) => has_bool = true,
+            SqlValue::Null => {}
         }
     }
-
-    pub fn from_sql(value: SqlValue) -> Cell {
-        let display = sql_display(&value);
-        Cell { value, display }
+    if has_str {
+        ColumnType::NVarChar {
+            max_len: max_len.min(4000) as u16,
+        }
+    } else if has_float {
+        ColumnType::Float
+    } else if has_int {
+        ColumnType::BigInt
+    } else if has_bool {
+        ColumnType::Bit
+    } else {
+        ColumnType::Int
     }
+}
+
+/// SQL value -> storage value using the value's own natural type (computed
+/// result columns): integers widen to BIGINT, strings to NVARCHAR. Pairs
+/// with [`infer_type`].
+pub fn sql_to_datum_loose(value: &SqlValue) -> Datum {
+    match value {
+        SqlValue::Null => Datum::Null,
+        SqlValue::Int(v) => Datum::BigInt(*v),
+        SqlValue::Float(v) => Datum::Float(*v),
+        SqlValue::Bool(v) => Datum::Bit(*v),
+        SqlValue::Str(s) => Datum::NVarChar(s.clone()),
+    }
+}
+
+/// Renders a datum to its result-cell display string (`None` = NULL).
+pub fn display(datum: &Datum, column_type: &ColumnType) -> Option<String> {
+    datum_display(datum, column_type)
 }
 
 /// Storage value -> SQL value for expression evaluation. Lossy for types the
@@ -156,16 +189,6 @@ fn datum_display(datum: &Datum, column_type: &ColumnType) -> Option<String> {
             serde_json::Value::String(s) => Some(s),
             other => Some(other.to_string()),
         },
-    }
-}
-
-fn sql_display(value: &SqlValue) -> Option<String> {
-    match value {
-        SqlValue::Null => None,
-        SqlValue::Bool(b) => Some(if *b { "1" } else { "0" }.to_string()),
-        SqlValue::Int(v) => Some(v.to_string()),
-        SqlValue::Float(v) => Some(format_float(*v)),
-        SqlValue::Str(s) => Some(s.clone()),
     }
 }
 

--- a/crates/truthdb-tds/Cargo.toml
+++ b/crates/truthdb-tds/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "truthdb-tds"
+version = "0.1.0"
+edition = "2024"
+description = "TruthDB TDS (Tabular Data Stream) gateway: a plaintext SQL Server-protocol front end on TCP/1433, so real SQL Server drivers (pymssql, go-mssqldb) can talk to TruthDB."
+license = "MIT"
+
+[dependencies]
+tokio = { workspace = true }
+tracing = { workspace = true }
+truthdb-core = { path = "../truthdb-core", version = "0.1.0" }
+
+[dev-dependencies]

--- a/crates/truthdb-tds/src/lib.rs
+++ b/crates/truthdb-tds/src/lib.rs
@@ -1,0 +1,90 @@
+//! TDS (Tabular Data Stream) gateway for TruthDB.
+//!
+//! A plaintext SQL Server-protocol front end so real drivers (pymssql,
+//! go-mssqldb with `encrypt=disable`) can connect to TruthDB. Stage 4 covers
+//! the packet layer, PRELOGIN (encryption not supported), LOGIN7 with
+//! config-file auth, and SQLBatch → token-stream execution over the engine's
+//! typed SQL results. TLS and RPC/prepared statements arrive in Stage 9.
+
+pub mod login;
+pub mod packet;
+pub mod server;
+pub mod token;
+pub mod typeinfo;
+
+use std::sync::{Arc, Mutex};
+
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::watch;
+use tracing::{debug, error, info};
+use truthdb_core::engine::Engine;
+
+pub use server::{TdsConfig, serve_connection};
+
+/// A TDS listener bound to an address; serves connections until shutdown.
+pub struct TdsListener {
+    listener: TcpListener,
+    engine: Arc<Mutex<Engine>>,
+    config: Arc<TdsConfig>,
+}
+
+impl TdsListener {
+    /// Binds the listener. Returns the bound address for logging/tests.
+    pub async fn bind(
+        addr: &str,
+        port: u16,
+        engine: Arc<Mutex<Engine>>,
+        config: TdsConfig,
+    ) -> std::io::Result<Self> {
+        let listener = TcpListener::bind((addr, port)).await?;
+        Ok(TdsListener {
+            listener,
+            engine,
+            config: Arc::new(config),
+        })
+    }
+
+    pub fn local_addr(&self) -> std::io::Result<std::net::SocketAddr> {
+        self.listener.local_addr()
+    }
+
+    /// Accepts connections until `shutdown` flips to true.
+    pub async fn run(self, mut shutdown: watch::Receiver<bool>) -> std::io::Result<()> {
+        loop {
+            tokio::select! {
+                accepted = self.listener.accept() => {
+                    let (stream, peer) = accepted?;
+                    debug!(%peer, "TDS connection accepted");
+                    let engine = Arc::clone(&self.engine);
+                    let config = Arc::clone(&self.config);
+                    tokio::spawn(async move {
+                        if let Err(err) = handle(stream, engine, config).await {
+                            debug!(%peer, error = %err, "TDS connection closed");
+                        }
+                    });
+                }
+                _ = shutdown.changed() => {
+                    if *shutdown.borrow() {
+                        info!("TDS listener shutting down");
+                        return Ok(());
+                    }
+                }
+            }
+        }
+    }
+}
+
+async fn handle(
+    stream: TcpStream,
+    engine: Arc<Mutex<Engine>>,
+    config: Arc<TdsConfig>,
+) -> std::io::Result<()> {
+    stream.set_nodelay(true).ok();
+    match serve_connection(stream, engine, config).await {
+        Ok(()) => Ok(()),
+        Err(err) => {
+            error!(error = %err, "TDS connection error");
+            Err(err)
+        }
+    }
+}

--- a/crates/truthdb-tds/src/login.rs
+++ b/crates/truthdb-tds/src/login.rs
@@ -1,0 +1,196 @@
+//! PRELOGIN response and LOGIN7 parsing (MS-TDS 2.2.6.5, 2.2.6.4).
+
+/// Builds a PRELOGIN response: version, ENCRYPTION = NOT_SUP (plaintext
+/// only), MARS off. The option table is a list of
+/// `token u8 | offset u16 (BE) | length u16 (BE)` entries ended by `0xFF`,
+/// followed by the option data.
+pub fn prelogin_response() -> Vec<u8> {
+    const TOKEN_VERSION: u8 = 0x00;
+    const TOKEN_ENCRYPTION: u8 = 0x01;
+    const TOKEN_MARS: u8 = 0x04;
+    const TERMINATOR: u8 = 0xff;
+    /// ENCRYPT_NOT_SUP: this server does not support TLS (Stage 4 plaintext).
+    const ENCRYPT_NOT_SUP: u8 = 0x02;
+
+    // Three options + terminator: table is 3*5 + 1 = 16 bytes; data follows.
+    let table_len = 3 * 5 + 1;
+    let version = [16u8, 0, 0, 0, 0, 0]; // major 16, build/subbuild 0
+    let mut out = Vec::new();
+
+    let version_off = table_len;
+    let encryption_off = version_off + version.len();
+    let mars_off = encryption_off + 1;
+
+    let push_option = |out: &mut Vec<u8>, token: u8, offset: usize, len: usize| {
+        out.push(token);
+        out.extend_from_slice(&(offset as u16).to_be_bytes());
+        out.extend_from_slice(&(len as u16).to_be_bytes());
+    };
+    push_option(&mut out, TOKEN_VERSION, version_off, version.len());
+    push_option(&mut out, TOKEN_ENCRYPTION, encryption_off, 1);
+    push_option(&mut out, TOKEN_MARS, mars_off, 1);
+    out.push(TERMINATOR);
+
+    out.extend_from_slice(&version);
+    out.push(ENCRYPT_NOT_SUP);
+    out.push(0x00); // MARS off
+    out
+}
+
+/// The fields a LOGIN7 request carries that Stage 4 uses.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Login7 {
+    pub username: String,
+    pub password: String,
+    pub database: String,
+    /// Client-requested packet size (0 = keep the current one).
+    pub packet_size: u32,
+}
+
+const FIXED_HEADER_LEN: usize = 36;
+const OFFSET_TABLE_LEN: usize = 58; // 36..94
+
+/// Parses a LOGIN7 message payload, extracting username, de-obfuscated
+/// password, database, and requested packet size.
+pub fn parse_login7(payload: &[u8]) -> Result<Login7, LoginError> {
+    if payload.len() < FIXED_HEADER_LEN + OFFSET_TABLE_LEN {
+        return Err(LoginError("LOGIN7 shorter than its fixed header"));
+    }
+    let packet_size = u32::from_le_bytes(payload[8..12].try_into().unwrap());
+
+    // Offset/length pairs are relative to the start of the message and count
+    // UCS-2 characters (2 bytes each).
+    let field = |at: usize| -> (usize, usize) {
+        let off = u16::from_le_bytes([payload[at], payload[at + 1]]) as usize;
+        let cch = u16::from_le_bytes([payload[at + 2], payload[at + 3]]) as usize;
+        (off, cch)
+    };
+    let (user_off, user_cch) = field(40);
+    let (pass_off, pass_cch) = field(44);
+    let (db_off, db_cch) = field(68);
+
+    let username = read_ucs2(payload, user_off, user_cch, false)?;
+    let password = read_ucs2(payload, pass_off, pass_cch, true)?;
+    let database = read_ucs2(payload, db_off, db_cch, false)?;
+
+    Ok(Login7 {
+        username,
+        password,
+        database,
+        packet_size,
+    })
+}
+
+/// Reads `cch` UCS-2LE characters at `offset`. When `deobfuscate` is set the
+/// bytes are un-scrambled first (LOGIN7 password obfuscation: swap nibbles,
+/// XOR 0xA5).
+fn read_ucs2(
+    payload: &[u8],
+    offset: usize,
+    cch: usize,
+    deobfuscate: bool,
+) -> Result<String, LoginError> {
+    let byte_len = cch * 2;
+    if offset + byte_len > payload.len() {
+        return Err(LoginError("LOGIN7 field extends past the message"));
+    }
+    let mut units = Vec::with_capacity(cch);
+    for i in 0..cch {
+        let mut lo = payload[offset + i * 2];
+        let mut hi = payload[offset + i * 2 + 1];
+        if deobfuscate {
+            lo = deobfuscate_byte(lo);
+            hi = deobfuscate_byte(hi);
+        }
+        units.push(u16::from_le_bytes([lo, hi]));
+    }
+    String::from_utf16(&units).map_err(|_| LoginError("invalid UTF-16 in LOGIN7 field"))
+}
+
+/// Inverts the LOGIN7 password obfuscation. Per MS-TDS 2.2.6.4 the client
+/// obfuscates each byte by swapping its nibbles and then XOR-ing with 0xA5;
+/// de-obfuscation therefore XORs with 0xA5 first, then swaps nibbles back.
+fn deobfuscate_byte(b: u8) -> u8 {
+    (b ^ 0xa5).rotate_left(4)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LoginError(pub &'static str);
+
+impl std::fmt::Display for LoginError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.0)
+    }
+}
+
+/// Encodes a &str to UCS-2LE (test/response helper).
+pub fn ucs2le(s: &str) -> Vec<u8> {
+    s.encode_utf16().flat_map(|u| u.to_le_bytes()).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Obfuscates a password the way a client would, so the parser can be
+    /// tested against its own inverse.
+    fn obfuscate(s: &str) -> Vec<u8> {
+        ucs2le(s)
+            .into_iter()
+            .map(|b| b.rotate_left(4) ^ 0xa5)
+            .collect()
+    }
+
+    fn build_login7(user: &str, password: &str, database: &str) -> Vec<u8> {
+        let mut payload = vec![0u8; 94];
+        // Packet size field.
+        payload[8..12].copy_from_slice(&4096u32.to_le_bytes());
+        let mut data = Vec::new();
+        let add = |payload: &mut Vec<u8>, data: &mut Vec<u8>, at: usize, bytes: &[u8]| {
+            let offset = 94 + data.len();
+            let cch = bytes.len() / 2;
+            payload[at..at + 2].copy_from_slice(&(offset as u16).to_le_bytes());
+            payload[at + 2..at + 4].copy_from_slice(&(cch as u16).to_le_bytes());
+            data.extend_from_slice(bytes);
+        };
+        add(&mut payload, &mut data, 40, &ucs2le(user));
+        add(&mut payload, &mut data, 44, &obfuscate(password));
+        add(&mut payload, &mut data, 68, &ucs2le(database));
+        payload.extend(data);
+        payload
+    }
+
+    #[test]
+    fn parses_login7_fields_and_deobfuscates_password() {
+        let payload = build_login7("sa", "S3cr3t!", "truthdb");
+        let login = parse_login7(&payload).expect("parse");
+        assert_eq!(login.username, "sa");
+        assert_eq!(login.password, "S3cr3t!");
+        assert_eq!(login.database, "truthdb");
+        assert_eq!(login.packet_size, 4096);
+    }
+
+    #[test]
+    fn deobfuscation_is_the_inverse_of_obfuscation() {
+        for b in 0u8..=255 {
+            let obf = b.rotate_left(4) ^ 0xa5;
+            assert_eq!(deobfuscate_byte(obf), b);
+        }
+    }
+
+    #[test]
+    fn prelogin_response_is_well_formed() {
+        let resp = prelogin_response();
+        // First option token is VERSION with a sane offset.
+        assert_eq!(resp[0], 0x00);
+        let version_off = u16::from_be_bytes([resp[1], resp[2]]) as usize;
+        assert_eq!(version_off, 16);
+        // Encryption byte is NOT_SUP.
+        assert_eq!(resp[16 + 6], 0x02);
+    }
+
+    #[test]
+    fn short_login7_errors() {
+        assert!(parse_login7(&[0u8; 10]).is_err());
+    }
+}

--- a/crates/truthdb-tds/src/packet.rs
+++ b/crates/truthdb-tds/src/packet.rs
@@ -1,0 +1,186 @@
+//! TDS packet framing (MS-TDS 2.2.3.1).
+//!
+//! Every TDS message is a sequence of packets, each with an 8-byte header:
+//!
+//! ```text
+//! type u8 | status u8 | length u16 (BE, incl. header) | spid u16 (BE) |
+//! packet_id u8 | window u8
+//! ```
+//!
+//! A message ends at the packet whose status has the EOM bit set. We read a
+//! whole message (reassembling packets) into one payload buffer, and write a
+//! response by splitting a payload into packets of the negotiated size.
+
+use tokio::io::{self, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+
+pub const PKT_SQL_BATCH: u8 = 0x01;
+pub const PKT_RPC: u8 = 0x03;
+pub const PKT_TABULAR_RESULT: u8 = 0x04;
+pub const PKT_ATTENTION: u8 = 0x06;
+pub const PKT_LOGIN7: u8 = 0x10;
+pub const PKT_PRELOGIN: u8 = 0x12;
+
+const HEADER_LEN: usize = 8;
+const STATUS_EOM: u8 = 0x01;
+
+/// Upper bound on a fully reassembled message. A peer controls the EOM bit, so
+/// without a cap it could stream non-EOM packets forever and grow the payload
+/// Vec until the process is OOM-killed (a pre-auth remote DoS, since the very
+/// first read is PRELOGIN). 16 MiB is far larger than any legitimate LOGIN7 or
+/// SQL batch yet bounds the damage.
+const MAX_MESSAGE_SIZE: usize = 16 * 1024 * 1024;
+
+pub const DEFAULT_PACKET_SIZE: usize = 4096;
+/// Clamp for a client-negotiated packet size (MS-TDS allows 512..=32767).
+pub const MIN_PACKET_SIZE: usize = 512;
+pub const MAX_PACKET_SIZE: usize = 32_767;
+
+/// A fully reassembled TDS message.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Message {
+    pub kind: u8,
+    pub payload: Vec<u8>,
+}
+
+/// Reads one complete message (all packets up to and including EOM).
+pub async fn read_message<R: AsyncRead + Unpin>(reader: &mut R) -> io::Result<Message> {
+    let mut header = [0u8; HEADER_LEN];
+    reader.read_exact(&mut header).await?;
+    let kind = header[0];
+    let mut payload = read_packet_body(reader, &header).await?;
+    let mut status = header[1];
+
+    // Continue while EOM is not set. All packets of a message share the type.
+    while status & STATUS_EOM == 0 {
+        reader.read_exact(&mut header).await?;
+        if header[0] != kind {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "TDS message packets changed type mid-stream",
+            ));
+        }
+        status = header[1];
+        payload.extend(read_packet_body(reader, &header).await?);
+        if payload.len() > MAX_MESSAGE_SIZE {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "TDS message exceeds the maximum reassembled size",
+            ));
+        }
+    }
+
+    Ok(Message { kind, payload })
+}
+
+async fn read_packet_body<R: AsyncRead + Unpin>(
+    reader: &mut R,
+    header: &[u8; HEADER_LEN],
+) -> io::Result<Vec<u8>> {
+    let length = u16::from_be_bytes([header[2], header[3]]) as usize;
+    if length < HEADER_LEN {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "TDS packet length smaller than its header",
+        ));
+    }
+    let body_len = length - HEADER_LEN;
+    let mut body = vec![0u8; body_len];
+    reader.read_exact(&mut body).await?;
+    Ok(body)
+}
+
+/// Writes a message as one or more packets of `packet_size` (splitting the
+/// payload at packet-data boundaries; the last packet carries EOM).
+pub async fn write_message<W: AsyncWrite + Unpin>(
+    writer: &mut W,
+    kind: u8,
+    payload: &[u8],
+    packet_size: usize,
+) -> io::Result<()> {
+    let data_per_packet = packet_size.clamp(MIN_PACKET_SIZE, MAX_PACKET_SIZE) - HEADER_LEN;
+    let mut packet_id: u8 = 1;
+    let mut offset = 0;
+    loop {
+        let end = (offset + data_per_packet).min(payload.len());
+        let is_last = end == payload.len();
+        let chunk = &payload[offset..end];
+        let length = (HEADER_LEN + chunk.len()) as u16;
+        let header = [
+            kind,
+            if is_last { STATUS_EOM } else { 0 },
+            (length >> 8) as u8,
+            (length & 0xff) as u8,
+            0,
+            0, // SPID (server sends 0 in Stage 4)
+            packet_id,
+            0, // window
+        ];
+        writer.write_all(&header).await?;
+        writer.write_all(chunk).await?;
+        packet_id = packet_id.wrapping_add(1);
+        offset = end;
+        if is_last {
+            break;
+        }
+    }
+    writer.flush().await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn single_packet_round_trip() {
+        let mut buf = Vec::new();
+        write_message(&mut buf, PKT_SQL_BATCH, b"hello tds", DEFAULT_PACKET_SIZE)
+            .await
+            .unwrap();
+        // Header then body.
+        assert_eq!(buf[0], PKT_SQL_BATCH);
+        assert_eq!(buf[1], STATUS_EOM);
+        assert_eq!(u16::from_be_bytes([buf[2], buf[3]]), (8 + 9) as u16);
+
+        let mut cursor = std::io::Cursor::new(buf);
+        let message = read_message(&mut cursor).await.unwrap();
+        assert_eq!(message.kind, PKT_SQL_BATCH);
+        assert_eq!(message.payload, b"hello tds");
+    }
+
+    #[tokio::test]
+    async fn multi_packet_reassembly() {
+        // Force tiny packets so a 2000-byte payload spans several.
+        let payload: Vec<u8> = (0..2000).map(|i| (i % 251) as u8).collect();
+        let mut buf = Vec::new();
+        write_message(&mut buf, PKT_TABULAR_RESULT, &payload, MIN_PACKET_SIZE)
+            .await
+            .unwrap();
+        // More than one packet was emitted.
+        assert!(buf.len() > payload.len() + HEADER_LEN);
+
+        let mut cursor = std::io::Cursor::new(buf);
+        let message = read_message(&mut cursor).await.unwrap();
+        assert_eq!(message.kind, PKT_TABULAR_RESULT);
+        assert_eq!(message.payload, payload);
+    }
+
+    #[tokio::test]
+    async fn oversized_message_is_rejected() {
+        // A peer that never sets EOM cannot grow the payload without bound.
+        let body = vec![0u8; 65527];
+        let mut buf = Vec::new();
+        let packets = MAX_MESSAGE_SIZE / body.len() + 2;
+        for _ in 0..packets {
+            let length = (HEADER_LEN + body.len()) as u16;
+            buf.push(PKT_SQL_BATCH);
+            buf.push(0); // status: no EOM
+            buf.extend_from_slice(&length.to_be_bytes());
+            buf.extend_from_slice(&[0, 0, 0, 0]); // spid, packet_id, window
+            buf.extend_from_slice(&body);
+        }
+        let mut cursor = std::io::Cursor::new(buf);
+        let err = read_message(&mut cursor).await.unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+}

--- a/crates/truthdb-tds/src/server.rs
+++ b/crates/truthdb-tds/src/server.rs
@@ -1,0 +1,226 @@
+//! TDS connection handler: PRELOGIN -> LOGIN7 (auth) -> SQLBatch loop.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use tokio::io::{self, AsyncRead, AsyncWrite};
+use truthdb_core::engine::Engine;
+use truthdb_core::rel::{BatchOutcome, StatementResult};
+
+use crate::login::{self, parse_login7};
+use crate::packet::{
+    self, DEFAULT_PACKET_SIZE, Message, PKT_ATTENTION, PKT_LOGIN7, PKT_PRELOGIN, PKT_SQL_BATCH,
+    PKT_TABULAR_RESULT, read_message, write_message,
+};
+use crate::token;
+
+/// Server-side TDS configuration: the login users and the reported database.
+#[derive(Debug, Clone)]
+pub struct TdsConfig {
+    /// username -> password (plaintext config auth for Stage 4).
+    pub users: HashMap<String, String>,
+    /// The single database name reported to clients.
+    pub database: String,
+}
+
+/// Handles one TDS connection to completion (or disconnect).
+pub async fn serve_connection<S>(
+    mut stream: S,
+    engine: Arc<Mutex<Engine>>,
+    config: Arc<TdsConfig>,
+) -> io::Result<()>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    let mut packet_size = DEFAULT_PACKET_SIZE;
+
+    // --- PRELOGIN ---
+    let prelogin = read_message(&mut stream).await?;
+    if prelogin.kind != PKT_PRELOGIN {
+        return Err(protocol_err("expected PRELOGIN"));
+    }
+    // The PRELOGIN *response* is sent as a REPLY (Tabular Result) packet;
+    // clients (pytds/go-mssqldb) expect type 0x04 here, not 0x12.
+    write_message(
+        &mut stream,
+        PKT_TABULAR_RESULT,
+        &login::prelogin_response(),
+        packet_size,
+    )
+    .await?;
+
+    // --- LOGIN7 ---
+    let login_msg = read_message(&mut stream).await?;
+    if login_msg.kind != PKT_LOGIN7 {
+        return Err(protocol_err("expected LOGIN7"));
+    }
+    let login = parse_login7(&login_msg.payload).map_err(|e| protocol_err(e.0))?;
+
+    if !authenticate(&config, &login.username, &login.password) {
+        let mut out = Vec::new();
+        // 18456: login failed for user.
+        token::error(
+            &mut out,
+            18456,
+            1,
+            14,
+            &format!("Login failed for user '{}'.", login.username),
+        );
+        token::done(&mut out, false, true, None);
+        write_message(&mut stream, PKT_TABULAR_RESULT, &out, packet_size).await?;
+        return Ok(());
+    }
+
+    // Negotiate packet size if the client requested a valid one.
+    let requested = login.packet_size as usize;
+    if requested >= packet::MIN_PACKET_SIZE {
+        packet_size = requested.min(packet::MAX_PACKET_SIZE);
+    }
+
+    // Login response token stream.
+    let database = if login.database.is_empty() {
+        config.database.clone()
+    } else {
+        login.database.clone()
+    };
+    let mut out = Vec::new();
+    token::loginack(&mut out);
+    token::envchange_database(&mut out, &database);
+    token::envchange_packet_size(&mut out, packet_size, DEFAULT_PACKET_SIZE);
+    token::info(
+        &mut out,
+        5701,
+        2,
+        10,
+        &format!("Changed database context to '{database}'."),
+    );
+    token::done(&mut out, false, false, None);
+    write_message(&mut stream, PKT_TABULAR_RESULT, &out, packet_size).await?;
+
+    // --- request loop ---
+    loop {
+        let message = match read_message(&mut stream).await {
+            Ok(message) => message,
+            // Clean disconnect.
+            Err(err) if err.kind() == io::ErrorKind::UnexpectedEof => return Ok(()),
+            Err(err) => return Err(err),
+        };
+        match message.kind {
+            PKT_SQL_BATCH => {
+                let sql = batch_sql(&message.payload)?;
+                let response = run_batch(&engine, &sql);
+                write_message(&mut stream, PKT_TABULAR_RESULT, &response, packet_size).await?;
+            }
+            PKT_ATTENTION => {
+                // Acknowledge cancel with a DONE(attention). True mid-batch
+                // interruption arrives in a later stage; batches here run to
+                // completion.
+                let mut out = Vec::new();
+                token::done_attention(&mut out);
+                write_message(&mut stream, PKT_TABULAR_RESULT, &out, packet_size).await?;
+            }
+            _ => return Err(protocol_err("unexpected TDS message type")),
+        }
+    }
+}
+
+fn authenticate(config: &TdsConfig, username: &str, password: &str) -> bool {
+    config
+        .users
+        .get(username)
+        .is_some_and(|expected| expected == password)
+}
+
+/// Runs a SQL batch through the engine and builds its token stream.
+fn run_batch(engine: &Arc<Mutex<Engine>>, sql: &str) -> Vec<u8> {
+    let outcome = {
+        let mut engine = engine.lock().expect("engine mutex poisoned");
+        engine.sql_batch(sql)
+    };
+    match outcome {
+        Ok(outcome) => build_batch_tokens(&outcome),
+        Err(err) => {
+            // A genuine engine/storage failure (not a SQL-level error).
+            let mut out = Vec::new();
+            token::error(&mut out, 50000, 1, 16, &err.to_string());
+            token::done(&mut out, false, true, None);
+            out
+        }
+    }
+}
+
+/// Builds the COLMETADATA/ROW/DONE/ERROR token stream for a batch outcome.
+fn build_batch_tokens(outcome: &BatchOutcome) -> Vec<u8> {
+    let mut out = Vec::new();
+    let has_error = outcome.error.is_some();
+    let last_index = outcome.results.len().saturating_sub(1);
+    for (index, result) in outcome.results.iter().enumerate() {
+        // A DONE is final only when it is the last token group of the whole
+        // response (no more results and no trailing error).
+        let more = index != last_index || has_error;
+        match result {
+            StatementResult::Rows(rowset) => {
+                token::colmetadata(&mut out, &rowset.columns);
+                for row in &rowset.rows {
+                    token::row(&mut out, row, &rowset.columns);
+                }
+                token::done(&mut out, more, false, Some(rowset.rows.len() as u64));
+            }
+            StatementResult::RowsAffected(n) => {
+                token::done(&mut out, more, false, Some(*n));
+            }
+            StatementResult::Done => {
+                token::done(&mut out, more, false, None);
+            }
+        }
+    }
+    if let Some(error) = &outcome.error {
+        token::error(
+            &mut out,
+            error.number,
+            error.state,
+            error.level,
+            &error.message,
+        );
+        token::done(&mut out, false, true, None);
+    } else if outcome.results.is_empty() {
+        // Empty batch (e.g. only comments): a single final DONE.
+        token::done(&mut out, false, false, None);
+    }
+    out
+}
+
+/// Extracts the SQL text from a SQLBatch payload: an ALL_HEADERS block
+/// (`TotalLength u32` covering the headers) followed by the UCS-2LE query.
+fn batch_sql(payload: &[u8]) -> io::Result<String> {
+    let sql_start = if payload.len() >= 4 {
+        let total = u32::from_le_bytes(payload[0..4].try_into().unwrap()) as usize;
+        if (4..=payload.len()).contains(&total) {
+            total
+        } else {
+            0 // No (or malformed) ALL_HEADERS: treat the whole payload as SQL.
+        }
+    } else {
+        0
+    };
+    let text = &payload[sql_start..];
+    if !text.len().is_multiple_of(2) {
+        return Err(protocol_err("SQLBatch text is not UCS-2 aligned"));
+    }
+    let units: Vec<u16> = text
+        .chunks_exact(2)
+        .map(|c| u16::from_le_bytes([c[0], c[1]]))
+        .collect();
+    String::from_utf16(&units).map_err(|_| protocol_err("SQLBatch text is not valid UTF-16"))
+}
+
+fn protocol_err(message: &str) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, message.to_string())
+}
+
+/// Test hook: the raw message reader (used by the in-process TDS client
+/// integration test).
+#[doc(hidden)]
+pub async fn read_raw_message<R: AsyncRead + Unpin>(reader: &mut R) -> io::Result<Message> {
+    read_message(reader).await
+}

--- a/crates/truthdb-tds/src/token.rs
+++ b/crates/truthdb-tds/src/token.rs
@@ -1,0 +1,253 @@
+//! TDS server token-stream builders (MS-TDS 2.2.7): LOGINACK, ENVCHANGE,
+//! INFO, ERROR, COLMETADATA, ROW, DONE. All strings are UCS-2LE.
+
+use truthdb_core::rel::ResultColumn;
+use truthdb_core::relstore::types::Datum;
+
+use crate::typeinfo;
+
+const TOKEN_COLMETADATA: u8 = 0x81;
+const TOKEN_ERROR: u8 = 0xaa;
+const TOKEN_INFO: u8 = 0xab;
+const TOKEN_LOGINACK: u8 = 0xad;
+const TOKEN_ROW: u8 = 0xd1;
+const TOKEN_ENVCHANGE: u8 = 0xe3;
+const TOKEN_DONE: u8 = 0xfd;
+
+// DONE status bits.
+const DONE_FINAL: u16 = 0x0000;
+const DONE_MORE: u16 = 0x0001;
+const DONE_ERROR: u16 = 0x0002;
+const DONE_COUNT: u16 = 0x0010;
+const DONE_ATTN: u16 = 0x0020;
+
+// ENVCHANGE types.
+const ENV_DATABASE: u8 = 1;
+const ENV_PACKET_SIZE: u8 = 4;
+
+/// UCS-2LE code units of `s`, truncated to at most `max` units. Truncating
+/// keeps the emitted body consistent with a length prefix that can only count
+/// up to `max`; without it an over-long string wraps the prefix while the full
+/// body is still written, desyncing the whole token stream. A boundary split of
+/// a surrogate pair is harmless for framing (the byte count still matches).
+fn ucs2_capped(s: &str, max: usize) -> Vec<u16> {
+    s.encode_utf16().take(max).collect()
+}
+
+fn push_units(out: &mut Vec<u8>, units: &[u16]) {
+    for u in units {
+        out.extend_from_slice(&u.to_le_bytes());
+    }
+}
+
+/// B_VARCHAR: 1-byte character count then UCS-2LE (count capped at 255).
+fn push_b_varchar(out: &mut Vec<u8>, s: &str) {
+    let units = ucs2_capped(s, u8::MAX as usize);
+    out.push(units.len() as u8);
+    push_units(out, &units);
+}
+
+/// US_VARCHAR: 2-byte character count then UCS-2LE (count capped at 65535).
+fn push_us_varchar(out: &mut Vec<u8>, s: &str) {
+    let units = ucs2_capped(s, u16::MAX as usize);
+    out.extend_from_slice(&(units.len() as u16).to_le_bytes());
+    push_units(out, &units);
+}
+
+/// LOGINACK: interface = T-SQL, TDS 7.4, server program name + version.
+pub fn loginack(out: &mut Vec<u8>) {
+    let mut body = Vec::new();
+    body.push(1); // interface: SQL_TSQL
+    // TDS 7.4 version 0x74000004, sent so a big-endian read yields that value.
+    body.extend_from_slice(&[0x74, 0x00, 0x00, 0x04]);
+    push_b_varchar(&mut body, "TruthDB");
+    body.extend_from_slice(&[16, 0, 0, 0]); // program version major.minor.build
+
+    out.push(TOKEN_LOGINACK);
+    out.extend_from_slice(&(body.len() as u16).to_le_bytes());
+    out.extend_from_slice(&body);
+}
+
+/// ENVCHANGE for the current database (new = old = database name).
+pub fn envchange_database(out: &mut Vec<u8>, database: &str) {
+    let mut body = Vec::new();
+    body.push(ENV_DATABASE);
+    push_b_varchar(&mut body, database);
+    push_b_varchar(&mut body, database);
+    out.push(TOKEN_ENVCHANGE);
+    out.extend_from_slice(&(body.len() as u16).to_le_bytes());
+    out.extend_from_slice(&body);
+}
+
+/// ENVCHANGE for the negotiated packet size.
+pub fn envchange_packet_size(out: &mut Vec<u8>, new_size: usize, old_size: usize) {
+    let mut body = Vec::new();
+    body.push(ENV_PACKET_SIZE);
+    push_b_varchar(&mut body, &new_size.to_string());
+    push_b_varchar(&mut body, &old_size.to_string());
+    out.push(TOKEN_ENVCHANGE);
+    out.extend_from_slice(&(body.len() as u16).to_le_bytes());
+    out.extend_from_slice(&body);
+}
+
+/// INFO token (informational message, same shape as ERROR).
+pub fn info(out: &mut Vec<u8>, number: i32, state: u8, class: u8, message: &str) {
+    message_token(out, TOKEN_INFO, number, state, class, message);
+}
+
+/// ERROR token.
+pub fn error(out: &mut Vec<u8>, number: i32, state: u8, class: u8, message: &str) {
+    message_token(out, TOKEN_ERROR, number, state, class, message);
+}
+
+/// Cap on an ERROR/INFO message's character count. SQL error text embeds
+/// attacker-controlled identifiers (e.g. an invalid object name) and the batch
+/// text is uncapped, so a pathological message could otherwise overflow the
+/// token's own u16 Length field. 32000 UCS-2 units (64000 bytes) leaves room
+/// for the fixed fields to keep the whole token body under 65535.
+const MAX_MESSAGE_CHARS: usize = 32000;
+
+fn message_token(out: &mut Vec<u8>, token: u8, number: i32, state: u8, class: u8, message: &str) {
+    let mut body = Vec::new();
+    body.extend_from_slice(&number.to_le_bytes());
+    body.push(state);
+    body.push(class);
+    let capped: String = message.chars().take(MAX_MESSAGE_CHARS).collect();
+    push_us_varchar(&mut body, &capped);
+    push_b_varchar(&mut body, "TruthDB"); // server name
+    push_b_varchar(&mut body, ""); // proc name
+    body.extend_from_slice(&1u32.to_le_bytes()); // line number
+
+    out.push(token);
+    out.extend_from_slice(&(body.len() as u16).to_le_bytes());
+    out.extend_from_slice(&body);
+}
+
+/// COLMETADATA for a result set's columns.
+pub fn colmetadata(out: &mut Vec<u8>, columns: &[ResultColumn]) {
+    out.push(TOKEN_COLMETADATA);
+    out.extend_from_slice(&(columns.len() as u16).to_le_bytes());
+    for column in columns {
+        out.extend_from_slice(&0u32.to_le_bytes()); // UserType
+        out.extend_from_slice(&0x0009u16.to_le_bytes()); // flags: nullable + updatable
+        out.extend_from_slice(&typeinfo::encode_type_info(&column.column_type));
+        push_b_varchar(out, &column.name);
+    }
+}
+
+/// ROW token for one row.
+pub fn row(out: &mut Vec<u8>, values: &[Datum], columns: &[ResultColumn]) {
+    out.push(TOKEN_ROW);
+    for (datum, column) in values.iter().zip(columns) {
+        out.extend_from_slice(&typeinfo::encode_value(datum, &column.column_type));
+    }
+}
+
+/// DONE token. `more` sets DONE_MORE (another result follows); `count`
+/// carries a row count (DONE_COUNT); `error` sets DONE_ERROR.
+pub fn done(out: &mut Vec<u8>, more: bool, error: bool, count: Option<u64>) {
+    let mut status = if more { DONE_MORE } else { DONE_FINAL };
+    if error {
+        status |= DONE_ERROR;
+    }
+    if count.is_some() {
+        status |= DONE_COUNT;
+    }
+    out.push(TOKEN_DONE);
+    out.extend_from_slice(&status.to_le_bytes());
+    out.extend_from_slice(&0u16.to_le_bytes()); // CurCmd
+    out.extend_from_slice(&count.unwrap_or(0).to_le_bytes());
+}
+
+/// DONE acknowledging an Attention (cancel) request.
+pub fn done_attention(out: &mut Vec<u8>) {
+    out.push(TOKEN_DONE);
+    out.extend_from_slice(&(DONE_FINAL | DONE_ATTN).to_le_bytes());
+    out.extend_from_slice(&0u16.to_le_bytes());
+    out.extend_from_slice(&0u64.to_le_bytes());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use truthdb_core::relstore::types::ColumnType;
+
+    #[test]
+    fn loginack_shape() {
+        let mut out = Vec::new();
+        loginack(&mut out);
+        assert_eq!(out[0], TOKEN_LOGINACK);
+        let len = u16::from_le_bytes([out[1], out[2]]) as usize;
+        assert_eq!(out.len(), 3 + len);
+        assert_eq!(out[3], 1); // interface
+    }
+
+    #[test]
+    fn error_token_carries_number_and_message() {
+        let mut out = Vec::new();
+        error(&mut out, 2627, 1, 14, "PK violation");
+        assert_eq!(out[0], TOKEN_ERROR);
+        let number = i32::from_le_bytes([out[3], out[4], out[5], out[6]]);
+        assert_eq!(number, 2627);
+        assert_eq!(out[7], 1); // state
+        assert_eq!(out[8], 14); // class
+    }
+
+    #[test]
+    fn colmetadata_and_row_for_int_column() {
+        let columns = vec![ResultColumn {
+            name: "id".to_string(),
+            column_type: ColumnType::Int,
+        }];
+        let mut meta = Vec::new();
+        colmetadata(&mut meta, &columns);
+        assert_eq!(meta[0], TOKEN_COLMETADATA);
+        assert_eq!(u16::from_le_bytes([meta[1], meta[2]]), 1);
+
+        let mut r = Vec::new();
+        row(&mut r, &[Datum::Int(7)], &columns);
+        assert_eq!(r[0], TOKEN_ROW);
+        // INTN value: len 4 then LE bytes.
+        assert_eq!(r[1], 4);
+        assert_eq!(&r[2..6], &[7, 0, 0, 0]);
+    }
+
+    #[test]
+    fn done_status_bits() {
+        let mut out = Vec::new();
+        done(&mut out, false, false, Some(3));
+        assert_eq!(out[0], TOKEN_DONE);
+        let status = u16::from_le_bytes([out[1], out[2]]);
+        assert_eq!(status, DONE_COUNT);
+        let count = u64::from_le_bytes(out[5..13].try_into().unwrap());
+        assert_eq!(count, 3);
+    }
+
+    #[test]
+    fn colmetadata_long_name_count_matches_bytes() {
+        // A >255-char column name must not wrap the B_VARCHAR count byte and
+        // desync the stream: the count is capped at 255 and exactly that many
+        // UCS-2 units follow.
+        let columns = vec![ResultColumn {
+            name: "a".repeat(300),
+            column_type: ColumnType::Int,
+        }];
+        let mut out = Vec::new();
+        colmetadata(&mut out, &columns);
+        // token(1) + count(2) + UserType(4) + flags(2) + INTN type_info(2) = 11,
+        // then the ColName B_VARCHAR count byte.
+        let name_count = out[11] as usize;
+        assert_eq!(name_count, 255);
+        assert_eq!(out.len(), 11 + 1 + name_count * 2);
+    }
+
+    #[test]
+    fn error_message_length_never_wraps() {
+        // A pathological error message must keep the ERROR token's own u16
+        // Length consistent with the emitted body.
+        let mut out = Vec::new();
+        error(&mut out, 208, 1, 16, &"x".repeat(100_000));
+        let declared = u16::from_le_bytes([out[1], out[2]]) as usize;
+        assert_eq!(out.len(), 3 + declared);
+    }
+}

--- a/crates/truthdb-tds/src/typeinfo.rs
+++ b/crates/truthdb-tds/src/typeinfo.rs
@@ -1,0 +1,306 @@
+//! TDS TYPE_INFO and value codecs for the Stage 4 type set: INTN, BITN,
+//! FLTN, NVARCHAR, and BIGVARCHR (MS-TDS 2.2.5.4 / 2.2.5.5).
+//!
+//! Every Stage 3 result column maps to one of these nullable ("N") variants
+//! so a NULL is always representable.
+
+use truthdb_core::relstore::types::{ColumnType, Datum};
+
+// Type tokens.
+const INTN: u8 = 0x26;
+const BITN: u8 = 0x68;
+const FLTN: u8 = 0x6d;
+const NVARCHAR: u8 = 0xe7;
+const BIGVARCHR: u8 = 0xa7;
+
+/// A 5-byte collation for a Latin1-general, case-insensitive, accent-
+/// sensitive locale (LCID 0x0409, SortId 0x34 = code page 1252). Character
+/// columns carry it; clients use it to pick a decoder for BIGVARCHR bytes.
+const COLLATION: [u8; 5] = [0x09, 0x04, 0xd0, 0x00, 0x34];
+
+/// Max UCS-2 code units in a non-MAX NVARCHAR row value: 32767 units = 65534
+/// bytes, the largest even byte count a u16 value-length prefix can hold.
+const MAX_USHORT_UCS2_UNITS: usize = 32767;
+
+/// The TDS type a result column is sent as.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TdsType {
+    Int(u8),   // INTN with max byte length 1/2/4/8
+    Bit,       // BITN
+    Float(u8), // FLTN with max byte length 4/8
+    NVarChar(u16),
+    VarChar(u16),
+}
+
+fn tds_type(column_type: &ColumnType) -> TdsType {
+    match column_type {
+        ColumnType::TinyInt => TdsType::Int(1),
+        ColumnType::SmallInt => TdsType::Int(2),
+        ColumnType::Int => TdsType::Int(4),
+        ColumnType::BigInt => TdsType::Int(8),
+        ColumnType::Bit => TdsType::Bit,
+        ColumnType::Real => TdsType::Float(4),
+        ColumnType::Float => TdsType::Float(8),
+        ColumnType::NVarChar { max_len } => TdsType::NVarChar((*max_len).max(1)),
+        ColumnType::VarChar { max_len } => TdsType::VarChar((*max_len).max(1)),
+        // Types not producible by Stage 3/4 SQL fall back to NVARCHAR of the
+        // rendered text.
+        _ => TdsType::NVarChar(4000),
+    }
+}
+
+/// Encodes the TYPE_INFO bytes for a result column.
+pub fn encode_type_info(column_type: &ColumnType) -> Vec<u8> {
+    let mut out = Vec::new();
+    match tds_type(column_type) {
+        TdsType::Int(len) => {
+            out.push(INTN);
+            out.push(len);
+        }
+        TdsType::Bit => {
+            out.push(BITN);
+            out.push(1);
+        }
+        TdsType::Float(len) => {
+            out.push(FLTN);
+            out.push(len);
+        }
+        TdsType::NVarChar(max_len) => {
+            out.push(NVARCHAR);
+            // NVARCHAR length is in bytes; UCS-2 doubles the char count.
+            out.extend_from_slice(&max_byte_len(max_len).to_le_bytes());
+            out.extend_from_slice(&COLLATION);
+        }
+        TdsType::VarChar(max_len) => {
+            out.push(BIGVARCHR);
+            out.extend_from_slice(&max_len.to_le_bytes());
+            out.extend_from_slice(&COLLATION);
+        }
+    }
+    out
+}
+
+/// NVARCHAR max byte length, clamped to the non-MAX limit (8000 bytes).
+fn max_byte_len(max_chars: u16) -> u16 {
+    (max_chars as u32 * 2).min(8000) as u16
+}
+
+/// Encodes one row value for a column.
+pub fn encode_value(datum: &Datum, column_type: &ColumnType) -> Vec<u8> {
+    let mut out = Vec::new();
+    match tds_type(column_type) {
+        TdsType::Int(len) => match int_value(datum) {
+            Some(v) => {
+                out.push(len);
+                out.extend_from_slice(&v.to_le_bytes()[..len as usize]);
+            }
+            None => out.push(0), // NULL: zero-length
+        },
+        TdsType::Bit => match datum {
+            Datum::Bit(b) => {
+                out.push(1);
+                out.push(*b as u8);
+            }
+            Datum::Null => out.push(0),
+            _ => out.push(0),
+        },
+        TdsType::Float(len) => match float_value(datum) {
+            Some(v) => {
+                out.push(len);
+                if len == 4 {
+                    out.extend_from_slice(&(v as f32).to_le_bytes());
+                } else {
+                    out.extend_from_slice(&v.to_le_bytes());
+                }
+            }
+            None => out.push(0),
+        },
+        TdsType::NVarChar(_) => match string_value(datum) {
+            Some(s) => {
+                // Cap at 32767 UCS-2 units so the u16 byte-length prefix
+                // (<= 65534) never wraps; a longer value would need
+                // NVARCHAR(MAX)/PLP, which arrives in a later stage.
+                let bytes: Vec<u8> = s
+                    .encode_utf16()
+                    .take(MAX_USHORT_UCS2_UNITS)
+                    .flat_map(|u| u.to_le_bytes())
+                    .collect();
+                out.extend_from_slice(&(bytes.len() as u16).to_le_bytes());
+                out.extend_from_slice(&bytes);
+            }
+            // NULL charbin uses the 0xFFFF sentinel length.
+            None => out.extend_from_slice(&0xffffu16.to_le_bytes()),
+        },
+        TdsType::VarChar(_) => match string_value(datum) {
+            Some(s) => {
+                // BIGVARCHR bytes are decoded by the client in the advertised
+                // CP1252 collation, so transcode from UTF-8 (unmappable ->
+                // '?', matching SQL Server) instead of shipping raw UTF-8 that
+                // a CP1252 client would mojibake. Cap at 65535 bytes for u16.
+                let mut bytes = encode_cp1252(&s);
+                bytes.truncate(u16::MAX as usize);
+                out.extend_from_slice(&(bytes.len() as u16).to_le_bytes());
+                out.extend_from_slice(&bytes);
+            }
+            None => out.extend_from_slice(&0xffffu16.to_le_bytes()),
+        },
+    }
+    out
+}
+
+fn int_value(datum: &Datum) -> Option<i64> {
+    match datum {
+        Datum::TinyInt(v) => Some(*v as i64),
+        Datum::SmallInt(v) => Some(*v as i64),
+        Datum::Int(v) => Some(*v as i64),
+        Datum::BigInt(v) => Some(*v),
+        _ => None,
+    }
+}
+
+fn float_value(datum: &Datum) -> Option<f64> {
+    match datum {
+        Datum::Real(v) => Some(*v as f64),
+        Datum::Float(v) => Some(*v),
+        _ => None,
+    }
+}
+
+fn string_value(datum: &Datum) -> Option<String> {
+    match datum {
+        Datum::VarChar(s) | Datum::NVarChar(s) => Some(s.clone()),
+        Datum::Null => None,
+        // Any other datum reaching a string column is rendered as text.
+        other => truthdb_core::rel::render_cell(other, &ColumnType::NVarChar { max_len: 4000 }),
+    }
+}
+
+/// Encodes a string as Windows-1252 (the advertised BIGVARCHR collation),
+/// substituting '?' for characters with no CP1252 representation — the same
+/// lossy behavior SQL Server applies when storing Unicode into a Latin1
+/// VARCHAR. CP1252 equals ISO-8859-1 except the 0x80..=0x9F block, which maps
+/// a handful of punctuation/symbol code points.
+fn encode_cp1252(s: &str) -> Vec<u8> {
+    s.chars()
+        .map(|c| char_to_cp1252(c).unwrap_or(b'?'))
+        .collect()
+}
+
+fn char_to_cp1252(c: char) -> Option<u8> {
+    let cp = c as u32;
+    let byte = match cp {
+        0x00..=0x7F | 0xA0..=0xFF => cp as u8,
+        0x20AC => 0x80,
+        0x201A => 0x82,
+        0x0192 => 0x83,
+        0x201E => 0x84,
+        0x2026 => 0x85,
+        0x2020 => 0x86,
+        0x2021 => 0x87,
+        0x02C6 => 0x88,
+        0x2030 => 0x89,
+        0x0160 => 0x8A,
+        0x2039 => 0x8B,
+        0x0152 => 0x8C,
+        0x017D => 0x8E,
+        0x2018 => 0x91,
+        0x2019 => 0x92,
+        0x201C => 0x93,
+        0x201D => 0x94,
+        0x2022 => 0x95,
+        0x2013 => 0x96,
+        0x2014 => 0x97,
+        0x02DC => 0x98,
+        0x2122 => 0x99,
+        0x0161 => 0x9A,
+        0x203A => 0x9B,
+        0x0153 => 0x9C,
+        0x017E => 0x9E,
+        0x0178 => 0x9F,
+        _ => return None,
+    };
+    Some(byte)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn int_type_info_and_values() {
+        assert_eq!(encode_type_info(&ColumnType::Int), vec![INTN, 4]);
+        assert_eq!(
+            encode_value(&Datum::Int(258), &ColumnType::Int),
+            vec![4, 0x02, 0x01, 0x00, 0x00]
+        );
+        assert_eq!(encode_value(&Datum::Null, &ColumnType::Int), vec![0]);
+        assert_eq!(
+            encode_value(&Datum::BigInt(-1), &ColumnType::BigInt),
+            vec![8, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]
+        );
+    }
+
+    #[test]
+    fn bit_and_float_values() {
+        assert_eq!(encode_type_info(&ColumnType::Bit), vec![BITN, 1]);
+        assert_eq!(
+            encode_value(&Datum::Bit(true), &ColumnType::Bit),
+            vec![1, 1]
+        );
+        assert_eq!(encode_value(&Datum::Null, &ColumnType::Bit), vec![0]);
+        assert_eq!(encode_type_info(&ColumnType::Float), vec![FLTN, 8]);
+        assert_eq!(encode_value(&Datum::Float(1.5), &ColumnType::Float), {
+            let mut v = vec![8u8];
+            v.extend_from_slice(&1.5f64.to_le_bytes());
+            v
+        });
+    }
+
+    #[test]
+    fn nvarchar_type_info_and_values() {
+        let ct = ColumnType::NVarChar { max_len: 50 };
+        let ti = encode_type_info(&ct);
+        assert_eq!(ti[0], NVARCHAR);
+        assert_eq!(u16::from_le_bytes([ti[1], ti[2]]), 100); // 50 chars * 2
+        assert_eq!(&ti[3..8], &COLLATION);
+
+        let value = encode_value(&Datum::NVarChar("hi".to_string()), &ct);
+        assert_eq!(u16::from_le_bytes([value[0], value[1]]), 4); // 2 chars * 2
+        assert_eq!(&value[2..], &[b'h', 0, b'i', 0]);
+
+        // NULL uses 0xFFFF.
+        assert_eq!(encode_value(&Datum::Null, &ct), vec![0xff, 0xff]);
+    }
+
+    #[test]
+    fn varchar_bytes_are_single_byte() {
+        let ct = ColumnType::VarChar { max_len: 20 };
+        let ti = encode_type_info(&ct);
+        assert_eq!(ti[0], BIGVARCHR);
+        let value = encode_value(&Datum::VarChar("abc".to_string()), &ct);
+        assert_eq!(u16::from_le_bytes([value[0], value[1]]), 3);
+        assert_eq!(&value[2..], b"abc");
+    }
+
+    #[test]
+    fn varchar_transcodes_to_cp1252_not_utf8() {
+        let ct = ColumnType::VarChar { max_len: 20 };
+        // 'café': é is one CP1252 byte 0xE9 (two UTF-8 bytes); '€' is 0x80;
+        // an unmappable char ('中') becomes '?'.
+        let value = encode_value(&Datum::VarChar("café€中".to_string()), &ct);
+        assert_eq!(u16::from_le_bytes([value[0], value[1]]), 6);
+        assert_eq!(&value[2..], &[b'c', b'a', b'f', 0xE9, 0x80, b'?']);
+    }
+
+    #[test]
+    fn nvarchar_value_length_prefix_never_wraps() {
+        // A 40000-char value is 80000 UTF-16 bytes; a naive `as u16` would wrap
+        // to 14464 and desync the ROW stream. The value is capped so the prefix
+        // matches the emitted bytes exactly.
+        let ct = ColumnType::NVarChar { max_len: 4000 };
+        let value = encode_value(&Datum::NVarChar("a".repeat(40000)), &ct);
+        let declared = u16::from_le_bytes([value[0], value[1]]) as usize;
+        assert_eq!(declared, MAX_USHORT_UCS2_UNITS * 2); // 65534
+        assert_eq!(value.len(), 2 + declared);
+    }
+}

--- a/crates/truthdb-tds/tests/tds_client.rs
+++ b/crates/truthdb-tds/tests/tds_client.rs
@@ -1,0 +1,483 @@
+//! End-to-end TDS test: a minimal in-process TDS client drives the full
+//! handshake and query flow against `serve_connection` over an in-memory
+//! duplex stream, then decodes the token stream. This exercises every byte
+//! path a real driver would (PRELOGIN, LOGIN7, SQLBatch, COLMETADATA, ROW,
+//! DONE, ERROR) without needing an external SQL Server driver.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt, DuplexStream};
+use truthdb_core::engine::Engine;
+use truthdb_core::storage::{Storage, StorageOptions};
+use truthdb_tds::server::{TdsConfig, serve_connection};
+
+// Packet types.
+const PKT_SQL_BATCH: u8 = 0x01;
+const PKT_LOGIN7: u8 = 0x10;
+const PKT_PRELOGIN: u8 = 0x12;
+
+fn temp_path(label: &str) -> std::path::PathBuf {
+    let mut path = std::env::temp_dir();
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    path.push(format!("truthdb-tds-{label}-{nanos}.db"));
+    path
+}
+
+fn engine(path: &std::path::Path) -> Arc<Mutex<Engine>> {
+    let opts = StorageOptions {
+        size_gib: 1,
+        wal_ratio: 0.05,
+        metadata_ratio: 0.08,
+        snapshot_ratio: 0.02,
+        allocator_ratio: 0.02,
+        reserved_ratio: 0.17,
+    };
+    let storage = Storage::create(path.to_path_buf(), opts).expect("storage");
+    Arc::new(Mutex::new(Engine::new(storage).expect("engine")))
+}
+
+fn config() -> TdsConfig {
+    let mut users = HashMap::new();
+    users.insert("sa".to_string(), "secret".to_string());
+    TdsConfig {
+        users,
+        database: "truthdb".to_string(),
+    }
+}
+
+fn ucs2le(s: &str) -> Vec<u8> {
+    s.encode_utf16().flat_map(|u| u.to_le_bytes()).collect()
+}
+
+/// A minimal client that speaks just enough TDS to test the server.
+struct Client {
+    stream: DuplexStream,
+}
+
+impl Client {
+    async fn write_packet(&mut self, kind: u8, payload: &[u8]) {
+        let length = (8 + payload.len()) as u16;
+        let header = [
+            kind,
+            0x01, // EOM
+            (length >> 8) as u8,
+            (length & 0xff) as u8,
+            0,
+            0,
+            1,
+            0,
+        ];
+        self.stream.write_all(&header).await.unwrap();
+        self.stream.write_all(payload).await.unwrap();
+        self.stream.flush().await.unwrap();
+    }
+
+    /// Reads a full message (packets until EOM) -> (kind, payload).
+    async fn read_message(&mut self) -> (u8, Vec<u8>) {
+        let mut header = [0u8; 8];
+        self.stream.read_exact(&mut header).await.unwrap();
+        let kind = header[0];
+        let mut payload = self.read_body(&header).await;
+        let mut status = header[1];
+        while status & 0x01 == 0 {
+            self.stream.read_exact(&mut header).await.unwrap();
+            status = header[1];
+            payload.extend(self.read_body(&header).await);
+        }
+        (kind, payload)
+    }
+
+    async fn read_body(&mut self, header: &[u8; 8]) -> Vec<u8> {
+        let length = u16::from_be_bytes([header[2], header[3]]) as usize;
+        let mut body = vec![0u8; length - 8];
+        self.stream.read_exact(&mut body).await.unwrap();
+        body
+    }
+
+    async fn prelogin(&mut self) {
+        // Minimal PRELOGIN: just a terminator (server ignores the contents).
+        self.write_packet(PKT_PRELOGIN, &[0xff]).await;
+        let (kind, _) = self.read_message().await;
+        assert!(kind == 0x04 || kind == PKT_PRELOGIN);
+    }
+
+    async fn login(&mut self, user: &str, password: &str) -> Vec<Token> {
+        self.write_packet(PKT_LOGIN7, &build_login7(user, password, "truthdb"))
+            .await;
+        let (_, payload) = self.read_message().await;
+        parse_tokens(&payload)
+    }
+
+    async fn batch(&mut self, sql: &str) -> Vec<Token> {
+        let mut payload = Vec::new();
+        // ALL_HEADERS: TotalLength includes itself (the 4-byte field) plus
+        // the header block; the SQL text starts right after.
+        let headers = all_headers();
+        let total = 4 + headers.len();
+        payload.extend_from_slice(&(total as u32).to_le_bytes());
+        payload.extend_from_slice(&headers);
+        payload.extend(ucs2le(sql));
+        self.write_packet(PKT_SQL_BATCH, &payload).await;
+        let (_, response) = self.read_message().await;
+        parse_tokens(&response)
+    }
+}
+
+/// A minimal ALL_HEADERS with a transaction-descriptor header (type 2).
+fn all_headers() -> Vec<u8> {
+    // Header: length u32 | type u16 | transaction descriptor u64 | request count u32
+    let mut header = Vec::new();
+    let body_len = 4 + 2 + 8 + 4;
+    header.extend_from_slice(&(body_len as u32).to_le_bytes());
+    header.extend_from_slice(&2u16.to_le_bytes()); // transaction descriptor
+    header.extend_from_slice(&0u64.to_le_bytes());
+    header.extend_from_slice(&1u32.to_le_bytes());
+    header
+}
+
+fn build_login7(user: &str, password: &str, database: &str) -> Vec<u8> {
+    let mut payload = vec![0u8; 94];
+    payload[8..12].copy_from_slice(&4096u32.to_le_bytes());
+    let mut data = Vec::new();
+    let obfuscate = |s: &str| -> Vec<u8> {
+        ucs2le(s)
+            .into_iter()
+            .map(|b| b.rotate_left(4) ^ 0xa5)
+            .collect()
+    };
+    let add = |payload: &mut Vec<u8>, data: &mut Vec<u8>, at: usize, bytes: &[u8]| {
+        let offset = 94 + data.len();
+        payload[at..at + 2].copy_from_slice(&(offset as u16).to_le_bytes());
+        payload[at + 2..at + 4].copy_from_slice(&((bytes.len() / 2) as u16).to_le_bytes());
+        data.extend_from_slice(bytes);
+    };
+    add(&mut payload, &mut data, 40, &ucs2le(user));
+    add(&mut payload, &mut data, 44, &obfuscate(password));
+    add(&mut payload, &mut data, 68, &ucs2le(database));
+    payload.extend(data);
+    payload
+}
+
+/// A decoded token relevant to the tests.
+#[derive(Debug, Clone, PartialEq)]
+enum Token {
+    LoginAck,
+    ColMetadata(Vec<ColType>),
+    Row(Vec<Cell>),
+    Error { number: i32 },
+    Done { count: Option<u64> },
+    Other(u8),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum ColType {
+    Int,
+    Bit,
+    Float,
+    NVarChar,
+    VarChar,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+enum Cell {
+    Null,
+    Int(i64),
+    Bool(bool),
+    Float(f64),
+    Str(String),
+}
+
+/// Parses a server token stream into decodable tokens (covers only what the
+/// tests need: the Stage 4 type set).
+fn parse_tokens(payload: &[u8]) -> Vec<Token> {
+    let mut tokens = Vec::new();
+    let mut i = 0;
+    let mut last_meta: Vec<ColType> = Vec::new();
+    while i < payload.len() {
+        let token = payload[i];
+        i += 1;
+        match token {
+            0xad => {
+                // LOGINACK: length-prefixed, skip body.
+                let len = u16::from_le_bytes([payload[i], payload[i + 1]]) as usize;
+                i += 2 + len;
+                tokens.push(Token::LoginAck);
+            }
+            0xe3 | 0xab | 0xaa => {
+                // ENVCHANGE / INFO / ERROR: length-prefixed.
+                let len = u16::from_le_bytes([payload[i], payload[i + 1]]) as usize;
+                let body = &payload[i + 2..i + 2 + len];
+                if token == 0xaa {
+                    let number = i32::from_le_bytes(body[0..4].try_into().unwrap());
+                    tokens.push(Token::Error { number });
+                }
+                i += 2 + len;
+            }
+            0x81 => {
+                let (meta, consumed) = parse_colmetadata(&payload[i..]);
+                i += consumed;
+                last_meta = meta.clone();
+                tokens.push(Token::ColMetadata(meta));
+            }
+            0xd1 => {
+                let (cells, consumed) = parse_row(&payload[i..], &last_meta);
+                i += consumed;
+                tokens.push(Token::Row(cells));
+            }
+            0xfd..=0xff => {
+                // DONE / DONEPROC / DONEINPROC: status u16, curcmd u16, count u64.
+                let status = u16::from_le_bytes([payload[i], payload[i + 1]]);
+                let count = u64::from_le_bytes(payload[i + 4..i + 12].try_into().unwrap());
+                let has_count = status & 0x0010 != 0;
+                i += 12;
+                tokens.push(Token::Done {
+                    count: has_count.then_some(count),
+                });
+            }
+            other => {
+                tokens.push(Token::Other(other));
+                break; // unknown token: stop to avoid misparsing
+            }
+        }
+    }
+    tokens
+}
+
+fn parse_colmetadata(bytes: &[u8]) -> (Vec<ColType>, usize) {
+    let count = u16::from_le_bytes([bytes[0], bytes[1]]) as usize;
+    let mut i = 2;
+    let mut cols = Vec::with_capacity(count);
+    for _ in 0..count {
+        i += 4; // usertype
+        i += 2; // flags
+        let type_token = bytes[i];
+        i += 1;
+        let col_type = match type_token {
+            0x26 => {
+                i += 1; // max len byte
+                ColType::Int
+            }
+            0x68 => {
+                i += 1;
+                ColType::Bit
+            }
+            0x6d => {
+                i += 1;
+                ColType::Float
+            }
+            0xe7 => {
+                i += 2 + 5; // max len u16 + collation
+                ColType::NVarChar
+            }
+            0xa7 => {
+                i += 2 + 5;
+                ColType::VarChar
+            }
+            other => panic!("unhandled type token {other:#x}"),
+        };
+        // ColName: b_varchar (char count then UCS-2).
+        let name_len = bytes[i] as usize;
+        i += 1 + name_len * 2;
+        cols.push(col_type);
+    }
+    (cols, i)
+}
+
+fn parse_row(bytes: &[u8], meta: &[ColType]) -> (Vec<Cell>, usize) {
+    let mut i = 0;
+    let mut cells = Vec::with_capacity(meta.len());
+    for col in meta {
+        match col {
+            ColType::Int => {
+                let len = bytes[i] as usize;
+                i += 1;
+                if len == 0 {
+                    cells.push(Cell::Null);
+                } else {
+                    let mut v = [0u8; 8];
+                    v[..len].copy_from_slice(&bytes[i..i + len]);
+                    // Sign-extend from the actual width.
+                    let mut n = i64::from_le_bytes(v);
+                    let bits = len * 8;
+                    if bits < 64 && (n >> (bits - 1)) & 1 == 1 {
+                        n |= -1i64 << bits;
+                    }
+                    cells.push(Cell::Int(n));
+                    i += len;
+                }
+            }
+            ColType::Bit => {
+                let len = bytes[i] as usize;
+                i += 1;
+                if len == 0 {
+                    cells.push(Cell::Null);
+                } else {
+                    cells.push(Cell::Bool(bytes[i] != 0));
+                    i += len;
+                }
+            }
+            ColType::Float => {
+                let len = bytes[i] as usize;
+                i += 1;
+                match len {
+                    0 => cells.push(Cell::Null),
+                    4 => {
+                        let v = f32::from_le_bytes(bytes[i..i + 4].try_into().unwrap());
+                        cells.push(Cell::Float(v as f64));
+                        i += 4;
+                    }
+                    8 => {
+                        let v = f64::from_le_bytes(bytes[i..i + 8].try_into().unwrap());
+                        cells.push(Cell::Float(v));
+                        i += 8;
+                    }
+                    other => panic!("bad float len {other}"),
+                }
+            }
+            ColType::NVarChar => {
+                let len = u16::from_le_bytes([bytes[i], bytes[i + 1]]);
+                i += 2;
+                if len == 0xffff {
+                    cells.push(Cell::Null);
+                } else {
+                    let len = len as usize;
+                    let units: Vec<u16> = bytes[i..i + len]
+                        .chunks_exact(2)
+                        .map(|c| u16::from_le_bytes([c[0], c[1]]))
+                        .collect();
+                    cells.push(Cell::Str(String::from_utf16(&units).unwrap()));
+                    i += len;
+                }
+            }
+            ColType::VarChar => {
+                let len = u16::from_le_bytes([bytes[i], bytes[i + 1]]);
+                i += 2;
+                if len == 0xffff {
+                    cells.push(Cell::Null);
+                } else {
+                    let len = len as usize;
+                    cells.push(Cell::Str(
+                        String::from_utf8_lossy(&bytes[i..i + len]).into_owned(),
+                    ));
+                    i += len;
+                }
+            }
+        }
+    }
+    (cells, i)
+}
+
+async fn connect(engine: Arc<Mutex<Engine>>) -> Client {
+    let (client_half, server_half) = tokio::io::duplex(64 * 1024);
+    let cfg = Arc::new(config());
+    tokio::spawn(async move {
+        let _ = serve_connection(server_half, engine, cfg).await;
+    });
+    Client {
+        stream: client_half,
+    }
+}
+
+#[tokio::test]
+async fn full_handshake_query_and_error() {
+    let path = temp_path("e2e");
+    let engine = engine(&path);
+    let mut client = connect(Arc::clone(&engine)).await;
+
+    client.prelogin().await;
+    let login = client.login("sa", "secret").await;
+    assert!(login.contains(&Token::LoginAck), "login tokens: {login:?}");
+    assert!(!login.iter().any(|t| matches!(t, Token::Error { .. })));
+
+    // DDL + insert.
+    client
+        .batch("CREATE TABLE t (id INT NOT NULL PRIMARY KEY, name NVARCHAR(50), active BIT)")
+        .await;
+    let insert = client
+        .batch("INSERT INTO t VALUES (1, 'Skor', 1), (2, 'Kangor', 0), (3, NULL, NULL)")
+        .await;
+    assert!(
+        insert
+            .iter()
+            .any(|t| matches!(t, Token::Done { count: Some(3) })),
+        "insert tokens: {insert:?}"
+    );
+
+    // SELECT: typed COLMETADATA + ROWs.
+    let select = client
+        .batch("SELECT id, name, active FROM t ORDER BY id")
+        .await;
+    let rows: Vec<&Vec<Cell>> = select
+        .iter()
+        .filter_map(|t| match t {
+            Token::Row(cells) => Some(cells),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(rows.len(), 3, "tokens: {select:?}");
+    assert_eq!(
+        *rows[0],
+        vec![Cell::Int(1), Cell::Str("Skor".into()), Cell::Bool(true)]
+    );
+    assert_eq!(
+        *rows[1],
+        vec![Cell::Int(2), Cell::Str("Kangor".into()), Cell::Bool(false)]
+    );
+    assert_eq!(*rows[2], vec![Cell::Int(3), Cell::Null, Cell::Null]);
+
+    // Error path: duplicate PK -> 2627 in the token stream.
+    let dup = client.batch("INSERT INTO t VALUES (1, 'x', 1)").await;
+    assert!(
+        dup.iter()
+            .any(|t| matches!(t, Token::Error { number: 2627 })),
+        "dup tokens: {dup:?}"
+    );
+
+    let _ = std::fs::remove_file(path);
+}
+
+#[tokio::test]
+async fn login_failure_reports_18456() {
+    let path = temp_path("login-fail");
+    let engine = engine(&path);
+    let mut client = connect(engine).await;
+
+    client.prelogin().await;
+    let tokens = client.login("sa", "wrong-password").await;
+    assert!(
+        tokens
+            .iter()
+            .any(|t| matches!(t, Token::Error { number: 18456 })),
+        "tokens: {tokens:?}"
+    );
+    let _ = std::fs::remove_file(path);
+}
+
+#[tokio::test]
+async fn computed_columns_and_constant_select() {
+    let path = temp_path("computed");
+    let engine = engine(&path);
+    let mut client = connect(engine).await;
+    client.prelogin().await;
+    client.login("sa", "secret").await;
+
+    client
+        .batch("CREATE TABLE t (id INT NOT NULL PRIMARY KEY)")
+        .await;
+    client.batch("INSERT INTO t VALUES (10), (20)").await;
+    let select = client.batch("SELECT id, id * 2 FROM t ORDER BY id").await;
+    let rows: Vec<&Vec<Cell>> = select
+        .iter()
+        .filter_map(|t| match t {
+            Token::Row(cells) => Some(cells),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(*rows[0], vec![Cell::Int(10), Cell::Int(20)]);
+    assert_eq!(*rows[1], vec![Cell::Int(20), Cell::Int(40)]);
+    let _ = std::fs::remove_file(path);
+}

--- a/scripts/tds_conformance.go
+++ b/scripts/tds_conformance.go
@@ -1,0 +1,233 @@
+// TDS conformance smoke: drive the TruthDB TDS gateway with go-mssqldb, an
+// independent TDS client — create/insert/select/error/login-fail. This is the
+// second driver (alongside scripts/tds_conformance.py) so a shared spec
+// misunderstanding in either client is unlikely to pass both.
+//
+// Usage: go run . <host> <port> <user> <password>
+// Exits non-zero on any mismatch. Uses its own table so it can run against the
+// same live server as the Python conformance without colliding.
+package main
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	mssql "github.com/microsoft/go-mssqldb"
+)
+
+func dsn(host, port, user, pass string) string {
+	return fmt.Sprintf("sqlserver://%s:%s@%s:%s?database=truthdb&encrypt=disable",
+		user, pass, host, port)
+}
+
+func fail(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "FAIL: "+format+"\n", args...)
+	os.Exit(1)
+}
+
+func main() {
+	if len(os.Args) != 5 {
+		fail("usage: tds_conformance <host> <port> <user> <password>")
+	}
+	host, port, user, pass := os.Args[1], os.Args[2], os.Args[3], os.Args[4]
+
+	// 1. Login failure must be reported (not a hang / crash).
+	badDB, err := sql.Open("sqlserver", dsn(host, port, user, "definitely-wrong"))
+	if err != nil {
+		fail("open (bad password): %v", err)
+	}
+	if err := badDB.Ping(); err == nil {
+		fail("bad password unexpectedly connected")
+	}
+	badDB.Close()
+
+	db, err := sql.Open("sqlserver", dsn(host, port, user, pass))
+	if err != nil {
+		fail("open: %v", err)
+	}
+	defer db.Close()
+	if err := db.Ping(); err != nil {
+		fail("connect: %v", err)
+	}
+
+	mustExec(db, "CREATE TABLE products_go (id INT NOT NULL PRIMARY KEY, "+
+		"name NVARCHAR(50), price FLOAT, active BIT)")
+	mustExec(db, "INSERT INTO products_go VALUES (1, 'Skor', 79.5, 1), "+
+		"(2, 'Kangor', 129.0, 0), (3, NULL, NULL, NULL)")
+
+	// 2. Typed SELECT: values round-trip with their SQL types, NULLs included.
+	rows, err := db.Query("SELECT id, name, price, active FROM products_go ORDER BY id")
+	if err != nil {
+		fail("SELECT: %v", err)
+	}
+	type record struct {
+		id     int64
+		name   sql.NullString
+		price  sql.NullFloat64
+		active sql.NullBool
+	}
+	var got []record
+	for rows.Next() {
+		var r record
+		if err := rows.Scan(&r.id, &r.name, &r.price, &r.active); err != nil {
+			fail("scan: %v", err)
+		}
+		got = append(got, r)
+	}
+	if err := rows.Err(); err != nil {
+		fail("rows: %v", err)
+	}
+	want := []record{
+		{1, sql.NullString{String: "Skor", Valid: true}, sql.NullFloat64{Float64: 79.5, Valid: true}, sql.NullBool{Bool: true, Valid: true}},
+		{2, sql.NullString{String: "Kangor", Valid: true}, sql.NullFloat64{Float64: 129.0, Valid: true}, sql.NullBool{Bool: false, Valid: true}},
+		{3, sql.NullString{}, sql.NullFloat64{}, sql.NullBool{}},
+	}
+	if fmt.Sprintf("%v", got) != fmt.Sprintf("%v", want) {
+		fail("SELECT mismatch\n got: %v\n want: %v", got, want)
+	}
+
+	// 3. Computed column comes back typed (int, not text).
+	var id, doubled int64
+	if err := db.QueryRow("SELECT id, id * 2 AS doubled FROM products_go WHERE id = 2").
+		Scan(&id, &doubled); err != nil {
+		fail("computed column: %v", err)
+	}
+	if id != 2 || doubled != 4 {
+		fail("computed column mismatch: id=%d doubled=%d", id, doubled)
+	}
+
+	// 4. Error path: duplicate PK must surface SQL Server error 2627.
+	_, err = db.Exec("INSERT INTO products_go VALUES (1, 'dup', 0, 1)")
+	if err == nil {
+		fail("duplicate PK did not raise")
+	}
+	var mssqlErr mssql.Error
+	if !errors.As(err, &mssqlErr) || mssqlErr.Number != 2627 {
+		fail("expected error 2627, got: %v", err)
+	}
+
+	// 5. sys.tables is queryable.
+	var name string
+	if err := db.QueryRow("SELECT name FROM sys.tables WHERE name = 'products_go'").
+		Scan(&name); err != nil {
+		fail("sys.tables missing products_go: %v", err)
+	}
+
+	// 6. Bare-column alias is carried in the result metadata (COLMETADATA).
+	aliasRows, err := db.Query("SELECT id AS thing FROM products_go WHERE id = 1")
+	if err != nil {
+		fail("alias query: %v", err)
+	}
+	cols, err := aliasRows.Columns()
+	aliasRows.Close()
+	if err != nil || len(cols) != 1 || cols[0] != "thing" {
+		fail("alias not surfaced: %v (%v)", cols, err)
+	}
+
+	// 7. VARCHAR (BIGVARCHR / CP1252) round-trips non-ASCII text and NULL.
+	mustExec(db, "CREATE TABLE vtext_go (id INT NOT NULL PRIMARY KEY, s VARCHAR(20))")
+	mustExec(db, "INSERT INTO vtext_go VALUES (1, 'café'), (2, 'Zürich'), (3, NULL)")
+	vwant := []sql.NullString{
+		{String: "café", Valid: true},
+		{String: "Zürich", Valid: true},
+		{},
+	}
+	if got := scanNullStrings(db, "SELECT s FROM vtext_go ORDER BY id"); fmt.Sprintf("%v", got) != fmt.Sprintf("%v", vwant) {
+		fail("VARCHAR round-trip: got %v want %v", got, vwant)
+	}
+
+	// 8. NULL in a nullable INT column round-trips (INTN zero-length form).
+	mustExec(db, "CREATE TABLE nints_go (id INT NOT NULL PRIMARY KEY, n INT)")
+	mustExec(db, "INSERT INTO nints_go VALUES (1, 42), (2, NULL)")
+	nwant := []sql.NullInt64{{Int64: 42, Valid: true}, {}}
+	if got := scanNullInts(db, "SELECT n FROM nints_go ORDER BY id"); fmt.Sprintf("%v", got) != fmt.Sprintf("%v", nwant) {
+		fail("NULL INT round-trip: got %v want %v", got, nwant)
+	}
+
+	// 9. Multi-statement batch yields multiple result sets (DONE_MORE path).
+	// database/sql only surfaces the next set once the current one is drained.
+	mrows, err := db.Query("SELECT 1 AS a; SELECT 2 AS b")
+	if err != nil {
+		fail("multi-result query: %v", err)
+	}
+	if first := drainInts(mrows); len(first) != 1 || first[0] != 1 {
+		fail("first result set wrong: %v", first)
+	}
+	if !mrows.NextResultSet() {
+		fail("expected a second result set: %v", mrows.Err())
+	}
+	if second := drainInts(mrows); len(second) != 1 || second[0] != 2 {
+		fail("second result set wrong: %v", second)
+	}
+	mrows.Close()
+
+	// 10. A result larger than one 4096-byte packet reassembles intact. A
+	// computed literal (6000 bytes UCS-2) avoids the heap in-row size cap.
+	big := strings.Repeat("x", 3000)
+	var large string
+	if err := db.QueryRow("SELECT '" + big + "' AS big").Scan(&large); err != nil {
+		fail("large select: %v", err)
+	}
+	if large != big {
+		fail("large multi-packet value: len %d != 3000", len(large))
+	}
+
+	fmt.Println("tds conformance (go-mssqldb): OK")
+}
+
+func scanNullStrings(db *sql.DB, query string) []sql.NullString {
+	rows, err := db.Query(query)
+	if err != nil {
+		fail("query %q: %v", query, err)
+	}
+	defer rows.Close()
+	var out []sql.NullString
+	for rows.Next() {
+		var v sql.NullString
+		if err := rows.Scan(&v); err != nil {
+			fail("scan: %v", err)
+		}
+		out = append(out, v)
+	}
+	return out
+}
+
+// drainInts reads every row of the current result set as int64 (advancing the
+// cursor so a following NextResultSet can surface the next set).
+func drainInts(rows *sql.Rows) []int64 {
+	var out []int64
+	for rows.Next() {
+		var v int64
+		if err := rows.Scan(&v); err != nil {
+			fail("scan int: %v", err)
+		}
+		out = append(out, v)
+	}
+	return out
+}
+
+func scanNullInts(db *sql.DB, query string) []sql.NullInt64 {
+	rows, err := db.Query(query)
+	if err != nil {
+		fail("query %q: %v", query, err)
+	}
+	defer rows.Close()
+	var out []sql.NullInt64
+	for rows.Next() {
+		var v sql.NullInt64
+		if err := rows.Scan(&v); err != nil {
+			fail("scan: %v", err)
+		}
+		out = append(out, v)
+	}
+	return out
+}
+
+func mustExec(db *sql.DB, query string) {
+	if _, err := db.Exec(query); err != nil {
+		fail("exec %q: %v", query, err)
+	}
+}

--- a/scripts/tds_conformance.py
+++ b/scripts/tds_conformance.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""TDS conformance smoke: drive the TruthDB TDS gateway with an independent
+TDS client (python-tds / pytds) — create/insert/select/error/login-fail.
+
+Usage: tds_conformance.py <host> <port> <user> <password>
+Exits non-zero on any mismatch.
+"""
+import sys
+import pytds
+
+
+def main() -> int:
+    host, port, user, password = sys.argv[1], int(sys.argv[2]), sys.argv[3], sys.argv[4]
+
+    # 1. Login failure must be reported (not a hang / crash).
+    try:
+        pytds.connect(host, "truthdb", user, "definitely-wrong", port=port, login_timeout=10)
+        print("FAIL: bad password unexpectedly connected")
+        return 1
+    except pytds.Error:
+        pass  # expected
+
+    conn = pytds.connect(host, "truthdb", user, password, port=port, login_timeout=10,
+                         autocommit=True)
+    cur = conn.cursor()
+
+    cur.execute("CREATE TABLE products (id INT NOT NULL PRIMARY KEY, "
+                "name NVARCHAR(50), price FLOAT, active BIT)")
+    cur.execute("INSERT INTO products VALUES (1, 'Skor', 79.5, 1), "
+                "(2, 'Kangor', 129.0, 0), (3, NULL, NULL, NULL)")
+
+    cur.execute("SELECT id, name, price, active FROM products ORDER BY id")
+    rows = cur.fetchall()
+    expected = [
+        (1, "Skor", 79.5, True),
+        (2, "Kangor", 129.0, False),
+        (3, None, None, None),
+    ]
+    if rows != expected:
+        print(f"FAIL: SELECT mismatch\n got: {rows}\n want: {expected}")
+        return 1
+
+    # Typed columns: id should come back as an int, not a string.
+    cur.execute("SELECT id, id * 2 AS doubled FROM products WHERE id = 2")
+    row = cur.fetchone()
+    if row != (2, 4):
+        print(f"FAIL: computed column mismatch: {row}")
+        return 1
+
+    # Error path: duplicate PK must raise with the SQL Server number 2627.
+    try:
+        cur.execute("INSERT INTO products VALUES (1, 'dup', 0, 1)")
+        print("FAIL: duplicate PK did not raise")
+        return 1
+    except pytds.Error as exc:
+        if "2627" not in str(exc) and getattr(exc, "number", None) != 2627:
+            print(f"FAIL: expected error 2627, got: {exc!r}")
+            return 1
+
+    # sys.tables is queryable.
+    cur.execute("SELECT name FROM sys.tables")
+    names = {r[0] for r in cur.fetchall()}
+    if "products" not in names:
+        print(f"FAIL: sys.tables missing products: {names}")
+        return 1
+
+    # A bare column's alias is carried in the result metadata (COLMETADATA).
+    cur.execute("SELECT id AS thing FROM products WHERE id = 1")
+    if cur.description[0][0] != "thing":
+        print(f"FAIL: alias not surfaced: {cur.description[0][0]!r}")
+        return 1
+
+    # VARCHAR (BIGVARCHR / CP1252) round-trips non-ASCII text, and NULL.
+    cur.execute("CREATE TABLE vtext (id INT NOT NULL PRIMARY KEY, s VARCHAR(20))")
+    cur.execute("INSERT INTO vtext VALUES (1, 'café'), (2, 'Zürich'), (3, NULL)")
+    cur.execute("SELECT s FROM vtext ORDER BY id")
+    vals = [r[0] for r in cur.fetchall()]
+    if vals != ["café", "Zürich", None]:
+        print(f"FAIL: VARCHAR round-trip: {vals!r}")
+        return 1
+
+    # NULL in a nullable INT column round-trips (INTN zero-length form).
+    cur.execute("CREATE TABLE nints (id INT NOT NULL PRIMARY KEY, n INT)")
+    cur.execute("INSERT INTO nints VALUES (1, 42), (2, NULL)")
+    cur.execute("SELECT n FROM nints ORDER BY id")
+    if [r[0] for r in cur.fetchall()] != [42, None]:
+        print("FAIL: NULL INT did not round-trip")
+        return 1
+
+    # Multi-statement batch yields multiple result sets (DONE_MORE path).
+    cur.execute("SELECT 1 AS a; SELECT 2 AS b")
+    if cur.fetchall() != [(1,)]:
+        print("FAIL: first result set wrong")
+        return 1
+    if not cur.nextset() or cur.fetchall() != [(2,)]:
+        print("FAIL: second result set missing/wrong")
+        return 1
+
+    # A result larger than one 4096-byte packet must reassemble intact. A
+    # computed literal (6000 bytes UCS-2) avoids the heap in-row size cap.
+    big = "x" * 3000
+    cur.execute(f"SELECT '{big}' AS big")
+    if cur.fetchone()[0] != big:
+        print("FAIL: large multi-packet value did not round-trip")
+        return 1
+
+    conn.close()
+    print("tds conformance: OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,6 @@
 use directories::ProjectDirs;
 use serde::Deserialize;
+use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -10,6 +11,50 @@ pub struct Config {
 
     #[serde(default)]
     pub storage: StorageConfig,
+
+    #[serde(default)]
+    pub tds: TdsConfig,
+}
+
+/// TDS (SQL Server protocol) gateway settings. Disabled by default; when
+/// enabled it listens on `port` (default 1433) and authenticates against the
+/// `[tds.auth]` username→password map.
+#[derive(Debug, Deserialize)]
+pub struct TdsConfig {
+    #[serde(default)]
+    pub enabled: bool,
+
+    #[serde(default = "default_addr")]
+    pub addr: String,
+
+    #[serde(default = "default_tds_port")]
+    pub port: u16,
+
+    #[serde(default = "default_tds_database")]
+    pub database: String,
+
+    #[serde(default)]
+    pub auth: HashMap<String, String>,
+}
+
+impl Default for TdsConfig {
+    fn default() -> Self {
+        TdsConfig {
+            enabled: false,
+            addr: default_addr(),
+            port: default_tds_port(),
+            database: default_tds_database(),
+            auth: HashMap::new(),
+        }
+    }
+}
+
+fn default_tds_port() -> u16 {
+    1433
+}
+
+fn default_tds_database() -> String {
+    "truthdb".to_string()
 }
 
 #[derive(Debug, Deserialize)]
@@ -234,6 +279,9 @@ fn apply_override(override_cfg: ConfigOverride, config: &mut Config) {
     if let Some(storage) = override_cfg.storage {
         apply_storage_override(&mut config.storage, storage);
     }
+    if let Some(tds) = override_cfg.tds {
+        apply_tds_override(&mut config.tds, tds);
+    }
 }
 
 #[derive(Debug, Deserialize, Default)]
@@ -242,6 +290,34 @@ struct ConfigOverride {
     port: Option<u16>,
     network: Option<NetworkConfigOverride>,
     storage: Option<StorageConfigOverride>,
+    tds: Option<TdsConfigOverride>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct TdsConfigOverride {
+    enabled: Option<bool>,
+    addr: Option<String>,
+    port: Option<u16>,
+    database: Option<String>,
+    auth: Option<HashMap<String, String>>,
+}
+
+fn apply_tds_override(target: &mut TdsConfig, source: TdsConfigOverride) {
+    if let Some(enabled) = source.enabled {
+        target.enabled = enabled;
+    }
+    if let Some(addr) = source.addr {
+        target.addr = addr;
+    }
+    if let Some(port) = source.port {
+        target.port = port;
+    }
+    if let Some(database) = source.database {
+        target.database = database;
+    }
+    if let Some(auth) = source.auth {
+        target.auth = auth;
+    }
 }
 
 #[derive(Debug, Deserialize, Default)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -114,6 +114,41 @@ async fn main() {
         }
     });
 
+    // Optional TDS (SQL Server protocol) gateway.
+    let tds_task = if config.tds.enabled {
+        let tds_config = truthdb_tds::TdsConfig {
+            users: config.tds.auth.clone(),
+            database: config.tds.database.clone(),
+        };
+        match truthdb_tds::TdsListener::bind(
+            &config.tds.addr,
+            config.tds.port,
+            Arc::clone(&engine),
+            tds_config,
+        )
+        .await
+        {
+            Ok(listener) => {
+                info!(
+                    "TDS gateway listening on {}:{}",
+                    config.tds.addr, config.tds.port
+                );
+                let shutdown_rx = shutdown_tx.subscribe();
+                Some(tokio::spawn(async move {
+                    if let Err(err) = listener.run(shutdown_rx).await {
+                        eprintln!("TDS listener error: {err}");
+                    }
+                }))
+            }
+            Err(err) => {
+                eprintln!("Failed to start TDS gateway: {err}");
+                None
+            }
+        }
+    } else {
+        None
+    };
+
     info!("Starting TruthDB...");
 
     info!("TruthDB running (waiting for stop signal)");
@@ -122,5 +157,8 @@ async fn main() {
     info!("Stop signal received; shutting down...");
     let _ = shutdown_tx.send(true);
     let _ = listener_task.await;
+    if let Some(tds_task) = tds_task {
+        let _ = tds_task.await;
+    }
     info!("TruthDB exiting");
 }


### PR DESCRIPTION
## Stage 4 — TDS gateway

A plaintext MS-TDS front end so real SQL Server drivers (**pytds**, **go-mssqldb** with `encrypt=disable`) can speak to the TruthDB engine over the wire.

### New crate `truthdb-tds`
- Packet framing: 8-byte header, EOM multi-packet reassembly, response chunking at the negotiated packet size (with a reassembly size cap to bound pre-auth memory).
- PRELOGIN (encryption not supported) + LOGIN7 (offset/length table, password de-obfuscation, config-file auth).
- TYPE_INFO / value codecs for `INTN`, `BITN`, `FLTN`, `NVARCHAR`, `BIGVARCHR`.
- Token streams: `LOGINACK`/`ENVCHANGE`/`INFO`/`ERROR`/`COLMETADATA`/`ROW`/`DONE`.
- `SQLBatch` → typed engine results → token stream.

### Engine
- Typed `RowSet` (`ResultColumn` + `Datum`) replacing `Vec<String>`, so result columns carry a real SQL type. `sql_batch` returns the typed outcome the gateway serializes. The native/REPL text path renders identically.

### Wiring
- `[tds]` / `[tds.auth]` config; listener spawned in `main` sharing the engine mutex with the native listener.
- CI **conformance job** drives a live server with both pytds and go-mssqldb.

### Adversarial review of this diff — fixes applied
Ran a multi-agent review (5 dimensions × dual verification); 9 findings confirmed, 5 rejected. Fixed:
- **[high]** preserve a bare column's `AS alias` in result metadata (typed-refactor regression).
- **[med]** transcode `VARCHAR` to CP1252 to match the advertised collation (was shipping raw UTF-8, mojibaking non-ASCII values).
- **[med]** cap reassembled message size — pre-auth remote OOM guard.
- **[med]** make token length prefixes self-consistent (column name / string value / error message) so pathological lengths can't desync the token stream.

Each fix has a unit test; the confirmed defects that involve wire behavior are also covered by the conformance scripts (alias metadata, non-ASCII VARCHAR, NULL INT, multi-statement result sets, multi-packet framing).

### Verification
- `cargo test --workspace`: 167 passing
- `cargo fmt --check` clean, `cargo clippy --all-targets --all-features -D warnings` clean
- Live e2e: pytds **and** go-mssqldb both report conformance OK against a running server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)