### PR TITLE
Sessions, transactions, table locking; driver transactions over TDS [Stage 6]

### DIFF
--- a/crates/truthdb-core/src/client_listener.rs
+++ b/crates/truthdb-core/src/client_listener.rs
@@ -1,5 +1,4 @@
 use std::net::SocketAddr;
-use std::sync::{Arc, Mutex};
 
 use thiserror::Error;
 use tokio::net::{TcpListener, TcpStream};
@@ -9,7 +8,7 @@ use truthdb_net::{read_frame, write_frame};
 use truthdb_proto::ProtoError;
 
 use crate::dispatcher::Dispatcher;
-use crate::engine::Engine;
+use crate::session::EngineHandle;
 
 #[derive(Error, Debug)]
 pub enum ClientListenerError {
@@ -25,15 +24,11 @@ pub enum ClientListenerError {
 
 pub struct ClientListener {
     addr: SocketAddr,
-    engine: Arc<Mutex<Engine>>,
+    engine: EngineHandle,
 }
 
 impl ClientListener {
-    pub fn new(
-        host: &str,
-        port: u16,
-        engine: Arc<Mutex<Engine>>,
-    ) -> Result<Self, ClientListenerError> {
+    pub fn new(host: &str, port: u16, engine: EngineHandle) -> Result<Self, ClientListenerError> {
         let addr: SocketAddr = format!("{host}:{port}").parse()?;
         Ok(ClientListener { addr, engine })
     }
@@ -49,7 +44,7 @@ impl ClientListener {
                 res = listener.accept() => {
                     let (stream, _) = res?;
                     let mut conn_shutdown = shutdown.clone();
-                    let engine = Arc::clone(&self.engine);
+                    let engine = self.engine.clone();
                     tokio::spawn(async move {
                         if let Err(err) = handle_client(stream, engine, &mut conn_shutdown).await
                             && !is_expected_disconnect(&err)
@@ -67,7 +62,7 @@ impl ClientListener {
 
 async fn handle_client(
     mut stream: TcpStream,
-    engine: Arc<Mutex<Engine>>,
+    engine: EngineHandle,
     shutdown: &mut watch::Receiver<bool>,
 ) -> Result<(), ClientListenerError> {
     let dispatcher = Dispatcher::new(engine);
@@ -82,7 +77,7 @@ async fn handle_client(
             }
         };
 
-        if let Some(resp) = dispatcher.dispatch(frame)? {
+        if let Some(resp) = dispatcher.dispatch(frame).await? {
             write_frame(&mut stream, &resp).await?;
         }
     }

--- a/crates/truthdb-core/src/dispatcher.rs
+++ b/crates/truthdb-core/src/dispatcher.rs
@@ -1,4 +1,3 @@
-use std::sync::{Arc, Mutex};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use truthdb_proto::{
@@ -6,18 +5,18 @@ use truthdb_proto::{
     PROTOCOL_VERSION, ProtoError, decode_message, encode_message,
 };
 
-use crate::engine::Engine;
+use crate::session::EngineHandle;
 
 pub struct Dispatcher {
-    engine: Arc<Mutex<Engine>>,
+    engine: EngineHandle,
 }
 
 impl Dispatcher {
-    pub fn new(engine: Arc<Mutex<Engine>>) -> Self {
+    pub fn new(engine: EngineHandle) -> Self {
         Dispatcher { engine }
     }
 
-    pub fn dispatch(&self, frame: Frame) -> Result<Option<Frame>, ProtoError> {
+    pub async fn dispatch(&self, frame: Frame) -> Result<Option<Frame>, ProtoError> {
         match frame.msg_type {
             MsgType::HelloReq => {
                 let _req: HelloReq = decode_message(&frame.payload)?;
@@ -54,23 +53,16 @@ impl Dispatcher {
             }
             MsgType::CommandReq => {
                 let req: CommandReq = decode_message(&frame.payload)?;
-                let resp = match self.engine.lock() {
-                    Ok(mut engine) => match engine.execute(&req.command) {
-                        Ok(message) => CommandResp {
-                            id: req.id,
-                            ok: true,
-                            message,
-                        },
-                        Err(err) => CommandResp {
-                            id: req.id,
-                            ok: false,
-                            message: err.to_string(),
-                        },
+                let resp = match self.engine.run_native(req.command).await {
+                    Ok(message) => CommandResp {
+                        id: req.id,
+                        ok: true,
+                        message,
                     },
-                    Err(_) => CommandResp {
+                    Err(err) => CommandResp {
                         id: req.id,
                         ok: false,
-                        message: "engine lock poisoned".to_string(),
+                        message: err.to_string(),
                     },
                 };
 

--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -575,6 +575,9 @@ pub enum EngineError {
 
     #[error("{0}")]
     Replay(String),
+
+    #[error("engine is shutting down")]
+    Unavailable,
 }
 
 #[derive(Debug, Error)]

--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -123,7 +123,12 @@ impl Engine {
     /// along with any error in one envelope, transported as a normal
     /// response (TDS-like) rather than failing the connection.
     fn execute_sql(&mut self, input: &str) -> Result<String, EngineError> {
-        let outcome = crate::rel::execute_batch(&mut self.storage, input);
+        // The native (session-less) path has nowhere to carry an open
+        // transaction across calls, so it uses a transient context and rolls
+        // back anything an unbalanced BEGIN leaves dangling.
+        let mut txn_ctx = crate::rel::TxnContext::default();
+        let outcome = crate::rel::execute_batch(&mut self.storage, input, &mut txn_ctx);
+        txn_ctx.abort(&mut self.storage);
         self.maybe_checkpoint()?;
         Ok(render_sql_outcome(&outcome))
     }
@@ -131,11 +136,34 @@ impl Engine {
     /// Runs a SQL batch and returns the typed outcome (result sets +
     /// optional error). The TDS gateway uses this to emit COLMETADATA / ROW
     /// / DONE / ERROR token streams; a TDS client only ever speaks SQL, so
-    /// there is no ES routing here.
-    pub fn sql_batch(&mut self, input: &str) -> Result<crate::rel::BatchOutcome, EngineError> {
-        let outcome = crate::rel::execute_batch(&mut self.storage, input);
+    /// there is no ES routing here. The `txn_ctx` carries transaction state
+    /// (open transaction, `@@TRANCOUNT`, isolation) across batches within a
+    /// session.
+    pub fn sql_batch(
+        &mut self,
+        input: &str,
+        txn_ctx: &mut crate::rel::TxnContext,
+    ) -> Result<crate::rel::BatchOutcome, EngineError> {
+        let outcome = crate::rel::execute_batch(&mut self.storage, input, txn_ctx);
         self.maybe_checkpoint()?;
         Ok(outcome)
+    }
+
+    /// Rolls back and discards a session's open transaction (connection
+    /// teardown). No-op when the session has no transaction.
+    pub fn abort_session_txn(&mut self, txn_ctx: &mut crate::rel::TxnContext) {
+        txn_ctx.abort(&mut self.storage);
+    }
+
+    /// The table/database locks a SQL batch needs at the given isolation
+    /// level (see [`crate::rel::analyze_locks`]). The session loop acquires
+    /// these before running the batch.
+    pub fn analyze_locks(
+        &self,
+        input: &str,
+        isolation: crate::rel::Isolation,
+    ) -> Vec<(crate::lock::Resource, crate::lock::LockMode)> {
+        crate::rel::analyze_locks(&self.storage, input, isolation)
     }
 
     pub fn checkpoint(&mut self) -> Result<(), EngineError> {
@@ -155,6 +183,14 @@ impl Engine {
     }
 
     fn maybe_checkpoint(&mut self) -> Result<(), EngineError> {
+        // A checkpoint flushes dirty pages and truncates the WAL head. While an
+        // explicit transaction is open its uncommitted pages would be made
+        // durable and its undo records discarded, so a crash could not roll it
+        // back. Defer the checkpoint until every transaction has closed; the
+        // WAL keeps growing until then (bounded, non-corrupting).
+        if self.storage.has_active_transactions() {
+            return Ok(());
+        }
         if self.wal_usage_ratio() >= WAL_CHECKPOINT_THRESHOLD {
             self.checkpoint()?;
         }
@@ -1944,6 +1980,268 @@ mod tests {
         // The first row is durably present.
         let (_, rows) = sql_rows(&mut engine, "SELECT id FROM t");
         assert_eq!(rows, vec![vec![Some("1".into())]]);
+        let _ = std::fs::remove_file(path);
+    }
+
+    // ---- explicit transactions (Stage 6, M2) ---------------------------
+
+    use crate::rel::{BatchOutcome, StatementResult, TxnContext};
+    use crate::relstore::types::Datum;
+
+    /// Runs a SQL batch through the session path with a persistent transaction
+    /// context (as a TDS connection would), returning the typed outcome.
+    fn batch(engine: &mut Engine, ctx: &mut TxnContext, sql: &str) -> BatchOutcome {
+        engine.sql_batch(sql, ctx).expect("sql_batch")
+    }
+
+    /// The integer `id` column (column 0) of the first rowset in an outcome.
+    fn ids(outcome: &BatchOutcome) -> Vec<i32> {
+        for result in &outcome.results {
+            if let StatementResult::Rows(rowset) = result {
+                return rowset
+                    .rows
+                    .iter()
+                    .map(|row| match row[0] {
+                        Datum::TinyInt(v) => v as i32,
+                        Datum::SmallInt(v) => v as i32,
+                        Datum::Int(v) => v,
+                        Datum::BigInt(v) => v as i32,
+                        ref other => panic!("expected integer id, got {other:?}"),
+                    })
+                    .collect();
+            }
+        }
+        panic!("no rowset in outcome: {:?}", outcome.results);
+    }
+
+    #[test]
+    fn txn_commit_is_durable_across_restart() {
+        let path = unique_temp_path("txn-commit-durable");
+        let mut engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+
+        batch(
+            &mut engine,
+            &mut ctx,
+            "CREATE TABLE t (id INT NOT NULL PRIMARY KEY)",
+        );
+        let out = batch(
+            &mut engine,
+            &mut ctx,
+            "BEGIN TRANSACTION; INSERT INTO t VALUES (1); INSERT INTO t VALUES (2); COMMIT TRANSACTION;",
+        );
+        assert!(out.error.is_none(), "{:?}", out.error);
+        assert!(
+            !ctx.has_open_transaction(),
+            "COMMIT must close the transaction"
+        );
+
+        // Reopen: the committed rows must survive ARIES recovery.
+        drop(engine);
+        let storage = Storage::open(path.clone()).expect("reopen");
+        let mut engine = Engine::new(storage).expect("replay");
+        let mut ctx = TxnContext::default();
+        let out = batch(&mut engine, &mut ctx, "SELECT id FROM t ORDER BY id");
+        assert_eq!(ids(&out), vec![1, 2]);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn txn_rollback_discards_all_writes() {
+        let path = unique_temp_path("txn-rollback");
+        let mut engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+
+        batch(
+            &mut engine,
+            &mut ctx,
+            "CREATE TABLE t (id INT NOT NULL PRIMARY KEY)",
+        );
+        batch(&mut engine, &mut ctx, "INSERT INTO t VALUES (1)");
+        let out = batch(
+            &mut engine,
+            &mut ctx,
+            "BEGIN TRANSACTION; INSERT INTO t VALUES (2); INSERT INTO t VALUES (3); ROLLBACK TRANSACTION;",
+        );
+        assert!(out.error.is_none(), "{:?}", out.error);
+        assert!(!ctx.has_open_transaction());
+
+        // Only the pre-transaction row 1 remains.
+        let out = batch(&mut engine, &mut ctx, "SELECT id FROM t ORDER BY id");
+        assert_eq!(ids(&out), vec![1]);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn txn_trancount_reflects_nesting() {
+        let path = unique_temp_path("txn-trancount");
+        let mut engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+
+        // Outside any transaction, @@TRANCOUNT is 0.
+        let out = batch(&mut engine, &mut ctx, "SELECT @@TRANCOUNT AS n");
+        assert_eq!(ids(&out), vec![0]);
+
+        // Nested BEGINs bump the count; only the outermost COMMIT commits.
+        let out = batch(
+            &mut engine,
+            &mut ctx,
+            "BEGIN TRAN; BEGIN TRAN; SELECT @@TRANCOUNT AS n;",
+        );
+        assert_eq!(ids(&out), vec![2]);
+        assert!(ctx.has_open_transaction());
+
+        let out = batch(&mut engine, &mut ctx, "COMMIT; SELECT @@TRANCOUNT AS n;");
+        assert_eq!(ids(&out), vec![1], "inner COMMIT only decrements");
+        assert!(
+            ctx.has_open_transaction(),
+            "transaction still open at count 1"
+        );
+
+        batch(&mut engine, &mut ctx, "COMMIT");
+        assert!(!ctx.has_open_transaction());
+        let out = batch(&mut engine, &mut ctx, "SELECT @@TRANCOUNT AS n");
+        assert_eq!(ids(&out), vec![0]);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn txn_error_dooms_transaction_until_rollback() {
+        let path = unique_temp_path("txn-doomed");
+        let mut engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+
+        batch(
+            &mut engine,
+            &mut ctx,
+            "CREATE TABLE t (id INT NOT NULL PRIMARY KEY)",
+        );
+        // A duplicate-PK failure inside the transaction dooms it.
+        let out = batch(
+            &mut engine,
+            &mut ctx,
+            "BEGIN TRAN; INSERT INTO t VALUES (1); INSERT INTO t VALUES (1);",
+        );
+        assert_eq!(out.error.as_ref().map(|e| e.number), Some(2627));
+
+        // A doomed transaction rejects further work with 3930...
+        let out = batch(&mut engine, &mut ctx, "SELECT 1 AS n");
+        assert_eq!(out.error.as_ref().map(|e| e.number), Some(3930));
+
+        // ...but ROLLBACK is allowed and clears the doom.
+        let out = batch(&mut engine, &mut ctx, "ROLLBACK");
+        assert!(out.error.is_none(), "{:?}", out.error);
+        assert!(!ctx.has_open_transaction());
+
+        // The table is usable again and holds nothing (the txn rolled back).
+        let out = batch(&mut engine, &mut ctx, "SELECT id FROM t");
+        assert_eq!(ids(&out), Vec::<i32>::new());
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn txn_ddl_inside_transaction_is_rejected() {
+        let path = unique_temp_path("txn-ddl");
+        let mut engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+
+        let out = batch(
+            &mut engine,
+            &mut ctx,
+            "BEGIN TRAN; CREATE TABLE t (id INT NOT NULL PRIMARY KEY);",
+        );
+        assert_eq!(out.error.as_ref().map(|e| e.number), Some(226));
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn txn_bare_commit_and_rollback_error() {
+        let path = unique_temp_path("txn-bare");
+        let mut engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+
+        let out = batch(&mut engine, &mut ctx, "COMMIT TRANSACTION");
+        assert_eq!(out.error.as_ref().map(|e| e.number), Some(3902));
+
+        let out = batch(&mut engine, &mut ctx, "ROLLBACK TRANSACTION");
+        assert_eq!(out.error.as_ref().map(|e| e.number), Some(3903));
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn txn_abort_on_disconnect_rolls_back() {
+        let path = unique_temp_path("txn-disconnect");
+        let mut engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+
+        batch(
+            &mut engine,
+            &mut ctx,
+            "CREATE TABLE t (id INT NOT NULL PRIMARY KEY)",
+        );
+        batch(
+            &mut engine,
+            &mut ctx,
+            "BEGIN TRAN; INSERT INTO t VALUES (7);",
+        );
+        assert!(ctx.has_open_transaction());
+
+        // Simulate the session teardown that CloseSession performs.
+        engine.abort_session_txn(&mut ctx);
+        assert!(!ctx.has_open_transaction());
+
+        let mut ctx2 = TxnContext::default();
+        let out = batch(&mut engine, &mut ctx2, "SELECT id FROM t");
+        assert_eq!(
+            ids(&out),
+            Vec::<i32>::new(),
+            "uncommitted insert was rolled back"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn txn_uncommitted_explicit_txn_is_undone_after_crash() {
+        let path = unique_temp_path("txn-crash-undo");
+        let mut engine = new_engine(&path);
+        batch(
+            &mut engine,
+            &mut TxnContext::default(),
+            "CREATE TABLE t (id INT NOT NULL PRIMARY KEY)",
+        );
+
+        // Session A opens a transaction and inserts 99 but never commits.
+        let mut ctx_a = TxnContext::default();
+        batch(
+            &mut engine,
+            &mut ctx_a,
+            "BEGIN TRAN; INSERT INTO t VALUES (99);",
+        );
+        assert!(ctx_a.has_open_transaction());
+
+        // An autocommit insert commits, forcing the WAL to disk — including
+        // A's (earlier, still-uncommitted) log records.
+        batch(
+            &mut engine,
+            &mut TxnContext::default(),
+            "INSERT INTO t VALUES (1)",
+        );
+
+        // Crash: drop the engine and A's context without a graceful rollback
+        // (StorageTxn has no Drop, so nothing is committed on the way out).
+        drop(ctx_a);
+        drop(engine);
+
+        // Recovery on reopen redoes history then undoes the loser (A): row 99
+        // is gone, the committed row 1 survives.
+        let storage = Storage::open(path.clone()).expect("reopen");
+        let mut engine = Engine::new(storage).expect("replay");
+        let out = batch(
+            &mut engine,
+            &mut TxnContext::default(),
+            "SELECT id FROM t ORDER BY id",
+        );
+        assert_eq!(ids(&out), vec![1]);
         let _ = std::fs::remove_file(path);
     }
 

--- a/crates/truthdb-core/src/lib.rs
+++ b/crates/truthdb-core/src/lib.rs
@@ -5,6 +5,7 @@ pub mod dispatcher;
 pub mod engine;
 pub mod rel;
 pub mod relstore;
+pub mod session;
 pub mod storage;
 mod storage_layout;
 pub mod wal;

--- a/crates/truthdb-core/src/lib.rs
+++ b/crates/truthdb-core/src/lib.rs
@@ -3,6 +3,7 @@ pub mod client_listener;
 mod direct_io;
 pub mod dispatcher;
 pub mod engine;
+pub mod lock;
 pub mod rel;
 pub mod relstore;
 pub mod session;

--- a/crates/truthdb-core/src/lock.rs
+++ b/crates/truthdb-core/src/lock.rs
@@ -1,0 +1,241 @@
+//! Table/database lock manager (Stage 6): coarse, table-granular two-phase
+//! locking that serializes conflicting transactions across sessions.
+//!
+//! The engine is a single actor thread, so it never blocks in place on a
+//! lock — the [`session`](crate::session) loop acquires a batch's locks up
+//! front and *parks* the whole request when one conflicts (see that module).
+//! This type is the pure bookkeeping underneath: which owner holds what, and
+//! whether a requested mode conflicts. Row-level keys arrive in Stage 12; for
+//! now the finest resource is a table.
+
+use std::collections::HashMap;
+
+/// A lockable resource. `Database` is the hierarchy root (intent locks);
+/// `Table` is keyed by catalog object id.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Resource {
+    Database,
+    Table(u32),
+}
+
+/// Lock modes, weakest to strongest by [`LockMode::rank`]. Intent modes
+/// (`IntentShared`/`IntentExclusive`) sit on the `Database` parent; base
+/// modes (`Shared`/`Exclusive`) sit on tables.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LockMode {
+    IntentShared,
+    IntentExclusive,
+    Shared,
+    Exclusive,
+}
+
+impl LockMode {
+    /// Rank for upgrade/combine. Stage 6 only ever combines within the intent
+    /// pair `{IS,IX}` (on `Database`) or the base pair `{S,X}` (on a table),
+    /// so a plain max-by-rank is exact — no SIX lock is ever needed.
+    fn rank(self) -> u8 {
+        match self {
+            LockMode::IntentShared => 0,
+            LockMode::IntentExclusive => 1,
+            LockMode::Shared => 2,
+            LockMode::Exclusive => 3,
+        }
+    }
+
+    /// The stronger of two modes an owner needs on one resource.
+    pub fn combine(self, other: LockMode) -> LockMode {
+        if self.rank() >= other.rank() {
+            self
+        } else {
+            other
+        }
+    }
+
+    /// A read mode (`S`/`IS`) — released per-statement under READ COMMITTED,
+    /// held to commit under REPEATABLE READ / SERIALIZABLE.
+    fn is_read(self) -> bool {
+        matches!(self, LockMode::IntentShared | LockMode::Shared)
+    }
+
+    /// Whether two modes held on the same resource by *different* owners can
+    /// coexist. Standard IS/IX/S/X compatibility matrix; symmetric.
+    fn compatible_with(self, other: LockMode) -> bool {
+        use LockMode::*;
+        !matches!(
+            (self, other),
+            (IntentShared, Exclusive)
+                | (Exclusive, IntentShared)
+                | (IntentExclusive, Shared)
+                | (Shared, IntentExclusive)
+                | (IntentExclusive, Exclusive)
+                | (Exclusive, IntentExclusive)
+                | (Shared, Exclusive)
+                | (Exclusive, Shared)
+                | (Exclusive, Exclusive)
+        )
+    }
+}
+
+/// One held lock: an owner and the (possibly upgraded) mode.
+#[derive(Debug, Clone, Copy)]
+struct Grant {
+    owner: u64,
+    mode: LockMode,
+}
+
+/// Tracks granted locks per resource. Owners are session ids. This structure
+/// carries no wait queue — parking and FIFO fairness live in the engine loop,
+/// which owns the parked requests and their reply channels.
+#[derive(Default)]
+pub struct LockManager {
+    grants: HashMap<Resource, Vec<Grant>>,
+}
+
+impl LockManager {
+    pub fn new() -> Self {
+        LockManager::default()
+    }
+
+    /// The owner already blocking `owner` from taking `mode` on `resource`, if
+    /// any (a single conflicting owner suffices to block). An owner never
+    /// conflicts with its own held lock (upgrades are allowed).
+    pub fn conflict(&self, owner: u64, resource: Resource, mode: LockMode) -> Option<u64> {
+        let grants = self.grants.get(&resource)?;
+        grants
+            .iter()
+            .find(|g| g.owner != owner && !g.mode.compatible_with(mode))
+            .map(|g| g.owner)
+    }
+
+    /// Whether `owner` already holds any lock on `resource`. Used to exempt a
+    /// re-acquisition or upgrade from FIFO anti-barging: an owner that already
+    /// holds a resource is not jumping the queue for it.
+    pub fn holds(&self, owner: u64, resource: Resource) -> bool {
+        self.grants
+            .get(&resource)
+            .is_some_and(|grants| grants.iter().any(|g| g.owner == owner))
+    }
+
+    /// Grants (or upgrades) `owner`'s lock on `resource` to at least `mode`.
+    /// The caller must have checked [`LockManager::conflict`] first.
+    pub fn grant(&mut self, owner: u64, resource: Resource, mode: LockMode) {
+        let grants = self.grants.entry(resource).or_default();
+        if let Some(existing) = grants.iter_mut().find(|g| g.owner == owner) {
+            existing.mode = existing.mode.combine(mode);
+        } else {
+            grants.push(Grant { owner, mode });
+        }
+    }
+
+    /// Releases every lock held by `owner` (transaction end / disconnect).
+    /// Returns the resources that had a grant removed, so the caller can wake
+    /// waiters queued on them.
+    pub fn release_all(&mut self, owner: u64) -> Vec<Resource> {
+        let mut freed = Vec::new();
+        self.grants.retain(|resource, grants| {
+            let before = grants.len();
+            grants.retain(|g| g.owner != owner);
+            if grants.len() != before {
+                freed.push(*resource);
+            }
+            !grants.is_empty()
+        });
+        freed
+    }
+
+    /// Releases only `owner`'s read locks (`S`/`IS`), keeping write locks.
+    /// Used at statement end under READ COMMITTED, where shared locks do not
+    /// survive the statement. Returns the resources that were freed.
+    pub fn release_read_locks(&mut self, owner: u64) -> Vec<Resource> {
+        let mut freed = Vec::new();
+        self.grants.retain(|resource, grants| {
+            let before = grants.len();
+            grants.retain(|g| !(g.owner == owner && g.mode.is_read()));
+            if grants.len() != before {
+                freed.push(*resource);
+            }
+            !grants.is_empty()
+        });
+        freed
+    }
+
+    /// True if `owner` holds no locks at all.
+    #[cfg(test)]
+    fn holds_nothing(&self, owner: u64) -> bool {
+        self.grants
+            .values()
+            .all(|grants| grants.iter().all(|g| g.owner != owner))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const A: u64 = 1;
+    const B: u64 = 2;
+    const T: Resource = Resource::Table(10);
+
+    #[test]
+    fn compatibility_matrix_is_standard() {
+        use LockMode::*;
+        // Shared readers coexist; a writer excludes everyone.
+        assert!(Shared.compatible_with(Shared));
+        assert!(!Shared.compatible_with(Exclusive));
+        assert!(!Exclusive.compatible_with(Shared));
+        assert!(!Exclusive.compatible_with(Exclusive));
+        // Intent locks coexist with each other.
+        assert!(IntentShared.compatible_with(IntentExclusive));
+        assert!(IntentExclusive.compatible_with(IntentExclusive));
+        // IX excludes S (a writer's intent blocks a table-wide reader).
+        assert!(!IntentExclusive.compatible_with(Shared));
+        // IS coexists with S but not X.
+        assert!(IntentShared.compatible_with(Shared));
+        assert!(!IntentShared.compatible_with(Exclusive));
+    }
+
+    #[test]
+    fn writer_blocks_reader_across_owners() {
+        let mut lm = LockManager::new();
+        assert!(lm.conflict(A, T, LockMode::Exclusive).is_none());
+        lm.grant(A, T, LockMode::Exclusive);
+        // B cannot read while A writes.
+        assert_eq!(lm.conflict(B, T, LockMode::Shared), Some(A));
+        // A itself is never blocked by its own lock.
+        assert!(lm.conflict(A, T, LockMode::Shared).is_none());
+    }
+
+    #[test]
+    fn shared_readers_share_but_block_a_writer() {
+        let mut lm = LockManager::new();
+        lm.grant(A, T, LockMode::Shared);
+        assert!(lm.conflict(B, T, LockMode::Shared).is_none());
+        lm.grant(B, T, LockMode::Shared);
+        // A writer must wait for either reader.
+        assert!(lm.conflict(A, T, LockMode::Exclusive).is_some());
+    }
+
+    #[test]
+    fn upgrade_shared_to_exclusive_when_sole_holder() {
+        let mut lm = LockManager::new();
+        lm.grant(A, T, LockMode::Shared);
+        // No other holder → A upgrades to X.
+        assert!(lm.conflict(A, T, LockMode::Exclusive).is_none());
+        lm.grant(A, T, LockMode::Exclusive);
+        // Now B is excluded.
+        assert_eq!(lm.conflict(B, T, LockMode::Shared), Some(A));
+    }
+
+    #[test]
+    fn release_all_frees_resources_and_reports_them() {
+        let mut lm = LockManager::new();
+        lm.grant(A, Resource::Database, LockMode::IntentExclusive);
+        lm.grant(A, T, LockMode::Exclusive);
+        let freed = lm.release_all(A);
+        assert!(freed.contains(&Resource::Database));
+        assert!(freed.contains(&T));
+        assert!(lm.holds_nothing(A));
+        // B can now acquire.
+        assert!(lm.conflict(B, T, LockMode::Exclusive).is_none());
+    }
+}

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -11,17 +11,76 @@ pub mod collation;
 mod value;
 
 use truthdb_sql::ast::{
-    ColumnDef, CreateTable, DataType, Delete, DropTable, Expr, ExprKind, Insert, Name, OrderItem,
-    Select, SelectItem, Statement, Update,
+    ColumnDef, CreateTable, DataType, Delete, DropTable, Expr, ExprKind, Insert, IsolationLevel,
+    Name, OrderItem, Select, SelectItem, SetStatement, Statement, Update,
 };
 use truthdb_sql::error::SqlError;
+use truthdb_sql::eval::EvalContext;
 use truthdb_sql::value::{SqlValue, order_key_cmp};
 use truthdb_sql::{ast, eval};
 
+use crate::lock::{LockMode, Resource};
 use crate::relstore::catalog::{self, TableDef};
 use crate::relstore::row::{Column, Schema};
 use crate::relstore::types::{ColumnType, Datum};
-use crate::storage::{Storage, StorageError};
+use crate::storage::{Storage, StorageError, StorageTxn, TxnScope};
+
+/// Per-session transaction state carried across statements/batches. Lives in
+/// the session (engine thread); autocommit statements use `Default`.
+#[derive(Default)]
+pub struct TxnContext {
+    txn: Option<StorageTxn>,
+    /// `@@TRANCOUNT` — nested BEGINs increment; only the outermost COMMIT
+    /// actually commits.
+    trancount: u32,
+    /// Set when a statement failed inside the transaction (SQL Server
+    /// XACT_ABORT-style): only ROLLBACK is then allowed.
+    doomed: bool,
+    xact_abort: bool,
+    isolation: Isolation,
+}
+
+/// Session isolation level (defaults to READ COMMITTED, like SQL Server).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Isolation {
+    ReadUncommitted,
+    #[default]
+    ReadCommitted,
+    RepeatableRead,
+    Serializable,
+}
+
+impl TxnContext {
+    fn in_txn(&self) -> bool {
+        self.txn.is_some()
+    }
+
+    fn eval_context(&self) -> EvalContext {
+        EvalContext {
+            trancount: self.trancount as i32,
+        }
+    }
+
+    /// True if a transaction is open (used by the session to decide whether a
+    /// disconnect must roll back).
+    pub fn has_open_transaction(&self) -> bool {
+        self.txn.is_some()
+    }
+
+    /// The session's current isolation level (drives which locks reads take).
+    pub fn isolation(&self) -> Isolation {
+        self.isolation
+    }
+
+    /// Rolls back and discards any open transaction (connection teardown).
+    pub fn abort(&mut self, storage: &mut Storage) {
+        if let Some(txn) = self.txn.take() {
+            let _ = storage.rel_rollback(txn);
+        }
+        self.trancount = 0;
+        self.doomed = false;
+    }
+}
 
 /// Result of one executed statement.
 #[derive(Debug, Clone, PartialEq)]
@@ -58,7 +117,7 @@ pub struct BatchOutcome {
 
 /// Parses and executes a SQL batch. A parse error yields an empty batch with
 /// the error; a runtime error stops the batch but keeps earlier results.
-pub fn execute_batch(storage: &mut Storage, sql: &str) -> BatchOutcome {
+pub fn execute_batch(storage: &mut Storage, sql: &str, txn_ctx: &mut TxnContext) -> BatchOutcome {
     let statements = match truthdb_sql::parse(sql) {
         Ok(statements) => statements,
         Err(error) => {
@@ -70,9 +129,14 @@ pub fn execute_batch(storage: &mut Storage, sql: &str) -> BatchOutcome {
     };
     let mut results = Vec::with_capacity(statements.len());
     for statement in &statements {
-        match exec_statement(storage, statement) {
+        match exec_statement(storage, statement, txn_ctx) {
             Ok(result) => results.push(result),
             Err(error) => {
+                // A statement failure inside an explicit transaction dooms it
+                // (XACT_ABORT-style): only ROLLBACK is then permitted.
+                if txn_ctx.in_txn() {
+                    txn_ctx.doomed = true;
+                }
                 return BatchOutcome {
                     results,
                     error: Some(error),
@@ -86,30 +150,238 @@ pub fn execute_batch(storage: &mut Storage, sql: &str) -> BatchOutcome {
     }
 }
 
+/// The table/database locks a batch needs, from its statements and the
+/// session isolation level, deduped to the strongest mode per resource. The
+/// engine acquires these up front (before running any statement) so a
+/// conflicting batch can be parked and restarted cleanly.
+///
+/// A parse error yields no locks — execution re-parses and surfaces it.
+/// `sys.*` views and unresolved tables take no lock (catalog reads are
+/// unlocked; missing tables error at execution).
+pub fn analyze_locks(
+    storage: &Storage,
+    sql: &str,
+    isolation: Isolation,
+) -> Vec<(Resource, LockMode)> {
+    let Ok(statements) = truthdb_sql::parse(sql) else {
+        return Vec::new();
+    };
+    // Reads take shared locks except under READ UNCOMMITTED, which takes none.
+    // A batch that raises the isolation level (e.g. `SET ISOLATION LEVEL
+    // SERIALIZABLE; SELECT ...`) must lock its reads even if the session was
+    // READ UNCOMMITTED on entry — otherwise the post-SET read would run
+    // unlocked. We therefore take read locks unless the whole batch is READ
+    // UNCOMMITTED: the session is RU and no SET raises it above RU.
+    let escalates_reads = statements.iter().any(|s| {
+        matches!(
+            s,
+            Statement::Set(SetStatement::IsolationLevel(level))
+                if !matches!(level, IsolationLevel::ReadUncommitted)
+        )
+    });
+    let reads_lock = !matches!(isolation, Isolation::ReadUncommitted) || escalates_reads;
+    let mut needs: std::collections::HashMap<Resource, LockMode> = std::collections::HashMap::new();
+    let mut add = |resource: Resource, mode: LockMode| {
+        needs
+            .entry(resource)
+            .and_modify(|m| *m = m.combine(mode))
+            .or_insert(mode);
+    };
+    for statement in &statements {
+        match statement {
+            Statement::Select(select) => {
+                if !reads_lock {
+                    continue;
+                }
+                if let Some(from) = &select.from {
+                    let lower = from.value.to_ascii_lowercase();
+                    if lower.starts_with("sys.") {
+                        continue; // catalog view: unlocked
+                    }
+                    if let Some(def) = resolve_table(storage, &from.value) {
+                        add(Resource::Database, LockMode::IntentShared);
+                        add(Resource::Table(def.object_id), LockMode::Shared);
+                    }
+                }
+            }
+            Statement::Insert(Insert { table, .. })
+            | Statement::Update(Update { table, .. })
+            | Statement::Delete(Delete { table, .. }) => {
+                if let Some(def) = resolve_table(storage, &table.value) {
+                    add(Resource::Database, LockMode::IntentExclusive);
+                    add(Resource::Table(def.object_id), LockMode::Exclusive);
+                }
+            }
+            // DDL serializes against every active transaction via a
+            // database-exclusive lock (it is disallowed inside a txn anyway).
+            Statement::CreateTable(_) | Statement::DropTable(_) => {
+                add(Resource::Database, LockMode::Exclusive);
+            }
+            // Transaction control and SET take no data locks.
+            Statement::BeginTransaction { .. }
+            | Statement::Commit { .. }
+            | Statement::Rollback { .. }
+            | Statement::Set(_) => {}
+        }
+    }
+    needs.into_iter().collect()
+}
+
 /// Parses and executes a SQL batch, returning one result per statement, or
 /// the first error (discarding earlier results). Kept for tests; the server
 /// uses [`execute_batch`].
 #[cfg(test)]
 pub fn execute(storage: &mut Storage, sql: &str) -> Result<Vec<StatementResult>, SqlError> {
-    let outcome = execute_batch(storage, sql);
+    let mut txn_ctx = TxnContext::default();
+    let outcome = execute_batch(storage, sql, &mut txn_ctx);
     match outcome.error {
         Some(error) => Err(error),
         None => Ok(outcome.results),
     }
 }
 
+impl TxnContext {
+    fn scope(&mut self) -> TxnScope<'_> {
+        match &mut self.txn {
+            Some(txn) => TxnScope::Explicit(txn),
+            None => TxnScope::Auto,
+        }
+    }
+}
+
 fn exec_statement(
     storage: &mut Storage,
     statement: &Statement,
+    txn_ctx: &mut TxnContext,
 ) -> Result<StatementResult, SqlError> {
-    match statement {
-        Statement::CreateTable(create) => exec_create_table(storage, create),
-        Statement::DropTable(drop) => exec_drop_table(storage, drop),
-        Statement::Insert(insert) => exec_insert(storage, insert),
-        Statement::Update(update) => exec_update(storage, update),
-        Statement::Delete(delete) => exec_delete(storage, delete),
-        Statement::Select(select) => Ok(StatementResult::Rows(exec_select(storage, select)?)),
+    // A doomed transaction rejects everything but ROLLBACK.
+    if txn_ctx.doomed && !matches!(statement, Statement::Rollback { .. }) {
+        return Err(SqlError::new(
+            3930,
+            16,
+            1,
+            "The current transaction cannot be committed and cannot support operations that write to the log file. Roll back the transaction.",
+        ));
     }
+    match statement {
+        Statement::BeginTransaction { .. } => exec_begin(storage, txn_ctx),
+        Statement::Commit { .. } => exec_commit(storage, txn_ctx),
+        Statement::Rollback { .. } => exec_rollback(storage, txn_ctx),
+        Statement::Set(set) => exec_set(txn_ctx, set),
+        Statement::CreateTable(create) => {
+            if txn_ctx.in_txn() {
+                return Err(ddl_in_txn_err());
+            }
+            exec_create_table(storage, create)
+        }
+        Statement::DropTable(drop) => {
+            if txn_ctx.in_txn() {
+                return Err(ddl_in_txn_err());
+            }
+            exec_drop_table(storage, drop)
+        }
+        Statement::Insert(insert) => {
+            let eval_ctx = txn_ctx.eval_context();
+            let mut scope = txn_ctx.scope();
+            exec_insert(storage, insert, &mut scope, &eval_ctx)
+        }
+        Statement::Update(update) => {
+            let eval_ctx = txn_ctx.eval_context();
+            let mut scope = txn_ctx.scope();
+            exec_update(storage, update, &mut scope, &eval_ctx)
+        }
+        Statement::Delete(delete) => {
+            let eval_ctx = txn_ctx.eval_context();
+            let mut scope = txn_ctx.scope();
+            exec_delete(storage, delete, &mut scope, &eval_ctx)
+        }
+        Statement::Select(select) => {
+            let eval_ctx = txn_ctx.eval_context();
+            Ok(StatementResult::Rows(exec_select(
+                storage, select, &eval_ctx,
+            )?))
+        }
+    }
+}
+
+fn ddl_in_txn_err() -> SqlError {
+    SqlError::new(
+        226,
+        16,
+        1,
+        "DDL statements are not allowed inside an explicit transaction in this version.",
+    )
+}
+
+// ---- transaction control -----------------------------------------------
+
+fn exec_begin(storage: &mut Storage, ctx: &mut TxnContext) -> Result<StatementResult, SqlError> {
+    if ctx.txn.is_none() {
+        ctx.txn = Some(storage.rel_begin().map_err(|e| map_storage_err(e, ""))?);
+    }
+    // Nested BEGIN only bumps the count (SQL Server semantics).
+    ctx.trancount += 1;
+    Ok(StatementResult::Done)
+}
+
+fn exec_commit(storage: &mut Storage, ctx: &mut TxnContext) -> Result<StatementResult, SqlError> {
+    if ctx.trancount == 0 {
+        return Err(SqlError::new(
+            3902,
+            16,
+            1,
+            "The COMMIT TRANSACTION request has no corresponding BEGIN TRANSACTION.",
+        ));
+    }
+    ctx.trancount -= 1;
+    // Only the outermost COMMIT actually commits.
+    if ctx.trancount == 0
+        && let Some(txn) = ctx.txn.take()
+    {
+        storage
+            .rel_commit(txn)
+            .map_err(|e| map_storage_err(e, ""))?;
+    }
+    Ok(StatementResult::Done)
+}
+
+fn exec_rollback(storage: &mut Storage, ctx: &mut TxnContext) -> Result<StatementResult, SqlError> {
+    if ctx.trancount == 0 {
+        return Err(SqlError::new(
+            3903,
+            16,
+            1,
+            "The ROLLBACK TRANSACTION request has no corresponding BEGIN TRANSACTION.",
+        ));
+    }
+    // ROLLBACK always unwinds the whole transaction, regardless of nesting.
+    // Reset the session's transaction counters even if the storage rollback
+    // fails (which wedges the store): the transaction is over either way, so
+    // leaving @@TRANCOUNT / doomed set would desync the session.
+    let result = match ctx.txn.take() {
+        Some(txn) => storage
+            .rel_rollback(txn)
+            .map_err(|e| map_storage_err(e, "")),
+        None => Ok(()),
+    };
+    ctx.trancount = 0;
+    ctx.doomed = false;
+    result.map(|()| StatementResult::Done)
+}
+
+fn exec_set(ctx: &mut TxnContext, set: &SetStatement) -> Result<StatementResult, SqlError> {
+    match set {
+        SetStatement::XactAbort(on) => ctx.xact_abort = *on,
+        SetStatement::IsolationLevel(level) => {
+            ctx.isolation = match level {
+                IsolationLevel::ReadUncommitted => Isolation::ReadUncommitted,
+                IsolationLevel::ReadCommitted => Isolation::ReadCommitted,
+                IsolationLevel::RepeatableRead => Isolation::RepeatableRead,
+                IsolationLevel::Serializable => Isolation::Serializable,
+            }
+        }
+    }
+    Ok(StatementResult::Done)
 }
 
 // ---- CREATE TABLE -------------------------------------------------------
@@ -341,7 +613,12 @@ fn exec_drop_table(storage: &mut Storage, drop: &DropTable) -> Result<StatementR
 
 // ---- INSERT -------------------------------------------------------------
 
-fn exec_insert(storage: &mut Storage, insert: &Insert) -> Result<StatementResult, SqlError> {
+fn exec_insert(
+    storage: &mut Storage,
+    insert: &Insert,
+    scope: &mut TxnScope,
+    eval_ctx: &EvalContext,
+) -> Result<StatementResult, SqlError> {
     let def = resolve_table(storage, &insert.table.value)
         .ok_or_else(|| SqlError::invalid_object(&insert.table.value).at(insert.table.span))?;
     let schema = def.schema().map_err(|e| map_storage_err(e, &def.name))?;
@@ -414,7 +691,7 @@ fn exec_insert(storage: &mut Storage, insert: &Insert) -> Result<StatementResult
         let mut values = vec![Datum::Null; ncols];
         for (position, expr) in target.iter().zip(row_exprs) {
             let column = &schema.columns[*position];
-            let sql_value = eval_constant(expr)?;
+            let sql_value = eval_constant(expr, eval_ctx)?;
             if sql_value.is_null() && !column.nullable {
                 return Err(SqlError::null_into_not_null(
                     &column.name,
@@ -434,7 +711,7 @@ fn exec_insert(storage: &mut Storage, insert: &Insert) -> Result<StatementResult
                 continue;
             }
             if let Some(text) = def.default_for(index) {
-                let sql_value = eval_default(text)?;
+                let sql_value = eval_default(text, eval_ctx)?;
                 values[index] = value::sql_to_datum(&sql_value, &column.column_type, &column.name)?;
             }
         }
@@ -452,15 +729,15 @@ fn exec_insert(storage: &mut Storage, insert: &Insert) -> Result<StatementResult
 
     let inserted = rows.len() as u64;
     storage
-        .rel_insert_many(&def.name, rows)
+        .rel_insert_many(&def.name, rows, scope)
         .map_err(|err| map_storage_err(err, &def.name))?;
     Ok(StatementResult::RowsAffected(inserted))
 }
 
 /// Evaluates a column DEFAULT (re-parsed from its stored source text).
-fn eval_default(text: &str) -> Result<SqlValue, SqlError> {
+fn eval_default(text: &str, eval_ctx: &EvalContext) -> Result<SqlValue, SqlError> {
     let expr = truthdb_sql::parse_expr(text)?;
-    eval_constant(&expr)
+    eval_constant(&expr, eval_ctx)
 }
 
 /// Coerces a generated identity value to its column's integer type, erroring
@@ -491,7 +768,12 @@ fn identity_datum(column_type: &ColumnType, v: i64) -> Result<Datum, SqlError> {
 
 // ---- UPDATE / DELETE ----------------------------------------------------
 
-fn exec_update(storage: &mut Storage, update: &Update) -> Result<StatementResult, SqlError> {
+fn exec_update(
+    storage: &mut Storage,
+    update: &Update,
+    scope: &mut TxnScope,
+    eval_ctx: &EvalContext,
+) -> Result<StatementResult, SqlError> {
     let def = resolve_table(storage, &update.table.value)
         .ok_or_else(|| SqlError::invalid_object(&update.table.value).at(update.table.span))?;
     let schema = def.schema().map_err(|e| map_storage_err(e, &def.name))?;
@@ -539,7 +821,7 @@ fn exec_update(storage: &mut Storage, update: &Update) -> Result<StatementResult
     let types = schema_types(&schema);
     let mut updates = Vec::new();
     for (locator, row) in located {
-        if !predicate_true(&update.where_clause, &row, &types, &resolver)? {
+        if !predicate_true(&update.where_clause, &row, &types, &resolver, eval_ctx)? {
             continue;
         }
         // Every SET expression sees the pre-update row.
@@ -547,7 +829,7 @@ fn exec_update(storage: &mut Storage, update: &Update) -> Result<StatementResult
         let mut new_row = row;
         for (index, expr) in &assignments {
             let column = &schema.columns[*index];
-            let sql_value = eval::eval(expr, &old_scope, &resolver)?;
+            let sql_value = eval::eval(expr, &old_scope, &resolver, eval_ctx)?;
             if sql_value.is_null() && !column.nullable {
                 return Err(SqlError::null_into_not_null(
                     &column.name,
@@ -559,12 +841,17 @@ fn exec_update(storage: &mut Storage, update: &Update) -> Result<StatementResult
         updates.push((locator, new_row));
     }
     let count = storage
-        .rel_update_located(&def.name, updates)
+        .rel_update_located(&def.name, updates, scope)
         .map_err(|e| map_storage_err(e, &def.name))?;
     Ok(StatementResult::RowsAffected(count as u64))
 }
 
-fn exec_delete(storage: &mut Storage, delete: &Delete) -> Result<StatementResult, SqlError> {
+fn exec_delete(
+    storage: &mut Storage,
+    delete: &Delete,
+    scope: &mut TxnScope,
+    eval_ctx: &EvalContext,
+) -> Result<StatementResult, SqlError> {
     let def = resolve_table(storage, &delete.table.value)
         .ok_or_else(|| SqlError::invalid_object(&delete.table.value).at(delete.table.span))?;
     let schema = def.schema().map_err(|e| map_storage_err(e, &def.name))?;
@@ -576,12 +863,12 @@ fn exec_delete(storage: &mut Storage, delete: &Delete) -> Result<StatementResult
         .map_err(|e| map_storage_err(e, &def.name))?;
     let mut targets = Vec::new();
     for (locator, row) in located {
-        if predicate_true(&delete.where_clause, &row, &types, &resolver)? {
+        if predicate_true(&delete.where_clause, &row, &types, &resolver, eval_ctx)? {
             targets.push(locator);
         }
     }
     let count = storage
-        .rel_delete_located(&def.name, targets)
+        .rel_delete_located(&def.name, targets, scope)
         .map_err(|e| map_storage_err(e, &def.name))?;
     Ok(StatementResult::RowsAffected(count as u64))
 }
@@ -602,11 +889,12 @@ fn predicate_true(
     row: &[Datum],
     types: &[ColumnType],
     resolver: &Vec<String>,
+    eval_ctx: &EvalContext,
 ) -> Result<bool, SqlError> {
     let Some(predicate) = where_clause else {
         return Ok(true);
     };
-    match eval::eval(predicate, &row_values(row, types), resolver)? {
+    match eval::eval(predicate, &row_values(row, types), resolver, eval_ctx)? {
         SqlValue::Bool(b) => Ok(b),
         SqlValue::Null => Ok(false),
         _ => Err(SqlError::new(
@@ -649,7 +937,11 @@ fn row_values(row: &[Datum], types: &[ColumnType]) -> Vec<SqlValue> {
         .collect()
 }
 
-fn exec_select(storage: &mut Storage, select: &Select) -> Result<RowSet, SqlError> {
+fn exec_select(
+    storage: &mut Storage,
+    select: &Select,
+    eval_ctx: &EvalContext,
+) -> Result<RowSet, SqlError> {
     let source = build_source(storage, select.from.as_ref())?;
     let resolver = source.names();
     let types = source.types();
@@ -661,7 +953,7 @@ fn exec_select(storage: &mut Storage, select: &Select) -> Result<RowSet, SqlErro
         let keep = match &select.where_clause {
             None => true,
             Some(predicate) => {
-                let value = eval::eval(predicate, &row_values(&row, &types), &resolver)?;
+                let value = eval::eval(predicate, &row_values(&row, &types), &resolver, eval_ctx)?;
                 match value {
                     SqlValue::Bool(b) => b,
                     SqlValue::Null => false,
@@ -691,6 +983,7 @@ fn exec_select(storage: &mut Storage, select: &Select) -> Result<RowSet, SqlErro
             &types,
             &source.collations,
             &resolver,
+            eval_ctx,
         )?;
     }
 
@@ -699,7 +992,14 @@ fn exec_select(storage: &mut Storage, select: &Select) -> Result<RowSet, SqlErro
         rows.truncate(top as usize);
     }
 
-    project(&select.items, &source.columns, &rows, &types, &resolver)
+    project(
+        &select.items,
+        &source.columns,
+        &rows,
+        &types,
+        &resolver,
+        eval_ctx,
+    )
 }
 
 fn order_rows(
@@ -708,6 +1008,7 @@ fn order_rows(
     types: &[ColumnType],
     collations: &[Option<String>],
     resolver: &Vec<String>,
+    eval_ctx: &EvalContext,
 ) -> Result<(), SqlError> {
     use std::cmp::Ordering;
     // A bare character column is ordered by its collation (its COLLATE clause,
@@ -739,7 +1040,7 @@ fn order_rows(
         let values = row_values(row, types);
         let mut key = Vec::with_capacity(order_by.len());
         for item in order_by {
-            key.push(eval::eval(&item.expr, &values, resolver)?);
+            key.push(eval::eval(&item.expr, &values, resolver, eval_ctx)?);
         }
         keyed.push((key, index));
     }
@@ -772,6 +1073,7 @@ fn project(
     rows: &[Vec<Datum>],
     types: &[ColumnType],
     resolver: &Vec<String>,
+    eval_ctx: &EvalContext,
 ) -> Result<RowSet, SqlError> {
     // Output column plan: a source column (typed, pass-through) or a
     // computed expression (evaluated then typed by inference).
@@ -827,7 +1129,7 @@ fn project(
                 // Evaluate the column for every row, then infer one type.
                 let mut values = Vec::with_capacity(rows.len());
                 for row in &row_sql {
-                    values.push(eval::eval(expr, row, resolver)?);
+                    values.push(eval::eval(expr, row, resolver, eval_ctx)?);
                 }
                 let column_type = value::infer_type(&values);
                 for (out, value) in out_rows.iter_mut().zip(&values) {
@@ -975,9 +1277,9 @@ fn sys_columns(storage: &Storage) -> Source {
 // ---- helpers ------------------------------------------------------------
 
 /// Evaluates a constant expression (INSERT VALUES): no columns in scope.
-fn eval_constant(expr: &Expr) -> Result<SqlValue, SqlError> {
+fn eval_constant(expr: &Expr, eval_ctx: &EvalContext) -> Result<SqlValue, SqlError> {
     let empty: Vec<String> = Vec::new();
-    eval::eval(expr, &[], &empty)
+    eval::eval(expr, &[], &empty, eval_ctx)
 }
 
 fn column_index(schema: &Schema, name: &str) -> Option<usize> {

--- a/crates/truthdb-core/src/relstore/mod.rs
+++ b/crates/truthdb-core/src/relstore/mod.rs
@@ -38,6 +38,11 @@ pub(crate) struct RelState {
     pub tables: HashMap<String, TableDef>,
     pub next_txn_id: u64,
     pub next_object_id: u32,
+    /// Open explicit (multi-statement) transactions. A checkpoint must not run
+    /// while any is open: it would flush their uncommitted pages and truncate
+    /// the WAL past their undo records, making uncommitted writes permanent on
+    /// crash. Autocommit statements never leave one open across calls.
+    pub active_txns: u32,
 }
 
 impl RelState {
@@ -50,6 +55,7 @@ impl RelState {
             tables: HashMap::new(),
             next_txn_id: 1,
             next_object_id: FIRST_USER_OBJECT_ID,
+            active_txns: 0,
         }
     }
 

--- a/crates/truthdb-core/src/relstore/tests.rs
+++ b/crates/truthdb-core/src/relstore/tests.rs
@@ -153,6 +153,39 @@ fn committed_statements_survive_crash_without_checkpoint() {
 }
 
 #[test]
+fn active_transaction_count_gates_checkpoints() {
+    // The checkpoint gate (Engine::maybe_checkpoint) reads
+    // `has_active_transactions`; verify it tracks explicit transactions across
+    // both the commit and rollback paths so a checkpoint can never run while
+    // an explicit transaction is open (which would truncate its undo records).
+    let path = unique_temp_path("active-txn-gate");
+    let mut storage = create_storage(&path);
+    assert!(!storage.has_active_transactions());
+
+    let txn = storage.rel_begin().expect("begin");
+    assert!(
+        storage.has_active_transactions(),
+        "open transaction is active"
+    );
+    storage.rel_commit(txn).expect("commit");
+    assert!(
+        !storage.has_active_transactions(),
+        "commit clears the active transaction"
+    );
+
+    let txn = storage.rel_begin().expect("begin");
+    assert!(storage.has_active_transactions());
+    storage.rel_rollback(txn).expect("rollback");
+    assert!(
+        !storage.has_active_transactions(),
+        "rollback clears the active transaction"
+    );
+
+    drop(storage);
+    let _ = std::fs::remove_file(path);
+}
+
+#[test]
 fn uncommitted_statement_is_undone_and_recovery_rerun_is_clean() {
     let path = unique_temp_path("loser-undo");
     let mut storage = create_storage(&path);

--- a/crates/truthdb-core/src/session.rs
+++ b/crates/truthdb-core/src/session.rs
@@ -1,0 +1,163 @@
+//! The engine actor: a dedicated OS thread owns the [`Engine`] and a
+//! [`SessionManager`], and serves [`EngineCall`]s over a channel. This replaces
+//! the shared `Arc<Mutex<Engine>>` — it serializes engine access (as the mutex
+//! did) but adds per-connection sessions (transaction state lands in Stage 6's
+//! later milestones) and moves the engine's synchronous io_uring work off the
+//! async reactor onto its own thread.
+
+use std::collections::HashMap;
+use std::sync::mpsc;
+use std::thread::JoinHandle;
+
+use tokio::sync::oneshot;
+
+use crate::engine::{Engine, EngineError};
+use crate::rel::BatchOutcome;
+
+/// Identifies a connection's session on the engine thread.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub struct SessionId(u64);
+
+/// Per-connection engine-side state. Transaction/isolation/SET state is added
+/// in later Stage 6 milestones; for now a session is just an identity.
+#[derive(Default)]
+struct Session {}
+
+struct SessionManager {
+    sessions: HashMap<SessionId, Session>,
+    next_id: u64,
+}
+
+impl SessionManager {
+    fn new() -> Self {
+        SessionManager {
+            sessions: HashMap::new(),
+            next_id: 1,
+        }
+    }
+
+    fn open(&mut self) -> SessionId {
+        let id = SessionId(self.next_id);
+        self.next_id += 1;
+        self.sessions.insert(id, Session::default());
+        id
+    }
+
+    fn close(&mut self, id: SessionId) -> Option<Session> {
+        self.sessions.remove(&id)
+    }
+}
+
+/// A message to the engine thread. Each carries a one-shot reply channel the
+/// async caller awaits.
+enum EngineCall {
+    OpenSession {
+        reply: oneshot::Sender<SessionId>,
+    },
+    /// A SQL batch on behalf of a session (TDS path): typed results.
+    RunBatch {
+        session: SessionId,
+        sql: String,
+        reply: oneshot::Sender<Result<BatchOutcome, EngineError>>,
+    },
+    /// A native-protocol command (ES or SQL): rendered text.
+    RunNative {
+        command: String,
+        reply: oneshot::Sender<Result<String, EngineError>>,
+    },
+    CloseSession {
+        session: SessionId,
+    },
+    Shutdown,
+}
+
+/// A cloneable handle to the engine thread. Cheap to clone (shares the sender).
+#[derive(Clone)]
+pub struct EngineHandle {
+    tx: mpsc::Sender<EngineCall>,
+}
+
+impl EngineHandle {
+    /// Opens a session; returns its id (or a placeholder if the engine is gone).
+    pub async fn open_session(&self) -> SessionId {
+        let (reply, rx) = oneshot::channel();
+        if self.tx.send(EngineCall::OpenSession { reply }).is_err() {
+            return SessionId(0);
+        }
+        rx.await.unwrap_or(SessionId(0))
+    }
+
+    /// Runs a SQL batch for a session and returns its typed outcome.
+    pub async fn run_batch(
+        &self,
+        session: SessionId,
+        sql: String,
+    ) -> Result<BatchOutcome, EngineError> {
+        let (reply, rx) = oneshot::channel();
+        self.tx
+            .send(EngineCall::RunBatch {
+                session,
+                sql,
+                reply,
+            })
+            .map_err(|_| EngineError::Unavailable)?;
+        rx.await.map_err(|_| EngineError::Unavailable)?
+    }
+
+    /// Runs a native-protocol command (ES or SQL) and returns rendered text.
+    pub async fn run_native(&self, command: String) -> Result<String, EngineError> {
+        let (reply, rx) = oneshot::channel();
+        self.tx
+            .send(EngineCall::RunNative { command, reply })
+            .map_err(|_| EngineError::Unavailable)?;
+        rx.await.map_err(|_| EngineError::Unavailable)?
+    }
+
+    /// Closes a session (rolling back any open transaction — later milestone).
+    pub fn close_session(&self, session: SessionId) {
+        let _ = self.tx.send(EngineCall::CloseSession { session });
+    }
+
+    /// Asks the engine thread to stop after draining queued calls.
+    pub fn shutdown(&self) {
+        let _ = self.tx.send(EngineCall::Shutdown);
+    }
+}
+
+/// Spawns the engine thread and returns a handle plus its join handle.
+pub fn spawn_engine(engine: Engine) -> (EngineHandle, JoinHandle<()>) {
+    let (tx, rx) = mpsc::channel();
+    let join = std::thread::Builder::new()
+        .name("truthdb-engine".to_string())
+        .spawn(move || engine_loop(engine, rx))
+        .expect("spawn engine thread");
+    (EngineHandle { tx }, join)
+}
+
+fn engine_loop(mut engine: Engine, rx: mpsc::Receiver<EngineCall>) {
+    let mut sessions = SessionManager::new();
+    while let Ok(call) = rx.recv() {
+        match call {
+            EngineCall::OpenSession { reply } => {
+                let _ = reply.send(sessions.open());
+            }
+            EngineCall::RunBatch {
+                session,
+                sql,
+                reply,
+            } => {
+                // The session context (transactions/locks) is threaded here in
+                // later milestones; for now every batch is autocommit.
+                let _ = &session;
+                let _ = reply.send(engine.sql_batch(&sql));
+            }
+            EngineCall::RunNative { command, reply } => {
+                let _ = reply.send(engine.execute(&command));
+            }
+            EngineCall::CloseSession { session } => {
+                sessions.close(session);
+            }
+            EngineCall::Shutdown => break,
+        }
+    }
+}

--- a/crates/truthdb-core/src/session.rs
+++ b/crates/truthdb-core/src/session.rs
@@ -1,27 +1,67 @@
 //! The engine actor: a dedicated OS thread owns the [`Engine`] and a
 //! [`SessionManager`], and serves [`EngineCall`]s over a channel. This replaces
 //! the shared `Arc<Mutex<Engine>>` — it serializes engine access (as the mutex
-//! did) but adds per-connection sessions (transaction state lands in Stage 6's
-//! later milestones) and moves the engine's synchronous io_uring work off the
-//! async reactor onto its own thread.
+//! did), carries per-connection sessions (transaction/isolation state) and
+//! moves the engine's synchronous io_uring work off the async reactor onto its
+//! own thread.
+//!
+//! ## Locking without blocking the actor
+//!
+//! The actor runs one call at a time, so it must never block in place waiting
+//! for a lock — the lock's holder could only release by having its own call
+//! processed, which the blocked thread would prevent (self-deadlock). Instead
+//! a batch acquires *all* the table/database locks it needs up front (see
+//! [`crate::rel::analyze_locks`]) before running any statement. If one
+//! conflicts, the whole [`EngineCall::RunBatch`] is *parked* — its reply
+//! deferred — and the actor moves on. Releasing locks (commit / rollback /
+//! disconnect) wakes parked batches in FIFO order and re-attempts them; since
+//! a parked batch never ran, restarting it is exact. A 5 s deadline reaps a
+//! batch stuck behind a deadlock, rolling it back as the victim (error 1205).
 
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::sync::mpsc;
 use std::thread::JoinHandle;
+use std::time::{Duration, Instant};
 
 use tokio::sync::oneshot;
 
+use truthdb_sql::error::SqlError;
+
 use crate::engine::{Engine, EngineError};
-use crate::rel::BatchOutcome;
+use crate::lock::{LockManager, LockMode, Resource};
+use crate::rel::{BatchOutcome, Isolation, TxnContext};
+
+/// How long a batch may wait on a lock before it is treated as a deadlock
+/// victim and rolled back (SQL Server-style, plan: "5 s wait timeout →
+/// abort youngest").
+const LOCK_WAIT_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// The result of running a batch for a session: its typed outcome plus
+/// whether the connection is still inside a transaction afterwards (so the
+/// TDS gateway can set `DONE_INXACT`).
+pub struct BatchReply {
+    pub outcome: BatchOutcome,
+    pub in_transaction: bool,
+}
 
 /// Identifies a connection's session on the engine thread.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub struct SessionId(u64);
 
-/// Per-connection engine-side state. Transaction/isolation/SET state is added
-/// in later Stage 6 milestones; for now a session is just an identity.
+impl SessionId {
+    /// The raw id used as the lock-manager owner key.
+    fn raw(self) -> u64 {
+        self.0
+    }
+}
+
+/// Per-connection engine-side state: the transaction context carried across a
+/// connection's batches (open transaction, `@@TRANCOUNT`, isolation, SET
+/// options).
 #[derive(Default)]
-struct Session {}
+struct Session {
+    txn_ctx: TxnContext,
+}
 
 struct SessionManager {
     sessions: HashMap<SessionId, Session>,
@@ -46,6 +86,14 @@ impl SessionManager {
     fn close(&mut self, id: SessionId) -> Option<Session> {
         self.sessions.remove(&id)
     }
+
+    fn get(&self, id: SessionId) -> Option<&Session> {
+        self.sessions.get(&id)
+    }
+
+    fn get_mut(&mut self, id: SessionId) -> Option<&mut Session> {
+        self.sessions.get_mut(&id)
+    }
 }
 
 /// A message to the engine thread. Each carries a one-shot reply channel the
@@ -58,7 +106,7 @@ enum EngineCall {
     RunBatch {
         session: SessionId,
         sql: String,
-        reply: oneshot::Sender<Result<BatchOutcome, EngineError>>,
+        reply: oneshot::Sender<Result<BatchReply, EngineError>>,
     },
     /// A native-protocol command (ES or SQL): rendered text.
     RunNative {
@@ -87,12 +135,13 @@ impl EngineHandle {
         rx.await.unwrap_or(SessionId(0))
     }
 
-    /// Runs a SQL batch for a session and returns its typed outcome.
+    /// Runs a SQL batch for a session and returns its typed outcome plus the
+    /// connection's post-batch transaction state.
     pub async fn run_batch(
         &self,
         session: SessionId,
         sql: String,
-    ) -> Result<BatchOutcome, EngineError> {
+    ) -> Result<BatchReply, EngineError> {
         let (reply, rx) = oneshot::channel();
         self.tx
             .send(EngineCall::RunBatch {
@@ -129,35 +178,743 @@ pub fn spawn_engine(engine: Engine) -> (EngineHandle, JoinHandle<()>) {
     let (tx, rx) = mpsc::channel();
     let join = std::thread::Builder::new()
         .name("truthdb-engine".to_string())
-        .spawn(move || engine_loop(engine, rx))
+        .spawn(move || EngineLoop::new(engine).run(rx))
         .expect("spawn engine thread");
     (EngineHandle { tx }, join)
 }
 
-fn engine_loop(mut engine: Engine, rx: mpsc::Receiver<EngineCall>) {
-    let mut sessions = SessionManager::new();
-    while let Ok(call) = rx.recv() {
-        match call {
-            EngineCall::OpenSession { reply } => {
-                let _ = reply.send(sessions.open());
+/// Like [`spawn_engine`] but with a custom lock-wait timeout, so tests can
+/// exercise the deadlock reaper without a real 5 s wait.
+#[cfg(test)]
+fn spawn_engine_with_timeout(engine: Engine, timeout: Duration) -> (EngineHandle, JoinHandle<()>) {
+    let (tx, rx) = mpsc::channel();
+    let join = std::thread::Builder::new()
+        .name("truthdb-engine-test".to_string())
+        .spawn(move || {
+            let mut engine_loop = EngineLoop::new(engine);
+            engine_loop.lock_wait_timeout = timeout;
+            engine_loop.run(rx);
+        })
+        .expect("spawn engine thread");
+    (EngineHandle { tx }, join)
+}
+
+/// A SQL batch waiting for locks: its request, the locks it needs, and the
+/// deadline past which it is treated as a deadlock victim.
+struct Parked {
+    session: SessionId,
+    sql: String,
+    reply: oneshot::Sender<Result<BatchReply, EngineError>>,
+    needs: Vec<(Resource, LockMode)>,
+    deadline: Instant,
+}
+
+/// The engine actor's mutable world: the engine, its sessions, the lock
+/// manager, and the FIFO queue of batches parked on locks.
+struct EngineLoop {
+    engine: Engine,
+    sessions: SessionManager,
+    locks: LockManager,
+    parked: VecDeque<Parked>,
+    lock_wait_timeout: Duration,
+}
+
+impl EngineLoop {
+    fn new(engine: Engine) -> Self {
+        EngineLoop {
+            engine,
+            sessions: SessionManager::new(),
+            locks: LockManager::new(),
+            parked: VecDeque::new(),
+            lock_wait_timeout: LOCK_WAIT_TIMEOUT,
+        }
+    }
+
+    fn run(mut self, rx: mpsc::Receiver<EngineCall>) {
+        loop {
+            // Wake at the earliest parked deadline so deadlocked waiters are
+            // reaped even if no new call arrives.
+            let call = match self.earliest_deadline() {
+                Some(deadline) => {
+                    let wait = deadline.saturating_duration_since(Instant::now());
+                    match rx.recv_timeout(wait) {
+                        Ok(call) => Some(call),
+                        Err(mpsc::RecvTimeoutError::Timeout) => None,
+                        Err(mpsc::RecvTimeoutError::Disconnected) => break,
+                    }
+                }
+                None => match rx.recv() {
+                    Ok(call) => Some(call),
+                    Err(_) => break,
+                },
+            };
+            self.reap_expired();
+            match call {
+                Some(EngineCall::OpenSession { reply }) => {
+                    let _ = reply.send(self.sessions.open());
+                }
+                Some(EngineCall::RunBatch {
+                    session,
+                    sql,
+                    reply,
+                }) => self.dispatch_batch(session, sql, reply),
+                Some(EngineCall::RunNative { command, reply }) => {
+                    let _ = reply.send(self.engine.execute(&command));
+                }
+                Some(EngineCall::CloseSession { session }) => self.close_session(session),
+                Some(EngineCall::Shutdown) => break,
+                None => {}
             }
-            EngineCall::RunBatch {
+        }
+        // Draining: fail any batches still parked so their callers unblock.
+        for parked in self.parked.drain(..) {
+            let _ = parked.reply.send(Err(EngineError::Unavailable));
+        }
+    }
+
+    fn earliest_deadline(&self) -> Option<Instant> {
+        self.parked.iter().map(|p| p.deadline).min()
+    }
+
+    /// Acquires a batch's locks and runs it, or parks it behind a conflict.
+    fn dispatch_batch(
+        &mut self,
+        session: SessionId,
+        sql: String,
+        reply: oneshot::Sender<Result<BatchReply, EngineError>>,
+    ) {
+        let isolation = self
+            .sessions
+            .get(session)
+            .map(|s| s.txn_ctx.isolation())
+            .unwrap_or_default();
+        let needs = self.engine.analyze_locks(&sql, isolation);
+        if self.try_acquire(session.raw(), &needs, true) {
+            self.run_and_reply(session, &sql, reply);
+            self.wake_parked();
+        } else {
+            self.parked.push_back(Parked {
                 session,
                 sql,
                 reply,
-            } => {
-                // The session context (transactions/locks) is threaded here in
-                // later milestones; for now every batch is autocommit.
-                let _ = &session;
-                let _ = reply.send(engine.sql_batch(&sql));
-            }
-            EngineCall::RunNative { command, reply } => {
-                let _ = reply.send(engine.execute(&command));
-            }
-            EngineCall::CloseSession { session } => {
-                sessions.close(session);
-            }
-            EngineCall::Shutdown => break,
+                needs,
+                deadline: Instant::now() + self.lock_wait_timeout,
+            });
         }
+    }
+
+    /// Tries to grant every lock in `needs` to `owner` atomically. When
+    /// `respect_queue` is set, an incoming batch also yields to any resource a
+    /// parked waiter (of another owner) is already queued for — FIFO fairness,
+    /// no barging. A resource the owner ALREADY holds is exempt from that
+    /// yield: re-acquiring or upgrading a held lock is not queue-jumping, and
+    /// yielding there would make a transaction wait on its own lock (a waiter
+    /// parked behind that lock can never release it), a false self-deadlock.
+    /// Returns whether all locks were granted.
+    fn try_acquire(
+        &mut self,
+        owner: u64,
+        needs: &[(Resource, LockMode)],
+        respect_queue: bool,
+    ) -> bool {
+        let blocked = needs.iter().any(|(resource, mode)| {
+            let queued = respect_queue
+                && !self.locks.holds(owner, *resource)
+                && self.parked.iter().any(|p| {
+                    p.session.raw() != owner && p.needs.iter().any(|(r, _)| r == resource)
+                });
+            queued || self.locks.conflict(owner, *resource, *mode).is_some()
+        });
+        if blocked {
+            return false;
+        }
+        for (resource, mode) in needs {
+            self.locks.grant(owner, *resource, *mode);
+        }
+        true
+    }
+
+    /// Runs a batch whose locks are already held, replies, then releases the
+    /// locks that do not outlive it (all of them once the transaction closes;
+    /// read locks after each statement under READ COMMITTED).
+    fn run_and_reply(
+        &mut self,
+        session: SessionId,
+        sql: &str,
+        reply: oneshot::Sender<Result<BatchReply, EngineError>>,
+    ) {
+        let owner = session.raw();
+        let outcome = match self.sessions.get_mut(session) {
+            Some(state) => self.engine.sql_batch(sql, &mut state.txn_ctx),
+            None => {
+                // Unknown session: one-shot autocommit, hold no locks after.
+                let mut txn_ctx = TxnContext::default();
+                let out = self.engine.sql_batch(sql, &mut txn_ctx);
+                self.engine.abort_session_txn(&mut txn_ctx);
+                out
+            }
+        };
+        let in_transaction = match self.sessions.get(session) {
+            Some(state) if state.txn_ctx.has_open_transaction() => {
+                // Transaction still open: keep write locks. Under READ
+                // COMMITTED shared locks do not survive the statement.
+                if matches!(state.txn_ctx.isolation(), Isolation::ReadCommitted) {
+                    self.locks.release_read_locks(owner);
+                }
+                true
+            }
+            // Transaction closed (autocommit or COMMIT/ROLLBACK) or unknown
+            // session: drop every lock the batch acquired.
+            _ => {
+                self.locks.release_all(owner);
+                false
+            }
+        };
+        let _ = reply.send(outcome.map(|outcome| BatchReply {
+            outcome,
+            in_transaction,
+        }));
+    }
+
+    /// Re-attempts parked batches in FIFO order until none can proceed. A
+    /// woken batch may itself release locks (autocommit / commit), so this
+    /// re-scans from the front after each grant.
+    fn wake_parked(&mut self) {
+        loop {
+            let mut ran = false;
+            let mut i = 0;
+            while i < self.parked.len() {
+                let owner = self.parked[i].session.raw();
+                // Only waiters ahead in the queue have priority (FIFO); a
+                // waiter never yields to itself or to those behind it.
+                let ahead: Vec<(Resource, LockMode)> = self
+                    .parked
+                    .iter()
+                    .take(i)
+                    .filter(|p| p.session.raw() != owner)
+                    .flat_map(|p| p.needs.iter().copied())
+                    .collect();
+                let grantable = self.parked[i].needs.iter().all(|(resource, mode)| {
+                    // A resource the waiter already holds is exempt from the
+                    // FIFO yield (it is not jumping the queue for it), matching
+                    // try_acquire.
+                    (self.locks.holds(owner, *resource)
+                        || !ahead.iter().any(|(r, _)| r == resource))
+                        && self.locks.conflict(owner, *resource, *mode).is_none()
+                });
+                if grantable {
+                    let parked = self.parked.remove(i).expect("index in bounds");
+                    for (resource, mode) in &parked.needs {
+                        self.locks.grant(owner, *resource, *mode);
+                    }
+                    self.run_and_reply(parked.session, &parked.sql, parked.reply);
+                    ran = true;
+                    break; // re-scan from the front (locks may have changed)
+                }
+                i += 1;
+            }
+            if !ran {
+                break;
+            }
+        }
+    }
+
+    /// Rolls back the single earliest-deadline batch whose wait has expired
+    /// (the deadlock victim), then wakes anyone its released locks unblock —
+    /// which typically rescues its deadlock partner before that partner is
+    /// itself reaped. Any further expired waiters are handled on the next
+    /// loop iteration.
+    fn reap_expired(&mut self) {
+        let now = Instant::now();
+        let victim_idx = self
+            .parked
+            .iter()
+            .enumerate()
+            .filter(|(_, p)| p.deadline <= now)
+            .min_by_key(|(_, p)| p.deadline)
+            .map(|(i, _)| i);
+        let Some(idx) = victim_idx else {
+            return;
+        };
+        let victim = self.parked.remove(idx).expect("index in bounds");
+        if let Some(state) = self.sessions.get_mut(victim.session) {
+            self.engine.abort_session_txn(&mut state.txn_ctx);
+        }
+        self.locks.release_all(victim.session.raw());
+        let _ = victim.reply.send(Ok(deadlock_victim_reply()));
+        self.wake_parked();
+    }
+
+    /// Handles a disconnect: roll back any open transaction, release the
+    /// session's locks, and wake anyone that was waiting on them.
+    fn close_session(&mut self, session: SessionId) {
+        if let Some(mut state) = self.sessions.close(session)
+            && state.txn_ctx.has_open_transaction()
+        {
+            self.engine.abort_session_txn(&mut state.txn_ctx);
+        }
+        self.locks.release_all(session.raw());
+        self.wake_parked();
+    }
+}
+
+/// The reply delivered to a deadlock victim: no results, error 1205, and the
+/// transaction is over (it was rolled back).
+fn deadlock_victim_reply() -> BatchReply {
+    BatchReply {
+        outcome: BatchOutcome {
+            results: Vec::new(),
+            error: Some(SqlError::new(
+                1205,
+                13,
+                51,
+                "Transaction was deadlocked on lock resources with another process and has been chosen as the deadlock victim. Rerun the transaction.",
+            )),
+        },
+        in_transaction: false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::engine::Engine;
+    use crate::rel::StatementResult;
+    use crate::relstore::types::Datum;
+    use crate::storage::{Storage, StorageOptions};
+    use std::path::PathBuf;
+
+    fn test_storage_options() -> StorageOptions {
+        StorageOptions {
+            size_gib: 1,
+            wal_ratio: 0.05,
+            metadata_ratio: 0.08,
+            snapshot_ratio: 0.02,
+            allocator_ratio: 0.02,
+            reserved_ratio: 0.17,
+        }
+    }
+
+    fn unique_temp_path(label: &str) -> PathBuf {
+        let mut path = std::env::temp_dir();
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system time before unix epoch")
+            .as_nanos();
+        path.push(format!("truthdb-lock-{label}-{nanos}.db"));
+        path
+    }
+
+    /// A running engine plus the temp file backing it (removed on drop).
+    struct Harness {
+        handle: EngineHandle,
+        path: PathBuf,
+    }
+
+    impl Drop for Harness {
+        fn drop(&mut self) {
+            self.handle.shutdown();
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+
+    fn start(timeout: Duration) -> Harness {
+        let path = unique_temp_path("engine");
+        let storage = Storage::create(path.clone(), test_storage_options()).expect("create");
+        let engine = Engine::new(storage).expect("engine");
+        let (handle, _join) = spawn_engine_with_timeout(engine, timeout);
+        Harness { handle, path }
+    }
+
+    /// The `id` column (column 0) of the first rowset, as i64s.
+    fn ids(reply: &BatchReply) -> Vec<i64> {
+        for result in &reply.outcome.results {
+            if let StatementResult::Rows(rowset) = result {
+                return rowset
+                    .rows
+                    .iter()
+                    .map(|row| match row[0] {
+                        Datum::TinyInt(v) => v as i64,
+                        Datum::SmallInt(v) => v as i64,
+                        Datum::Int(v) => v as i64,
+                        Datum::BigInt(v) => v,
+                        ref other => panic!("expected integer id, got {other:?}"),
+                    })
+                    .collect();
+            }
+        }
+        panic!("no rowset in outcome");
+    }
+
+    fn error_number(reply: &BatchReply) -> Option<i32> {
+        reply.outcome.error.as_ref().map(|e| e.number)
+    }
+
+    #[tokio::test]
+    async fn writer_blocks_reader_until_commit() {
+        let h = start(Duration::from_secs(30));
+        let a = h.handle.open_session().await;
+        let b = h.handle.open_session().await;
+
+        h.handle
+            .run_batch(a, "CREATE TABLE t (id INT NOT NULL PRIMARY KEY)".into())
+            .await
+            .unwrap();
+        // A opens a transaction and writes, holding X on t.
+        h.handle
+            .run_batch(a, "BEGIN TRAN; INSERT INTO t VALUES (1);".into())
+            .await
+            .unwrap();
+
+        // B's read must block (READ COMMITTED cannot read A's uncommitted row).
+        let handle_b = h.handle.clone();
+        let read = tokio::spawn(async move {
+            handle_b
+                .run_batch(b, "SELECT id FROM t".into())
+                .await
+                .unwrap()
+        });
+        tokio::time::sleep(Duration::from_millis(150)).await;
+        assert!(
+            !read.is_finished(),
+            "reader should be blocked by the writer"
+        );
+
+        // A commits → releases X → B unblocks and sees the committed row.
+        h.handle.run_batch(a, "COMMIT".into()).await.unwrap();
+        let out = tokio::time::timeout(Duration::from_secs(5), read)
+            .await
+            .expect("reader should unblock after commit")
+            .unwrap();
+        assert_eq!(ids(&out), vec![1]);
+    }
+
+    #[tokio::test]
+    async fn read_uncommitted_sees_uncommitted_rows_without_blocking() {
+        let h = start(Duration::from_secs(30));
+        let a = h.handle.open_session().await;
+        let b = h.handle.open_session().await;
+
+        h.handle
+            .run_batch(a, "CREATE TABLE t (id INT NOT NULL PRIMARY KEY)".into())
+            .await
+            .unwrap();
+        h.handle
+            .run_batch(a, "BEGIN TRAN; INSERT INTO t VALUES (7);".into())
+            .await
+            .unwrap();
+
+        // B under READ UNCOMMITTED takes no read lock → dirty-reads A's row.
+        h.handle
+            .run_batch(b, "SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED".into())
+            .await
+            .unwrap();
+        let out = tokio::time::timeout(
+            Duration::from_secs(2),
+            h.handle.run_batch(b, "SELECT id FROM t".into()),
+        )
+        .await
+        .expect("READ UNCOMMITTED must not block")
+        .unwrap();
+        assert_eq!(ids(&out), vec![7], "dirty read sees the uncommitted row");
+
+        h.handle.run_batch(a, "ROLLBACK".into()).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn disconnect_releases_locks_and_wakes_waiter() {
+        let h = start(Duration::from_secs(30));
+        let a = h.handle.open_session().await;
+        let b = h.handle.open_session().await;
+
+        h.handle
+            .run_batch(a, "CREATE TABLE t (id INT NOT NULL PRIMARY KEY)".into())
+            .await
+            .unwrap();
+        h.handle
+            .run_batch(a, "BEGIN TRAN; INSERT INTO t VALUES (1);".into())
+            .await
+            .unwrap();
+
+        let handle_b = h.handle.clone();
+        let read = tokio::spawn(async move {
+            handle_b
+                .run_batch(b, "SELECT id FROM t".into())
+                .await
+                .unwrap()
+        });
+        tokio::time::sleep(Duration::from_millis(150)).await;
+        assert!(!read.is_finished(), "reader blocked by open writer txn");
+
+        // A disconnects mid-transaction: rollback releases the lock, waking B,
+        // which now sees an empty table (the insert was undone).
+        h.handle.close_session(a);
+        let out = tokio::time::timeout(Duration::from_secs(5), read)
+            .await
+            .expect("reader should unblock on disconnect")
+            .unwrap();
+        assert_eq!(ids(&out), Vec::<i64>::new());
+    }
+
+    #[tokio::test]
+    async fn deadlock_is_broken_by_timeout_with_1205() {
+        // Short timeout so the reaper fires quickly.
+        let h = start(Duration::from_millis(300));
+        let a = h.handle.open_session().await;
+        let b = h.handle.open_session().await;
+
+        for stmt in [
+            "CREATE TABLE a (id INT NOT NULL PRIMARY KEY)",
+            "CREATE TABLE b (id INT NOT NULL PRIMARY KEY)",
+            "INSERT INTO a VALUES (1)",
+            "INSERT INTO b VALUES (1)",
+        ] {
+            h.handle.run_batch(a, stmt.into()).await.unwrap();
+        }
+
+        // A locks table a; B locks table b (each in its own transaction).
+        h.handle
+            .run_batch(a, "BEGIN TRAN; UPDATE a SET id = id".into())
+            .await
+            .unwrap();
+        h.handle
+            .run_batch(b, "BEGIN TRAN; UPDATE b SET id = id".into())
+            .await
+            .unwrap();
+
+        // Now each waits for the other's table → deadlock.
+        let ha = h.handle.clone();
+        let a_waits =
+            tokio::spawn(async move { ha.run_batch(a, "UPDATE b SET id = id".into()).await });
+        let hb = h.handle.clone();
+        let b_waits =
+            tokio::spawn(async move { hb.run_batch(b, "UPDATE a SET id = id".into()).await });
+
+        let a_out = tokio::time::timeout(Duration::from_secs(5), a_waits)
+            .await
+            .expect("a_waits resolved")
+            .unwrap()
+            .unwrap();
+        let b_out = tokio::time::timeout(Duration::from_secs(5), b_waits)
+            .await
+            .expect("b_waits resolved")
+            .unwrap()
+            .unwrap();
+
+        // Exactly one is the deadlock victim (1205); the other succeeds.
+        let victims = [&a_out, &b_out]
+            .iter()
+            .filter(|o| error_number(o) == Some(1205))
+            .count();
+        assert_eq!(victims, 1, "exactly one transaction is the deadlock victim");
+    }
+
+    #[tokio::test]
+    async fn repeatable_read_holds_shared_lock_and_blocks_a_writer() {
+        let h = start(Duration::from_secs(30));
+        let a = h.handle.open_session().await;
+        let b = h.handle.open_session().await;
+        h.handle
+            .run_batch(a, "CREATE TABLE t (id INT NOT NULL PRIMARY KEY)".into())
+            .await
+            .unwrap();
+        h.handle
+            .run_batch(a, "INSERT INTO t VALUES (1)".into())
+            .await
+            .unwrap();
+
+        // A reads under REPEATABLE READ inside a transaction → holds S on t.
+        h.handle
+            .run_batch(a, "SET TRANSACTION ISOLATION LEVEL REPEATABLE READ".into())
+            .await
+            .unwrap();
+        h.handle
+            .run_batch(a, "BEGIN TRAN; SELECT id FROM t;".into())
+            .await
+            .unwrap();
+
+        // B's write must block on A's retained shared lock.
+        let hb = h.handle.clone();
+        let write = tokio::spawn(async move {
+            hb.run_batch(b, "UPDATE t SET id = id".into())
+                .await
+                .unwrap()
+        });
+        tokio::time::sleep(Duration::from_millis(150)).await;
+        assert!(
+            !write.is_finished(),
+            "REPEATABLE READ keeps the shared lock, blocking the writer"
+        );
+
+        // A commits → releases S → B proceeds.
+        h.handle.run_batch(a, "COMMIT".into()).await.unwrap();
+        let out = tokio::time::timeout(Duration::from_secs(5), write)
+            .await
+            .expect("writer unblocks after reader commits")
+            .unwrap();
+        assert!(out.outcome.error.is_none(), "{:?}", out.outcome.error);
+    }
+
+    #[tokio::test]
+    async fn read_committed_releases_shared_lock_so_a_writer_proceeds() {
+        let h = start(Duration::from_secs(30));
+        let a = h.handle.open_session().await;
+        let b = h.handle.open_session().await;
+        h.handle
+            .run_batch(a, "CREATE TABLE t (id INT NOT NULL PRIMARY KEY)".into())
+            .await
+            .unwrap();
+        h.handle
+            .run_batch(a, "INSERT INTO t VALUES (1)".into())
+            .await
+            .unwrap();
+
+        // A reads under READ COMMITTED (the default) inside a transaction; its
+        // shared lock is dropped at statement end even though the txn stays open.
+        h.handle
+            .run_batch(a, "BEGIN TRAN; SELECT id FROM t;".into())
+            .await
+            .unwrap();
+
+        // B's write is NOT blocked — unlike REPEATABLE READ above.
+        let out = tokio::time::timeout(
+            Duration::from_secs(2),
+            h.handle.run_batch(b, "UPDATE t SET id = id".into()),
+        )
+        .await
+        .expect("READ COMMITTED releases the shared lock, so the writer runs")
+        .unwrap();
+        assert!(out.outcome.error.is_none(), "{:?}", out.outcome.error);
+
+        h.handle.run_batch(a, "ROLLBACK".into()).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn isolation_escalation_within_a_batch_locks_the_read() {
+        let h = start(Duration::from_secs(30));
+        let a = h.handle.open_session().await;
+        let b = h.handle.open_session().await;
+        h.handle
+            .run_batch(a, "CREATE TABLE t (id INT NOT NULL PRIMARY KEY)".into())
+            .await
+            .unwrap();
+        h.handle
+            .run_batch(a, "INSERT INTO t VALUES (1)".into())
+            .await
+            .unwrap();
+
+        // A holds X on t.
+        h.handle
+            .run_batch(a, "BEGIN TRAN; UPDATE t SET id = id;".into())
+            .await
+            .unwrap();
+
+        // B is READ UNCOMMITTED, so a plain read would take no lock and could
+        // dirty-read. But B raises the level to SERIALIZABLE in the SAME batch
+        // as the read, which must lock the read → it blocks on A's writer.
+        h.handle
+            .run_batch(b, "SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED".into())
+            .await
+            .unwrap();
+        let hb = h.handle.clone();
+        let read = tokio::spawn(async move {
+            hb.run_batch(
+                b,
+                "SET TRANSACTION ISOLATION LEVEL SERIALIZABLE; SELECT id FROM t;".into(),
+            )
+            .await
+            .unwrap()
+        });
+        tokio::time::sleep(Duration::from_millis(150)).await;
+        assert!(
+            !read.is_finished(),
+            "an escalated read must lock and block on the uncommitted writer"
+        );
+
+        h.handle.run_batch(a, "COMMIT".into()).await.unwrap();
+        let out = tokio::time::timeout(Duration::from_secs(5), read)
+            .await
+            .expect("escalated read unblocks after commit")
+            .unwrap();
+        assert_eq!(ids(&out), vec![1]);
+    }
+
+    #[tokio::test]
+    async fn holder_is_not_blocked_by_a_waiter_on_its_own_lock() {
+        let h = start(Duration::from_secs(30));
+        let a = h.handle.open_session().await;
+        let b = h.handle.open_session().await;
+        h.handle
+            .run_batch(a, "CREATE TABLE t (id INT NOT NULL PRIMARY KEY)".into())
+            .await
+            .unwrap();
+        h.handle
+            .run_batch(a, "INSERT INTO t VALUES (1)".into())
+            .await
+            .unwrap();
+
+        // A holds X on t via an open transaction.
+        h.handle
+            .run_batch(a, "BEGIN TRAN; UPDATE t SET id = id;".into())
+            .await
+            .unwrap();
+
+        // B blocks on t and parks in the queue.
+        let hb = h.handle.clone();
+        let b_read =
+            tokio::spawn(async move { hb.run_batch(b, "SELECT id FROM t".into()).await.unwrap() });
+        tokio::time::sleep(Duration::from_millis(150)).await;
+        assert!(!b_read.is_finished(), "B parks on A's lock");
+
+        // A re-touches t in a new batch. Because A already holds the lock, it
+        // must NOT yield to the queued waiter B — doing so would deadlock A on
+        // its own lock. This completes promptly.
+        let again = tokio::time::timeout(
+            Duration::from_secs(2),
+            h.handle.run_batch(a, "UPDATE t SET id = id".into()),
+        )
+        .await
+        .expect("holder must not self-deadlock on a waiter behind its own lock")
+        .unwrap();
+        assert!(again.outcome.error.is_none(), "{:?}", again.outcome.error);
+
+        // A commits → B finally proceeds.
+        h.handle.run_batch(a, "COMMIT".into()).await.unwrap();
+        let out = tokio::time::timeout(Duration::from_secs(5), b_read)
+            .await
+            .expect("B unblocks after A commits")
+            .unwrap();
+        assert_eq!(ids(&out), vec![1]);
+    }
+
+    #[tokio::test]
+    async fn autocommit_reads_run_concurrently() {
+        let h = start(Duration::from_secs(30));
+        let a = h.handle.open_session().await;
+        let b = h.handle.open_session().await;
+        h.handle
+            .run_batch(a, "CREATE TABLE t (id INT NOT NULL PRIMARY KEY)".into())
+            .await
+            .unwrap();
+        h.handle
+            .run_batch(a, "INSERT INTO t VALUES (1)".into())
+            .await
+            .unwrap();
+
+        // Two shared readers never block each other.
+        let out_a = h
+            .handle
+            .run_batch(a, "SELECT id FROM t".into())
+            .await
+            .unwrap();
+        let out_b = tokio::time::timeout(
+            Duration::from_secs(2),
+            h.handle.run_batch(b, "SELECT id FROM t".into()),
+        )
+        .await
+        .expect("concurrent shared reads must not block")
+        .unwrap();
+        assert_eq!(ids(&out_a), vec![1]);
+        assert_eq!(ids(&out_b), vec![1]);
     }
 }

--- a/crates/truthdb-core/src/storage.rs
+++ b/crates/truthdb-core/src/storage.rs
@@ -313,16 +313,17 @@ impl Storage {
     }
 
     pub fn rel_insert(&mut self, name: &str, values: Vec<Datum>) -> Result<(), StorageError> {
-        self.rel_insert_many(name, vec![values])
+        self.rel_insert_many(name, vec![values], &mut TxnScope::Auto)
     }
 
     /// Inserts many rows as ONE atomic statement: all rows land or none do
     /// (a later row's constraint failure rolls back the whole statement,
     /// matching T-SQL multi-row `INSERT ... VALUES` semantics).
-    pub fn rel_insert_many(
+    pub(crate) fn rel_insert_many(
         &mut self,
         name: &str,
         rows: Vec<Vec<Datum>>,
+        scope: &mut TxnScope,
     ) -> Result<(), StorageError> {
         self.file.ensure_rel_usable()?;
         let (def, schema) = self.rel_def(name)?;
@@ -345,7 +346,7 @@ impl Storage {
                 object_id: def.object_id,
                 root: def.root_page,
             };
-            self.file.rel_statement(move |ctx, txn| {
+            self.file.rel_statement_scoped(scope, move |ctx, txn| {
                 for (key, row) in &encoded {
                     let key = key.as_ref().expect("tree row has a key");
                     match tree.insert_unique(ctx, &mut OpMode::Txn(txn), key, row)? {
@@ -364,7 +365,7 @@ impl Storage {
                 object_id: def.object_id,
                 first_page: def.root_page,
             };
-            self.file.rel_statement(move |ctx, txn| {
+            self.file.rel_statement_scoped(scope, move |ctx, txn| {
                 for (_, row) in &encoded {
                     heap.insert(ctx, txn, row)?;
                 }
@@ -635,6 +636,7 @@ impl Storage {
         &mut self,
         name: &str,
         locators: Vec<RowLocator>,
+        scope: &mut TxnScope,
     ) -> Result<usize, StorageError> {
         self.file.ensure_rel_usable()?;
         let (def, _schema) = self.rel_def(name)?;
@@ -647,7 +649,7 @@ impl Storage {
                 object_id: def.object_id,
                 root: def.root_page,
             };
-            self.file.rel_statement(move |ctx, txn| {
+            self.file.rel_statement_scoped(scope, move |ctx, txn| {
                 for loc in &locators {
                     if let RowLocator::Key(key) = loc {
                         tree.delete(ctx, &mut OpMode::Txn(txn), key)?;
@@ -660,7 +662,7 @@ impl Storage {
                 object_id: def.object_id,
                 first_page: def.root_page,
             };
-            self.file.rel_statement(move |ctx, txn| {
+            self.file.rel_statement_scoped(scope, move |ctx, txn| {
                 for loc in &locators {
                     if let RowLocator::Rid(rid) = loc {
                         heap.delete(ctx, txn, *rid)?;
@@ -680,6 +682,7 @@ impl Storage {
         &mut self,
         name: &str,
         updates: Vec<(RowLocator, Vec<Datum>)>,
+        scope: &mut TxnScope,
     ) -> Result<usize, StorageError> {
         self.file.ensure_rel_usable()?;
         let (def, schema) = self.rel_def(name)?;
@@ -710,7 +713,7 @@ impl Storage {
                     rekey.push((old_key, new_key, row));
                 }
             }
-            self.file.rel_statement(move |ctx, txn| {
+            self.file.rel_statement_scoped(scope, move |ctx, txn| {
                 // Delete all re-keyed olds first so a new key may reuse one.
                 for (old_key, _, _) in &rekey {
                     tree.delete(ctx, &mut OpMode::Txn(txn), old_key)?;
@@ -745,7 +748,7 @@ impl Storage {
                 validate_not_null(&schema, &values)?;
                 encoded.push((rid, encode_row(&schema, &values)?));
             }
-            self.file.rel_statement(move |ctx, txn| {
+            self.file.rel_statement_scoped(scope, move |ctx, txn| {
                 for (rid, row) in &encoded {
                     heap.update(ctx, txn, *rid, row)?;
                 }
@@ -753,6 +756,30 @@ impl Storage {
             })?;
         }
         Ok(count)
+    }
+
+    /// Opens a multi-statement transaction (`BEGIN TRAN`).
+    pub(crate) fn rel_begin(&mut self) -> Result<StorageTxn, StorageError> {
+        self.file.ensure_rel_usable()?;
+        self.file.begin_txn()
+    }
+
+    /// Commits a caller-held transaction.
+    pub(crate) fn rel_commit(&mut self, txn: StorageTxn) -> Result<(), StorageError> {
+        self.file.ensure_rel_usable()?;
+        self.file.commit_txn(txn)
+    }
+
+    /// Rolls back a caller-held transaction.
+    pub(crate) fn rel_rollback(&mut self, txn: StorageTxn) -> Result<(), StorageError> {
+        self.file.ensure_rel_usable()?;
+        self.file.rollback_txn(txn)
+    }
+
+    /// Whether any explicit transaction is open. Checkpoints must be skipped
+    /// while this holds — see [`StorageFile::has_active_transactions`].
+    pub(crate) fn has_active_transactions(&self) -> bool {
+        self.file.has_active_transactions()
     }
 
     /// Reserves `count` identity values for a table's IDENTITY column,
@@ -899,6 +926,24 @@ fn validate_not_null(schema: &Schema, values: &[Datum]) -> Result<(), StorageErr
 pub(crate) enum RowLocator {
     Key(Vec<u8>),
     Rid(Rid),
+}
+
+/// A caller-held (multi-statement) relational transaction: the WAL/undo chain
+/// plus the tree-root snapshot taken at BEGIN (used to re-descend trees during
+/// rollback).
+pub(crate) struct StorageTxn {
+    txn: TxnLink,
+    roots: std::collections::HashMap<u32, u64>,
+}
+
+/// The transaction a statement runs under.
+pub(crate) enum TxnScope<'a> {
+    /// Autocommit: begin + commit around the single statement.
+    Auto,
+    /// A caller-held transaction; the statement's ops are appended and NOT
+    /// committed. A statement error leaves its partial ops in place — the
+    /// caller dooms the transaction and a later ROLLBACK undoes everything.
+    Explicit(&'a mut StorageTxn),
 }
 
 pub struct SnapshotData {
@@ -1256,6 +1301,75 @@ impl StorageFile {
             self.rel.wedged = true;
         }
         result
+    }
+
+    /// Runs one statement under `scope`: autocommit (begin+commit) or appended
+    /// to a caller-held transaction (no commit; partial ops survive an error).
+    fn rel_statement_scoped<T>(
+        &mut self,
+        scope: &mut TxnScope,
+        f: impl FnOnce(&mut RelCtx<'_>, &mut TxnLink) -> Result<T, StorageError>,
+    ) -> Result<T, StorageError> {
+        match scope {
+            TxnScope::Auto => self.rel_statement(f),
+            TxnScope::Explicit(stx) => {
+                let mut ctx = self.rel_ctx();
+                f(&mut ctx, &mut stx.txn)
+            }
+        }
+    }
+
+    /// Opens a multi-statement transaction (BEGIN TRAN), snapshotting tree roots
+    /// for a later rollback.
+    fn begin_txn(&mut self) -> Result<StorageTxn, StorageError> {
+        let txn_id = self.rel.next_txn_id;
+        self.rel.next_txn_id += 1;
+        let roots = self.rel.tree_roots();
+        let mut ctx = self.rel_ctx();
+        let txn = ctx.begin(txn_id)?;
+        // The transaction is now open (its undo records must survive until it
+        // commits or rolls back, which gates checkpoints — see `active_txns`).
+        self.rel.active_txns += 1;
+        Ok(StorageTxn { txn, roots })
+    }
+
+    /// Commits a caller-held transaction (forces the log). A failure wedges the
+    /// store, as for autocommit commits.
+    fn commit_txn(&mut self, stx: StorageTxn) -> Result<(), StorageError> {
+        // The transaction is ending (the `StorageTxn` is consumed either way).
+        self.rel.active_txns = self.rel.active_txns.saturating_sub(1);
+        let mut ctx = self.rel_ctx();
+        match ctx.commit(stx.txn) {
+            Ok(()) => Ok(()),
+            Err(err) => {
+                self.rel.wedged = true;
+                Err(err)
+            }
+        }
+    }
+
+    /// Rolls back a caller-held transaction via its in-memory undo log (CLRs).
+    fn rollback_txn(&mut self, stx: StorageTxn) -> Result<(), StorageError> {
+        self.rel.active_txns = self.rel.active_txns.saturating_sub(1);
+        let roots = stx.roots;
+        let mut ctx = self.rel_ctx();
+        match rel_recovery::rollback(&mut ctx, stx.txn, &roots) {
+            Ok(()) => {
+                let _ = ctx.io.wal.sync_all();
+                Ok(())
+            }
+            Err(err) => {
+                self.rel.wedged = true;
+                Err(err)
+            }
+        }
+    }
+
+    /// Whether any explicit transaction is open. A checkpoint must be skipped
+    /// while this is true (its WAL truncation would discard undo records still
+    /// needed to roll the open transaction back after a crash).
+    fn has_active_transactions(&self) -> bool {
+        self.rel.active_txns > 0
     }
 
     fn ensure_rel_usable(&self) -> Result<(), StorageError> {

--- a/crates/truthdb-sql/src/ast.rs
+++ b/crates/truthdb-sql/src/ast.rs
@@ -11,6 +11,35 @@ pub enum Statement {
     Update(Update),
     Delete(Delete),
     Select(Select),
+    /// `BEGIN TRAN[SACTION] [name]`.
+    BeginTransaction {
+        name: Option<Name>,
+        span: Span,
+    },
+    /// `COMMIT [TRAN[SACTION]] [name]`.
+    Commit {
+        span: Span,
+    },
+    /// `ROLLBACK [TRAN[SACTION]] [name]`.
+    Rollback {
+        span: Span,
+    },
+    /// `SET` session option (XACT_ABORT / TRANSACTION ISOLATION LEVEL).
+    Set(SetStatement),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum SetStatement {
+    XactAbort(bool),
+    IsolationLevel(IsolationLevel),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IsolationLevel {
+    ReadUncommitted,
+    ReadCommitted,
+    RepeatableRead,
+    Serializable,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -214,6 +243,9 @@ pub enum ExprKind {
         name: String,
         args: Vec<Expr>,
     },
+    /// A `@@`-prefixed global/session variable (e.g. `@@TRANCOUNT`), evaluated
+    /// from the session's [`EvalContext`](crate::eval::EvalContext).
+    GlobalVar(String),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/truthdb-sql/src/eval.rs
+++ b/crates/truthdb-sql/src/eval.rs
@@ -37,15 +37,29 @@ impl ColumnResolver for Vec<String> {
 /// kept small (heavy arms delegate to out-of-line helpers) so this is safe.
 const MAX_EVAL_DEPTH: usize = 500;
 
+/// Session context available to expression evaluation: `@@`-variables (and,
+/// in later stages, the current time / SCOPE_IDENTITY). `Default` is a
+/// no-transaction context, used where no session is in scope.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct EvalContext {
+    pub trancount: i32,
+}
+
 /// Evaluates `expr` against `row`, resolving columns via `resolver`.
-pub fn eval(expr: &Expr, row: &[SqlValue], resolver: &impl ColumnResolver) -> SqlResult<SqlValue> {
-    eval_at(expr, row, resolver, 0)
+pub fn eval(
+    expr: &Expr,
+    row: &[SqlValue],
+    resolver: &impl ColumnResolver,
+    ctx: &EvalContext,
+) -> SqlResult<SqlValue> {
+    eval_at(expr, row, resolver, ctx, 0)
 }
 
 fn eval_at(
     expr: &Expr,
     row: &[SqlValue],
     resolver: &impl ColumnResolver,
+    ctx: &EvalContext,
     depth: usize,
 ) -> SqlResult<SqlValue> {
     if depth > MAX_EVAL_DEPTH {
@@ -61,20 +75,21 @@ fn eval_at(
         ExprKind::Str(s) => Ok(SqlValue::Str(s.clone())),
         ExprKind::Bool(b) => Ok(SqlValue::Bool(*b)),
         ExprKind::Column(name) => eval_column(name, row, resolver),
+        ExprKind::GlobalVar(name) => eval_global_var(name, ctx),
         ExprKind::Unary { op, expr: inner } => {
-            let value = eval_at(inner, row, resolver, depth + 1)?;
+            let value = eval_at(inner, row, resolver, ctx, depth + 1)?;
             eval_unary(*op, value)
         }
         ExprKind::IsNull {
             expr: inner,
             negated,
         } => {
-            let value = eval_at(inner, row, resolver, depth + 1)?;
+            let value = eval_at(inner, row, resolver, ctx, depth + 1)?;
             Ok(SqlValue::Bool(value.is_null() != *negated))
         }
         ExprKind::Binary { op, left, right } => {
-            let l = eval_at(left, row, resolver, depth + 1)?;
-            let r = eval_at(right, row, resolver, depth + 1)?;
+            let l = eval_at(left, row, resolver, ctx, depth + 1)?;
+            let r = eval_at(right, row, resolver, ctx, depth + 1)?;
             eval_binary(*op, l, r)
         }
         ExprKind::Like {
@@ -82,18 +97,18 @@ fn eval_at(
             pattern,
             escape,
             negated,
-        } => eval_like_expr(expr, pattern, *escape, *negated, row, resolver, depth),
+        } => eval_like_expr(expr, pattern, *escape, *negated, row, resolver, ctx, depth),
         ExprKind::InList {
             expr,
             list,
             negated,
-        } => eval_in_expr(expr, list, *negated, row, resolver, depth),
+        } => eval_in_expr(expr, list, *negated, row, resolver, ctx, depth),
         ExprKind::Between {
             expr,
             low,
             high,
             negated,
-        } => eval_between_expr(expr, low, high, *negated, row, resolver, depth),
+        } => eval_between_expr(expr, low, high, *negated, row, resolver, ctx, depth),
         ExprKind::Case {
             operand,
             branches,
@@ -104,13 +119,14 @@ fn eval_at(
             else_result.as_deref(),
             row,
             resolver,
+            ctx,
             depth,
         ),
         ExprKind::Cast { expr, target } => {
-            let v = eval_at(expr, row, resolver, depth + 1)?;
+            let v = eval_at(expr, row, resolver, ctx, depth + 1)?;
             cast_value(v, target)
         }
-        ExprKind::Function { name, args } => eval_call(name, args, row, resolver, depth),
+        ExprKind::Function { name, args } => eval_call(name, args, row, resolver, ctx, depth),
     }
 }
 
@@ -124,6 +140,20 @@ fn eval_column(
         .resolve(&name.value)
         .ok_or_else(|| SqlError::invalid_column(&name.value).at(name.span))?;
     Ok(row[index].clone())
+}
+
+#[inline(never)]
+fn eval_global_var(name: &str, ctx: &EvalContext) -> SqlResult<SqlValue> {
+    match name {
+        "trancount" => Ok(SqlValue::Int(ctx.trancount as i64)),
+        "spid" => Ok(SqlValue::Int(0)),
+        "version" => Ok(SqlValue::Str("TruthDB".to_string())),
+        "error" | "rowcount" | "identity" => Ok(SqlValue::Int(0)),
+        other => Err(SqlError::message_only(
+            102,
+            format!("Incorrect syntax near '@@{other}'."),
+        )),
+    }
 }
 
 #[inline(never)]
@@ -151,6 +181,7 @@ fn eval_unary(op: UnaryOp, value: SqlValue) -> SqlResult<SqlValue> {
 // one that recurses down a long operator chain — stays small.
 
 #[inline(never)]
+#[allow(clippy::too_many_arguments)]
 fn eval_like_expr<R: ColumnResolver>(
     expr: &Expr,
     pattern: &Expr,
@@ -158,10 +189,11 @@ fn eval_like_expr<R: ColumnResolver>(
     negated: bool,
     row: &[SqlValue],
     resolver: &R,
+    ctx: &EvalContext,
     depth: usize,
 ) -> SqlResult<SqlValue> {
-    let value = eval_at(expr, row, resolver, depth + 1)?;
-    let pat = eval_at(pattern, row, resolver, depth + 1)?;
+    let value = eval_at(expr, row, resolver, ctx, depth + 1)?;
+    let pat = eval_at(pattern, row, resolver, ctx, depth + 1)?;
     if value.is_null() || pat.is_null() {
         return Ok(SqlValue::Null);
     }
@@ -181,16 +213,17 @@ fn eval_in_expr<R: ColumnResolver>(
     negated: bool,
     row: &[SqlValue],
     resolver: &R,
+    ctx: &EvalContext,
     depth: usize,
 ) -> SqlResult<SqlValue> {
-    let value = eval_at(expr, row, resolver, depth + 1)?;
+    let value = eval_at(expr, row, resolver, ctx, depth + 1)?;
     if value.is_null() {
         return Ok(SqlValue::Null);
     }
     // `x IN (list)` is `x=a OR x=b OR ...` under three-valued logic.
     let mut any_unknown = false;
     for item in list {
-        let candidate = eval_at(item, row, resolver, depth + 1)?;
+        let candidate = eval_at(item, row, resolver, ctx, depth + 1)?;
         match value.compare(&candidate)? {
             Some(std::cmp::Ordering::Equal) => return Ok(SqlValue::Bool(!negated)),
             None => any_unknown = true,
@@ -205,6 +238,7 @@ fn eval_in_expr<R: ColumnResolver>(
 }
 
 #[inline(never)]
+#[allow(clippy::too_many_arguments)]
 fn eval_between_expr<R: ColumnResolver>(
     expr: &Expr,
     low: &Expr,
@@ -212,11 +246,12 @@ fn eval_between_expr<R: ColumnResolver>(
     negated: bool,
     row: &[SqlValue],
     resolver: &R,
+    ctx: &EvalContext,
     depth: usize,
 ) -> SqlResult<SqlValue> {
-    let value = eval_at(expr, row, resolver, depth + 1)?;
-    let lo = eval_at(low, row, resolver, depth + 1)?;
-    let hi = eval_at(high, row, resolver, depth + 1)?;
+    let value = eval_at(expr, row, resolver, ctx, depth + 1)?;
+    let lo = eval_at(low, row, resolver, ctx, depth + 1)?;
+    let hi = eval_at(high, row, resolver, ctx, depth + 1)?;
     // `x BETWEEN a AND b` is `x>=a AND x<=b` (three-valued).
     let ge = value.compare(&lo)?.map(|o| o != Ordering::Less);
     let le = value.compare(&hi)?.map(|o| o != Ordering::Greater);
@@ -235,31 +270,32 @@ fn eval_case_expr<R: ColumnResolver>(
     else_result: Option<&Expr>,
     row: &[SqlValue],
     resolver: &R,
+    ctx: &EvalContext,
     depth: usize,
 ) -> SqlResult<SqlValue> {
     let operand_value = match operand {
-        Some(o) => Some(eval_at(o, row, resolver, depth + 1)?),
+        Some(o) => Some(eval_at(o, row, resolver, ctx, depth + 1)?),
         None => None,
     };
     for (cond, result) in branches {
         let matched = match &operand_value {
             // Simple CASE: operand = WHEN value (NULL never matches).
             Some(ov) => {
-                let cv = eval_at(cond, row, resolver, depth + 1)?;
+                let cv = eval_at(cond, row, resolver, ctx, depth + 1)?;
                 matches!(ov.compare(&cv)?, Some(Ordering::Equal))
             }
             // Searched CASE: WHEN is a boolean predicate.
             None => matches!(
-                eval_at(cond, row, resolver, depth + 1)?,
+                eval_at(cond, row, resolver, ctx, depth + 1)?,
                 SqlValue::Bool(true)
             ),
         };
         if matched {
-            return eval_at(result, row, resolver, depth + 1);
+            return eval_at(result, row, resolver, ctx, depth + 1);
         }
     }
     match else_result {
-        Some(e) => eval_at(e, row, resolver, depth + 1),
+        Some(e) => eval_at(e, row, resolver, ctx, depth + 1),
         None => Ok(SqlValue::Null),
     }
 }
@@ -270,11 +306,12 @@ fn eval_call<R: ColumnResolver>(
     args: &[Expr],
     row: &[SqlValue],
     resolver: &R,
+    ctx: &EvalContext,
     depth: usize,
 ) -> SqlResult<SqlValue> {
     let mut values = Vec::with_capacity(args.len());
     for arg in args {
-        values.push(eval_at(arg, row, resolver, depth + 1)?);
+        values.push(eval_at(arg, row, resolver, ctx, depth + 1)?);
     }
     functions::eval_function(name, values)
 }
@@ -668,7 +705,7 @@ mod tests {
             _ => panic!("expected expr"),
         };
         let names: Vec<String> = columns.iter().map(|c| c.to_string()).collect();
-        eval(expr, row, &names).expect("eval")
+        eval(expr, row, &names, &EvalContext::default()).expect("eval")
     }
 
     #[test]
@@ -695,7 +732,12 @@ mod tests {
             panic!()
         };
         let empty: Vec<String> = Vec::new();
-        assert_eq!(eval(expr, &[], &empty).unwrap_err().number, 8134);
+        assert_eq!(
+            eval(expr, &[], &empty, &EvalContext::default())
+                .unwrap_err()
+                .number,
+            8134
+        );
     }
 
     #[test]
@@ -763,7 +805,12 @@ mod tests {
             panic!()
         };
         let empty: Vec<String> = Vec::new();
-        assert_eq!(eval(expr, &[], &empty).unwrap_err().number, 191);
+        assert_eq!(
+            eval(expr, &[], &empty, &EvalContext::default())
+                .unwrap_err()
+                .number,
+            191
+        );
     }
 
     #[test]

--- a/crates/truthdb-sql/src/lexer.rs
+++ b/crates/truthdb-sql/src/lexer.rs
@@ -36,6 +36,8 @@ pub enum TokenKind {
     /// Numeric/decimal literal text (kept exact; typed at bind time).
     Number(String),
     String(String),
+    /// A `@@`-prefixed global variable name (without the `@@`), lowercased.
+    GlobalVar(String),
     // Operators / punctuation.
     Comma,
     Semicolon,
@@ -253,6 +255,20 @@ impl<'a> Lexer<'a> {
             b'\'' => self.lex_string(start),
             b'[' => self.lex_bracket_ident(start),
             b'"' => self.lex_quoted_ident(start),
+            b'@' if self.peek2() == Some(b'@') => {
+                // `@@name` — a global/session variable (e.g. @@TRANCOUNT).
+                self.pos += 2;
+                let name_start = self.pos;
+                while self.peek().is_some_and(is_ident_cont) {
+                    self.pos += 1;
+                }
+                let name =
+                    String::from_utf8_lossy(&self.src[name_start..self.pos]).to_ascii_lowercase();
+                Ok(Token {
+                    kind: TokenKind::GlobalVar(name),
+                    span: Span::new(start, self.pos),
+                })
+            }
             b'@' => Err(
                 SqlError::message_only(102, "Variables are not supported yet.")
                     .at(Span::new(start, start + 1)),

--- a/crates/truthdb-sql/src/parser.rs
+++ b/crates/truthdb-sql/src/parser.rs
@@ -111,6 +111,152 @@ impl Parser {
             Some("UPDATE") => self.parse_update(),
             Some("DELETE") => self.parse_delete(),
             Some("SELECT") => Ok(Statement::Select(self.parse_select()?)),
+            Some("BEGIN") => self.parse_begin(),
+            Some("COMMIT") => self.parse_commit(),
+            Some("ROLLBACK") => self.parse_rollback(),
+            Some("SET") => self.parse_set(),
+            _ => {
+                let token = self.peek().clone();
+                Err(SqlError::syntax(self.token_text(&token), token.span))
+            }
+        }
+    }
+
+    // ---- transaction control --------------------------------------------
+
+    fn parse_begin(&mut self) -> SqlResult<Statement> {
+        let start = self.expect_keyword("BEGIN")?;
+        // Stage 6 has no BEGIN...END blocks; BEGIN must open a transaction.
+        let mut end = match self.peek_keyword().as_deref() {
+            Some("TRAN") | Some("TRANSACTION") => self.bump().span,
+            _ => {
+                let token = self.peek().clone();
+                return Err(SqlError::syntax(self.token_text(&token), token.span));
+            }
+        };
+        let name = self.parse_optional_txn_name();
+        if let Some(n) = &name {
+            end = n.span;
+        }
+        Ok(Statement::BeginTransaction {
+            name,
+            span: start.to(end),
+        })
+    }
+
+    fn parse_commit(&mut self) -> SqlResult<Statement> {
+        let start = self.expect_keyword("COMMIT")?;
+        let end = self.eat_optional_tran_and_name(start);
+        Ok(Statement::Commit {
+            span: start.to(end),
+        })
+    }
+
+    fn parse_rollback(&mut self) -> SqlResult<Statement> {
+        let start = self.expect_keyword("ROLLBACK")?;
+        let end = self.eat_optional_tran_and_name(start);
+        Ok(Statement::Rollback {
+            span: start.to(end),
+        })
+    }
+
+    /// Consumes an optional `TRAN`/`TRANSACTION`/`WORK` keyword and transaction
+    /// name after COMMIT/ROLLBACK; returns the end span.
+    fn eat_optional_tran_and_name(&mut self, start: Span) -> Span {
+        let mut end = start;
+        if matches!(
+            self.peek_keyword().as_deref(),
+            Some("TRAN") | Some("TRANSACTION") | Some("WORK")
+        ) {
+            end = self.bump().span;
+        }
+        if let Some(n) = self.parse_optional_txn_name() {
+            end = n.span;
+        }
+        end
+    }
+
+    fn parse_optional_txn_name(&mut self) -> Option<Name> {
+        // A bare (non-clause) identifier following is the transaction name.
+        if matches!(self.peek().kind, TokenKind::Word { quoted: true, .. }) {
+            return self.parse_name().ok();
+        }
+        if let Some(kw) = self.peek_keyword() {
+            if is_reserved(&kw) {
+                return None;
+            }
+            return self.parse_name().ok();
+        }
+        None
+    }
+
+    fn parse_set(&mut self) -> SqlResult<Statement> {
+        self.expect_keyword("SET")?;
+        match self.peek_keyword().as_deref() {
+            Some("XACT_ABORT") => {
+                self.bump();
+                let on = self.parse_on_off()?;
+                Ok(Statement::Set(SetStatement::XactAbort(on)))
+            }
+            Some("TRANSACTION") => {
+                self.bump();
+                self.expect_keyword("ISOLATION")?;
+                self.expect_keyword("LEVEL")?;
+                let level = self.parse_isolation_level()?;
+                Ok(Statement::Set(SetStatement::IsolationLevel(level)))
+            }
+            _ => {
+                let token = self.peek().clone();
+                Err(SqlError::syntax(self.token_text(&token), token.span))
+            }
+        }
+    }
+
+    fn parse_on_off(&mut self) -> SqlResult<bool> {
+        match self.peek_keyword().as_deref() {
+            Some("ON") => {
+                self.bump();
+                Ok(true)
+            }
+            Some("OFF") => {
+                self.bump();
+                Ok(false)
+            }
+            _ => {
+                let token = self.peek().clone();
+                Err(SqlError::syntax(self.token_text(&token), token.span))
+            }
+        }
+    }
+
+    fn parse_isolation_level(&mut self) -> SqlResult<IsolationLevel> {
+        match self.peek_keyword().as_deref() {
+            Some("READ") => {
+                self.bump();
+                match self.peek_keyword().as_deref() {
+                    Some("UNCOMMITTED") => {
+                        self.bump();
+                        Ok(IsolationLevel::ReadUncommitted)
+                    }
+                    Some("COMMITTED") => {
+                        self.bump();
+                        Ok(IsolationLevel::ReadCommitted)
+                    }
+                    _ => {
+                        let token = self.peek().clone();
+                        Err(SqlError::syntax(self.token_text(&token), token.span))
+                    }
+                }
+            }
+            Some("REPEATABLE") => {
+                self.bump();
+                self.expect_keyword("READ")?;
+                Ok(IsolationLevel::RepeatableRead)
+            }
+            Some("SERIALIZABLE") => {
+                self.bump();
+                Ok(IsolationLevel::Serializable)
+            }
             _ => {
                 let token = self.peek().clone();
                 Err(SqlError::syntax(self.token_text(&token), token.span))
@@ -913,6 +1059,13 @@ impl Parser {
                 self.bump();
                 Ok(Expr {
                     kind: ExprKind::Str(s.clone()),
+                    span: token.span,
+                })
+            }
+            TokenKind::GlobalVar(name) => {
+                self.bump();
+                Ok(Expr {
+                    kind: ExprKind::GlobalVar(name.clone()),
                     span: token.span,
                 })
             }

--- a/crates/truthdb-sql/tests/corpus/ok/transactions.ast
+++ b/crates/truthdb-sql/tests/corpus/ok/transactions.ast
@@ -1,0 +1,148 @@
+[
+    BeginTransaction {
+        name: None,
+        span: Span {
+            start: 0,
+            end: 17,
+        },
+    },
+    Update(
+        Update {
+            table: Name {
+                value: "accounts",
+                quoted: false,
+                span: Span {
+                    start: 26,
+                    end: 34,
+                },
+            },
+            assignments: [
+                Assignment {
+                    column: Name {
+                        value: "balance",
+                        quoted: false,
+                        span: Span {
+                            start: 39,
+                            end: 46,
+                        },
+                    },
+                    value: Expr {
+                        kind: Binary {
+                            op: Sub,
+                            left: Expr {
+                                kind: Column(
+                                    Name {
+                                        value: "balance",
+                                        quoted: false,
+                                        span: Span {
+                                            start: 49,
+                                            end: 56,
+                                        },
+                                    },
+                                ),
+                                span: Span {
+                                    start: 49,
+                                    end: 56,
+                                },
+                            },
+                            right: Expr {
+                                kind: Int(
+                                    100,
+                                ),
+                                span: Span {
+                                    start: 59,
+                                    end: 62,
+                                },
+                            },
+                        },
+                        span: Span {
+                            start: 49,
+                            end: 62,
+                        },
+                    },
+                },
+            ],
+            where_clause: Some(
+                Expr {
+                    kind: Binary {
+                        op: Eq,
+                        left: Expr {
+                            kind: Column(
+                                Name {
+                                    value: "id",
+                                    quoted: false,
+                                    span: Span {
+                                        start: 69,
+                                        end: 71,
+                                    },
+                                },
+                            ),
+                            span: Span {
+                                start: 69,
+                                end: 71,
+                            },
+                        },
+                        right: Expr {
+                            kind: Int(
+                                1,
+                            ),
+                            span: Span {
+                                start: 74,
+                                end: 75,
+                            },
+                        },
+                    },
+                    span: Span {
+                        start: 69,
+                        end: 75,
+                    },
+                },
+            ),
+            span: Span {
+                start: 19,
+                end: 75,
+            },
+        },
+    ),
+    Select(
+        Select {
+            top: None,
+            items: [
+                Expr {
+                    expr: Expr {
+                        kind: GlobalVar(
+                            "trancount",
+                        ),
+                        span: Span {
+                            start: 84,
+                            end: 95,
+                        },
+                    },
+                    alias: Some(
+                        Name {
+                            value: "depth",
+                            quoted: false,
+                            span: Span {
+                                start: 99,
+                                end: 104,
+                            },
+                        },
+                    ),
+                },
+            ],
+            from: None,
+            where_clause: None,
+            order_by: [],
+            span: Span {
+                start: 77,
+                end: 104,
+            },
+        },
+    ),
+    Commit {
+        span: Span {
+            start: 106,
+            end: 124,
+        },
+    },
+]

--- a/crates/truthdb-sql/tests/corpus/ok/transactions.sql
+++ b/crates/truthdb-sql/tests/corpus/ok/transactions.sql
@@ -1,0 +1,4 @@
+BEGIN TRANSACTION;
+UPDATE accounts SET balance = balance - 100 WHERE id = 1;
+SELECT @@TRANCOUNT AS depth;
+COMMIT TRANSACTION

--- a/crates/truthdb-tds/src/lib.rs
+++ b/crates/truthdb-tds/src/lib.rs
@@ -12,19 +12,19 @@ pub mod server;
 pub mod token;
 pub mod typeinfo;
 
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::watch;
 use tracing::{debug, error, info};
-use truthdb_core::engine::Engine;
+use truthdb_core::session::EngineHandle;
 
 pub use server::{TdsConfig, serve_connection};
 
 /// A TDS listener bound to an address; serves connections until shutdown.
 pub struct TdsListener {
     listener: TcpListener,
-    engine: Arc<Mutex<Engine>>,
+    engine: EngineHandle,
     config: Arc<TdsConfig>,
 }
 
@@ -33,7 +33,7 @@ impl TdsListener {
     pub async fn bind(
         addr: &str,
         port: u16,
-        engine: Arc<Mutex<Engine>>,
+        engine: EngineHandle,
         config: TdsConfig,
     ) -> std::io::Result<Self> {
         let listener = TcpListener::bind((addr, port)).await?;
@@ -55,7 +55,7 @@ impl TdsListener {
                 accepted = self.listener.accept() => {
                     let (stream, peer) = accepted?;
                     debug!(%peer, "TDS connection accepted");
-                    let engine = Arc::clone(&self.engine);
+                    let engine = self.engine.clone();
                     let config = Arc::clone(&self.config);
                     tokio::spawn(async move {
                         if let Err(err) = handle(stream, engine, config).await {
@@ -76,7 +76,7 @@ impl TdsListener {
 
 async fn handle(
     stream: TcpStream,
-    engine: Arc<Mutex<Engine>>,
+    engine: EngineHandle,
     config: Arc<TdsConfig>,
 ) -> std::io::Result<()> {
     stream.set_nodelay(true).ok();

--- a/crates/truthdb-tds/src/packet.rs
+++ b/crates/truthdb-tds/src/packet.rs
@@ -17,6 +17,7 @@ pub const PKT_SQL_BATCH: u8 = 0x01;
 pub const PKT_RPC: u8 = 0x03;
 pub const PKT_TABULAR_RESULT: u8 = 0x04;
 pub const PKT_ATTENTION: u8 = 0x06;
+pub const PKT_TRANSACTION_MANAGER: u8 = 0x0e;
 pub const PKT_LOGIN7: u8 = 0x10;
 pub const PKT_PRELOGIN: u8 = 0x12;
 

--- a/crates/truthdb-tds/src/server.rs
+++ b/crates/truthdb-tds/src/server.rs
@@ -1,11 +1,11 @@
 //! TDS connection handler: PRELOGIN -> LOGIN7 (auth) -> SQLBatch loop.
 
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use tokio::io::{self, AsyncRead, AsyncWrite};
-use truthdb_core::engine::Engine;
 use truthdb_core::rel::{BatchOutcome, StatementResult};
+use truthdb_core::session::{EngineHandle, SessionId};
 
 use crate::login::{self, parse_login7};
 use crate::packet::{
@@ -26,7 +26,7 @@ pub struct TdsConfig {
 /// Handles one TDS connection to completion (or disconnect).
 pub async fn serve_connection<S>(
     mut stream: S,
-    engine: Arc<Mutex<Engine>>,
+    engine: EngineHandle,
     config: Arc<TdsConfig>,
 ) -> io::Result<()>
 where
@@ -97,9 +97,25 @@ where
     token::done(&mut out, false, false, None);
     write_message(&mut stream, PKT_TABULAR_RESULT, &out, packet_size).await?;
 
-    // --- request loop ---
+    // Each connection gets an engine-side session; it is closed (rolling back
+    // any open transaction) whenever the connection ends, cleanly or not.
+    let session = engine.open_session().await;
+    let result = request_loop(&mut stream, &engine, session, packet_size).await;
+    engine.close_session(session);
+    result
+}
+
+async fn request_loop<S>(
+    stream: &mut S,
+    engine: &EngineHandle,
+    session: SessionId,
+    packet_size: usize,
+) -> io::Result<()>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
     loop {
-        let message = match read_message(&mut stream).await {
+        let message = match read_message(stream).await {
             Ok(message) => message,
             // Clean disconnect.
             Err(err) if err.kind() == io::ErrorKind::UnexpectedEof => return Ok(()),
@@ -108,8 +124,8 @@ where
         match message.kind {
             PKT_SQL_BATCH => {
                 let sql = batch_sql(&message.payload)?;
-                let response = run_batch(&engine, &sql);
-                write_message(&mut stream, PKT_TABULAR_RESULT, &response, packet_size).await?;
+                let response = run_batch(engine, session, &sql).await;
+                write_message(stream, PKT_TABULAR_RESULT, &response, packet_size).await?;
             }
             PKT_ATTENTION => {
                 // Acknowledge cancel with a DONE(attention). True mid-batch
@@ -117,7 +133,7 @@ where
                 // completion.
                 let mut out = Vec::new();
                 token::done_attention(&mut out);
-                write_message(&mut stream, PKT_TABULAR_RESULT, &out, packet_size).await?;
+                write_message(stream, PKT_TABULAR_RESULT, &out, packet_size).await?;
             }
             _ => return Err(protocol_err("unexpected TDS message type")),
         }
@@ -131,13 +147,9 @@ fn authenticate(config: &TdsConfig, username: &str, password: &str) -> bool {
         .is_some_and(|expected| expected == password)
 }
 
-/// Runs a SQL batch through the engine and builds its token stream.
-fn run_batch(engine: &Arc<Mutex<Engine>>, sql: &str) -> Vec<u8> {
-    let outcome = {
-        let mut engine = engine.lock().expect("engine mutex poisoned");
-        engine.sql_batch(sql)
-    };
-    match outcome {
+/// Runs a SQL batch through the engine actor and builds its token stream.
+async fn run_batch(engine: &EngineHandle, session: SessionId, sql: &str) -> Vec<u8> {
+    match engine.run_batch(session, sql.to_string()).await {
         Ok(outcome) => build_batch_tokens(&outcome),
         Err(err) => {
             // A genuine engine/storage failure (not a SQL-level error).

--- a/crates/truthdb-tds/src/server.rs
+++ b/crates/truthdb-tds/src/server.rs
@@ -10,9 +10,14 @@ use truthdb_core::session::{EngineHandle, SessionId};
 use crate::login::{self, parse_login7};
 use crate::packet::{
     self, DEFAULT_PACKET_SIZE, Message, PKT_ATTENTION, PKT_LOGIN7, PKT_PRELOGIN, PKT_SQL_BATCH,
-    PKT_TABULAR_RESULT, read_message, write_message,
+    PKT_TABULAR_RESULT, PKT_TRANSACTION_MANAGER, read_message, write_message,
 };
 use crate::token;
+
+// Transaction Manager request types (MS-TDS 2.2.6.9).
+const TM_BEGIN_XACT: u16 = 5;
+const TM_COMMIT_XACT: u16 = 7;
+const TM_ROLLBACK_XACT: u16 = 8;
 
 /// Server-side TDS configuration: the login users and the reported database.
 #[derive(Debug, Clone)]
@@ -66,7 +71,7 @@ where
             14,
             &format!("Login failed for user '{}'.", login.username),
         );
-        token::done(&mut out, false, true, None);
+        token::done(&mut out, false, true, false, None);
         write_message(&mut stream, PKT_TABULAR_RESULT, &out, packet_size).await?;
         return Ok(());
     }
@@ -94,7 +99,7 @@ where
         10,
         &format!("Changed database context to '{database}'."),
     );
-    token::done(&mut out, false, false, None);
+    token::done(&mut out, false, false, false, None);
     write_message(&mut stream, PKT_TABULAR_RESULT, &out, packet_size).await?;
 
     // Each connection gets an engine-side session; it is closed (rolling back
@@ -114,6 +119,10 @@ async fn request_loop<S>(
 where
     S: AsyncRead + AsyncWrite + Unpin,
 {
+    // The connection's current transaction descriptor (0 = none). A fresh
+    // value is minted per BEGIN so the client can echo it in ALL_HEADERS.
+    let mut tran_descriptor: u64 = 0;
+    let mut next_descriptor: u64 = 1;
     loop {
         let message = match read_message(stream).await {
             Ok(message) => message,
@@ -125,6 +134,17 @@ where
             PKT_SQL_BATCH => {
                 let sql = batch_sql(&message.payload)?;
                 let response = run_batch(engine, session, &sql).await;
+                write_message(stream, PKT_TABULAR_RESULT, &response, packet_size).await?;
+            }
+            PKT_TRANSACTION_MANAGER => {
+                let response = handle_tm_request(
+                    engine,
+                    session,
+                    &message.payload,
+                    &mut tran_descriptor,
+                    &mut next_descriptor,
+                )
+                .await?;
                 write_message(stream, PKT_TABULAR_RESULT, &response, packet_size).await?;
             }
             PKT_ATTENTION => {
@@ -140,6 +160,109 @@ where
     }
 }
 
+/// Handles a Transaction Manager request (`db.BeginTx()` / `Commit` /
+/// `Rollback` in drivers). Translates it to the equivalent SQL transaction
+/// statement, runs it through the session, and answers with the matching
+/// transaction ENVCHANGE (types 8/9/10) plus a final DONE.
+async fn handle_tm_request(
+    engine: &EngineHandle,
+    session: SessionId,
+    payload: &[u8],
+    tran_descriptor: &mut u64,
+    next_descriptor: &mut u64,
+) -> io::Result<Vec<u8>> {
+    let (request_type, isolation) = parse_tm_request(payload)?;
+    let sql = match request_type {
+        TM_BEGIN_XACT => match isolation_set_clause(isolation) {
+            Some(set) => format!("{set}; BEGIN TRANSACTION"),
+            None => "BEGIN TRANSACTION".to_string(),
+        },
+        TM_COMMIT_XACT => "COMMIT TRANSACTION".to_string(),
+        TM_ROLLBACK_XACT => "ROLLBACK TRANSACTION".to_string(),
+        other => {
+            return Err(protocol_err(&format!(
+                "unsupported transaction manager request type {other}"
+            )));
+        }
+    };
+
+    let reply = match engine.run_batch(session, sql).await {
+        Ok(reply) => reply,
+        Err(err) => {
+            let mut out = Vec::new();
+            token::error(&mut out, 50000, 1, 16, &err.to_string());
+            token::done(&mut out, false, true, false, None);
+            return Ok(out);
+        }
+    };
+
+    let mut out = Vec::new();
+    // A SQL-level failure (e.g. COMMIT with no matching BEGIN) is reported as
+    // an ERROR with no ENVCHANGE; the descriptor is left unchanged.
+    if let Some(error) = &reply.outcome.error {
+        token::error(
+            &mut out,
+            error.number,
+            error.state,
+            error.level,
+            &error.message,
+        );
+        token::done(&mut out, false, true, reply.in_transaction, None);
+        return Ok(out);
+    }
+
+    match request_type {
+        TM_BEGIN_XACT => {
+            let descriptor = *next_descriptor;
+            *next_descriptor += 1;
+            *tran_descriptor = descriptor;
+            token::envchange_begin_tran(&mut out, descriptor);
+        }
+        TM_COMMIT_XACT => {
+            token::envchange_commit_tran(&mut out, *tran_descriptor);
+            *tran_descriptor = 0;
+        }
+        TM_ROLLBACK_XACT => {
+            token::envchange_rollback_tran(&mut out, *tran_descriptor);
+            *tran_descriptor = 0;
+        }
+        _ => unreachable!("request type validated above"),
+    }
+    token::done(&mut out, false, false, reply.in_transaction, None);
+    Ok(out)
+}
+
+/// Parses a Transaction Manager request payload: an ALL_HEADERS block, then a
+/// `RequestType` (u16 LE), then for `TM_BEGIN_XACT` an isolation-level byte.
+/// Returns the request type and (for BEGIN) the isolation byte.
+fn parse_tm_request(payload: &[u8]) -> io::Result<(u16, u8)> {
+    let body = skip_all_headers(payload);
+    if body.len() < 2 {
+        return Err(protocol_err("transaction manager request too short"));
+    }
+    let request_type = u16::from_le_bytes([body[0], body[1]]);
+    // TM_BEGIN_XACT carries: IsolationLevel (u8), then a B_VARCHAR name.
+    let isolation = if request_type == TM_BEGIN_XACT {
+        body.get(2).copied().unwrap_or(0)
+    } else {
+        0
+    };
+    Ok((request_type, isolation))
+}
+
+/// Maps a TDS isolation-level byte to the equivalent `SET TRANSACTION
+/// ISOLATION LEVEL` statement, or `None` to keep the session default.
+fn isolation_set_clause(isolation: u8) -> Option<&'static str> {
+    match isolation {
+        1 => Some("SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED"),
+        2 => Some("SET TRANSACTION ISOLATION LEVEL READ COMMITTED"),
+        3 => Some("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ"),
+        4 => Some("SET TRANSACTION ISOLATION LEVEL SERIALIZABLE"),
+        // 0 (unspecified) and 5 (snapshot, unsupported) keep the default.
+        _ => None,
+    }
+}
+
 fn authenticate(config: &TdsConfig, username: &str, password: &str) -> bool {
     config
         .users
@@ -150,19 +273,21 @@ fn authenticate(config: &TdsConfig, username: &str, password: &str) -> bool {
 /// Runs a SQL batch through the engine actor and builds its token stream.
 async fn run_batch(engine: &EngineHandle, session: SessionId, sql: &str) -> Vec<u8> {
     match engine.run_batch(session, sql.to_string()).await {
-        Ok(outcome) => build_batch_tokens(&outcome),
+        Ok(reply) => build_batch_tokens(&reply.outcome, reply.in_transaction),
         Err(err) => {
             // A genuine engine/storage failure (not a SQL-level error).
             let mut out = Vec::new();
             token::error(&mut out, 50000, 1, 16, &err.to_string());
-            token::done(&mut out, false, true, None);
+            token::done(&mut out, false, true, false, None);
             out
         }
     }
 }
 
 /// Builds the COLMETADATA/ROW/DONE/ERROR token stream for a batch outcome.
-fn build_batch_tokens(outcome: &BatchOutcome) -> Vec<u8> {
+/// `in_transaction` sets `DONE_INXACT` so the client knows the connection is
+/// still inside a transaction.
+fn build_batch_tokens(outcome: &BatchOutcome, in_transaction: bool) -> Vec<u8> {
     let mut out = Vec::new();
     let has_error = outcome.error.is_some();
     let last_index = outcome.results.len().saturating_sub(1);
@@ -176,13 +301,19 @@ fn build_batch_tokens(outcome: &BatchOutcome) -> Vec<u8> {
                 for row in &rowset.rows {
                     token::row(&mut out, row, &rowset.columns);
                 }
-                token::done(&mut out, more, false, Some(rowset.rows.len() as u64));
+                token::done(
+                    &mut out,
+                    more,
+                    false,
+                    in_transaction,
+                    Some(rowset.rows.len() as u64),
+                );
             }
             StatementResult::RowsAffected(n) => {
-                token::done(&mut out, more, false, Some(*n));
+                token::done(&mut out, more, false, in_transaction, Some(*n));
             }
             StatementResult::Done => {
-                token::done(&mut out, more, false, None);
+                token::done(&mut out, more, false, in_transaction, None);
             }
         }
     }
@@ -194,28 +325,35 @@ fn build_batch_tokens(outcome: &BatchOutcome) -> Vec<u8> {
             error.level,
             &error.message,
         );
-        token::done(&mut out, false, true, None);
+        token::done(&mut out, false, true, in_transaction, None);
     } else if outcome.results.is_empty() {
         // Empty batch (e.g. only comments): a single final DONE.
-        token::done(&mut out, false, false, None);
+        token::done(&mut out, false, false, in_transaction, None);
     }
     out
+}
+
+/// Skips a request payload's ALL_HEADERS block, returning the bytes after it.
+/// ALL_HEADERS starts with a `TotalLength u32` covering the whole block (incl.
+/// itself); a missing or malformed block means the payload has no headers.
+fn skip_all_headers(payload: &[u8]) -> &[u8] {
+    let start = if payload.len() >= 4 {
+        let total = u32::from_le_bytes(payload[0..4].try_into().unwrap()) as usize;
+        if (4..=payload.len()).contains(&total) {
+            total
+        } else {
+            0
+        }
+    } else {
+        0
+    };
+    &payload[start..]
 }
 
 /// Extracts the SQL text from a SQLBatch payload: an ALL_HEADERS block
 /// (`TotalLength u32` covering the headers) followed by the UCS-2LE query.
 fn batch_sql(payload: &[u8]) -> io::Result<String> {
-    let sql_start = if payload.len() >= 4 {
-        let total = u32::from_le_bytes(payload[0..4].try_into().unwrap()) as usize;
-        if (4..=payload.len()).contains(&total) {
-            total
-        } else {
-            0 // No (or malformed) ALL_HEADERS: treat the whole payload as SQL.
-        }
-    } else {
-        0
-    };
-    let text = &payload[sql_start..];
+    let text = skip_all_headers(payload);
     if !text.len().is_multiple_of(2) {
         return Err(protocol_err("SQLBatch text is not UCS-2 aligned"));
     }

--- a/crates/truthdb-tds/src/token.rs
+++ b/crates/truthdb-tds/src/token.rs
@@ -18,12 +18,16 @@ const TOKEN_DONE: u8 = 0xfd;
 const DONE_FINAL: u16 = 0x0000;
 const DONE_MORE: u16 = 0x0001;
 const DONE_ERROR: u16 = 0x0002;
+const DONE_INXACT: u16 = 0x0004;
 const DONE_COUNT: u16 = 0x0010;
 const DONE_ATTN: u16 = 0x0020;
 
 // ENVCHANGE types.
 const ENV_DATABASE: u8 = 1;
 const ENV_PACKET_SIZE: u8 = 4;
+const ENV_BEGIN_TRAN: u8 = 8;
+const ENV_COMMIT_TRAN: u8 = 9;
+const ENV_ROLLBACK_TRAN: u8 = 10;
 
 /// UCS-2LE code units of `s`, truncated to at most `max` units. Truncating
 /// keeps the emitted body consistent with a length prefix that can only count
@@ -90,6 +94,46 @@ pub fn envchange_packet_size(out: &mut Vec<u8>, new_size: usize, old_size: usize
     out.extend_from_slice(&body);
 }
 
+/// A transaction descriptor as a B_VARBYTE (1-byte length + 8 LE bytes).
+fn push_b_varbyte_descriptor(out: &mut Vec<u8>, descriptor: u64) {
+    out.push(8);
+    out.extend_from_slice(&descriptor.to_le_bytes());
+}
+
+/// ENVCHANGE type 8 (Begin Transaction): NewValue = the new descriptor,
+/// OldValue empty. Drives `db.BeginTx()` on the client.
+pub fn envchange_begin_tran(out: &mut Vec<u8>, descriptor: u64) {
+    let mut body = Vec::new();
+    body.push(ENV_BEGIN_TRAN);
+    push_b_varbyte_descriptor(&mut body, descriptor); // new value
+    body.push(0); // old value: empty
+    out.push(TOKEN_ENVCHANGE);
+    out.extend_from_slice(&(body.len() as u16).to_le_bytes());
+    out.extend_from_slice(&body);
+}
+
+/// ENVCHANGE type 9 (Commit Transaction): NewValue empty, OldValue = the
+/// descriptor that just committed.
+pub fn envchange_commit_tran(out: &mut Vec<u8>, descriptor: u64) {
+    envchange_end_tran(out, ENV_COMMIT_TRAN, descriptor);
+}
+
+/// ENVCHANGE type 10 (Rollback Transaction): NewValue empty, OldValue = the
+/// descriptor that just rolled back.
+pub fn envchange_rollback_tran(out: &mut Vec<u8>, descriptor: u64) {
+    envchange_end_tran(out, ENV_ROLLBACK_TRAN, descriptor);
+}
+
+fn envchange_end_tran(out: &mut Vec<u8>, env_type: u8, descriptor: u64) {
+    let mut body = Vec::new();
+    body.push(env_type);
+    body.push(0); // new value: empty
+    push_b_varbyte_descriptor(&mut body, descriptor); // old value
+    out.push(TOKEN_ENVCHANGE);
+    out.extend_from_slice(&(body.len() as u16).to_le_bytes());
+    out.extend_from_slice(&body);
+}
+
 /// INFO token (informational message, same shape as ERROR).
 pub fn info(out: &mut Vec<u8>, number: i32, state: u8, class: u8, message: &str) {
     message_token(out, TOKEN_INFO, number, state, class, message);
@@ -144,11 +188,15 @@ pub fn row(out: &mut Vec<u8>, values: &[Datum], columns: &[ResultColumn]) {
 }
 
 /// DONE token. `more` sets DONE_MORE (another result follows); `count`
-/// carries a row count (DONE_COUNT); `error` sets DONE_ERROR.
-pub fn done(out: &mut Vec<u8>, more: bool, error: bool, count: Option<u64>) {
+/// carries a row count (DONE_COUNT); `error` sets DONE_ERROR; `in_xact` sets
+/// DONE_INXACT (a transaction is still active for the connection).
+pub fn done(out: &mut Vec<u8>, more: bool, error: bool, in_xact: bool, count: Option<u64>) {
     let mut status = if more { DONE_MORE } else { DONE_FINAL };
     if error {
         status |= DONE_ERROR;
+    }
+    if in_xact {
+        status |= DONE_INXACT;
     }
     if count.is_some() {
         status |= DONE_COUNT;
@@ -215,12 +263,45 @@ mod tests {
     #[test]
     fn done_status_bits() {
         let mut out = Vec::new();
-        done(&mut out, false, false, Some(3));
+        done(&mut out, false, false, false, Some(3));
         assert_eq!(out[0], TOKEN_DONE);
         let status = u16::from_le_bytes([out[1], out[2]]);
         assert_eq!(status, DONE_COUNT);
         let count = u64::from_le_bytes(out[5..13].try_into().unwrap());
         assert_eq!(count, 3);
+    }
+
+    #[test]
+    fn done_sets_inxact_flag() {
+        let mut out = Vec::new();
+        done(&mut out, false, false, true, None);
+        let status = u16::from_le_bytes([out[1], out[2]]);
+        assert_eq!(status & DONE_INXACT, DONE_INXACT);
+    }
+
+    #[test]
+    fn envchange_begin_tran_carries_descriptor() {
+        let mut out = Vec::new();
+        envchange_begin_tran(&mut out, 0x1122334455667788);
+        assert_eq!(out[0], TOKEN_ENVCHANGE);
+        let len = u16::from_le_bytes([out[1], out[2]]) as usize;
+        assert_eq!(out.len(), 3 + len);
+        assert_eq!(out[3], ENV_BEGIN_TRAN);
+        assert_eq!(out[4], 8); // new value length
+        let desc = u64::from_le_bytes(out[5..13].try_into().unwrap());
+        assert_eq!(desc, 0x1122334455667788);
+        assert_eq!(out[13], 0); // old value length
+    }
+
+    #[test]
+    fn envchange_commit_tran_carries_old_descriptor() {
+        let mut out = Vec::new();
+        envchange_commit_tran(&mut out, 0x42);
+        assert_eq!(out[3], ENV_COMMIT_TRAN);
+        assert_eq!(out[4], 0); // new value length
+        assert_eq!(out[5], 8); // old value length
+        let desc = u64::from_le_bytes(out[6..14].try_into().unwrap());
+        assert_eq!(desc, 0x42);
     }
 
     #[test]

--- a/crates/truthdb-tds/tests/tds_client.rs
+++ b/crates/truthdb-tds/tests/tds_client.rs
@@ -5,10 +5,11 @@
 //! DONE, ERROR) without needing an external SQL Server driver.
 
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use tokio::io::{AsyncReadExt, AsyncWriteExt, DuplexStream};
 use truthdb_core::engine::Engine;
+use truthdb_core::session::{EngineHandle, spawn_engine};
 use truthdb_core::storage::{Storage, StorageOptions};
 use truthdb_tds::server::{TdsConfig, serve_connection};
 
@@ -27,7 +28,7 @@ fn temp_path(label: &str) -> std::path::PathBuf {
     path
 }
 
-fn engine(path: &std::path::Path) -> Arc<Mutex<Engine>> {
+fn engine(path: &std::path::Path) -> EngineHandle {
     let opts = StorageOptions {
         size_gib: 1,
         wal_ratio: 0.05,
@@ -37,7 +38,9 @@ fn engine(path: &std::path::Path) -> Arc<Mutex<Engine>> {
         reserved_ratio: 0.17,
     };
     let storage = Storage::create(path.to_path_buf(), opts).expect("storage");
-    Arc::new(Mutex::new(Engine::new(storage).expect("engine")))
+    // The JoinHandle is dropped; the engine thread exits when the last
+    // EngineHandle drops at end of test.
+    spawn_engine(Engine::new(storage).expect("engine")).0
 }
 
 fn config() -> TdsConfig {
@@ -371,7 +374,7 @@ fn parse_row(bytes: &[u8], meta: &[ColType]) -> (Vec<Cell>, usize) {
     (cells, i)
 }
 
-async fn connect(engine: Arc<Mutex<Engine>>) -> Client {
+async fn connect(engine: EngineHandle) -> Client {
     let (client_half, server_half) = tokio::io::duplex(64 * 1024);
     let cfg = Arc::new(config());
     tokio::spawn(async move {
@@ -386,7 +389,7 @@ async fn connect(engine: Arc<Mutex<Engine>>) -> Client {
 async fn full_handshake_query_and_error() {
     let path = temp_path("e2e");
     let engine = engine(&path);
-    let mut client = connect(Arc::clone(&engine)).await;
+    let mut client = connect(engine.clone()).await;
 
     client.prelogin().await;
     let login = client.login("sa", "secret").await;

--- a/crates/truthdb-tds/tests/tds_client.rs
+++ b/crates/truthdb-tds/tests/tds_client.rs
@@ -15,6 +15,7 @@ use truthdb_tds::server::{TdsConfig, serve_connection};
 
 // Packet types.
 const PKT_SQL_BATCH: u8 = 0x01;
+const PKT_TRANSACTION_MANAGER: u8 = 0x0e;
 const PKT_LOGIN7: u8 = 0x10;
 const PKT_PRELOGIN: u8 = 0x12;
 
@@ -128,6 +129,24 @@ impl Client {
         let (_, response) = self.read_message().await;
         parse_tokens(&response)
     }
+
+    /// Sends a Transaction Manager request (request type + optional isolation
+    /// byte for BEGIN) and returns the decoded response tokens.
+    async fn tm_request(&mut self, request_type: u16, isolation: u8) -> Vec<Token> {
+        let mut payload = Vec::new();
+        let headers = all_headers();
+        let total = 4 + headers.len();
+        payload.extend_from_slice(&(total as u32).to_le_bytes());
+        payload.extend_from_slice(&headers);
+        payload.extend_from_slice(&request_type.to_le_bytes());
+        if request_type == 5 {
+            payload.push(isolation); // IsolationLevel
+            payload.push(0); // name length (B_VARCHAR, empty)
+        }
+        self.write_packet(PKT_TRANSACTION_MANAGER, &payload).await;
+        let (_, response) = self.read_message().await;
+        parse_tokens(&response)
+    }
 }
 
 /// A minimal ALL_HEADERS with a transaction-descriptor header (type 2).
@@ -172,7 +191,8 @@ enum Token {
     ColMetadata(Vec<ColType>),
     Row(Vec<Cell>),
     Error { number: i32 },
-    Done { count: Option<u64> },
+    EnvChange { kind: u8 },
+    Done { count: Option<u64>, in_xact: bool },
     Other(u8),
 }
 
@@ -217,6 +237,8 @@ fn parse_tokens(payload: &[u8]) -> Vec<Token> {
                 if token == 0xaa {
                     let number = i32::from_le_bytes(body[0..4].try_into().unwrap());
                     tokens.push(Token::Error { number });
+                } else if token == 0xe3 {
+                    tokens.push(Token::EnvChange { kind: body[0] });
                 }
                 i += 2 + len;
             }
@@ -236,9 +258,11 @@ fn parse_tokens(payload: &[u8]) -> Vec<Token> {
                 let status = u16::from_le_bytes([payload[i], payload[i + 1]]);
                 let count = u64::from_le_bytes(payload[i + 4..i + 12].try_into().unwrap());
                 let has_count = status & 0x0010 != 0;
+                let in_xact = status & 0x0004 != 0;
                 i += 12;
                 tokens.push(Token::Done {
                     count: has_count.then_some(count),
+                    in_xact,
                 });
             }
             other => {
@@ -406,7 +430,7 @@ async fn full_handshake_query_and_error() {
     assert!(
         insert
             .iter()
-            .any(|t| matches!(t, Token::Done { count: Some(3) })),
+            .any(|t| matches!(t, Token::Done { count: Some(3), .. })),
         "insert tokens: {insert:?}"
     );
 
@@ -482,5 +506,102 @@ async fn computed_columns_and_constant_select() {
         .collect();
     assert_eq!(*rows[0], vec![Cell::Int(10), Cell::Int(20)]);
     assert_eq!(*rows[1], vec![Cell::Int(20), Cell::Int(40)]);
+    let _ = std::fs::remove_file(path);
+}
+
+// Transaction Manager request types (MS-TDS 2.2.6.9).
+const TM_BEGIN_XACT: u16 = 5;
+const TM_COMMIT_XACT: u16 = 7;
+const TM_ROLLBACK_XACT: u16 = 8;
+
+fn has_envchange(tokens: &[Token], kind: u8) -> bool {
+    tokens
+        .iter()
+        .any(|t| matches!(t, Token::EnvChange { kind: k } if *k == kind))
+}
+
+fn row_ints(tokens: &[Token]) -> Vec<i64> {
+    tokens
+        .iter()
+        .filter_map(|t| match t {
+            Token::Row(cells) => match cells.first() {
+                Some(Cell::Int(v)) => Some(*v),
+                _ => None,
+            },
+            _ => None,
+        })
+        .collect()
+}
+
+#[tokio::test]
+async fn tm_begin_commit_persists_and_emits_envchanges() {
+    let path = temp_path("tm-commit");
+    let engine = engine(&path);
+    let mut client = connect(engine).await;
+    client.prelogin().await;
+    client.login("sa", "secret").await;
+    client
+        .batch("CREATE TABLE t (id INT NOT NULL PRIMARY KEY)")
+        .await;
+
+    // db.BeginTx(): a TM begin request → ENVCHANGE(8) + DONE(INXACT).
+    let begin = client.tm_request(TM_BEGIN_XACT, 0).await;
+    assert!(has_envchange(&begin, 8), "begin tokens: {begin:?}");
+    assert!(
+        begin
+            .iter()
+            .any(|t| matches!(t, Token::Done { in_xact: true, .. })),
+        "begin DONE must set INXACT: {begin:?}"
+    );
+
+    // A statement inside the transaction reports it is still in a transaction.
+    let insert = client.batch("INSERT INTO t VALUES (1)").await;
+    assert!(
+        insert
+            .iter()
+            .any(|t| matches!(t, Token::Done { in_xact: true, .. })),
+        "in-txn statement DONE must set INXACT: {insert:?}"
+    );
+
+    // Commit → ENVCHANGE(9) + DONE without INXACT.
+    let commit = client.tm_request(TM_COMMIT_XACT, 0).await;
+    assert!(has_envchange(&commit, 9), "commit tokens: {commit:?}");
+    assert!(
+        commit
+            .iter()
+            .any(|t| matches!(t, Token::Done { in_xact: false, .. })),
+        "commit DONE must clear INXACT: {commit:?}"
+    );
+
+    // The committed row is durable and visible after the transaction.
+    let select = client.batch("SELECT id FROM t").await;
+    assert_eq!(row_ints(&select), vec![1]);
+    let _ = std::fs::remove_file(path);
+}
+
+#[tokio::test]
+async fn tm_begin_rollback_discards_writes() {
+    let path = temp_path("tm-rollback");
+    let engine = engine(&path);
+    let mut client = connect(engine).await;
+    client.prelogin().await;
+    client.login("sa", "secret").await;
+    client
+        .batch("CREATE TABLE t (id INT NOT NULL PRIMARY KEY)")
+        .await;
+    client.batch("INSERT INTO t VALUES (1)").await;
+
+    client.tm_request(TM_BEGIN_XACT, 0).await;
+    client.batch("INSERT INTO t VALUES (2)").await;
+
+    // Rollback → ENVCHANGE(10); the second insert is discarded.
+    let rollback = client.tm_request(TM_ROLLBACK_XACT, 0).await;
+    assert!(
+        has_envchange(&rollback, 10),
+        "rollback tokens: {rollback:?}"
+    );
+
+    let select = client.batch("SELECT id FROM t ORDER BY id").await;
+    assert_eq!(row_ints(&select), vec![1], "only the pre-txn row survives");
     let _ = std::fs::remove_file(path);
 }

--- a/scripts/tds_conformance.go
+++ b/scripts/tds_conformance.go
@@ -9,11 +9,13 @@
 package main
 
 import (
+	"context"
 	"database/sql"
 	"errors"
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	mssql "github.com/microsoft/go-mssqldb"
 )
@@ -175,7 +177,116 @@ func main() {
 		fail("large multi-packet value: len %d != 3000", len(large))
 	}
 
+	// 11-13: transactions via the TDS Transaction Manager (db.BeginTx sends
+	// TM_BEGIN_XACT, tx.Commit/Rollback send TM_COMMIT/ROLLBACK_XACT).
+	transactionMatrix(db)
+	blockingDemo(db, host, port, user, pass)
+
 	fmt.Println("tds conformance (go-mssqldb): OK")
+}
+
+// transactionMatrix exercises db.BeginTx + Commit/Rollback (the TM request
+// path) and verifies commit durability and rollback discard.
+func transactionMatrix(db *sql.DB) {
+	ctx := context.Background()
+	mustExec(db, "CREATE TABLE tx_go (id INT NOT NULL PRIMARY KEY, v INT)")
+
+	// 11. BeginTx + Insert + Commit → the row persists.
+	tx, err := db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelReadCommitted})
+	if err != nil {
+		fail("BeginTx (commit case): %v", err)
+	}
+	if _, err := tx.Exec("INSERT INTO tx_go VALUES (1, 100)"); err != nil {
+		fail("tx insert: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		fail("tx commit: %v", err)
+	}
+	var v int64
+	if err := db.QueryRow("SELECT v FROM tx_go WHERE id = 1").Scan(&v); err != nil {
+		fail("committed row missing: %v", err)
+	}
+	if v != 100 {
+		fail("committed value wrong: %d", v)
+	}
+
+	// 12. BeginTx + Insert + Rollback → the row is discarded.
+	tx2, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		fail("BeginTx (rollback case): %v", err)
+	}
+	if _, err := tx2.Exec("INSERT INTO tx_go VALUES (2, 200)"); err != nil {
+		fail("tx2 insert: %v", err)
+	}
+	if err := tx2.Rollback(); err != nil {
+		fail("tx2 rollback: %v", err)
+	}
+	rows := scanNullInts(db, "SELECT id FROM tx_go ORDER BY id")
+	if len(rows) != 1 || rows[0].Int64 != 1 {
+		fail("rollback did not discard row 2: %v", rows)
+	}
+}
+
+// blockingDemo shows a two-connection blocking interaction: an uncommitted
+// writer blocks a reader on the same table until it commits (READ COMMITTED,
+// no dirty read). The reader runs in a goroutine and must stay blocked until
+// the writer commits, then observe the committed value.
+func blockingDemo(db *sql.DB, host, port, user, pass string) {
+	mustExec(db, "CREATE TABLE block_go (id INT NOT NULL PRIMARY KEY, v INT)")
+	mustExec(db, "INSERT INTO block_go VALUES (1, 1)")
+
+	// A second, independent connection for the writer.
+	writerDB, err := sql.Open("sqlserver", dsn(host, port, user, pass))
+	if err != nil {
+		fail("open writer db: %v", err)
+	}
+	defer writerDB.Close()
+
+	writerTx, err := writerDB.BeginTx(context.Background(), nil)
+	if err != nil {
+		fail("writer BeginTx: %v", err)
+	}
+	if _, err := writerTx.Exec("UPDATE block_go SET v = 2 WHERE id = 1"); err != nil {
+		fail("writer update: %v", err)
+	}
+
+	// The reader (independent connection) blocks on the writer's X lock.
+	value := make(chan int64, 1)
+	readErr := make(chan error, 1)
+	go func() {
+		var v int64
+		if err := db.QueryRow("SELECT v FROM block_go WHERE id = 1").Scan(&v); err != nil {
+			readErr <- err
+			return
+		}
+		value <- v
+	}()
+
+	// While the writer's transaction is open, the reader must not return.
+	select {
+	case <-value:
+		fail("reader was not blocked by the uncommitted writer (dirty read?)")
+	case err := <-readErr:
+		fail("reader errored while blocked: %v", err)
+	case <-time.After(400 * time.Millisecond):
+		// Still blocked, as expected.
+	}
+
+	// Committing the writer releases the lock; the reader unblocks and sees
+	// the committed value (2), never the original (1).
+	if err := writerTx.Commit(); err != nil {
+		fail("writer commit: %v", err)
+	}
+	select {
+	case v := <-value:
+		if v != 2 {
+			fail("reader saw %d, expected the committed value 2", v)
+		}
+	case err := <-readErr:
+		fail("reader errored after commit: %v", err)
+	case <-time.After(5 * time.Second):
+		fail("reader did not unblock after the writer committed")
+	}
 }
 
 func scanNullStrings(db *sql.DB, query string) []sql.NullString {

--- a/scripts/tds_conformance.py
+++ b/scripts/tds_conformance.py
@@ -130,6 +130,29 @@ def main() -> int:
         print(f"FAIL: UNIQUEIDENTIFIER round-trip: {g!r}")
         return 1
 
+    # Stage 6 transactions via the TDS Transaction Manager. DDL runs while
+    # autocommit is on (it is disallowed inside an explicit transaction); DML
+    # transactions then commit/rollback through TM_COMMIT/ROLLBACK requests.
+    cur.execute("CREATE TABLE tx_py (id INT NOT NULL PRIMARY KEY, v INT)")
+
+    conn.autocommit = False
+    cur.execute("INSERT INTO tx_py VALUES (1, 100)")
+    conn.commit()
+    conn.autocommit = True
+    cur.execute("SELECT v FROM tx_py WHERE id = 1")
+    if cur.fetchone()[0] != 100:
+        print("FAIL: committed transaction row missing")
+        return 1
+
+    conn.autocommit = False
+    cur.execute("INSERT INTO tx_py VALUES (2, 200)")
+    conn.rollback()
+    conn.autocommit = True
+    cur.execute("SELECT id FROM tx_py ORDER BY id")
+    if cur.fetchall() != [(1,)]:
+        print("FAIL: rolled-back transaction row was not discarded")
+        return 1
+
     conn.close()
     print("tds conformance: OK")
     return 0

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,6 @@
 #[cfg(not(target_os = "linux"))]
 compile_error!("TruthDB must be built for Linux targets. Use Docker or a Linux environment.");
 
-use std::sync::{Arc, Mutex};
-
 use tokio::sync::watch;
 use tracing::{debug, info};
 use tracing_subscriber::EnvFilter;
@@ -88,24 +86,24 @@ async fn main() {
     };
 
     let engine = match Engine::new(storage) {
-        Ok(engine) => Arc::new(Mutex::new(engine)),
+        Ok(engine) => engine,
         Err(err) => {
             eprintln!("Failed to initialize engine: {err}");
             return;
         }
     };
+    // The engine runs on its own thread behind a message channel; the async
+    // listeners talk to it through a cloneable handle.
+    let (engine, engine_join) = truthdb_core::session::spawn_engine(engine);
 
-    let client_listener = match ClientListener::new(
-        &config.network.addr,
-        config.network.port,
-        Arc::clone(&engine),
-    ) {
-        Ok(client_listener) => client_listener,
-        Err(err) => {
-            eprintln!("Failed to initialize server: {err}");
-            return;
-        }
-    };
+    let client_listener =
+        match ClientListener::new(&config.network.addr, config.network.port, engine.clone()) {
+            Ok(client_listener) => client_listener,
+            Err(err) => {
+                eprintln!("Failed to initialize server: {err}");
+                return;
+            }
+        };
 
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
     let listener_task = tokio::spawn(async move {
@@ -123,7 +121,7 @@ async fn main() {
         match truthdb_tds::TdsListener::bind(
             &config.tds.addr,
             config.tds.port,
-            Arc::clone(&engine),
+            engine.clone(),
             tds_config,
         )
         .await
@@ -160,5 +158,8 @@ async fn main() {
     if let Some(tds_task) = tds_task {
         let _ = tds_task.await;
     }
+    // Stop the engine thread and wait for it to drain/exit.
+    engine.shutdown();
+    let _ = tokio::task::spawn_blocking(move || engine_join.join()).await;
     info!("TruthDB exiting");
 }


### PR DESCRIPTION
Implements **Stage 6** of the relational DB plan: sessions, explicit transactions, table-level locking, isolation levels, and TDS Transaction Manager requests so real drivers can `BeginTx`/`Commit`/`Rollback`.

## What's in it

- **Engine actor** (M1): `Arc<Mutex<Engine>>` replaced by a dedicated engine thread served over an mpsc channel, with per-connection sessions (`SessionManager`) carrying transaction/isolation state. Connection drop rolls back and releases locks.
- **Transactions** (M2): `BEGIN`/`COMMIT`/`ROLLBACK TRANSACTION`, `@@TRANCOUNT` with T-SQL nesting, `SET XACT_ABORT`, `SET TRANSACTION ISOLATION LEVEL`, on ARIES (commit = flush-to-LSN, rollback = undo chain + CLRs). Error model is the **doomed-transaction** model (statement failure inside a txn dooms it → 3930 until `ROLLBACK`; equivalent to `SET XACT_ABORT ON`). DDL inside an explicit txn is rejected.
- **Lock manager** (M3): `IS/IX/S/X` on Database/Table resources, standard compatibility matrix. The single-threaded actor never blocks in place — a batch acquires all its locks up front and is *parked* on conflict, then woken (FIFO) when locks free. A 5s wait deadline reaps the deadlock victim (error **1205**).
- **Isolation levels** (M4): RU (no read locks), RC (shared locks released per statement), RR/SERIALIZABLE (shared locks held to commit).
- **TDS Transaction Manager** (M5): packet `0x0E` (`TM_BEGIN/COMMIT/ROLLBACK_XACT`), `ENVCHANGE` 8/9/10 with transaction descriptors, `DONE_INXACT`. `db.BeginTx()` / `setAutoCommit(false)` now work.

## Review-driven fixes

An adversarial multi-agent review (6 dimensions, per-finding verification) surfaced three real bugs, all fixed here with regression tests:

- **CRITICAL** — a checkpoint firing while an explicit transaction was open would flush its uncommitted pages and truncate the WAL past its undo records, making uncommitted writes permanent on crash. Checkpoints are now skipped while any transaction is open (safe pre-Stage-6 because every statement autocommitted).
- **HIGH** — FIFO anti-barging made a transaction re-touching its own already-locked table yield to a waiter blocked on that same lock, self-deadlocking into a spurious 1205. Already-held locks are now exempt from anti-barging.
- **LOW** — `ROLLBACK` left `@@TRANCOUNT`/doomed set if the storage rollback errored.

## Tests

- `truthdb-core`: engine-actor transaction tests (commit durability across restart, rollback, `@@TRANCOUNT` nesting, doomed-txn 3930, DDL-in-txn, disconnect rollback, uncommitted-explicit-txn crash-undo), lock-manager unit tests, and async blocking/deadlock/isolation tests (writer blocks reader, RC-vs-RR lock lifetime, RU dirty read, deadlock→1205, disconnect wakes waiter, holder-not-blocked-by-own-waiter, isolation escalation).
- `truthdb-tds`: TM begin/commit/rollback over the wire (ENVCHANGE 8/9/10, DONE_INXACT), durability + rollback.
- Two-driver conformance (`go-mssqldb` + `pytds`) extended with `BeginTx`/`Commit`/`Rollback` and a two-connection blocking demo.

`cargo fmt`, `cargo clippy --all-targets --all-features -D warnings`, and `cargo test --workspace` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)