### PR TITLE
Secondary indexes and the query planner [Stage 7]

### DIFF
--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -2245,6 +2245,382 @@ mod tests {
         let _ = std::fs::remove_file(path);
     }
 
+    // ---- secondary indexes + planner (Stage 7) -------------------------
+
+    /// Plan text lines for a SELECT under SHOWPLAN_TEXT (one batch so the SET
+    /// persists to the SELECT).
+    fn plan_lines(engine: &mut Engine, select: &str) -> Vec<String> {
+        let env = sql(engine, &format!("SET SHOWPLAN_TEXT ON; {select}"));
+        let results = env["results"].as_array().expect("results array");
+        let rows = results
+            .iter()
+            .find(|r| r["type"] == "rows")
+            .unwrap_or_else(|| panic!("no plan rows in {env}"));
+        rows["rows"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|r| r[0].as_str().unwrap().to_string())
+            .collect()
+    }
+
+    #[test]
+    fn sql_index_ab_harness_identical_results() {
+        let path = unique_temp_path("sql-index-ab");
+        let mut engine = new_engine(&path);
+        // Two identical tables; an index only on one.
+        for t in ["noidx", "idx"] {
+            engine
+                .execute(&format!(
+                    "CREATE TABLE {t} (id INT NOT NULL PRIMARY KEY, a INT, name NVARCHAR(20))"
+                ))
+                .expect("create");
+            engine
+                .execute(&format!(
+                    "INSERT INTO {t} VALUES (1,10,'a'),(2,20,'b'),(3,20,'c'),(4,30,NULL),(5,10,'e')"
+                ))
+                .expect("insert");
+        }
+        engine
+            .execute("CREATE INDEX ix_a ON idx (a)")
+            .expect("create index");
+
+        // Every query returns identical rows whether it scans or seeks.
+        for pred in [
+            "a = 20",
+            "a > 15",
+            "a >= 20",
+            "a < 25",
+            "a = 10 AND id > 1",
+            "a <> 20",
+        ] {
+            let q = |t: &str| format!("SELECT id, a FROM {t} WHERE {pred} ORDER BY id");
+            let (_, base) = sql_rows(&mut engine, &q("noidx"));
+            let (_, with_index) = sql_rows(&mut engine, &q("idx"));
+            assert_eq!(base, with_index, "mismatch for predicate `{pred}`");
+        }
+
+        // The equality predicate actually uses the index.
+        let plan = plan_lines(&mut engine, "SELECT id FROM idx WHERE a = 20");
+        assert!(
+            plan.iter()
+                .any(|l| l.contains("Index Seek") && l.contains("ix_a")),
+            "expected an index seek, got {plan:?}"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn sql_unique_index_rejects_duplicate_2601() {
+        let path = unique_temp_path("sql-unique-index");
+        let mut engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE t (id INT NOT NULL PRIMARY KEY, email NVARCHAR(50))")
+            .expect("create");
+        engine
+            .execute("INSERT INTO t VALUES (1, 'a@x'), (2, 'b@x')")
+            .expect("insert");
+        engine
+            .execute("CREATE UNIQUE INDEX ux_email ON t (email)")
+            .expect("create unique index");
+        // A duplicate email now violates the unique index (2601, not 2627).
+        assert_eq!(
+            sql_error_number(&mut engine, "INSERT INTO t VALUES (3, 'a@x')"),
+            2601
+        );
+        // Updating to a duplicate also violates it.
+        assert_eq!(
+            sql_error_number(&mut engine, "UPDATE t SET email = 'a@x' WHERE id = 2"),
+            2601
+        );
+        // A distinct value is fine.
+        engine
+            .execute("INSERT INTO t VALUES (3, 'c@x')")
+            .expect("distinct insert");
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn sql_unique_index_build_rejects_existing_duplicates() {
+        let path = unique_temp_path("sql-unique-build");
+        let mut engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE t (id INT NOT NULL PRIMARY KEY, a INT)")
+            .expect("create");
+        engine
+            .execute("INSERT INTO t VALUES (1, 5), (2, 5)")
+            .expect("insert");
+        // Building a unique index over duplicate data fails.
+        assert_eq!(
+            sql_error_number(&mut engine, "CREATE UNIQUE INDEX ux_a ON t (a)"),
+            2601
+        );
+        // ...and the failed build left no index behind (still scannable).
+        let (_, rows) = sql_rows(&mut engine, "SELECT id FROM t ORDER BY id");
+        assert_eq!(rows.len(), 2);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn sql_index_maintained_across_update_and_delete() {
+        let path = unique_temp_path("sql-index-maint");
+        let mut engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE t (id INT NOT NULL PRIMARY KEY, a INT)")
+            .expect("create");
+        engine
+            .execute("INSERT INTO t VALUES (1,10),(2,20),(3,30)")
+            .expect("insert");
+        engine.execute("CREATE INDEX ix_a ON t (a)").expect("index");
+
+        // Update moves a row from a=20 to a=25; delete removes a=30.
+        engine
+            .execute("UPDATE t SET a = 25 WHERE id = 2")
+            .expect("update");
+        engine
+            .execute("DELETE FROM t WHERE a = 30")
+            .expect("delete");
+
+        // Index seeks reflect the mutations.
+        let (_, at20) = sql_rows(&mut engine, "SELECT id FROM t WHERE a = 20");
+        assert!(at20.is_empty(), "a=20 gone after update");
+        let (_, at25) = sql_rows(&mut engine, "SELECT id FROM t WHERE a = 25");
+        assert_eq!(at25, vec![vec![Some("2".into())]]);
+        let (_, at30) = sql_rows(&mut engine, "SELECT id FROM t WHERE a = 30");
+        assert!(at30.is_empty(), "a=30 gone after delete");
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn sql_showplan_text_reports_seek_versus_scan() {
+        let path = unique_temp_path("sql-showplan");
+        let mut engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE t (id INT NOT NULL PRIMARY KEY, a INT)")
+            .expect("create");
+        engine.execute("CREATE INDEX ix_a ON t (a)").expect("index");
+
+        let seek = plan_lines(&mut engine, "SELECT id FROM t WHERE a = 7");
+        assert_eq!(seek[0], "Index Seek(t.ix_a), SEEK: a = 7");
+        assert_eq!(seek[1], "Key Lookup(t)");
+
+        // No sargable predicate → a scan.
+        let scan = plan_lines(&mut engine, "SELECT id FROM t WHERE a + 1 = 8");
+        assert_eq!(scan, vec!["Table Scan(t)".to_string()]);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn sql_index_survives_restart() {
+        let path = unique_temp_path("sql-index-restart");
+        let mut engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE t (id INT NOT NULL PRIMARY KEY, a INT)")
+            .expect("create");
+        engine
+            .execute("INSERT INTO t VALUES (1,10),(2,20)")
+            .expect("insert");
+        engine.execute("CREATE INDEX ix_a ON t (a)").expect("index");
+
+        drop(engine);
+        let storage = Storage::open(path.clone()).expect("reopen");
+        let mut engine = Engine::new(storage).expect("replay");
+        // The index is still usable after recovery.
+        let plan = plan_lines(&mut engine, "SELECT id FROM t WHERE a = 20");
+        assert!(plan.iter().any(|l| l.contains("Index Seek")), "{plan:?}");
+        let (_, rows) = sql_rows(&mut engine, "SELECT id FROM t WHERE a = 20");
+        assert_eq!(rows, vec![vec![Some("2".into())]]);
+        // Maintenance still works post-restart.
+        engine
+            .execute("INSERT INTO t VALUES (3, 20)")
+            .expect("insert after restart");
+        let (_, rows) = sql_rows(&mut engine, "SELECT id FROM t WHERE a = 20 ORDER BY id");
+        assert_eq!(rows, vec![vec![Some("2".into())], vec![Some("3".into())]]);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn sql_composite_and_descending_index_seek() {
+        let path = unique_temp_path("sql-composite-index");
+        let mut engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE t (id INT NOT NULL PRIMARY KEY, a INT, b INT)")
+            .expect("create");
+        engine
+            .execute("INSERT INTO t VALUES (1,1,100),(2,1,200),(3,2,100),(4,2,200)")
+            .expect("insert");
+        engine
+            .execute("CREATE INDEX ix_ab ON t (a, b DESC)")
+            .expect("create composite index");
+
+        // Equality on the leading column + range on the second seeks the index.
+        let plan = plan_lines(&mut engine, "SELECT id FROM t WHERE a = 2 AND b = 200");
+        assert!(plan.iter().any(|l| l.contains("Index Seek")), "{plan:?}");
+        let (_, rows) = sql_rows(&mut engine, "SELECT id FROM t WHERE a = 2 AND b = 200");
+        assert_eq!(rows, vec![vec![Some("4".into())]]);
+        // Leading-column-only seek returns both a=1 rows.
+        let (_, rows) = sql_rows(&mut engine, "SELECT id FROM t WHERE a = 1 ORDER BY id");
+        assert_eq!(rows, vec![vec![Some("1".into())], vec![Some("2".into())]]);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn sql_index_on_heap_table_uses_rid_locator() {
+        let path = unique_temp_path("sql-heap-index");
+        let mut engine = new_engine(&path);
+        // No PRIMARY KEY → heap table.
+        engine
+            .execute("CREATE TABLE h (a INT, name NVARCHAR(20))")
+            .expect("create heap");
+        engine
+            .execute("INSERT INTO h VALUES (10,'x'),(20,'y'),(10,'z')")
+            .expect("insert");
+        engine.execute("CREATE INDEX ix_a ON h (a)").expect("index");
+
+        let plan = plan_lines(&mut engine, "SELECT name FROM h WHERE a = 10");
+        assert!(plan.iter().any(|l| l.contains("Index Seek")), "{plan:?}");
+        let (_, mut rows) = sql_rows(&mut engine, "SELECT name FROM h WHERE a = 10");
+        rows.sort();
+        assert_eq!(rows, vec![vec![Some("x".into())], vec![Some("z".into())]]);
+        // Update through a heap row keeps the index consistent.
+        engine
+            .execute("UPDATE h SET a = 99 WHERE name = 'x'")
+            .expect("update");
+        let (_, rows) = sql_rows(&mut engine, "SELECT name FROM h WHERE a = 10");
+        assert_eq!(rows, vec![vec![Some("z".into())]]);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn sql_drop_index_and_sys_indexes() {
+        let path = unique_temp_path("sql-drop-index");
+        let mut engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE t (id INT NOT NULL PRIMARY KEY, a INT)")
+            .expect("create");
+        engine.execute("CREATE INDEX ix_a ON t (a)").expect("index");
+
+        // sys.indexes lists it.
+        let (_, rows) = sql_rows(&mut engine, "SELECT name FROM sys.indexes");
+        assert_eq!(rows, vec![vec![Some("ix_a".into())]]);
+
+        engine.execute("DROP INDEX ix_a ON t").expect("drop index");
+        let (_, rows) = sql_rows(&mut engine, "SELECT name FROM sys.indexes");
+        assert!(rows.is_empty(), "index gone from catalog");
+        // Queries now scan.
+        let plan = plan_lines(&mut engine, "SELECT id FROM t WHERE a = 1");
+        assert_eq!(plan, vec!["Table Scan(t)".to_string()]);
+        // Dropping a missing index errors 3701.
+        assert_eq!(sql_error_number(&mut engine, "DROP INDEX nope ON t"), 3701);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn sql_nvarchar_equality_seeks_but_range_scans() {
+        let path = unique_temp_path("sql-index-nvarchar");
+        let mut engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE t (id INT NOT NULL PRIMARY KEY, name NVARCHAR(20))")
+            .expect("create");
+        engine
+            .execute("INSERT INTO t VALUES (1, 'abc'), (2, 'ABC'), (3, 'xyz')")
+            .expect("insert");
+        engine
+            .execute("CREATE INDEX ix_name ON t (name)")
+            .expect("index");
+
+        // Equality is an exact byte match, so it seeks; the filter compares by
+        // code point, so it is case-sensitive.
+        let plan = plan_lines(&mut engine, "SELECT id FROM t WHERE name = 'abc'");
+        assert!(plan.iter().any(|l| l.contains("Index Seek")), "{plan:?}");
+        let (_, rows) = sql_rows(&mut engine, "SELECT id FROM t WHERE name = 'abc'");
+        assert_eq!(rows, vec![vec![Some("1".into())]], "'ABC' is not 'abc'");
+
+        // A range on NVARCHAR must NOT seek (UTF-16BE key order can diverge
+        // from code-point order at astral characters); it scans and stays
+        // correct.
+        let plan = plan_lines(&mut engine, "SELECT id FROM t WHERE name > 'a'");
+        assert_eq!(plan, vec!["Table Scan(t)".to_string()]);
+        let (_, mut rows) = sql_rows(&mut engine, "SELECT id FROM t WHERE name > 'a'");
+        rows.sort();
+        // 'ABC' (0x41..) < 'a' (0x61) by code point; 'abc','xyz' > 'a'.
+        assert_eq!(rows, vec![vec![Some("1".into())], vec![Some("3".into())]]);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn sql_varchar_range_can_index_seek() {
+        let path = unique_temp_path("sql-index-varchar");
+        let mut engine = new_engine(&path);
+        // VARCHAR keys are UTF-8 bytes, whose order equals code-point order, so
+        // a range seek is correct.
+        engine
+            .execute("CREATE TABLE t (id INT NOT NULL PRIMARY KEY, code VARCHAR(20))")
+            .expect("create");
+        engine
+            .execute("INSERT INTO t VALUES (1,'aaa'),(2,'mmm'),(3,'zzz')")
+            .expect("insert");
+        engine
+            .execute("CREATE INDEX ix_code ON t (code)")
+            .expect("index");
+
+        let plan = plan_lines(&mut engine, "SELECT id FROM t WHERE code > 'b'");
+        assert!(plan.iter().any(|l| l.contains("Index Seek")), "{plan:?}");
+        let (_, mut rows) = sql_rows(&mut engine, "SELECT id FROM t WHERE code > 'b'");
+        rows.sort();
+        assert_eq!(rows, vec![vec![Some("2".into())], vec![Some("3".into())]]);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn sql_drop_index_is_table_scoped() {
+        let path = unique_temp_path("sql-drop-scoped");
+        let mut engine = new_engine(&path);
+        // Two tables with same-named indexes; DROP INDEX must only touch the
+        // named table's index.
+        for t in ["t1", "t2"] {
+            engine
+                .execute(&format!(
+                    "CREATE TABLE {t} (id INT NOT NULL PRIMARY KEY, a INT)"
+                ))
+                .expect("create");
+            engine
+                .execute(&format!("CREATE INDEX ix ON {t} (a)"))
+                .expect("index");
+        }
+        engine.execute("DROP INDEX ix ON t1").expect("drop t1.ix");
+
+        // t2's index survives; t1's is gone.
+        let (_, rows) = sql_rows(
+            &mut engine,
+            "SELECT object_id FROM sys.indexes ORDER BY object_id",
+        );
+        assert_eq!(rows.len(), 1, "only t2's index remains");
+        let plan = plan_lines(&mut engine, "SELECT id FROM t2 WHERE a = 1");
+        assert!(
+            plan.iter().any(|l| l.contains("Index Seek")),
+            "t2 still seeks"
+        );
+        let plan = plan_lines(&mut engine, "SELECT id FROM t1 WHERE a = 1");
+        assert_eq!(plan, vec!["Table Scan(t1)".to_string()], "t1 index dropped");
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn sql_create_index_inside_transaction_is_rejected() {
+        let path = unique_temp_path("sql-index-in-txn");
+        let mut engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE t (id INT NOT NULL PRIMARY KEY, a INT)")
+            .expect("create");
+        // DDL (incl. CREATE INDEX) is disallowed inside an explicit transaction.
+        assert_eq!(
+            sql_error_number(&mut engine, "BEGIN TRAN; CREATE INDEX ix_a ON t (a);"),
+            226
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
     #[test]
     fn sql_non_boolean_where_is_rejected_4145() {
         let path = unique_temp_path("sql-where-4145");

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -8,11 +8,12 @@
 //! error numbers.
 
 pub mod collation;
+mod plan;
 mod value;
 
 use truthdb_sql::ast::{
-    ColumnDef, CreateTable, DataType, Delete, DropTable, Expr, ExprKind, Insert, IsolationLevel,
-    Name, OrderItem, Select, SelectItem, SetStatement, Statement, Update,
+    ColumnDef, CreateIndex, CreateTable, DataType, Delete, DropIndex, DropTable, Expr, ExprKind,
+    Insert, IsolationLevel, Name, OrderItem, Select, SelectItem, SetStatement, Statement, Update,
 };
 use truthdb_sql::error::SqlError;
 use truthdb_sql::eval::EvalContext;
@@ -38,6 +39,8 @@ pub struct TxnContext {
     doomed: bool,
     xact_abort: bool,
     isolation: Isolation,
+    /// `SET SHOWPLAN_TEXT ON` — a SELECT returns its plan text, not results.
+    showplan_text: bool,
 }
 
 /// Session isolation level (defaults to READ COMMITTED, like SQL Server).
@@ -214,7 +217,10 @@ pub fn analyze_locks(
             }
             // DDL serializes against every active transaction via a
             // database-exclusive lock (it is disallowed inside a txn anyway).
-            Statement::CreateTable(_) | Statement::DropTable(_) => {
+            Statement::CreateTable(_)
+            | Statement::DropTable(_)
+            | Statement::CreateIndex(_)
+            | Statement::DropIndex(_) => {
                 add(Resource::Database, LockMode::Exclusive);
             }
             // Transaction control and SET take no data locks.
@@ -280,6 +286,18 @@ fn exec_statement(
             }
             exec_drop_table(storage, drop)
         }
+        Statement::CreateIndex(create) => {
+            if txn_ctx.in_txn() {
+                return Err(ddl_in_txn_err());
+            }
+            exec_create_index(storage, create)
+        }
+        Statement::DropIndex(drop) => {
+            if txn_ctx.in_txn() {
+                return Err(ddl_in_txn_err());
+            }
+            exec_drop_index(storage, drop)
+        }
         Statement::Insert(insert) => {
             let eval_ctx = txn_ctx.eval_context();
             let mut scope = txn_ctx.scope();
@@ -297,11 +315,50 @@ fn exec_statement(
         }
         Statement::Select(select) => {
             let eval_ctx = txn_ctx.eval_context();
-            Ok(StatementResult::Rows(exec_select(
-                storage, select, &eval_ctx,
-            )?))
+            if txn_ctx.showplan_text {
+                Ok(StatementResult::Rows(showplan_rows(
+                    storage, select, &eval_ctx,
+                )?))
+            } else {
+                Ok(StatementResult::Rows(exec_select(
+                    storage, select, &eval_ctx,
+                )?))
+            }
         }
     }
+}
+
+/// Builds a one-column `SHOWPLAN_TEXT` rowset describing a SELECT's access
+/// path, without executing it.
+fn showplan_rows(
+    storage: &mut Storage,
+    select: &Select,
+    eval_ctx: &EvalContext,
+) -> Result<RowSet, SqlError> {
+    let lines = match select.from.as_ref() {
+        Some(from) if !from.value.to_ascii_lowercase().starts_with("sys.") => {
+            match resolve_table(storage, &from.value) {
+                Some(def) => {
+                    let schema = def.schema().map_err(|e| map_storage_err(e, &def.name))?;
+                    let path = plan::choose(&def, &schema, &select.where_clause, eval_ctx);
+                    plan::plan_text(&path, &def.name)
+                }
+                None => vec![format!("Table Scan({})", from.value)],
+            }
+        }
+        Some(from) => vec![format!("Table Scan({})", from.value)],
+        None => vec!["Constant Scan".to_string()],
+    };
+    Ok(RowSet {
+        columns: vec![ResultColumn {
+            name: "StmtText".to_string(),
+            column_type: ColumnType::NVarChar { max_len: 4000 },
+        }],
+        rows: lines
+            .into_iter()
+            .map(|line| vec![Datum::NVarChar(line)])
+            .collect(),
+    })
 }
 
 fn ddl_in_txn_err() -> SqlError {
@@ -380,6 +437,7 @@ fn exec_set(ctx: &mut TxnContext, set: &SetStatement) -> Result<StatementResult,
                 IsolationLevel::Serializable => Isolation::Serializable,
             }
         }
+        SetStatement::ShowplanText(on) => ctx.showplan_text = *on,
     }
     Ok(StatementResult::Done)
 }
@@ -611,6 +669,52 @@ fn exec_drop_table(storage: &mut Storage, drop: &DropTable) -> Result<StatementR
     }
 }
 
+// ---- CREATE / DROP INDEX ------------------------------------------------
+
+fn exec_create_index(
+    storage: &mut Storage,
+    create: &CreateIndex,
+) -> Result<StatementResult, SqlError> {
+    let def = resolve_table(storage, &create.table.value)
+        .ok_or_else(|| SqlError::invalid_object(&create.table.value).at(create.table.span))?;
+    let schema = def.schema().map_err(|e| map_storage_err(e, &def.name))?;
+    let mut columns = Vec::with_capacity(create.columns.len());
+    for col in &create.columns {
+        let index = schema
+            .columns
+            .iter()
+            .position(|c| c.name.eq_ignore_ascii_case(&col.name.value))
+            .ok_or_else(|| SqlError::invalid_column(&col.name.value).at(col.name.span))?;
+        columns.push((index, col.ascending));
+    }
+    storage
+        .rel_create_index(&def.name, create.name.value.clone(), columns, create.unique)
+        .map_err(|e| map_storage_err(e, &def.name))?;
+    Ok(StatementResult::Done)
+}
+
+fn exec_drop_index(storage: &mut Storage, drop: &DropIndex) -> Result<StatementResult, SqlError> {
+    // Resolve the table so the index lookup is scoped to it (index names are
+    // per-table; two tables may share an index name).
+    let table = resolve_table(storage, &drop.table.value)
+        .ok_or_else(|| SqlError::invalid_object(&drop.table.value).at(drop.table.span))?;
+    let existed = storage
+        .rel_drop_index(&table.name, &drop.name.value)
+        .map_err(|e| map_storage_err(e, &drop.name.value))?;
+    if !existed {
+        return Err(SqlError::new(
+            3701,
+            11,
+            5,
+            format!(
+                "Cannot drop the index '{}', because it does not exist or you do not have permission.",
+                drop.name.value
+            ),
+        ));
+    }
+    Ok(StatementResult::Done)
+}
+
 // ---- INSERT -------------------------------------------------------------
 
 fn exec_insert(
@@ -824,7 +928,9 @@ fn exec_update(
         if !predicate_true(&update.where_clause, &row, &types, &resolver, eval_ctx)? {
             continue;
         }
-        // Every SET expression sees the pre-update row.
+        // Every SET expression sees the pre-update row; keep the old values
+        // for secondary-index maintenance.
+        let old_values = row.clone();
         let old_scope = row_values(&row, &types);
         let mut new_row = row;
         for (index, expr) in &assignments {
@@ -838,7 +944,7 @@ fn exec_update(
             }
             new_row[*index] = value::sql_to_datum(&sql_value, &column.column_type, &column.name)?;
         }
-        updates.push((locator, new_row));
+        updates.push((locator, old_values, new_row));
     }
     let count = storage
         .rel_update_located(&def.name, updates, scope)
@@ -864,7 +970,8 @@ fn exec_delete(
     let mut targets = Vec::new();
     for (locator, row) in located {
         if predicate_true(&delete.where_clause, &row, &types, &resolver, eval_ctx)? {
-            targets.push(locator);
+            // Keep the row values for secondary-index maintenance.
+            targets.push((locator, row));
         }
     }
     let count = storage
@@ -942,7 +1049,12 @@ fn exec_select(
     select: &Select,
     eval_ctx: &EvalContext,
 ) -> Result<RowSet, SqlError> {
-    let source = build_source(storage, select.from.as_ref())?;
+    let source = build_source(
+        storage,
+        select.from.as_ref(),
+        &select.where_clause,
+        eval_ctx,
+    )?;
     let resolver = source.names();
     let types = source.types();
 
@@ -1166,7 +1278,12 @@ fn bare_column_index(expr: &Expr, columns: &[String]) -> Option<usize> {
     }
 }
 
-fn build_source(storage: &mut Storage, from: Option<&Name>) -> Result<Source, SqlError> {
+fn build_source(
+    storage: &mut Storage,
+    from: Option<&Name>,
+    where_clause: &Option<Expr>,
+    eval_ctx: &EvalContext,
+) -> Result<Source, SqlError> {
     let Some(from) = from else {
         // No FROM: one row, no columns (constant SELECT).
         return Ok(Source {
@@ -1178,13 +1295,26 @@ fn build_source(storage: &mut Storage, from: Option<&Name>) -> Result<Source, Sq
     match from.value.to_ascii_lowercase().as_str() {
         "sys.tables" => Ok(sys_tables(storage)),
         "sys.columns" => Ok(sys_columns(storage)),
+        "sys.indexes" => Ok(sys_indexes(storage)),
         _ => {
             let def = resolve_table(storage, &from.value)
                 .ok_or_else(|| SqlError::invalid_object(&from.value).at(from.span))?;
             let schema = def.schema().map_err(|e| map_storage_err(e, &def.name))?;
-            let rows = storage
-                .rel_scan(&def.name)
-                .map_err(|err| map_storage_err(err, &def.name))?;
+            // Access-path selection: an index seek narrows the candidate set;
+            // the WHERE filter above re-checks, so results match a full scan.
+            let rows = match plan::choose(&def, &schema, where_clause, eval_ctx) {
+                plan::AccessPath::TableScan => storage
+                    .rel_scan(&def.name)
+                    .map_err(|err| map_storage_err(err, &def.name))?,
+                plan::AccessPath::IndexSeek {
+                    index_object_id,
+                    lower,
+                    upper,
+                    ..
+                } => storage
+                    .rel_index_scan(&def.name, index_object_id, lower, upper)
+                    .map_err(|err| map_storage_err(err, &def.name))?,
+            };
             let columns = schema
                 .columns
                 .iter()
@@ -1274,6 +1404,35 @@ fn sys_columns(storage: &Storage) -> Source {
     }
 }
 
+fn sys_indexes(storage: &Storage) -> Source {
+    let columns = vec![
+        int_col("object_id"),
+        int_col("index_id"),
+        nvarchar("name", 128),
+        ResultColumn {
+            name: "is_unique".to_string(),
+            column_type: ColumnType::Bit,
+        },
+    ];
+    let mut rows = Vec::new();
+    for def in storage.rel_tables() {
+        for index in &def.indexes {
+            rows.push(vec![
+                Datum::Int(def.object_id as i32),
+                Datum::Int(index.object_id as i32),
+                Datum::NVarChar(index.name.clone()),
+                Datum::Bit(index.unique),
+            ]);
+        }
+    }
+    let collations = vec![None; columns.len()];
+    Source {
+        columns,
+        collations,
+        rows,
+    }
+}
+
 // ---- helpers ------------------------------------------------------------
 
 /// Evaluates a constant expression (INSERT VALUES): no columns in scope.
@@ -1317,6 +1476,14 @@ fn map_storage_err(err: StorageError, table: &str) -> SqlError {
     match err {
         StorageError::Constraint(msg) if msg.contains("duplicate primary key") => {
             SqlError::pk_violation(table)
+        }
+        StorageError::Constraint(msg) if msg.contains("duplicate unique index") => {
+            // 2601: cannot insert a duplicate key row in a unique index.
+            SqlError::new(2601, 14, 1, msg)
+        }
+        StorageError::Constraint(msg) if msg.contains("already exists") => {
+            // 1913: an index with that name already exists on the table.
+            SqlError::new(1913, 16, 1, msg)
         }
         StorageError::Constraint(msg) if msg.contains("does not allow NULL") => {
             SqlError::new(515, 16, 2, msg)

--- a/crates/truthdb-core/src/rel/plan.rs
+++ b/crates/truthdb-core/src/rel/plan.rs
@@ -1,0 +1,340 @@
+//! Single-table access-path selection (Stage 7): choose a sargable index seek
+//! over a full table scan. The chosen path only *narrows* the candidate set —
+//! the executor re-applies the whole WHERE afterwards — so seek bounds may
+//! over-fetch and results are always identical to a scan. That property keeps
+//! the planner simple and the A/B (index vs no-index) results equal.
+
+use truthdb_sql::ast::{BinaryOp, Expr, ExprKind};
+use truthdb_sql::eval::{self, EvalContext};
+
+use crate::relstore::catalog::{IndexDef, TableDef};
+use crate::relstore::index;
+use crate::relstore::row::{Column, Schema};
+use crate::relstore::types::{ColumnType, Datum};
+
+use super::value::sql_to_datum;
+
+/// The access path chosen for a single-table read.
+pub enum AccessPath {
+    /// Full clustered/heap scan.
+    TableScan,
+    /// Seek an index over `[lower, upper]` (either bound `None` = open), then
+    /// look up each row by its locator.
+    IndexSeek {
+        index_object_id: u32,
+        index_name: String,
+        lower: Option<Vec<u8>>,
+        upper: Option<Vec<u8>>,
+        /// Seek predicate descriptions, for `SHOWPLAN`.
+        predicates: Vec<String>,
+        unique: bool,
+    },
+}
+
+/// A sargable atom `column <op> constant`.
+struct Sarg {
+    column: usize,
+    op: BinaryOp,
+    value: Datum,
+}
+
+/// Inclusive `(lower, upper)` seek bounds (either side `None` = open).
+type Bounds = (Option<Vec<u8>>, Option<Vec<u8>>);
+
+/// Chooses the access path for a table read given its WHERE clause. Prefers
+/// the index matching the most equality columns (a fully-matched UNIQUE index
+/// — a unique seek — wins outright), else a range seek, else a scan.
+pub fn choose(
+    def: &TableDef,
+    schema: &Schema,
+    where_clause: &Option<Expr>,
+    eval_ctx: &EvalContext,
+) -> AccessPath {
+    let Some(predicate) = where_clause else {
+        return AccessPath::TableScan;
+    };
+    if def.indexes.is_empty() {
+        return AccessPath::TableScan;
+    }
+    let mut sargs = Vec::new();
+    collect_sargs(predicate, schema, eval_ctx, &mut sargs);
+    if sargs.is_empty() {
+        return AccessPath::TableScan;
+    }
+    let mut best: Option<(u32, AccessPath)> = None;
+    for index in &def.indexes {
+        if let Some((score, path)) = try_index(index, schema, &sargs)
+            && best.as_ref().is_none_or(|(s, _)| score > *s)
+        {
+            best = Some((score, path));
+        }
+    }
+    best.map(|(_, path)| path).unwrap_or(AccessPath::TableScan)
+}
+
+/// Renders the plan as `SHOWPLAN_TEXT` rows.
+pub fn plan_text(path: &AccessPath, table: &str) -> Vec<String> {
+    match path {
+        AccessPath::TableScan => vec![format!("Table Scan({table})")],
+        AccessPath::IndexSeek {
+            index_name,
+            predicates,
+            unique,
+            ..
+        } => {
+            let kind = if *unique {
+                "Index Seek (unique)"
+            } else {
+                "Index Seek"
+            };
+            vec![
+                format!(
+                    "{kind}({table}.{index_name}), SEEK: {}",
+                    predicates.join(", ")
+                ),
+                format!("Key Lookup({table})"),
+            ]
+        }
+    }
+}
+
+fn collect_sargs(expr: &Expr, schema: &Schema, eval_ctx: &EvalContext, out: &mut Vec<Sarg>) {
+    match &expr.kind {
+        ExprKind::Binary {
+            op: BinaryOp::And,
+            left,
+            right,
+        } => {
+            collect_sargs(left, schema, eval_ctx, out);
+            collect_sargs(right, schema, eval_ctx, out);
+        }
+        ExprKind::Binary { op, left, right } if is_seekable(*op) => {
+            if let Some(sarg) = as_sarg(*op, left, right, schema, eval_ctx) {
+                out.push(sarg);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn is_seekable(op: BinaryOp) -> bool {
+    matches!(
+        op,
+        BinaryOp::Eq | BinaryOp::Lt | BinaryOp::Le | BinaryOp::Gt | BinaryOp::Ge
+    )
+}
+
+fn flip(op: BinaryOp) -> BinaryOp {
+    match op {
+        BinaryOp::Lt => BinaryOp::Gt,
+        BinaryOp::Le => BinaryOp::Ge,
+        BinaryOp::Gt => BinaryOp::Lt,
+        BinaryOp::Ge => BinaryOp::Le,
+        other => other,
+    }
+}
+
+fn as_sarg(
+    op: BinaryOp,
+    left: &Expr,
+    right: &Expr,
+    schema: &Schema,
+    eval_ctx: &EvalContext,
+) -> Option<Sarg> {
+    if let ExprKind::Column(name) = &left.kind
+        && let Some(column) = resolve_column(schema, &name.value)
+        && let Some(value) = eval_const(
+            right,
+            &schema.columns[column].column_type,
+            &name.value,
+            eval_ctx,
+        )
+    {
+        return Some(Sarg { column, op, value });
+    }
+    if let ExprKind::Column(name) = &right.kind
+        && let Some(column) = resolve_column(schema, &name.value)
+        && let Some(value) = eval_const(
+            left,
+            &schema.columns[column].column_type,
+            &name.value,
+            eval_ctx,
+        )
+    {
+        return Some(Sarg {
+            column,
+            op: flip(op),
+            value,
+        });
+    }
+    None
+}
+
+/// Whether a column may back an index *range* seek. An index seek is correct
+/// only when the index's key byte order matches the WHERE filter's compare
+/// order for that column. The filter compares strings by Rust `str` order
+/// (Unicode code point; collation-insensitive for now). Numbers/dates/GUIDs
+/// and VARCHAR (UTF-8 bytes) already match. NVARCHAR index keys are UTF-16BE,
+/// whose byte order diverges from code-point order at supplementary-plane
+/// characters (surrogate pairs) — so an NVARCHAR *range* bound could exclude a
+/// matching row the filter keeps. Equality seeks are exact byte matches and
+/// stay correct for every type, so only NVARCHAR ranges are excluded here.
+///
+/// (When a later stage makes WHERE collation-aware, index keys must switch to
+/// collation sort keys or this gate must widen to non-binary collations too.)
+fn range_seekable_column(column: &Column) -> bool {
+    !matches!(column.column_type, ColumnType::NVarChar { .. })
+}
+
+/// Evaluates a would-be constant operand. Returns None if it references a
+/// column, is NULL, or does not coerce to the column type (all non-sargable —
+/// execution's own filter handles them).
+fn eval_const(
+    expr: &Expr,
+    column_type: &crate::relstore::types::ColumnType,
+    column_name: &str,
+    eval_ctx: &EvalContext,
+) -> Option<Datum> {
+    let empty: Vec<String> = Vec::new();
+    let value = eval::eval(expr, &[], &empty, eval_ctx).ok()?;
+    if value.is_null() {
+        return None;
+    }
+    sql_to_datum(&value, column_type, column_name).ok()
+}
+
+fn resolve_column(schema: &Schema, name: &str) -> Option<usize> {
+    schema
+        .columns
+        .iter()
+        .position(|c| c.name.eq_ignore_ascii_case(name))
+}
+
+fn try_index(index: &IndexDef, schema: &Schema, sargs: &[Sarg]) -> Option<(u32, AccessPath)> {
+    // Equality prefix over the leading index columns.
+    let mut eq_values: Vec<Datum> = Vec::new();
+    let mut predicates: Vec<String> = Vec::new();
+    let mut i = 0;
+    while i < index.columns.len() {
+        let (col, _) = index.columns[i];
+        if let Some(sarg) = sargs
+            .iter()
+            .find(|s| s.column == col && s.op == BinaryOp::Eq)
+        {
+            predicates.push(format!(
+                "{} = {}",
+                schema.columns[col].name,
+                datum_display(&sarg.value)
+            ));
+            eq_values.push(sarg.value.clone());
+            i += 1;
+        } else {
+            break;
+        }
+    }
+    // Optional single range on the next column. Ascending only (a descending
+    // range would need reversed bounds) and never NVARCHAR (UTF-16BE key order
+    // can diverge from the filter's code-point order); equality prefixes above
+    // are exact matches and stay correct for all types.
+    let mut lower_extra: Option<Datum> = None;
+    let mut upper_extra: Option<Datum> = None;
+    if i < index.columns.len() {
+        let (col, ascending) = index.columns[i];
+        if ascending && range_seekable_column(&schema.columns[col]) {
+            for sarg in sargs.iter().filter(|s| s.column == col) {
+                match sarg.op {
+                    BinaryOp::Gt | BinaryOp::Ge => {
+                        lower_extra = Some(sarg.value.clone());
+                        predicates.push(format!(
+                            "{} {} {}",
+                            schema.columns[col].name,
+                            op_text(sarg.op),
+                            datum_display(&sarg.value)
+                        ));
+                    }
+                    BinaryOp::Lt | BinaryOp::Le => {
+                        upper_extra = Some(sarg.value.clone());
+                        predicates.push(format!(
+                            "{} {} {}",
+                            schema.columns[col].name,
+                            op_text(sarg.op),
+                            datum_display(&sarg.value)
+                        ));
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+    if eq_values.is_empty() && lower_extra.is_none() && upper_extra.is_none() {
+        return None;
+    }
+    let (lower, upper) = build_bounds(index, &eq_values, &lower_extra, &upper_extra)?;
+    let unique_full = index.unique && eq_values.len() == index.columns.len();
+    let score = (eq_values.len() as u32) * 10
+        + if unique_full { 1000 } else { 0 }
+        + u32::from(lower_extra.is_some() || upper_extra.is_some());
+    Some((
+        score,
+        AccessPath::IndexSeek {
+            index_object_id: index.object_id,
+            index_name: index.name.clone(),
+            lower,
+            upper,
+            predicates,
+            unique: index.unique,
+        },
+    ))
+}
+
+fn build_bounds(
+    index: &IndexDef,
+    eq_values: &[Datum],
+    lower_extra: &Option<Datum>,
+    upper_extra: &Option<Datum>,
+) -> Option<Bounds> {
+    let cols = &index.columns;
+    let mut lower_vals = eq_values.to_vec();
+    if let Some(value) = lower_extra {
+        lower_vals.push(value.clone());
+    }
+    let lower = if lower_vals.is_empty() {
+        None
+    } else {
+        Some(index::encode_index_prefix(&lower_vals, cols).ok()?)
+    };
+    let upper = if let Some(value) = upper_extra {
+        let mut upper_vals = eq_values.to_vec();
+        upper_vals.push(value.clone());
+        let encoded = index::encode_index_prefix(&upper_vals, cols).ok()?;
+        index::prefix_upper_bound(&encoded)
+    } else if !eq_values.is_empty() {
+        let encoded = index::encode_index_prefix(eq_values, cols).ok()?;
+        index::prefix_upper_bound(&encoded)
+    } else {
+        None
+    };
+    Some((lower, upper))
+}
+
+fn op_text(op: BinaryOp) -> &'static str {
+    match op {
+        BinaryOp::Eq => "=",
+        BinaryOp::Lt => "<",
+        BinaryOp::Le => "<=",
+        BinaryOp::Gt => ">",
+        BinaryOp::Ge => ">=",
+        _ => "?",
+    }
+}
+
+fn datum_display(datum: &Datum) -> String {
+    match datum {
+        Datum::TinyInt(v) => v.to_string(),
+        Datum::SmallInt(v) => v.to_string(),
+        Datum::Int(v) => v.to_string(),
+        Datum::BigInt(v) => v.to_string(),
+        Datum::VarChar(s) | Datum::NVarChar(s) => format!("'{s}'"),
+        other => format!("{other:?}"),
+    }
+}

--- a/crates/truthdb-core/src/relstore/btree.rs
+++ b/crates/truthdb-core/src/relstore/btree.rs
@@ -15,7 +15,7 @@
 //! performed in memory, then logged as full-page images of every touched
 //! page (redo is idempotent by page LSN), never undone.
 
-use crate::relstore::ctx::{OpMode, RelCtx};
+use crate::relstore::ctx::{LogMode, OpMode, RelCtx};
 use crate::relstore::page::PAGE_TYPE_TREE;
 use crate::relstore::slotted::{NO_PAGE, SlottedPage, SlottedRead};
 use crate::storage::StorageError;
@@ -211,6 +211,54 @@ impl BTree {
         }
     }
 
+    /// Inserts a unique key logged as a system image (redo-only, no undo).
+    /// Used to backfill a freshly-created index tree: the tree is not yet in
+    /// the statement's undo roots, so per-insert undo could not re-descend it.
+    /// A failed build simply leaves the whole tree an unreferenced orphan (the
+    /// catalog entry that would name it is undone), matching the accepted
+    /// DDL-rollback page-leak trade-off.
+    pub fn insert_unique_bulk(
+        &self,
+        ctx: &mut RelCtx<'_>,
+        key: &[u8],
+        row: &[u8],
+    ) -> Result<TreeInsert, StorageError> {
+        let cell = leaf_cell(key, row);
+        if cell.len() > TREE_MAX_CELL {
+            return Err(StorageError::InvalidConfig(format!(
+                "tree row of {} bytes exceeds the per-cell cap of {TREE_MAX_CELL}",
+                cell.len()
+            )));
+        }
+        loop {
+            let path = self.descend(ctx, key)?;
+            let leaf = path.last().expect("leaf").page;
+            let frame = ctx.fetch(leaf)?;
+            let page = SlottedRead::new(ctx.pool.page(frame));
+            let position = match leaf_search(&page, key) {
+                Ok(_) => {
+                    ctx.pool.unpin(frame);
+                    return Ok(TreeInsert::DuplicateKey);
+                }
+                Err(position) => position,
+            };
+            let fits = page.total_free() >= cell.len() + 4;
+            ctx.pool.unpin(frame);
+            if fits {
+                ctx.apply_op(
+                    LogMode::System,
+                    PageOpRedo::InsertAt {
+                        page: leaf,
+                        index: position as u16,
+                        bytes: cell.clone(),
+                    },
+                )?;
+                return Ok(TreeInsert::Inserted);
+            }
+            self.split_one(ctx, &path)?;
+        }
+    }
+
     /// Deletes `key`, returning the removed row. No rebalancing (deletes
     /// leave pages sparse, SQL Server-style).
     pub fn delete(
@@ -346,6 +394,70 @@ impl BTree {
             page_no = next;
         }
         Ok(out)
+    }
+
+    /// Range scan in key order: `(key, row)` pairs with `lower <= key <= upper`
+    /// (either bound `None` = unbounded on that side). Descends to `lower`'s
+    /// leaf, then walks the leaf chain, stopping past `upper`.
+    pub fn scan_range(
+        &self,
+        ctx: &mut RelCtx<'_>,
+        lower: Option<&[u8]>,
+        upper: Option<&[u8]>,
+    ) -> Result<Vec<KeyRow>, StorageError> {
+        // Leaf and start index for the lower bound.
+        let (mut page_no, mut start) = match lower {
+            Some(key) => {
+                let path = self.descend(ctx, key)?;
+                let leaf = path.last().expect("leaf").page;
+                let frame = ctx.fetch(leaf)?;
+                let page = SlottedRead::new(ctx.pool.page(frame));
+                let index = match leaf_search(&page, key) {
+                    Ok(i) => i,
+                    Err(i) => i,
+                };
+                ctx.pool.unpin(frame);
+                (leaf, index)
+            }
+            None => (self.leftmost_leaf(ctx)?, 0),
+        };
+        let mut out = Vec::new();
+        while page_no != NO_PAGE {
+            let frame = ctx.fetch(page_no)?;
+            let page = SlottedRead::new(ctx.pool.page(frame));
+            for index in start..page.slot_count() {
+                let cell = page.get(index).expect("tree pages have no tombstones");
+                let key = cell_key(cell);
+                if let Some(upper) = upper
+                    && key > upper
+                {
+                    ctx.pool.unpin(frame);
+                    return Ok(out);
+                }
+                out.push((key.to_vec(), leaf_cell_row(cell).to_vec()));
+            }
+            let next = page.next_page();
+            ctx.pool.unpin(frame);
+            page_no = next;
+            start = 0;
+        }
+        Ok(out)
+    }
+
+    /// The leftmost leaf page (start of the leaf chain).
+    fn leftmost_leaf(&self, ctx: &mut RelCtx<'_>) -> Result<u64, StorageError> {
+        let mut page_no = self.root;
+        loop {
+            let frame = ctx.fetch(page_no)?;
+            let page = SlottedRead::new(ctx.pool.page(frame));
+            if page.level() == 0 {
+                ctx.pool.unpin(frame);
+                return Ok(page_no);
+            }
+            let child = internal_cell_child(page.get(0).expect("sentinel entry"));
+            ctx.pool.unpin(frame);
+            page_no = child;
+        }
     }
 
     /// Splits exactly one node: the deepest node on `path` whose parent can

--- a/crates/truthdb-core/src/relstore/catalog.rs
+++ b/crates/truthdb-core/src/relstore/catalog.rs
@@ -30,6 +30,23 @@ pub struct IdentitySpec {
     pub next: i64,
 }
 
+/// A nonclustered (secondary) B+ index over a base table. Its own tree (keyed
+/// by [`object_id`](IndexDef::object_id)) maps encoded index-key bytes to a
+/// row locator (the base table's PK key for a clustered table, or the heap
+/// RID). Indexes live embedded in their owning [`TableDef`] so they load and
+/// mutate with the catalog row.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IndexDef {
+    pub object_id: u32,
+    pub name: String,
+    /// (schema column index, ascending) for each index key column, in order.
+    pub columns: Vec<(usize, bool)>,
+    /// UNIQUE index: duplicate key values are rejected (error 2601).
+    pub unique: bool,
+    /// The index tree's root page.
+    pub root_page: u64,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TableDef {
     pub object_id: u32,
@@ -49,6 +66,9 @@ pub struct TableDef {
     /// The single IDENTITY column, if any.
     #[serde(default)]
     pub identity: Option<IdentitySpec>,
+    /// Secondary indexes over this table.
+    #[serde(default)]
+    pub indexes: Vec<IndexDef>,
 }
 
 impl TableDef {

--- a/crates/truthdb-core/src/relstore/heap.rs
+++ b/crates/truthdb-core/src/relstore/heap.rs
@@ -329,6 +329,35 @@ impl Heap {
         Ok(())
     }
 
+    /// Reads the row at a home RID, following a forwarding stub to its moved
+    /// copy. Returns the raw row bytes, or None if the slot is empty. Used by
+    /// index key lookups (the index stores home RIDs).
+    pub fn read_row(
+        &self,
+        ctx: &mut RelCtx<'_>,
+        rid: Rid,
+    ) -> Result<Option<Vec<u8>>, StorageError> {
+        let Some(cell) = self.read_cell(ctx, rid)? else {
+            return Ok(None);
+        };
+        match cell[0] {
+            TAG_ROW => Ok(Some(cell[1..].to_vec())),
+            TAG_MOVED => Ok(Some(cell[11..].to_vec())),
+            TAG_STUB => {
+                let target = parse_rid(&cell[1..]);
+                match self.read_cell(ctx, target)? {
+                    Some(target_cell) if target_cell[0] == TAG_MOVED => {
+                        Ok(Some(target_cell[11..].to_vec()))
+                    }
+                    _ => Ok(None),
+                }
+            }
+            other => Err(StorageError::InvalidFile(format!(
+                "unknown heap cell tag {other}"
+            ))),
+        }
+    }
+
     /// Scans all rows: (home RID, row bytes). Moved rows report their home
     /// RID; stubs and tombstones are skipped.
     pub fn scan(&self, ctx: &mut RelCtx<'_>) -> Result<Vec<(Rid, Vec<u8>)>, StorageError> {

--- a/crates/truthdb-core/src/relstore/index.rs
+++ b/crates/truthdb-core/src/relstore/index.rs
@@ -1,0 +1,210 @@
+//! Secondary (nonclustered) B+ index encoding.
+//!
+//! An index is its own [`BTree`](crate::relstore::btree::BTree) mapping encoded
+//! index-key bytes to a row *locator* (how to fetch the full row from the base
+//! table). Key layout:
+//! - key = the index columns encoded order-preserving (a DESC column has its
+//!   bytes bit-inverted so it sorts in reverse, which also puts its NULLs
+//!   last — matching SQL Server), then — for a NON-unique index only — the
+//!   locator bytes appended so otherwise-equal index values get distinct keys.
+//! - value = the locator bytes (always), so a key lookup never has to decode
+//!   the locator out of the key.
+//!
+//! A UNIQUE index keeps the locator out of the key, so two rows with equal
+//! index values collide on insert (`DuplicateKey` → error 2601); a single NULL
+//! is likewise unique (NULL encodes to one byte), as in SQL Server.
+
+use crate::relstore::heap::Rid;
+use crate::relstore::key::encode_datum;
+use crate::relstore::types::{Datum, TypeError};
+
+/// How to fetch a base-table row from an index entry: by clustered PK key
+/// bytes, or by heap home RID.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Locator {
+    Key(Vec<u8>),
+    Rid(Rid),
+}
+
+const LOCATOR_KEY: u8 = 0;
+const LOCATOR_RID: u8 = 1;
+
+/// Encodes an index's key columns from a row's values, applying per-column
+/// ASC/DESC direction. `columns` is `(schema index, ascending)` in key order.
+pub fn encode_index_columns(
+    values: &[Datum],
+    columns: &[(usize, bool)],
+) -> Result<Vec<u8>, TypeError> {
+    let mut out = Vec::new();
+    for &(index, ascending) in columns {
+        let value = values
+            .get(index)
+            .ok_or_else(|| TypeError(format!("index column {index} out of range")))?;
+        if ascending {
+            encode_datum(value, &mut out)?;
+        } else {
+            let start = out.len();
+            encode_datum(value, &mut out)?;
+            // DESC: invert this column's bytes so ordering reverses.
+            for b in &mut out[start..] {
+                *b = !*b;
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// Encodes a leading prefix of an index's columns directly from seek values
+/// (`values[i]` is the value for `columns[i]`), applying ASC/DESC. Used to
+/// build index-seek bounds.
+pub fn encode_index_prefix(
+    values: &[Datum],
+    columns: &[(usize, bool)],
+) -> Result<Vec<u8>, TypeError> {
+    let mut out = Vec::new();
+    for (i, value) in values.iter().enumerate() {
+        let (_, ascending) = columns[i];
+        if ascending {
+            encode_datum(value, &mut out)?;
+        } else {
+            let start = out.len();
+            encode_datum(value, &mut out)?;
+            for b in &mut out[start..] {
+                *b = !*b;
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// The smallest byte string greater than every string with `prefix` as a
+/// prefix — an inclusive upper bound covering the whole prefix block. `None`
+/// means unbounded (the prefix is all `0xFF`).
+pub fn prefix_upper_bound(prefix: &[u8]) -> Option<Vec<u8>> {
+    let mut bound = prefix.to_vec();
+    while let Some(last) = bound.last_mut() {
+        if *last < 0xFF {
+            *last += 1;
+            return Some(bound);
+        }
+        bound.pop();
+    }
+    None
+}
+
+/// Serializes a locator (tag byte + payload) for storage in an index leaf.
+pub fn encode_locator(locator: &Locator) -> Vec<u8> {
+    let mut out = Vec::new();
+    match locator {
+        Locator::Key(key) => {
+            out.push(LOCATOR_KEY);
+            out.extend_from_slice(key);
+        }
+        Locator::Rid(rid) => {
+            out.push(LOCATOR_RID);
+            out.extend_from_slice(&rid.page.to_le_bytes());
+            out.extend_from_slice(&rid.slot.to_le_bytes());
+        }
+    }
+    out
+}
+
+/// Inverse of [`encode_locator`].
+pub fn decode_locator(bytes: &[u8]) -> Locator {
+    match bytes[0] {
+        LOCATOR_KEY => Locator::Key(bytes[1..].to_vec()),
+        LOCATOR_RID => Locator::Rid(Rid {
+            page: u64::from_le_bytes(bytes[1..9].try_into().unwrap()),
+            slot: u16::from_le_bytes(bytes[9..11].try_into().unwrap()),
+        }),
+        other => unreachable!("unknown locator tag {other}"),
+    }
+}
+
+/// The `(leaf key, leaf value)` an index entry stores for one row, given the
+/// row's index-column encoding and its locator. Non-unique indexes append the
+/// locator to the key for uniqueness; unique indexes do not.
+pub fn leaf_entry(index_key: &[u8], locator: &Locator, unique: bool) -> (Vec<u8>, Vec<u8>) {
+    let value = encode_locator(locator);
+    let key = if unique {
+        index_key.to_vec()
+    } else {
+        let mut key = Vec::with_capacity(index_key.len() + value.len());
+        key.extend_from_slice(index_key);
+        key.extend_from_slice(&value);
+        key
+    };
+    (key, value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cmp::Ordering;
+
+    fn key(values: &[Datum], columns: &[(usize, bool)]) -> Vec<u8> {
+        encode_index_columns(values, columns).expect("encode")
+    }
+
+    #[test]
+    fn ascending_column_preserves_value_order() {
+        let asc = &[(0usize, true)];
+        assert_eq!(
+            key(&[Datum::Int(1)], asc).cmp(&key(&[Datum::Int(2)], asc)),
+            Ordering::Less
+        );
+        assert_eq!(
+            key(&[Datum::Int(-5)], asc).cmp(&key(&[Datum::Int(3)], asc)),
+            Ordering::Less
+        );
+    }
+
+    #[test]
+    fn descending_column_reverses_value_order_and_sorts_nulls_last() {
+        let desc = &[(0usize, false)];
+        // 2 sorts before 1 under DESC.
+        assert_eq!(
+            key(&[Datum::Int(2)], desc).cmp(&key(&[Datum::Int(1)], desc)),
+            Ordering::Less
+        );
+        // NULL sorts AFTER any value under DESC (SQL Server semantics).
+        assert_eq!(
+            key(&[Datum::Int(1)], desc).cmp(&key(&[Datum::Null], desc)),
+            Ordering::Less
+        );
+    }
+
+    #[test]
+    fn composite_key_is_column_major() {
+        let cols = &[(0usize, true), (1usize, true)];
+        let a = key(&[Datum::Int(1), Datum::Int(9)], cols);
+        let b = key(&[Datum::Int(2), Datum::Int(0)], cols);
+        assert_eq!(a.cmp(&b), Ordering::Less, "first column dominates");
+    }
+
+    #[test]
+    fn prefix_upper_bound_covers_the_whole_prefix_block() {
+        // Any key starting with the prefix is < the bound; the bound is
+        // minimal.
+        let prefix = vec![0x01, 0x05];
+        let bound = prefix_upper_bound(&prefix).expect("bound");
+        assert!(prefix.as_slice() < bound.as_slice());
+        let mut longer = prefix.clone();
+        longer.extend_from_slice(&[0xFF, 0xFF]);
+        assert!(longer.as_slice() < bound.as_slice());
+        // Trailing 0xFF is carried.
+        assert_eq!(prefix_upper_bound(&[0x01, 0xFF]), Some(vec![0x02]));
+        assert_eq!(prefix_upper_bound(&[0xFF, 0xFF]), None);
+    }
+
+    #[test]
+    fn unique_key_omits_locator_but_non_unique_appends_it() {
+        let index_key = vec![0x01, 0x2a];
+        let locator = Locator::Rid(Rid { page: 7, slot: 3 });
+        let (uk, uv) = leaf_entry(&index_key, &locator, true);
+        assert_eq!(uk, index_key, "unique index key is the columns alone");
+        assert_eq!(decode_locator(&uv), locator);
+        let (nk, _) = leaf_entry(&index_key, &locator, false);
+        assert!(nk.starts_with(&index_key) && nk.len() > index_key.len());
+    }
+}

--- a/crates/truthdb-core/src/relstore/mod.rs
+++ b/crates/truthdb-core/src/relstore/mod.rs
@@ -9,6 +9,7 @@ pub mod buffer_pool;
 pub mod catalog;
 pub(crate) mod ctx;
 pub mod heap;
+pub mod index;
 pub mod key;
 pub mod page;
 pub mod recovery;
@@ -60,7 +61,8 @@ impl RelState {
     }
 
     /// Stable root pages by object id (for logical tree undos), including
-    /// the catalog tree itself.
+    /// the catalog tree itself and every secondary index (index trees are
+    /// undone the same way as clustered tables).
     pub fn tree_roots(&self) -> HashMap<u32, u64> {
         let mut roots = HashMap::new();
         if let Some(root) = self.catalog_root {
@@ -69,6 +71,9 @@ impl RelState {
         for def in self.tables.values() {
             if def.is_tree() {
                 roots.insert(def.object_id, def.root_page);
+            }
+            for index in &def.indexes {
+                roots.insert(index.object_id, index.root_page);
             }
         }
         roots

--- a/crates/truthdb-core/src/storage.rs
+++ b/crates/truthdb-core/src/storage.rs
@@ -8,9 +8,10 @@ use crate::direct_io::{AlignedPageBuf, DirectFile};
 use crate::relstore::RelState;
 use crate::relstore::btree::{BTree, TreeInsert};
 use crate::relstore::buffer_pool::DEFAULT_CAPACITY_BYTES;
-use crate::relstore::catalog::{self, FIRST_USER_OBJECT_ID, TableDef};
+use crate::relstore::catalog::{self, FIRST_USER_OBJECT_ID, IndexDef, TableDef};
 use crate::relstore::ctx::{OpMode, PoolIo, RelCtx, TxnLink};
 use crate::relstore::heap::{Heap, Rid};
+use crate::relstore::index::{self, Locator};
 use crate::relstore::key::encode_key;
 use crate::relstore::recovery as rel_recovery;
 use crate::relstore::row::{Column, Schema, decode_row, encode_row};
@@ -272,6 +273,7 @@ impl Storage {
                 defaults,
                 collations,
                 identity,
+                indexes: Vec::new(),
             };
             catalog::insert_table(ctx, &mut OpMode::Txn(txn), catalog_root, &def)?;
             Ok(def)
@@ -312,6 +314,174 @@ impl Storage {
         Ok(true)
     }
 
+    /// Creates a secondary index over `table` and backfills it from the
+    /// current rows (blocking build). A duplicate on a UNIQUE index during the
+    /// build fails the whole statement (error 2601). The index is persisted in
+    /// the table's catalog row.
+    pub(crate) fn rel_create_index(
+        &mut self,
+        table: &str,
+        index_name: String,
+        columns: Vec<(usize, bool)>,
+        unique: bool,
+    ) -> Result<(), StorageError> {
+        self.file.ensure_rel_usable()?;
+        let mut def = self
+            .file
+            .rel
+            .tables
+            .get(table)
+            .cloned()
+            .ok_or_else(|| StorageError::InvalidConfig(format!("unknown table '{table}'")))?;
+        if def
+            .indexes
+            .iter()
+            .any(|i| i.name.eq_ignore_ascii_case(&index_name))
+        {
+            return Err(StorageError::Constraint(format!(
+                "index '{index_name}' already exists"
+            )));
+        }
+        let catalog_root = self
+            .file
+            .rel
+            .catalog_root
+            .ok_or_else(|| StorageError::InvalidFile("catalog root missing".to_string()))?;
+        let object_id = self.file.rel.next_object_id;
+        // Snapshot the rows to backfill (materialized before any mutation).
+        let located = self.rel_scan_located(table)?;
+
+        let updated = self.file.rel_statement(move |ctx, txn| {
+            let tree = BTree::create(ctx, object_id)?;
+            for (loc, values) in &located {
+                let locator = match loc {
+                    RowLocator::Key(key) => Locator::Key(key.clone()),
+                    RowLocator::Rid(rid) => Locator::Rid(*rid),
+                };
+                let index_key = index::encode_index_columns(values, &columns)
+                    .map_err(|err| StorageError::InvalidConfig(err.0))?;
+                let (key, value) = index::leaf_entry(&index_key, &locator, unique);
+                // Backfill is system-logged: the fresh tree is not in the
+                // rollback roots, so a failure leaks it (the catalog entry
+                // below is undone, leaving it unreferenced).
+                match tree.insert_unique_bulk(ctx, &key, &value)? {
+                    TreeInsert::Inserted => {}
+                    TreeInsert::DuplicateKey => {
+                        return Err(StorageError::Constraint(format!(
+                            "duplicate unique index '{index_name}'"
+                        )));
+                    }
+                }
+            }
+            def.indexes.push(IndexDef {
+                object_id,
+                name: index_name,
+                columns,
+                unique,
+                root_page: tree.root,
+            });
+            catalog::update_table(ctx, &mut OpMode::Txn(txn), catalog_root, &def)?;
+            Ok(def)
+        })?;
+        self.file.rel.next_object_id += 1;
+        self.file.rel.tables.insert(table.to_string(), updated);
+        Ok(())
+    }
+
+    /// Drops a secondary index by name (logical: index pages leak). Returns
+    /// false if no such index exists on any table.
+    pub(crate) fn rel_drop_index(
+        &mut self,
+        table: &str,
+        index_name: &str,
+    ) -> Result<bool, StorageError> {
+        self.file.ensure_rel_usable()?;
+        let Some(catalog_root) = self.file.rel.catalog_root else {
+            return Ok(false);
+        };
+        // Index names are scoped to their table, so confine the lookup there.
+        // The caller passes the table's canonical name.
+        let Some((table_key, mut def)) = self
+            .file
+            .rel
+            .tables
+            .iter()
+            .find(|(name, _)| name.eq_ignore_ascii_case(table))
+            .map(|(name, def)| (name.clone(), def.clone()))
+        else {
+            return Ok(false);
+        };
+        if !def
+            .indexes
+            .iter()
+            .any(|i| i.name.eq_ignore_ascii_case(index_name))
+        {
+            return Ok(false);
+        }
+        def.indexes
+            .retain(|i| !i.name.eq_ignore_ascii_case(index_name));
+        let updated = self.file.rel_statement(move |ctx, txn| {
+            catalog::update_table(ctx, &mut OpMode::Txn(txn), catalog_root, &def)?;
+            Ok(def)
+        })?;
+        self.file.rel.tables.insert(table_key, updated);
+        Ok(true)
+    }
+
+    /// Candidate rows for an index access path: walks the index tree over
+    /// `[lower, upper]`, then fetches each row by its locator. Returns a
+    /// superset the caller re-filters with the full WHERE (so loose bounds are
+    /// safe).
+    pub(crate) fn rel_index_scan(
+        &mut self,
+        table: &str,
+        index_object_id: u32,
+        lower: Option<Vec<u8>>,
+        upper: Option<Vec<u8>>,
+    ) -> Result<Vec<Vec<Datum>>, StorageError> {
+        self.file.ensure_rel_usable()?;
+        let (def, schema) = self.rel_def(table)?;
+        let index = def
+            .indexes
+            .iter()
+            .find(|i| i.object_id == index_object_id)
+            .cloned()
+            .ok_or_else(|| StorageError::InvalidConfig("unknown index".to_string()))?;
+        let mut ctx = self.file.rel_ctx();
+        let index_tree = BTree {
+            object_id: index.object_id,
+            root: index.root_page,
+        };
+        let entries = index_tree.scan_range(&mut ctx, lower.as_deref(), upper.as_deref())?;
+        let mut rows = Vec::with_capacity(entries.len());
+        if def.is_tree() {
+            let base = BTree {
+                object_id: def.object_id,
+                root: def.root_page,
+            };
+            for (_, value) in entries {
+                if let Locator::Key(pk) = index::decode_locator(&value)
+                    && let Some(row) = base.get(&mut ctx, &pk)?
+                {
+                    rows.push(decode_row(&schema, &row)?);
+                }
+            }
+        } else {
+            let heap = Heap {
+                object_id: def.object_id,
+                first_page: def.root_page,
+            };
+            for (_, value) in entries {
+                if let Locator::Rid(rid) = index::decode_locator(&value)
+                    && let Some(row) = heap.read_row(&mut ctx, rid)?
+                {
+                    rows.push(decode_row(&schema, &row)?);
+                }
+            }
+        }
+        Ok(rows)
+    }
+
     pub fn rel_insert(&mut self, name: &str, values: Vec<Datum>) -> Result<(), StorageError> {
         self.rel_insert_many(name, vec![values], &mut TxnScope::Auto)
     }
@@ -341,13 +511,14 @@ impl Storage {
             encoded.push((key, row));
         }
 
+        let indexes = def.indexes.clone();
         if def.is_tree() {
             let tree = BTree {
                 object_id: def.object_id,
                 root: def.root_page,
             };
             self.file.rel_statement_scoped(scope, move |ctx, txn| {
-                for (key, row) in &encoded {
+                for ((key, row), values) in encoded.iter().zip(rows.iter()) {
                     let key = key.as_ref().expect("tree row has a key");
                     match tree.insert_unique(ctx, &mut OpMode::Txn(txn), key, row)? {
                         TreeInsert::Inserted => {}
@@ -357,6 +528,8 @@ impl Storage {
                             ));
                         }
                     }
+                    // Clustered rows locate by PK key.
+                    index_insert_row(ctx, txn, &indexes, values, &Locator::Key(key.clone()))?;
                 }
                 Ok(())
             })
@@ -366,8 +539,10 @@ impl Storage {
                 first_page: def.root_page,
             };
             self.file.rel_statement_scoped(scope, move |ctx, txn| {
-                for (_, row) in &encoded {
-                    heap.insert(ctx, txn, row)?;
+                for ((_, row), values) in encoded.iter().zip(rows.iter()) {
+                    // Heap rows locate by their home RID.
+                    let rid = heap.insert(ctx, txn, row)?;
+                    index_insert_row(ctx, txn, &indexes, values, &Locator::Rid(rid))?;
                 }
                 Ok(())
             })
@@ -631,28 +806,31 @@ impl Storage {
         Ok(out)
     }
 
-    /// Deletes the located rows in one atomic statement; returns the count.
+    /// Deletes the located rows (each carrying its old values for index
+    /// upkeep) in one atomic statement; returns the count.
     pub(crate) fn rel_delete_located(
         &mut self,
         name: &str,
-        locators: Vec<RowLocator>,
+        targets: Vec<(RowLocator, Vec<Datum>)>,
         scope: &mut TxnScope,
     ) -> Result<usize, StorageError> {
         self.file.ensure_rel_usable()?;
         let (def, _schema) = self.rel_def(name)?;
-        let count = locators.len();
+        let count = targets.len();
         if count == 0 {
             return Ok(0);
         }
+        let indexes = def.indexes.clone();
         if def.is_tree() {
             let tree = BTree {
                 object_id: def.object_id,
                 root: def.root_page,
             };
             self.file.rel_statement_scoped(scope, move |ctx, txn| {
-                for loc in &locators {
+                for (loc, values) in &targets {
                     if let RowLocator::Key(key) = loc {
                         tree.delete(ctx, &mut OpMode::Txn(txn), key)?;
+                        index_delete_row(ctx, txn, &indexes, values, &Locator::Key(key.clone()))?;
                     }
                 }
                 Ok(())
@@ -663,9 +841,10 @@ impl Storage {
                 first_page: def.root_page,
             };
             self.file.rel_statement_scoped(scope, move |ctx, txn| {
-                for loc in &locators {
+                for (loc, values) in &targets {
                     if let RowLocator::Rid(rid) = loc {
                         heap.delete(ctx, txn, *rid)?;
+                        index_delete_row(ctx, txn, &indexes, values, &Locator::Rid(*rid))?;
                     }
                 }
                 Ok(())
@@ -674,14 +853,17 @@ impl Storage {
         Ok(count)
     }
 
-    /// Applies full-row updates (each already type-checked and NOT-NULL-checked
-    /// by the caller) in one atomic statement. For a clustered table a row
-    /// whose key changed is re-keyed (delete + insert with uniqueness
-    /// enforced); heaps update in place by RID. Returns the count.
+    /// Applies full-row updates (each carrying its old and new values; already
+    /// type-checked and NOT-NULL-checked by the caller) in one atomic
+    /// statement. For a clustered table a row whose key changed is re-keyed
+    /// (delete + insert with uniqueness enforced); heaps update in place by
+    /// RID. Secondary indexes are maintained by deleting every old entry then
+    /// inserting every new one (so a unique index tolerates value swaps).
+    /// Returns the count.
     pub(crate) fn rel_update_located(
         &mut self,
         name: &str,
-        updates: Vec<(RowLocator, Vec<Datum>)>,
+        updates: Vec<(RowLocator, Vec<Datum>, Vec<Datum>)>,
         scope: &mut TxnScope,
     ) -> Result<usize, StorageError> {
         self.file.ensure_rel_usable()?;
@@ -690,6 +872,9 @@ impl Storage {
         if count == 0 {
             return Ok(0);
         }
+        let indexes = def.indexes.clone();
+        // (old values, old locator, new values, new locator) for index upkeep.
+        let mut idx_ops: Vec<(Vec<Datum>, Locator, Vec<Datum>, Locator)> = Vec::new();
         if def.is_tree() {
             let tree = BTree {
                 object_id: def.object_id,
@@ -698,15 +883,23 @@ impl Storage {
             // Partition into in-place (key unchanged) and re-key (key changed).
             let mut in_place: Vec<(Vec<u8>, Vec<u8>)> = Vec::new();
             let mut rekey: Vec<(Vec<u8>, Vec<u8>, Vec<u8>)> = Vec::new();
-            for (loc, values) in updates {
+            for (loc, old_values, new_values) in updates {
                 let RowLocator::Key(old_key) = loc else {
                     return Err(StorageError::InvalidConfig(
                         "expected key locator for clustered table".to_string(),
                     ));
                 };
-                validate_not_null(&schema, &values)?;
-                let row = encode_row(&schema, &values)?;
-                let new_key = encode_key(&schema, &def.key_columns, &values)?;
+                validate_not_null(&schema, &new_values)?;
+                let row = encode_row(&schema, &new_values)?;
+                let new_key = encode_key(&schema, &def.key_columns, &new_values)?;
+                if !indexes.is_empty() {
+                    idx_ops.push((
+                        old_values,
+                        Locator::Key(old_key.clone()),
+                        new_values,
+                        Locator::Key(new_key.clone()),
+                    ));
+                }
                 if new_key == old_key {
                     in_place.push((old_key, row));
                 } else {
@@ -731,6 +924,7 @@ impl Storage {
                 for (key, row) in &in_place {
                     tree.update(ctx, &mut OpMode::Txn(txn), key, row)?;
                 }
+                apply_index_updates(ctx, txn, &indexes, &idx_ops)?;
                 Ok(())
             })?;
         } else {
@@ -739,19 +933,24 @@ impl Storage {
                 first_page: def.root_page,
             };
             let mut encoded: Vec<(Rid, Vec<u8>)> = Vec::with_capacity(count);
-            for (loc, values) in updates {
+            for (loc, old_values, new_values) in updates {
                 let RowLocator::Rid(rid) = loc else {
                     return Err(StorageError::InvalidConfig(
                         "expected rid locator for heap".to_string(),
                     ));
                 };
-                validate_not_null(&schema, &values)?;
-                encoded.push((rid, encode_row(&schema, &values)?));
+                validate_not_null(&schema, &new_values)?;
+                encoded.push((rid, encode_row(&schema, &new_values)?));
+                if !indexes.is_empty() {
+                    // Heap RIDs are stable across an update.
+                    idx_ops.push((old_values, Locator::Rid(rid), new_values, Locator::Rid(rid)));
+                }
             }
             self.file.rel_statement_scoped(scope, move |ctx, txn| {
                 for (rid, row) in &encoded {
                     heap.update(ctx, txn, *rid, row)?;
                 }
+                apply_index_updates(ctx, txn, &indexes, &idx_ops)?;
                 Ok(())
             })?;
         }
@@ -894,6 +1093,78 @@ impl Storage {
         let schema = def.schema()?;
         Ok((def, schema))
     }
+}
+
+/// Inserts one row's entries into every secondary index. A duplicate on a
+/// UNIQUE index surfaces as a constraint error the SQL layer maps to 2601.
+fn index_insert_row(
+    ctx: &mut RelCtx<'_>,
+    txn: &mut TxnLink,
+    indexes: &[IndexDef],
+    values: &[Datum],
+    locator: &Locator,
+) -> Result<(), StorageError> {
+    for index in indexes {
+        let index_key = index::encode_index_columns(values, &index.columns)
+            .map_err(|err| StorageError::InvalidConfig(err.0))?;
+        let (key, value) = index::leaf_entry(&index_key, locator, index.unique);
+        let tree = BTree {
+            object_id: index.object_id,
+            root: index.root_page,
+        };
+        match tree.insert_unique(ctx, &mut OpMode::Txn(txn), &key, &value)? {
+            TreeInsert::Inserted => {}
+            TreeInsert::DuplicateKey => {
+                return Err(StorageError::Constraint(format!(
+                    "duplicate unique index '{}'",
+                    index.name
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Reindexes a set of updated rows: deletes every old entry first, then
+/// inserts every new one, so a UNIQUE index tolerates value swaps within one
+/// statement.
+fn apply_index_updates(
+    ctx: &mut RelCtx<'_>,
+    txn: &mut TxnLink,
+    indexes: &[IndexDef],
+    ops: &[(Vec<Datum>, Locator, Vec<Datum>, Locator)],
+) -> Result<(), StorageError> {
+    if indexes.is_empty() {
+        return Ok(());
+    }
+    for (old_values, old_locator, _, _) in ops {
+        index_delete_row(ctx, txn, indexes, old_values, old_locator)?;
+    }
+    for (_, _, new_values, new_locator) in ops {
+        index_insert_row(ctx, txn, indexes, new_values, new_locator)?;
+    }
+    Ok(())
+}
+
+/// Removes one row's entries from every secondary index.
+fn index_delete_row(
+    ctx: &mut RelCtx<'_>,
+    txn: &mut TxnLink,
+    indexes: &[IndexDef],
+    values: &[Datum],
+    locator: &Locator,
+) -> Result<(), StorageError> {
+    for index in indexes {
+        let index_key = index::encode_index_columns(values, &index.columns)
+            .map_err(|err| StorageError::InvalidConfig(err.0))?;
+        let (key, _) = index::leaf_entry(&index_key, locator, index.unique);
+        let tree = BTree {
+            object_id: index.object_id,
+            root: index.root_page,
+        };
+        tree.delete(ctx, &mut OpMode::Txn(txn), &key)?;
+    }
+    Ok(())
 }
 
 fn column_index(schema: &Schema, name: &str) -> Result<usize, StorageError> {
@@ -1237,11 +1508,17 @@ impl StorageFile {
             rel_recovery::undo_losers(&mut ctx, &records, &outcome.losers, &roots)?;
             self.reload_catalog()?;
         }
+        // Object ids are shared by tables and their secondary indexes, so the
+        // next id must clear both (an index can outrank every table).
         self.rel.next_object_id = self
             .rel
             .tables
             .values()
-            .map(|def| def.object_id + 1)
+            .flat_map(|def| {
+                std::iter::once(def.object_id)
+                    .chain(def.indexes.iter().map(|index| index.object_id))
+            })
+            .map(|object_id| object_id + 1)
             .max()
             .unwrap_or(FIRST_USER_OBJECT_ID)
             .max(FIRST_USER_OBJECT_ID);

--- a/crates/truthdb-sql/src/ast.rs
+++ b/crates/truthdb-sql/src/ast.rs
@@ -7,6 +7,8 @@ use crate::lexer::Span;
 pub enum Statement {
     CreateTable(CreateTable),
     DropTable(DropTable),
+    CreateIndex(CreateIndex),
+    DropIndex(DropIndex),
     Insert(Insert),
     Update(Update),
     Delete(Delete),
@@ -32,6 +34,34 @@ pub enum Statement {
 pub enum SetStatement {
     XactAbort(bool),
     IsolationLevel(IsolationLevel),
+    /// `SET SHOWPLAN_TEXT ON|OFF` — when on, statements return their plan text
+    /// instead of executing.
+    ShowplanText(bool),
+}
+
+/// `CREATE [UNIQUE] INDEX <name> ON <table> (<col> [ASC|DESC], ...)`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CreateIndex {
+    pub name: Name,
+    pub table: Name,
+    pub unique: bool,
+    pub columns: Vec<IndexColumn>,
+    pub span: Span,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct IndexColumn {
+    pub name: Name,
+    /// Ascending (`ASC`, the default) or descending (`DESC`).
+    pub ascending: bool,
+}
+
+/// `DROP INDEX <name> ON <table>`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DropIndex {
+    pub name: Name,
+    pub table: Name,
+    pub span: Span,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/truthdb-sql/src/parser.rs
+++ b/crates/truthdb-sql/src/parser.rs
@@ -105,8 +105,8 @@ impl Parser {
 
     fn parse_statement(&mut self) -> SqlResult<Statement> {
         match self.peek_keyword().as_deref() {
-            Some("CREATE") => self.parse_create_table(),
-            Some("DROP") => self.parse_drop_table(),
+            Some("CREATE") => self.parse_create(),
+            Some("DROP") => self.parse_drop(),
             Some("INSERT") => self.parse_insert(),
             Some("UPDATE") => self.parse_update(),
             Some("DELETE") => self.parse_delete(),
@@ -205,6 +205,11 @@ impl Parser {
                 let level = self.parse_isolation_level()?;
                 Ok(Statement::Set(SetStatement::IsolationLevel(level)))
             }
+            Some("SHOWPLAN_TEXT") => {
+                self.bump();
+                let on = self.parse_on_off()?;
+                Ok(Statement::Set(SetStatement::ShowplanText(on)))
+            }
             _ => {
                 let token = self.peek().clone();
                 Err(SqlError::syntax(self.token_text(&token), token.span))
@@ -266,8 +271,62 @@ impl Parser {
 
     // ---- CREATE TABLE ---------------------------------------------------
 
-    fn parse_create_table(&mut self) -> SqlResult<Statement> {
+    /// Dispatches `CREATE TABLE` vs `CREATE [UNIQUE] INDEX`.
+    fn parse_create(&mut self) -> SqlResult<Statement> {
         let start = self.expect_keyword("CREATE")?;
+        let unique = self.peek_keyword().as_deref() == Some("UNIQUE");
+        if unique {
+            self.bump();
+        }
+        match self.peek_keyword().as_deref() {
+            Some("INDEX") => self.parse_create_index(start, unique),
+            Some("TABLE") if !unique => self.parse_create_table(start),
+            _ => {
+                let token = self.peek().clone();
+                Err(SqlError::syntax(self.token_text(&token), token.span))
+            }
+        }
+    }
+
+    fn parse_create_index(&mut self, start: Span, unique: bool) -> SqlResult<Statement> {
+        self.expect_keyword("INDEX")?;
+        let name = self.parse_name()?;
+        self.expect_keyword("ON")?;
+        let table = self.parse_name()?;
+        self.expect(&TokenKind::LParen)?;
+        let mut columns = Vec::new();
+        loop {
+            let col_name = self.parse_name()?;
+            let ascending = match self.peek_keyword().as_deref() {
+                Some("ASC") => {
+                    self.bump();
+                    true
+                }
+                Some("DESC") => {
+                    self.bump();
+                    false
+                }
+                _ => true,
+            };
+            columns.push(IndexColumn {
+                name: col_name,
+                ascending,
+            });
+            if !self.eat(&TokenKind::Comma) {
+                break;
+            }
+        }
+        let end = self.expect(&TokenKind::RParen)?;
+        Ok(Statement::CreateIndex(CreateIndex {
+            name,
+            table,
+            unique,
+            columns,
+            span: start.to(end),
+        }))
+    }
+
+    fn parse_create_table(&mut self, start: Span) -> SqlResult<Statement> {
         self.expect_keyword("TABLE")?;
         let table = self.parse_name()?;
         self.expect(&TokenKind::LParen)?;
@@ -483,8 +542,32 @@ impl Parser {
 
     // ---- DROP TABLE -----------------------------------------------------
 
-    fn parse_drop_table(&mut self) -> SqlResult<Statement> {
+    /// Dispatches `DROP TABLE` vs `DROP INDEX`.
+    fn parse_drop(&mut self) -> SqlResult<Statement> {
         let start = self.expect_keyword("DROP")?;
+        match self.peek_keyword().as_deref() {
+            Some("INDEX") => self.parse_drop_index(start),
+            Some("TABLE") => self.parse_drop_table(start),
+            _ => {
+                let token = self.peek().clone();
+                Err(SqlError::syntax(self.token_text(&token), token.span))
+            }
+        }
+    }
+
+    fn parse_drop_index(&mut self, start: Span) -> SqlResult<Statement> {
+        self.expect_keyword("INDEX")?;
+        let name = self.parse_name()?;
+        self.expect_keyword("ON")?;
+        let table = self.parse_name()?;
+        Ok(Statement::DropIndex(DropIndex {
+            span: start.to(table.span),
+            name,
+            table,
+        }))
+    }
+
+    fn parse_drop_table(&mut self, start: Span) -> SqlResult<Statement> {
         self.expect_keyword("TABLE")?;
         let if_exists = if self.peek_keyword().as_deref() == Some("IF") {
             self.bump();

--- a/crates/truthdb-sql/tests/corpus/ok/create_index.ast
+++ b/crates/truthdb-sql/tests/corpus/ok/create_index.ast
@@ -1,0 +1,113 @@
+[
+    CreateIndex(
+        CreateIndex {
+            name: Name {
+                value: "ix_users_email",
+                quoted: false,
+                span: Span {
+                    start: 20,
+                    end: 34,
+                },
+            },
+            table: Name {
+                value: "users",
+                quoted: false,
+                span: Span {
+                    start: 38,
+                    end: 43,
+                },
+            },
+            unique: true,
+            columns: [
+                IndexColumn {
+                    name: Name {
+                        value: "email",
+                        quoted: false,
+                        span: Span {
+                            start: 45,
+                            end: 50,
+                        },
+                    },
+                    ascending: true,
+                },
+            ],
+            span: Span {
+                start: 0,
+                end: 51,
+            },
+        },
+    ),
+    CreateIndex(
+        CreateIndex {
+            name: Name {
+                value: "ix_orders_customer",
+                quoted: false,
+                span: Span {
+                    start: 66,
+                    end: 84,
+                },
+            },
+            table: Name {
+                value: "orders",
+                quoted: false,
+                span: Span {
+                    start: 88,
+                    end: 94,
+                },
+            },
+            unique: false,
+            columns: [
+                IndexColumn {
+                    name: Name {
+                        value: "customer_id",
+                        quoted: false,
+                        span: Span {
+                            start: 96,
+                            end: 107,
+                        },
+                    },
+                    ascending: true,
+                },
+                IndexColumn {
+                    name: Name {
+                        value: "created_at",
+                        quoted: false,
+                        span: Span {
+                            start: 109,
+                            end: 119,
+                        },
+                    },
+                    ascending: false,
+                },
+            ],
+            span: Span {
+                start: 53,
+                end: 125,
+            },
+        },
+    ),
+    DropIndex(
+        DropIndex {
+            name: Name {
+                value: "ix_users_email",
+                quoted: false,
+                span: Span {
+                    start: 138,
+                    end: 152,
+                },
+            },
+            table: Name {
+                value: "users",
+                quoted: false,
+                span: Span {
+                    start: 156,
+                    end: 161,
+                },
+            },
+            span: Span {
+                start: 127,
+                end: 161,
+            },
+        },
+    ),
+]

--- a/crates/truthdb-sql/tests/corpus/ok/create_index.sql
+++ b/crates/truthdb-sql/tests/corpus/ok/create_index.sql
@@ -1,0 +1,3 @@
+CREATE UNIQUE INDEX ix_users_email ON users (email);
+CREATE INDEX ix_orders_customer ON orders (customer_id, created_at DESC);
+DROP INDEX ix_users_email ON users


### PR DESCRIPTION
Implements **Stage 7**: nonclustered (secondary) B+ indexes and a single-table access-path planner.

## What's in it

- **Index DDL + storage**: `CREATE [UNIQUE] INDEX name ON t (col [ASC|DESC], ...)`, `DROP INDEX name ON t`, `sys.indexes`. An index is its own B+ tree keyed by an order-preserving index key (DESC columns bit-inverted, NULLs last) mapping to a **row locator** — the clustered table's PK key bytes, or a heap home RID. Non-unique indexes append the locator to the key for uniqueness; a UNIQUE index omits it so duplicate values collide on insert (**error 2601**; a single NULL is unique, matching SQL Server).
- **Index maintenance** in `INSERT`/`UPDATE`/`DELETE`, including clustered PK re-key (locator changes), heap row moves (stable home RID), multi-row atomicity, and unique value-swaps within one statement. `tree_roots()` (ARIES undo) and `next_object_id` recovery now cover index object ids.
- **Blocking build**: `CREATE INDEX` backfills a fresh tree with system-logged inserts (redo-only), so a failed build leaks the orphan tree and the catalog entry is undone — crash-safe, matching the existing DDL page-leak trade-off.
- **Planner** (`rel/plan.rs`): sargability analysis picks an index seek when the WHERE has an equality prefix on an index's leading columns (+ optionally one range on the next ascending column), rule order unique-seek > seek > range > scan, else a table scan. The seek only **narrows** candidates — `exec_select` re-applies the full WHERE — so bounds are deliberately loose and results are provably identical to a scan (A/B harness). `IndexSeek` + `KeyLookup` executors; `SET SHOWPLAN_TEXT ON` returns the plan as a rowset.

## Review-driven fixes

An adversarial multi-agent review (5 dimensions + per-finding verification) found two real bugs, both fixed here with regression tests:

- **DROP INDEX** resolved the index name globally, ignoring `ON <table>` — it could drop a same-named index on the wrong table (index names are per-table). Now table-scoped.
- **NVARCHAR range seek** could under-fetch: NVARCHAR index keys are UTF-16BE, whose byte order diverges from the WHERE filter's code-point order at supplementary-plane characters (surrogate pairs). NVARCHAR ranges now fall back to a scan; equality seeks (exact byte match) and VARCHAR ranges (UTF-8 = code-point order) remain correct.
- (Also fixed during implementation) a unique-index build over existing duplicate data now rolls back cleanly instead of wedging (the fresh index tree was not yet in the undo roots).

## Tests

- Index key-codec order (ASC/DESC/composite, prefix bounds); **A/B harness** (identical results with/without an index across `=`, `>`, `>=`, `<`, composite, `<>`); UNIQUE 2601 (insert, update, build-over-duplicates); index maintenance across update/delete and heap moves; plan goldens (`SHOWPLAN_TEXT`); index survives restart + maintained post-recovery; composite/DESC seeks; table-scoped DROP INDEX; NVARCHAR-range-scans vs VARCHAR-range-seeks; CREATE INDEX-in-transaction rejected (226); parser corpus entry.

`cargo fmt`, `cargo clippy --all-targets --all-features -D warnings`, and `cargo test --workspace` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)