### PR TITLE
JOINs and the multi-table binder [Stage 8, part 2]

### DIFF
--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -2816,6 +2816,155 @@ mod tests {
         let _ = std::fs::remove_file(path);
     }
 
+    // ---- joins (Stage 8 part 2) ----------------------------------------
+
+    fn join_setup(label: &str) -> (Engine, PathBuf) {
+        let path = unique_temp_path(label);
+        let mut engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE cust (id INT NOT NULL PRIMARY KEY, name NVARCHAR(20))")
+            .expect("create cust");
+        engine
+            .execute("CREATE TABLE ord (id INT NOT NULL PRIMARY KEY, cust_id INT, amount INT)")
+            .expect("create ord");
+        engine
+            .execute("INSERT INTO cust VALUES (1,'alice'),(2,'bob'),(3,'carol')")
+            .expect("insert cust");
+        // carol(3) has no orders; order 13 references a missing customer (99).
+        engine
+            .execute("INSERT INTO ord VALUES (10,1,100),(11,1,200),(12,2,50),(13,99,7)")
+            .expect("insert ord");
+        (engine, path)
+    }
+
+    fn row_count(engine: &mut Engine, sql: &str) -> usize {
+        sql_rows(engine, sql).1.len()
+    }
+
+    #[test]
+    fn sql_inner_join() {
+        let (mut engine, path) = join_setup("join-inner");
+        let (_, rows) = sql_rows(
+            &mut engine,
+            "SELECT c.name, o.amount FROM cust c JOIN ord o ON c.id = o.cust_id ORDER BY o.id",
+        );
+        assert_eq!(
+            rows,
+            vec![
+                vec![Some("alice".into()), Some("100".into())],
+                vec![Some("alice".into()), Some("200".into())],
+                vec![Some("bob".into()), Some("50".into())],
+            ]
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn sql_left_join_keeps_unmatched_left() {
+        let (mut engine, path) = join_setup("join-left");
+        // carol has no orders → one row with NULL amount.
+        let (_, rows) = sql_rows(
+            &mut engine,
+            "SELECT c.name, o.amount FROM cust c LEFT JOIN ord o ON c.id = o.cust_id \
+             ORDER BY c.id, o.id",
+        );
+        assert_eq!(rows.len(), 4);
+        assert_eq!(rows[3], vec![Some("carol".into()), None]);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn sql_right_join_keeps_unmatched_right() {
+        let (mut engine, path) = join_setup("join-right");
+        // order 13 (cust 99) has no customer → NULL name.
+        let (_, rows) = sql_rows(
+            &mut engine,
+            "SELECT c.name, o.id FROM cust c RIGHT JOIN ord o ON c.id = o.cust_id ORDER BY o.id",
+        );
+        assert_eq!(rows.len(), 4);
+        assert_eq!(rows[3], vec![None, Some("13".into())]);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn sql_full_join_keeps_both_unmatched() {
+        let (mut engine, path) = join_setup("join-full");
+        // 3 matched + carol (left-only) + order 13 (right-only) = 5 rows.
+        assert_eq!(
+            row_count(
+                &mut engine,
+                "SELECT c.name, o.id FROM cust c FULL JOIN ord o ON c.id = o.cust_id",
+            ),
+            5
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn sql_cross_join_and_comma() {
+        let (mut engine, path) = join_setup("join-cross");
+        // 3 customers x 4 orders = 12.
+        assert_eq!(
+            row_count(
+                &mut engine,
+                "SELECT c.id, o.id FROM cust c CROSS JOIN ord o"
+            ),
+            12
+        );
+        assert_eq!(
+            row_count(&mut engine, "SELECT c.id, o.id FROM cust c, ord o"),
+            12
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn sql_join_with_where_and_qualified_wildcard() {
+        let (mut engine, path) = join_setup("join-where");
+        let (cols, rows) = sql_rows(
+            &mut engine,
+            "SELECT c.* FROM cust c JOIN ord o ON c.id = o.cust_id WHERE o.amount > 100 ORDER BY o.id",
+        );
+        // c.* expands to cust columns; only order 11 (amount 200, alice).
+        assert_eq!(cols, vec!["id", "name"]);
+        assert_eq!(rows, vec![vec![Some("1".into()), Some("alice".into())]]);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn sql_aggregate_over_join() {
+        let (mut engine, path) = join_setup("join-agg");
+        // Total amount per customer (inner join).
+        let (_, rows) = sql_rows(
+            &mut engine,
+            "SELECT c.name, SUM(o.amount) FROM cust c JOIN ord o ON c.id = o.cust_id \
+             GROUP BY c.name ORDER BY c.name",
+        );
+        assert_eq!(
+            rows,
+            vec![
+                vec![Some("alice".into()), Some("300".into())],
+                vec![Some("bob".into()), Some("50".into())],
+            ]
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn sql_ambiguous_column_errors() {
+        let (mut engine, path) = join_setup("join-ambig");
+        // `id` exists in both cust and ord → unresolvable.
+        let err = sql_error_number(
+            &mut engine,
+            "SELECT id FROM cust c JOIN ord o ON c.id = o.cust_id",
+        );
+        assert!(
+            err == 209 || err == 207,
+            "ambiguous column error, got {err}"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
     #[test]
     fn sql_grouped_coercion_error_is_not_swallowed() {
         let path = unique_temp_path("agg-coerce");

--- a/crates/truthdb-core/src/rel/aggregate.rs
+++ b/crates/truthdb-core/src/rel/aggregate.rs
@@ -15,7 +15,7 @@ use truthdb_sql::value::{SqlValue, order_key_cmp};
 use crate::relstore::types::{ColumnType, Datum};
 
 use super::value;
-use super::{ResultColumn, RowSet, row_values};
+use super::{JoinScope, ResultColumn, RowSet, row_values};
 
 /// True if the query aggregates: it has a GROUP BY, a HAVING, or any aggregate
 /// in its SELECT list.
@@ -24,7 +24,7 @@ pub fn is_aggregated(select: &Select) -> bool {
         || select.having.is_some()
         || select.items.iter().any(|item| match item {
             SelectItem::Expr { expr, .. } => contains_aggregate(expr),
-            SelectItem::Wildcard => false,
+            SelectItem::Wildcard | SelectItem::QualifiedWildcard(_) => false,
         })
 }
 
@@ -76,7 +76,7 @@ pub fn execute(
     select: &Select,
     rows: &[Vec<Datum>],
     types: &[ColumnType],
-    resolver: &[String],
+    resolver: &JoinScope,
     eval_ctx: &EvalContext,
 ) -> Result<RowSet, SqlError> {
     // Rewrite SELECT items + HAVING against the group row, collecting aggregates.
@@ -85,7 +85,7 @@ pub fn execute(
     let mut out_exprs: Vec<Expr> = Vec::new();
     for item in &select.items {
         match item {
-            SelectItem::Wildcard => {
+            SelectItem::Wildcard | SelectItem::QualifiedWildcard(_) => {
                 return Err(SqlError::new(
                     8120,
                     16,
@@ -152,7 +152,7 @@ fn group_rows(
     select: &Select,
     rows: &[Vec<Datum>],
     types: &[ColumnType],
-    resolver: &[String],
+    resolver: &JoinScope,
     eval_ctx: &EvalContext,
 ) -> Result<Vec<(Vec<SqlValue>, Vec<usize>)>, SqlError> {
     if select.group_by.is_empty() {
@@ -165,7 +165,7 @@ fn group_rows(
         let key = select
             .group_by
             .iter()
-            .map(|expr| eval::eval(expr, &sql_row, &resolver.to_vec(), eval_ctx))
+            .map(|expr| eval::eval(expr, &sql_row, resolver, eval_ctx))
             .collect::<Result<Vec<_>, _>>()?;
         keyed.push((key, index));
     }
@@ -191,7 +191,7 @@ fn compute_aggregate(
     spec: &AggSpec,
     rows: &[Vec<Datum>],
     types: &[ColumnType],
-    resolver: &[String],
+    resolver: &JoinScope,
     members: &[usize],
     eval_ctx: &EvalContext,
 ) -> Result<SqlValue, SqlError> {
@@ -199,11 +199,10 @@ fn compute_aggregate(
     let Some(arg) = &spec.arg else {
         return Ok(SqlValue::Int(members.len() as i64));
     };
-    let resolver = resolver.to_vec();
     let mut values: Vec<SqlValue> = Vec::new();
     for &index in members {
         let sql_row = row_values(&rows[index], types);
-        let value = eval::eval(arg, &sql_row, &resolver, eval_ctx)?;
+        let value = eval::eval(arg, &sql_row, resolver, eval_ctx)?;
         if !value.is_null() {
             values.push(value);
         }

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -14,7 +14,8 @@ mod value;
 
 use truthdb_sql::ast::{
     ColumnDef, CreateIndex, CreateTable, DataType, Delete, DropIndex, DropTable, Expr, ExprKind,
-    Insert, IsolationLevel, Name, OrderItem, Select, SelectItem, SetStatement, Statement, Update,
+    Insert, IsolationLevel, JoinKind, Name, OrderItem, Select, SelectItem, SetStatement, Statement,
+    TableRef, Update,
 };
 use truthdb_sql::error::SqlError;
 use truthdb_sql::eval::EvalContext;
@@ -198,13 +199,16 @@ pub fn analyze_locks(
                     continue;
                 }
                 if let Some(from) = &select.from {
-                    let lower = from.value.to_ascii_lowercase();
-                    if lower.starts_with("sys.") {
-                        continue; // catalog view: unlocked
-                    }
-                    if let Some(def) = resolve_table(storage, &from.value) {
-                        add(Resource::Database, LockMode::IntentShared);
-                        add(Resource::Table(def.object_id), LockMode::Shared);
+                    let mut tables = Vec::new();
+                    collect_table_names(from, &mut tables);
+                    for name in tables {
+                        if name.value.to_ascii_lowercase().starts_with("sys.") {
+                            continue; // catalog view: unlocked
+                        }
+                        if let Some(def) = resolve_table(storage, &name.value) {
+                            add(Resource::Database, LockMode::IntentShared);
+                            add(Resource::Table(def.object_id), LockMode::Shared);
+                        }
                     }
                 }
             }
@@ -337,18 +341,30 @@ fn showplan_rows(
     eval_ctx: &EvalContext,
 ) -> Result<RowSet, SqlError> {
     let lines = match select.from.as_ref() {
-        Some(from) if !from.value.to_ascii_lowercase().starts_with("sys.") => {
-            match resolve_table(storage, &from.value) {
+        None => vec!["Constant Scan".to_string()],
+        Some(TableRef::Table { name, .. })
+            if !name.value.to_ascii_lowercase().starts_with("sys.") =>
+        {
+            match resolve_table(storage, &name.value) {
                 Some(def) => {
                     let schema = def.schema().map_err(|e| map_storage_err(e, &def.name))?;
                     let path = plan::choose(&def, &schema, &select.where_clause, eval_ctx);
                     plan::plan_text(&path, &def.name)
                 }
-                None => vec![format!("Table Scan({})", from.value)],
+                None => vec![format!("Table Scan({})", name.value)],
             }
         }
-        Some(from) => vec![format!("Table Scan({})", from.value)],
-        None => vec!["Constant Scan".to_string()],
+        Some(TableRef::Table { name, .. }) => vec![format!("Table Scan({})", name.value)],
+        Some(join) => {
+            // Multi-table: a nested-loop join over full scans (Stage 8).
+            let mut tables = Vec::new();
+            collect_table_names(join, &mut tables);
+            let mut lines = vec!["Nested Loops (join)".to_string()];
+            for table in tables {
+                lines.push(format!("  Table Scan({})", strip_schema(&table.value)));
+            }
+            lines
+        }
     };
     Ok(RowSet {
         columns: vec![ResultColumn {
@@ -1019,6 +1035,9 @@ fn predicate_true(
 
 struct Source {
     columns: Vec<ResultColumn>,
+    /// Per-column table qualifier (alias or table name; `None` = virtual/
+    /// constant source), parallel to `columns`. Drives multi-table resolution.
+    qualifiers: Vec<Option<String>>,
     /// Per-column collation names (parallel to `columns`; `None` = database
     /// default). Used by ORDER BY on character columns.
     collations: Vec<Option<String>>,
@@ -1027,12 +1046,80 @@ struct Source {
 }
 
 impl Source {
-    fn names(&self) -> Vec<String> {
-        self.columns.iter().map(|c| c.name.clone()).collect()
-    }
-
     fn types(&self) -> Vec<ColumnType> {
         self.columns.iter().map(|c| c.column_type).collect()
+    }
+
+    fn scope(&self) -> JoinScope {
+        JoinScope {
+            columns: self
+                .qualifiers
+                .iter()
+                .zip(&self.columns)
+                .map(|(qualifier, column)| (qualifier.clone(), column.name.clone()))
+                .collect(),
+        }
+    }
+}
+
+/// Resolves column references against a (possibly multi-table) row source. A
+/// dotted `t.col` matches by qualifier + name; a bare `col` matches a unique
+/// column (ambiguous or unknown → `None`, surfaced by eval as an invalid-
+/// column error).
+pub(super) struct JoinScope {
+    /// (qualifier, bare column name) per source column.
+    columns: Vec<(Option<String>, String)>,
+}
+
+/// Resolver over an output RowSet's columns. Output columns are unqualified,
+/// so a qualified `t.col` reference (e.g. in a grouped query's ORDER BY)
+/// resolves by its bare name.
+struct OutputScope {
+    names: Vec<String>,
+}
+
+impl truthdb_sql::eval::ColumnResolver for OutputScope {
+    fn resolve(&self, name: &str) -> Option<usize> {
+        let bare = name.rsplit('.').next().unwrap_or(name);
+        self.names.iter().position(|n| n.eq_ignore_ascii_case(bare))
+    }
+}
+
+impl JoinScope {
+    /// Source-column indices belonging to a table qualifier (for `t.*`).
+    fn indices_for_qualifier(&self, qualifier: &str) -> Vec<usize> {
+        self.columns
+            .iter()
+            .enumerate()
+            .filter(|(_, (q, _))| {
+                q.as_deref()
+                    .is_some_and(|q| q.eq_ignore_ascii_case(qualifier))
+            })
+            .map(|(index, _)| index)
+            .collect()
+    }
+}
+
+impl truthdb_sql::eval::ColumnResolver for JoinScope {
+    fn resolve(&self, name: &str) -> Option<usize> {
+        if let Some((qualifier, column)) = name.rsplit_once('.') {
+            self.columns.iter().position(|(q, c)| {
+                q.as_deref()
+                    .is_some_and(|q| q.eq_ignore_ascii_case(qualifier))
+                    && c.eq_ignore_ascii_case(column)
+            })
+        } else {
+            let mut found = None;
+            for (index, (_, column)) in self.columns.iter().enumerate() {
+                if column.eq_ignore_ascii_case(name) {
+                    if found.is_some() {
+                        return None; // ambiguous
+                    }
+                    found = Some(index);
+                }
+            }
+            found
+        }
     }
 }
 
@@ -1056,7 +1143,7 @@ fn exec_select(
         &select.where_clause,
         eval_ctx,
     )?;
-    let resolver = source.names();
+    let resolver = source.scope();
     let types = source.types();
 
     // WHERE. The predicate must be boolean-typed (SQL Server 4145): a bare
@@ -1168,6 +1255,7 @@ fn order_output(
         return Ok(());
     }
     let names: Vec<String> = rowset.columns.iter().map(|c| c.name.clone()).collect();
+    let scope = OutputScope { names };
     let types: Vec<ColumnType> = rowset.columns.iter().map(|c| c.column_type).collect();
     let mut keyed: Vec<(Vec<SqlValue>, usize)> = Vec::with_capacity(rowset.rows.len());
     for (index, row) in rowset.rows.iter().enumerate() {
@@ -1189,7 +1277,7 @@ fn order_output(
                     })?;
                 sql_row[ordinal].clone()
             } else {
-                eval::eval(&item.expr, &sql_row, &names, eval_ctx)?
+                eval::eval(&item.expr, &sql_row, &scope, eval_ctx)?
             };
             key.push(value);
         }
@@ -1216,7 +1304,7 @@ fn order_rows(
     order_by: &[OrderItem],
     types: &[ColumnType],
     collations: &[Option<String>],
-    resolver: &Vec<String>,
+    resolver: &JoinScope,
     eval_ctx: &EvalContext,
 ) -> Result<(), SqlError> {
     use std::cmp::Ordering;
@@ -1281,7 +1369,7 @@ fn project(
     source_columns: &[ResultColumn],
     rows: &[Vec<Datum>],
     types: &[ColumnType],
-    resolver: &Vec<String>,
+    resolver: &JoinScope,
     eval_ctx: &EvalContext,
 ) -> Result<RowSet, SqlError> {
     // Output column plan: a source column (typed, pass-through) or a
@@ -1290,7 +1378,6 @@ fn project(
         SourceColumn { index: usize, name: String },
         Expr { name: String, expr: &'a Expr },
     }
-    let source_names: Vec<String> = source_columns.iter().map(|c| c.name.clone()).collect();
     let mut projs = Vec::new();
     for item in items {
         match item {
@@ -1302,13 +1389,34 @@ fn project(
                     });
                 }
             }
+            SelectItem::QualifiedWildcard(qualifier) => {
+                let indices = resolver.indices_for_qualifier(&qualifier.value);
+                if indices.is_empty() {
+                    return Err(SqlError::new(
+                        4104,
+                        16,
+                        1,
+                        format!(
+                            "The multi-part identifier \"{}.*\" could not be bound.",
+                            qualifier.value
+                        ),
+                    )
+                    .at(qualifier.span));
+                }
+                for index in indices {
+                    projs.push(Proj::SourceColumn {
+                        index,
+                        name: source_columns[index].name.clone(),
+                    });
+                }
+            }
             SelectItem::Expr { expr, alias } => {
                 let name = alias
                     .as_ref()
                     .map(|a| a.value.clone())
                     .or_else(|| bare_column_name(expr))
                     .unwrap_or_default();
-                match bare_column_index(expr, &source_names) {
+                match bare_column_index(expr, resolver) {
                     // A bare column still carries its resolved output name so an
                     // `AS alias` (or the referenced name's casing) is preserved.
                     Some(index) => projs.push(Proj::SourceColumn { index, name }),
@@ -1361,44 +1469,76 @@ fn project(
 
 fn bare_column_name(expr: &Expr) -> Option<String> {
     match &expr.kind {
-        ExprKind::Column(name) => Some(name.value.clone()),
+        // A qualified `t.col` reference outputs the bare column name.
+        ExprKind::Column(name) => Some(name.value.rsplit('.').next().unwrap_or("").to_string()),
         _ => None,
     }
 }
 
-fn bare_column_index(expr: &Expr, columns: &[String]) -> Option<usize> {
+fn bare_column_index(expr: &Expr, scope: &JoinScope) -> Option<usize> {
+    use truthdb_sql::eval::ColumnResolver;
     match &expr.kind {
-        ExprKind::Column(name) => columns
-            .iter()
-            .position(|c| c.eq_ignore_ascii_case(&name.value)),
+        ExprKind::Column(name) => scope.resolve(&name.value),
         _ => None,
+    }
+}
+
+/// Collects every base-table name referenced in a FROM join tree.
+fn collect_table_names<'a>(tref: &'a TableRef, out: &mut Vec<&'a Name>) {
+    match tref {
+        TableRef::Table { name, .. } => out.push(name),
+        TableRef::Join { left, right, .. } => {
+            collect_table_names(left, out);
+            collect_table_names(right, out);
+        }
     }
 }
 
 fn build_source(
     storage: &mut Storage,
-    from: Option<&Name>,
+    from: Option<&TableRef>,
     where_clause: &Option<Expr>,
     eval_ctx: &EvalContext,
 ) -> Result<Source, SqlError> {
-    let Some(from) = from else {
-        // No FROM: one row, no columns (constant SELECT).
-        return Ok(Source {
+    match from {
+        None => Ok(Source {
+            // No FROM: one row, no columns (constant SELECT).
             columns: Vec::new(),
+            qualifiers: Vec::new(),
             collations: Vec::new(),
             rows: vec![Vec::new()],
-        });
-    };
-    match from.value.to_ascii_lowercase().as_str() {
-        "sys.tables" => Ok(sys_tables(storage)),
-        "sys.columns" => Ok(sys_columns(storage)),
-        "sys.indexes" => Ok(sys_indexes(storage)),
+        }),
+        // A single top-level table may use the WHERE for an index seek; base
+        // tables inside a join scan fully (join-order planning is later).
+        Some(TableRef::Table { name, alias }) => {
+            build_table_source(storage, name, alias.as_ref(), where_clause, eval_ctx)
+        }
+        Some(join) => build_join(storage, join, eval_ctx),
+    }
+}
+
+/// Builds the row source for one base table (or `sys.*` view), stamping every
+/// column with the table's qualifier (its alias, else its name).
+fn build_table_source(
+    storage: &mut Storage,
+    name: &Name,
+    alias: Option<&Name>,
+    where_clause: &Option<Expr>,
+    eval_ctx: &EvalContext,
+) -> Result<Source, SqlError> {
+    let qualifier = alias
+        .map(|a| a.value.clone())
+        .unwrap_or_else(|| strip_schema(&name.value).to_string());
+    let base = match name.value.to_ascii_lowercase().as_str() {
+        "sys.tables" => sys_tables(storage),
+        "sys.columns" => sys_columns(storage),
+        "sys.indexes" => sys_indexes(storage),
         _ => {
-            let def = resolve_table(storage, &from.value)
-                .ok_or_else(|| SqlError::invalid_object(&from.value).at(from.span))?;
+            let def = resolve_table(storage, &name.value)
+                .ok_or_else(|| SqlError::invalid_object(&name.value).at(name.span))?;
             let schema = def.schema().map_err(|e| map_storage_err(e, &def.name))?;
-            // Access-path selection: an index seek narrows the candidate set;
-            // the WHERE filter above re-checks, so results match a full scan.
+            // An index seek narrows the candidate set; the WHERE filter later
+            // re-checks, so results match a full scan.
             let rows = match plan::choose(&def, &schema, where_clause, eval_ctx) {
                 plan::AccessPath::TableScan => storage
                     .rel_scan(&def.name)
@@ -1421,13 +1561,160 @@ fn build_source(
                 })
                 .collect();
             let collations = schema.columns.iter().map(|c| c.collation.clone()).collect();
-            Ok(Source {
+            Source {
                 columns,
+                qualifiers: Vec::new(),
                 collations,
                 rows,
-            })
+            }
+        }
+    };
+    let count = base.columns.len();
+    Ok(Source {
+        qualifiers: vec![Some(qualifier); count],
+        ..base
+    })
+}
+
+/// Recursively builds a join tree's combined row source (base tables scan
+/// fully).
+fn build_join(
+    storage: &mut Storage,
+    tref: &TableRef,
+    eval_ctx: &EvalContext,
+) -> Result<Source, SqlError> {
+    match tref {
+        TableRef::Table { name, alias } => {
+            build_table_source(storage, name, alias.as_ref(), &None, eval_ctx)
+        }
+        TableRef::Join {
+            left,
+            right,
+            kind,
+            on,
+        } => {
+            let left = build_join(storage, left, eval_ctx)?;
+            let right = build_join(storage, right, eval_ctx)?;
+            join_sources(left, right, *kind, on.as_ref(), eval_ctx)
         }
     }
+}
+
+/// Nested-loop join of two materialized sources. The ON predicate (absent for
+/// CROSS) is evaluated against the concatenated row; outer joins emit NULL-
+/// extended rows for unmatched sides.
+fn join_sources(
+    left: Source,
+    right: Source,
+    kind: JoinKind,
+    on: Option<&Expr>,
+    eval_ctx: &EvalContext,
+) -> Result<Source, SqlError> {
+    let mut columns = left.columns.clone();
+    columns.extend(right.columns.clone());
+    let mut qualifiers = left.qualifiers.clone();
+    qualifiers.extend(right.qualifiers.clone());
+    let mut collations = left.collations.clone();
+    collations.extend(right.collations.clone());
+    let types: Vec<ColumnType> = columns.iter().map(|c| c.column_type).collect();
+    let scope = JoinScope {
+        columns: qualifiers
+            .iter()
+            .zip(&columns)
+            .map(|(q, c)| (q.clone(), c.name.clone()))
+            .collect(),
+    };
+    let left_nulls = vec![Datum::Null; left.columns.len()];
+    let right_nulls = vec![Datum::Null; right.columns.len()];
+
+    let concat = |l: &[Datum], r: &[Datum]| -> Vec<Datum> { l.iter().chain(r).cloned().collect() };
+    let matches = |l: &[Datum], r: &[Datum]| -> Result<bool, SqlError> {
+        match on {
+            None => Ok(true),
+            Some(pred) => {
+                let row = concat(l, r);
+                match eval::eval(pred, &row_values(&row, &types), &scope, eval_ctx)? {
+                    SqlValue::Bool(b) => Ok(b),
+                    SqlValue::Null => Ok(false),
+                    _ => Err(SqlError::new(
+                        4145,
+                        15,
+                        1,
+                        "An expression of non-boolean type specified in a context where a condition is expected, near 'ON'.",
+                    )
+                    .at(pred.span)),
+                }
+            }
+        }
+    };
+
+    let mut rows = Vec::new();
+    match kind {
+        JoinKind::Cross | JoinKind::Inner => {
+            for l in &left.rows {
+                for r in &right.rows {
+                    if matches(l, r)? {
+                        rows.push(concat(l, r));
+                    }
+                }
+            }
+        }
+        JoinKind::Left => {
+            for l in &left.rows {
+                let mut matched = false;
+                for r in &right.rows {
+                    if matches(l, r)? {
+                        rows.push(concat(l, r));
+                        matched = true;
+                    }
+                }
+                if !matched {
+                    rows.push(concat(l, &right_nulls));
+                }
+            }
+        }
+        JoinKind::Right => {
+            for r in &right.rows {
+                let mut matched = false;
+                for l in &left.rows {
+                    if matches(l, r)? {
+                        rows.push(concat(l, r));
+                        matched = true;
+                    }
+                }
+                if !matched {
+                    rows.push(concat(&left_nulls, r));
+                }
+            }
+        }
+        JoinKind::Full => {
+            let mut right_matched = vec![false; right.rows.len()];
+            for l in &left.rows {
+                let mut matched = false;
+                for (index, r) in right.rows.iter().enumerate() {
+                    if matches(l, r)? {
+                        rows.push(concat(l, r));
+                        matched = true;
+                        right_matched[index] = true;
+                    }
+                }
+                if !matched {
+                    rows.push(concat(l, &right_nulls));
+                }
+            }
+            for (index, r) in right.rows.iter().enumerate() {
+                if !right_matched[index] {
+                    rows.push(concat(&left_nulls, r));
+                }
+            }
+        }
+    }
+    Ok(Source {
+        columns,
+        qualifiers,
+        collations,
+        rows,
+    })
 }
 
 // ---- sys.* virtual sources ---------------------------------------------
@@ -1454,8 +1741,10 @@ fn sys_tables(storage: &Storage) -> Source {
         .map(|def| vec![Datum::Int(def.object_id as i32), Datum::NVarChar(def.name)])
         .collect();
     let collations = vec![None; columns.len()];
+    let qualifiers = vec![None; columns.len()];
     Source {
         columns,
+        qualifiers,
         collations,
         rows,
     }
@@ -1494,8 +1783,10 @@ fn sys_columns(storage: &Storage) -> Source {
         }
     }
     let collations = vec![None; columns.len()];
+    let qualifiers = vec![None; columns.len()];
     Source {
         columns,
+        qualifiers,
         collations,
         rows,
     }
@@ -1523,8 +1814,10 @@ fn sys_indexes(storage: &Storage) -> Source {
         }
     }
     let collations = vec![None; columns.len()];
+    let qualifiers = vec![None; columns.len()];
     Source {
         columns,
+        qualifiers,
         collations,
         rows,
     }

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -1102,24 +1102,28 @@ impl JoinScope {
 
 impl truthdb_sql::eval::ColumnResolver for JoinScope {
     fn resolve(&self, name: &str) -> Option<usize> {
-        if let Some((qualifier, column)) = name.rsplit_once('.') {
-            self.columns.iter().position(|(q, c)| {
+        // Both branches reject an ambiguous match (more than one column) by
+        // returning None, so eval raises an invalid-column error rather than
+        // silently picking the first.
+        let mut found = None;
+        let matches = |q: &Option<String>, c: &str| -> bool {
+            if let Some((qualifier, column)) = name.rsplit_once('.') {
                 q.as_deref()
                     .is_some_and(|q| q.eq_ignore_ascii_case(qualifier))
                     && c.eq_ignore_ascii_case(column)
-            })
-        } else {
-            let mut found = None;
-            for (index, (_, column)) in self.columns.iter().enumerate() {
-                if column.eq_ignore_ascii_case(name) {
-                    if found.is_some() {
-                        return None; // ambiguous
-                    }
-                    found = Some(index);
-                }
+            } else {
+                c.eq_ignore_ascii_case(name)
             }
-            found
+        };
+        for (index, (qualifier, column)) in self.columns.iter().enumerate() {
+            if matches(qualifier, column) {
+                if found.is_some() {
+                    return None; // ambiguous
+                }
+                found = Some(index);
+            }
         }
+        found
     }
 }
 
@@ -1494,7 +1498,60 @@ fn collect_table_names<'a>(tref: &'a TableRef, out: &mut Vec<&'a Name>) {
     }
 }
 
+/// A table's exposed name: its alias, else its (schema-stripped) name.
+fn exposed_name(name: &Name, alias: Option<&Name>) -> String {
+    alias
+        .map(|a| a.value.clone())
+        .unwrap_or_else(|| strip_schema(&name.value).to_string())
+}
+
+/// Collects the exposed names of every table in a FROM tree.
+fn collect_exposed_names(tref: &TableRef, out: &mut Vec<String>) {
+    match tref {
+        TableRef::Table { name, alias } => out.push(exposed_name(name, alias.as_ref())),
+        TableRef::Join { left, right, .. } => {
+            collect_exposed_names(left, out);
+            collect_exposed_names(right, out);
+        }
+    }
+}
+
+/// Rejects a FROM clause with duplicate exposed table names / correlation
+/// names (SQL Server 1013), which would otherwise bind ambiguously.
+fn check_exposed_names(from: &TableRef) -> Result<(), SqlError> {
+    let mut names = Vec::new();
+    collect_exposed_names(from, &mut names);
+    for i in 0..names.len() {
+        for j in (i + 1)..names.len() {
+            if names[i].eq_ignore_ascii_case(&names[j]) {
+                return Err(SqlError::new(
+                    1013,
+                    16,
+                    1,
+                    format!(
+                        "The objects \"{}\" and \"{}\" in the FROM clause have the same exposed names. Use correlation names to distinguish them.",
+                        names[i], names[j]
+                    ),
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
 fn build_source(
+    storage: &mut Storage,
+    from: Option<&TableRef>,
+    where_clause: &Option<Expr>,
+    eval_ctx: &EvalContext,
+) -> Result<Source, SqlError> {
+    if let Some(from) = from {
+        check_exposed_names(from)?;
+    }
+    build_source_inner(storage, from, where_clause, eval_ctx)
+}
+
+fn build_source_inner(
     storage: &mut Storage,
     from: Option<&TableRef>,
     where_clause: &Option<Expr>,

--- a/crates/truthdb-core/tests/slt/joins.slt
+++ b/crates/truthdb-core/tests/slt/joins.slt
@@ -45,3 +45,34 @@ bob 50
 # Ambiguous unqualified column is rejected.
 statement error
 SELECT id FROM cust c JOIN ord o ON c.id = o.cust_id
+
+# Duplicate exposed table name (self-join without correlation names) is
+# rejected up front (SQL Server 1013) rather than binding ambiguously.
+statement error
+SELECT cust.name FROM cust JOIN cust ON cust.id = cust.id
+
+# A reused correlation name is likewise rejected.
+statement error
+SELECT c.name FROM cust c JOIN ord c ON c.id = c.id
+
+# A proper self-join with distinct aliases is fine.
+query II
+SELECT a.id, b.id FROM cust a JOIN cust b ON a.id = b.id ORDER BY a.id
+----
+1 1
+2 2
+3 3
+
+# Comma-FROM binds looser than JOIN: `cust, ord RIGHT JOIN cust2`
+# associates as `cust CROSS JOIN (ord RIGHT JOIN cust2)`, so every cust
+# row multiplies the right side rather than joining into it.
+statement ok
+CREATE TABLE cust2 (id INT NOT NULL PRIMARY KEY, cust_id INT)
+
+statement ok
+INSERT INTO cust2 VALUES (100, 1)
+
+query I
+SELECT COUNT(*) FROM cust, ord RIGHT JOIN cust2 ON ord.cust_id = cust2.id
+----
+3

--- a/crates/truthdb-core/tests/slt/joins.slt
+++ b/crates/truthdb-core/tests/slt/joins.slt
@@ -1,0 +1,47 @@
+# Joins (Stage 8 part 2)
+
+statement ok
+CREATE TABLE cust (id INT NOT NULL PRIMARY KEY, name NVARCHAR(20))
+
+statement ok
+CREATE TABLE ord (id INT NOT NULL PRIMARY KEY, cust_id INT, amount INT)
+
+statement ok
+INSERT INTO cust VALUES (1,'alice'),(2,'bob'),(3,'carol')
+
+statement ok
+INSERT INTO ord VALUES (10,1,100),(11,1,200),(12,2,50),(13,99,7)
+
+# INNER JOIN
+query TI
+SELECT c.name, o.amount FROM cust c JOIN ord o ON c.id = o.cust_id ORDER BY o.id
+----
+alice 100
+alice 200
+bob 50
+
+# LEFT JOIN keeps carol with a NULL amount.
+query TI
+SELECT c.name, o.amount FROM cust c LEFT JOIN ord o ON c.id = o.cust_id ORDER BY c.id, o.id
+----
+alice 100
+alice 200
+bob 50
+carol NULL
+
+# CROSS JOIN cardinality.
+query I
+SELECT COUNT(*) FROM cust CROSS JOIN ord
+----
+12
+
+# Aggregate over a join, grouped.
+query TI
+SELECT c.name, SUM(o.amount) FROM cust c JOIN ord o ON c.id = o.cust_id GROUP BY c.name ORDER BY c.name
+----
+alice 300
+bob 50
+
+# Ambiguous unqualified column is rejected.
+statement error
+SELECT id FROM cust c JOIN ord o ON c.id = o.cust_id

--- a/crates/truthdb-sql/src/ast.rs
+++ b/crates/truthdb-sql/src/ast.rs
@@ -168,7 +168,8 @@ pub struct Select {
     /// `SELECT DISTINCT` — deduplicate the projected rows.
     pub distinct: bool,
     pub items: Vec<SelectItem>,
-    pub from: Option<Name>,
+    /// The FROM clause: a table or a join tree (absent for a constant SELECT).
+    pub from: Option<TableRef>,
     pub where_clause: Option<Expr>,
     /// `GROUP BY <expr>, ...` (empty = no grouping).
     pub group_by: Vec<Expr>,
@@ -178,10 +179,38 @@ pub struct Select {
     pub span: Span,
 }
 
+/// A FROM clause: a base table (with optional alias) or a join of two table
+/// references. Comma-separated tables desugar to `CROSS JOIN`.
+#[derive(Debug, Clone, PartialEq)]
+pub enum TableRef {
+    Table {
+        name: Name,
+        alias: Option<Name>,
+    },
+    Join {
+        left: Box<TableRef>,
+        right: Box<TableRef>,
+        kind: JoinKind,
+        /// The `ON` predicate (absent for `CROSS JOIN`).
+        on: Option<Expr>,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum JoinKind {
+    Inner,
+    Left,
+    Right,
+    Full,
+    Cross,
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum SelectItem {
     /// `*`
     Wildcard,
+    /// `table.*`
+    QualifiedWildcard(Name),
     Expr {
         expr: Expr,
         alias: Option<Name>,

--- a/crates/truthdb-sql/src/parser.rs
+++ b/crates/truthdb-sql/src/parser.rs
@@ -844,19 +844,27 @@ impl Parser {
 
     /// Parses a FROM clause: a table primary followed by zero or more joins
     /// (comma = CROSS JOIN). Joins are left-associative.
+    /// Parses a FROM clause. Comma has the LOWEST precedence (each operand is
+    /// a full joined table), so `a, b RIGHT JOIN c` is `a CROSS JOIN (b RIGHT
+    /// JOIN c)`, matching SQL Server.
     fn parse_from(&mut self) -> SqlResult<TableRef> {
+        let mut left = self.parse_joined_table()?;
+        while self.eat(&TokenKind::Comma) {
+            let right = self.parse_joined_table()?;
+            left = TableRef::Join {
+                left: Box::new(left),
+                right: Box::new(right),
+                kind: JoinKind::Cross,
+                on: None,
+            };
+        }
+        Ok(left)
+    }
+
+    /// Parses one table reference followed by its JOIN operators (no comma).
+    fn parse_joined_table(&mut self) -> SqlResult<TableRef> {
         let mut left = self.parse_table_primary()?;
         loop {
-            if self.eat(&TokenKind::Comma) {
-                let right = self.parse_table_primary()?;
-                left = TableRef::Join {
-                    left: Box::new(left),
-                    right: Box::new(right),
-                    kind: JoinKind::Cross,
-                    on: None,
-                };
-                continue;
-            }
             let kind = match self.peek_keyword().as_deref() {
                 Some("INNER") => {
                     self.bump();

--- a/crates/truthdb-sql/src/parser.rs
+++ b/crates/truthdb-sql/src/parser.rs
@@ -717,6 +717,12 @@ impl Parser {
             if self.check(&TokenKind::Star) {
                 self.bump();
                 items.push(SelectItem::Wildcard);
+            } else if self.is_qualified_wildcard() {
+                // `table.*`
+                let name = self.parse_ident()?;
+                self.expect(&TokenKind::Dot)?;
+                self.expect(&TokenKind::Star)?;
+                items.push(SelectItem::QualifiedWildcard(name));
             } else {
                 let expr = self.parse_expr()?;
                 let alias = self.parse_optional_alias()?;
@@ -729,7 +735,7 @@ impl Parser {
 
         let from = if self.peek_keyword().as_deref() == Some("FROM") {
             self.bump();
-            Some(self.parse_name()?)
+            Some(self.parse_from()?)
         } else {
             None
         };
@@ -815,6 +821,126 @@ impl Parser {
             return Ok(Some(self.parse_name()?));
         }
         Ok(None)
+    }
+
+    /// True if the next three tokens are `<word> . *` (a qualified wildcard).
+    fn is_qualified_wildcard(&self) -> bool {
+        let is_word = matches!(
+            self.tokens.get(self.pos).map(|t| &t.kind),
+            Some(TokenKind::Word { .. })
+        );
+        let is_dot = matches!(
+            self.tokens.get(self.pos + 1).map(|t| &t.kind),
+            Some(TokenKind::Dot)
+        );
+        let is_star = matches!(
+            self.tokens.get(self.pos + 2).map(|t| &t.kind),
+            Some(TokenKind::Star)
+        );
+        is_word && is_dot && is_star
+    }
+
+    // ---- FROM / joins ---------------------------------------------------
+
+    /// Parses a FROM clause: a table primary followed by zero or more joins
+    /// (comma = CROSS JOIN). Joins are left-associative.
+    fn parse_from(&mut self) -> SqlResult<TableRef> {
+        let mut left = self.parse_table_primary()?;
+        loop {
+            if self.eat(&TokenKind::Comma) {
+                let right = self.parse_table_primary()?;
+                left = TableRef::Join {
+                    left: Box::new(left),
+                    right: Box::new(right),
+                    kind: JoinKind::Cross,
+                    on: None,
+                };
+                continue;
+            }
+            let kind = match self.peek_keyword().as_deref() {
+                Some("INNER") => {
+                    self.bump();
+                    self.expect_keyword("JOIN")?;
+                    JoinKind::Inner
+                }
+                Some("JOIN") => {
+                    self.bump();
+                    JoinKind::Inner
+                }
+                Some("LEFT") => {
+                    self.bump();
+                    let _ = self.eat_keyword("OUTER");
+                    self.expect_keyword("JOIN")?;
+                    JoinKind::Left
+                }
+                Some("RIGHT") => {
+                    self.bump();
+                    let _ = self.eat_keyword("OUTER");
+                    self.expect_keyword("JOIN")?;
+                    JoinKind::Right
+                }
+                Some("FULL") => {
+                    self.bump();
+                    let _ = self.eat_keyword("OUTER");
+                    self.expect_keyword("JOIN")?;
+                    JoinKind::Full
+                }
+                Some("CROSS") => {
+                    self.bump();
+                    self.expect_keyword("JOIN")?;
+                    JoinKind::Cross
+                }
+                _ => break,
+            };
+            let right = self.parse_table_primary()?;
+            let on = if kind == JoinKind::Cross {
+                None
+            } else {
+                self.expect_keyword("ON")?;
+                Some(self.parse_expr()?)
+            };
+            left = TableRef::Join {
+                left: Box::new(left),
+                right: Box::new(right),
+                kind,
+                on,
+            };
+        }
+        Ok(left)
+    }
+
+    fn parse_table_primary(&mut self) -> SqlResult<TableRef> {
+        // Derived tables (subqueries) arrive in Stage 11.
+        let name = self.parse_name()?;
+        let alias = self.parse_optional_table_alias()?;
+        Ok(TableRef::Table { name, alias })
+    }
+
+    fn parse_optional_table_alias(&mut self) -> SqlResult<Option<Name>> {
+        if self.peek_keyword().as_deref() == Some("AS") {
+            self.bump();
+            return Ok(Some(self.parse_name()?));
+        }
+        if let Some(keyword) = self.peek_keyword() {
+            if is_clause_keyword(&keyword) || is_join_keyword(&keyword) {
+                return Ok(None);
+            }
+            return Ok(Some(self.parse_name()?));
+        }
+        if matches!(self.peek().kind, TokenKind::Word { quoted: true, .. }) {
+            return Ok(Some(self.parse_name()?));
+        }
+        Ok(None)
+    }
+
+    /// Consumes `keyword` if it is next; returns whether it did.
+    fn eat_keyword(&mut self, keyword: &str) -> bool {
+        if self.peek_keyword().as_deref() == Some(keyword) {
+            self.bump();
+            true
+        } else {
+            false
+        }
     }
 
     // ---- expressions (precedence climbing) ------------------------------
@@ -1451,6 +1577,14 @@ fn is_clause_keyword(keyword: &str) -> bool {
     matches!(
         keyword,
         "FROM" | "WHERE" | "ORDER" | "GROUP" | "HAVING" | "AS"
+    )
+}
+
+/// Keywords that introduce a join (so they are not read as a table alias).
+fn is_join_keyword(keyword: &str) -> bool {
+    matches!(
+        keyword,
+        "JOIN" | "INNER" | "LEFT" | "RIGHT" | "FULL" | "CROSS" | "ON" | "OUTER"
     )
 }
 

--- a/crates/truthdb-sql/tests/corpus/ok/aggregation.ast
+++ b/crates/truthdb-sql/tests/corpus/ok/aggregation.ast
@@ -101,13 +101,16 @@
                 },
             ],
             from: Some(
-                Name {
-                    value: "sales",
-                    quoted: false,
-                    span: Span {
-                        start: 71,
-                        end: 76,
+                Table {
+                    name: Name {
+                        value: "sales",
+                        quoted: false,
+                        span: Span {
+                            start: 71,
+                            end: 76,
+                        },
                     },
+                    alias: None,
                 },
             ),
             where_clause: Some(

--- a/crates/truthdb-sql/tests/corpus/ok/expression_precedence.ast
+++ b/crates/truthdb-sql/tests/corpus/ok/expression_precedence.ast
@@ -225,13 +225,16 @@
                 },
             ],
             from: Some(
-                Name {
-                    value: "t",
-                    quoted: false,
-                    span: Span {
-                        start: 61,
-                        end: 62,
+                Table {
+                    name: Name {
+                        value: "t",
+                        quoted: false,
+                        span: Span {
+                            start: 61,
+                            end: 62,
+                        },
                     },
+                    alias: None,
                 },
             ),
             where_clause: None,

--- a/crates/truthdb-sql/tests/corpus/ok/joins.ast
+++ b/crates/truthdb-sql/tests/corpus/ok/joins.ast
@@ -1,0 +1,290 @@
+[
+    Select(
+        Select {
+            top: None,
+            distinct: false,
+            items: [
+                Expr {
+                    expr: Expr {
+                        kind: Column(
+                            Name {
+                                value: "c.name",
+                                quoted: false,
+                                span: Span {
+                                    start: 7,
+                                    end: 13,
+                                },
+                            },
+                        ),
+                        span: Span {
+                            start: 7,
+                            end: 13,
+                        },
+                    },
+                    alias: None,
+                },
+                Expr {
+                    expr: Expr {
+                        kind: Column(
+                            Name {
+                                value: "o.amount",
+                                quoted: false,
+                                span: Span {
+                                    start: 15,
+                                    end: 23,
+                                },
+                            },
+                        ),
+                        span: Span {
+                            start: 15,
+                            end: 23,
+                        },
+                    },
+                    alias: None,
+                },
+                QualifiedWildcard(
+                    Name {
+                        value: "s",
+                        quoted: false,
+                        span: Span {
+                            start: 25,
+                            end: 26,
+                        },
+                    },
+                ),
+            ],
+            from: Some(
+                Join {
+                    left: Join {
+                        left: Join {
+                            left: Table {
+                                name: Name {
+                                    value: "cust",
+                                    quoted: false,
+                                    span: Span {
+                                        start: 34,
+                                        end: 38,
+                                    },
+                                },
+                                alias: Some(
+                                    Name {
+                                        value: "c",
+                                        quoted: false,
+                                        span: Span {
+                                            start: 42,
+                                            end: 43,
+                                        },
+                                    },
+                                ),
+                            },
+                            right: Table {
+                                name: Name {
+                                    value: "ord",
+                                    quoted: false,
+                                    span: Span {
+                                        start: 55,
+                                        end: 58,
+                                    },
+                                },
+                                alias: Some(
+                                    Name {
+                                        value: "o",
+                                        quoted: false,
+                                        span: Span {
+                                            start: 59,
+                                            end: 60,
+                                        },
+                                    },
+                                ),
+                            },
+                            kind: Inner,
+                            on: Some(
+                                Expr {
+                                    kind: Binary {
+                                        op: Eq,
+                                        left: Expr {
+                                            kind: Column(
+                                                Name {
+                                                    value: "c.id",
+                                                    quoted: false,
+                                                    span: Span {
+                                                        start: 64,
+                                                        end: 68,
+                                                    },
+                                                },
+                                            ),
+                                            span: Span {
+                                                start: 64,
+                                                end: 68,
+                                            },
+                                        },
+                                        right: Expr {
+                                            kind: Column(
+                                                Name {
+                                                    value: "o.cust_id",
+                                                    quoted: false,
+                                                    span: Span {
+                                                        start: 71,
+                                                        end: 80,
+                                                    },
+                                                },
+                                            ),
+                                            span: Span {
+                                                start: 71,
+                                                end: 80,
+                                            },
+                                        },
+                                    },
+                                    span: Span {
+                                        start: 64,
+                                        end: 80,
+                                    },
+                                },
+                            ),
+                        },
+                        right: Table {
+                            name: Name {
+                                value: "ship",
+                                quoted: false,
+                                span: Span {
+                                    start: 97,
+                                    end: 101,
+                                },
+                            },
+                            alias: Some(
+                                Name {
+                                    value: "s",
+                                    quoted: false,
+                                    span: Span {
+                                        start: 102,
+                                        end: 103,
+                                    },
+                                },
+                            ),
+                        },
+                        kind: Left,
+                        on: Some(
+                            Expr {
+                                kind: Binary {
+                                    op: Eq,
+                                    left: Expr {
+                                        kind: Column(
+                                            Name {
+                                                value: "o.id",
+                                                quoted: false,
+                                                span: Span {
+                                                    start: 107,
+                                                    end: 111,
+                                                },
+                                            },
+                                        ),
+                                        span: Span {
+                                            start: 107,
+                                            end: 111,
+                                        },
+                                    },
+                                    right: Expr {
+                                        kind: Column(
+                                            Name {
+                                                value: "s.ord_id",
+                                                quoted: false,
+                                                span: Span {
+                                                    start: 114,
+                                                    end: 122,
+                                                },
+                                            },
+                                        ),
+                                        span: Span {
+                                            start: 114,
+                                            end: 122,
+                                        },
+                                    },
+                                },
+                                span: Span {
+                                    start: 107,
+                                    end: 122,
+                                },
+                            },
+                        ),
+                    },
+                    right: Table {
+                        name: Name {
+                            value: "region",
+                            quoted: false,
+                            span: Span {
+                                start: 134,
+                                end: 140,
+                            },
+                        },
+                        alias: None,
+                    },
+                    kind: Cross,
+                    on: None,
+                },
+            ),
+            where_clause: Some(
+                Expr {
+                    kind: Binary {
+                        op: Gt,
+                        left: Expr {
+                            kind: Column(
+                                Name {
+                                    value: "o.amount",
+                                    quoted: false,
+                                    span: Span {
+                                        start: 147,
+                                        end: 155,
+                                    },
+                                },
+                            ),
+                            span: Span {
+                                start: 147,
+                                end: 155,
+                            },
+                        },
+                        right: Expr {
+                            kind: Int(
+                                100,
+                            ),
+                            span: Span {
+                                start: 158,
+                                end: 161,
+                            },
+                        },
+                    },
+                    span: Span {
+                        start: 147,
+                        end: 161,
+                    },
+                },
+            ),
+            group_by: [],
+            having: None,
+            order_by: [
+                OrderItem {
+                    expr: Expr {
+                        kind: Column(
+                            Name {
+                                value: "c.name",
+                                quoted: false,
+                                span: Span {
+                                    start: 171,
+                                    end: 177,
+                                },
+                            },
+                        ),
+                        span: Span {
+                            start: 171,
+                            end: 177,
+                        },
+                    },
+                    descending: false,
+                },
+            ],
+            span: Span {
+                start: 0,
+                end: 177,
+            },
+        },
+    ),
+]

--- a/crates/truthdb-sql/tests/corpus/ok/joins.sql
+++ b/crates/truthdb-sql/tests/corpus/ok/joins.sql
@@ -1,0 +1,7 @@
+SELECT c.name, o.amount, s.*
+FROM cust AS c
+INNER JOIN ord o ON c.id = o.cust_id
+LEFT OUTER JOIN ship s ON o.id = s.ord_id
+CROSS JOIN region
+WHERE o.amount > 100
+ORDER BY c.name

--- a/crates/truthdb-sql/tests/corpus/ok/select_expressions.ast
+++ b/crates/truthdb-sql/tests/corpus/ok/select_expressions.ast
@@ -257,13 +257,16 @@
                 },
             ],
             from: Some(
-                Name {
-                    value: "students",
-                    quoted: false,
-                    span: Span {
-                        start: 195,
-                        end: 203,
+                Table {
+                    name: Name {
+                        value: "students",
+                        quoted: false,
+                        span: Span {
+                            start: 195,
+                            end: 203,
+                        },
                     },
+                    alias: None,
                 },
             ),
             where_clause: Some(

--- a/crates/truthdb-sql/tests/corpus/ok/select_star.ast
+++ b/crates/truthdb-sql/tests/corpus/ok/select_star.ast
@@ -7,13 +7,16 @@
                 Wildcard,
             ],
             from: Some(
-                Name {
-                    value: "products",
-                    quoted: false,
-                    span: Span {
-                        start: 32,
-                        end: 40,
+                Table {
+                    name: Name {
+                        value: "products",
+                        quoted: false,
+                        span: Span {
+                            start: 32,
+                            end: 40,
+                        },
                     },
+                    alias: None,
                 },
             ),
             where_clause: Some(

--- a/crates/truthdb-sql/tests/corpus/ok/select_where_order.ast
+++ b/crates/truthdb-sql/tests/corpus/ok/select_where_order.ast
@@ -92,13 +92,16 @@
                 },
             ],
             from: Some(
-                Name {
-                    value: "products",
-                    quoted: false,
-                    span: Span {
-                        start: 49,
-                        end: 57,
+                Table {
+                    name: Name {
+                        value: "products",
+                        quoted: false,
+                        span: Span {
+                            start: 49,
+                            end: 57,
+                        },
                     },
+                    alias: None,
                 },
             ),
             where_clause: Some(


### PR DESCRIPTION
Second part of **Stage 8**: multi-table FROM with all join types and a qualified-column binder. Together with PR #50 (aggregation) this completes Stage 8's functional surface. Hash operators and disk spilling remain deferred (documented) — the in-memory nested-loop operators are correct.

## What's in it

- **Join grammar**: `INNER`/`LEFT`/`RIGHT`/`FULL [OUTER] JOIN ... ON`, `CROSS JOIN`, and comma-FROM (desugars to CROSS JOIN); left-associative join trees. `FROM` is now a `TableRef` tree (table + optional alias, or a join). Table aliases (`FROM t AS a` / `FROM t a`) and qualified column references (`a.col`), plus `t.*` qualified wildcards.
- **Nested-loop join executor** (`join_sources`): the ON predicate is evaluated against the concatenated row; LEFT/RIGHT/FULL emit NULL-extended rows for unmatched sides. CROSS has no ON.
- **Multi-table binder** (`JoinScope`): each source column carries a table qualifier; a dotted `t.col` resolves by qualifier+name, a bare `col` resolves to a unique column (unresolvable/ambiguous → an invalid-column error). Aggregation, WHERE, and ORDER BY all resolve through it; grouped-query `ORDER BY t.col` resolves by bare name against the output.
- Locking (`analyze_locks`) now walks the whole join tree and takes a shared lock on every referenced table; `SHOWPLAN_TEXT` describes the nested-loop join.

## Notes / deferred

- Ambiguous bare columns currently raise the generic invalid-column error (207) rather than the dedicated ambiguous-column error (209) — the query fails either way; the exact code is a small follow-up.
- Base tables inside a join scan fully (join-order/index-driven join planning is a later stage). Hash join, hash aggregate, and external-merge/grace-hash disk spill are deferred (spilling needs SQL-layer page I/O that isn't surfaced yet).

## Tests

- Engine tests: INNER/LEFT/RIGHT/FULL/CROSS + comma-FROM (cardinalities and NULL-extension), qualified columns + aliases, `t.*`, WHERE over a join, aggregation grouped over a join, ambiguous-column error.
- slt: `joins.slt`; parser corpus: `joins.sql`.

`cargo fmt`, `cargo clippy --all-targets --all-features -D warnings`, and `cargo test --workspace` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)