### PR TITLE
CHECK constraints + named-constraint syntax [Stage 10, part 1]

### DIFF
--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -1560,6 +1560,116 @@ mod tests {
         let _ = std::fs::remove_file(path);
     }
 
+    /// Runs SQL expected to error and returns the SQL error message.
+    fn sql_error_message(engine: &mut Engine, text: &str) -> String {
+        let env = sql(engine, text);
+        env["error"]["message"]
+            .as_str()
+            .unwrap_or_else(|| panic!("expected an error envelope, got {env}"))
+            .to_string()
+    }
+
+    #[test]
+    fn sql_check_constraints_enforced_on_insert_and_update() {
+        let path = unique_temp_path("sql-check");
+        let mut engine = new_engine(&path);
+        engine
+            .execute(
+                "CREATE TABLE items (\
+                   id INT NOT NULL PRIMARY KEY, \
+                   qty INT CHECK (qty >= 0), \
+                   price INT, \
+                   CONSTRAINT ck_price CHECK ((price - qty) > 0))",
+            )
+            .expect("create");
+
+        // A row satisfying both checks inserts.
+        engine
+            .execute("INSERT INTO items VALUES (1, 5, 10)")
+            .expect("insert ok");
+
+        // Column check violation (qty < 0) → 547.
+        assert_eq!(
+            sql_error_number(&mut engine, "INSERT INTO items VALUES (2, -1, 10)"),
+            547
+        );
+        // Named table check violation (price <= qty) → 547, name in message.
+        let msg = sql_error_message(&mut engine, "INSERT INTO items VALUES (3, 5, 5)");
+        assert!(
+            msg.contains("ck_price"),
+            "message should name the constraint: {msg}"
+        );
+
+        // A NULL in a checked column yields UNKNOWN, which passes.
+        engine
+            .execute("INSERT INTO items VALUES (4, NULL, 10)")
+            .expect("null qty passes check");
+
+        // UPDATE is checked against the new row.
+        assert_eq!(
+            sql_error_number(&mut engine, "UPDATE items SET qty = -3 WHERE id = 1"),
+            547
+        );
+        engine
+            .execute("UPDATE items SET qty = 2 WHERE id = 1")
+            .expect("update ok");
+        let (_, rows) = sql_rows(&mut engine, "SELECT id FROM items ORDER BY id");
+        assert_eq!(rows, vec![vec![Some("1".into())], vec![Some("4".into())],]);
+
+        // The constraint survives a restart and still fires.
+        drop(engine);
+        let storage = Storage::open(path.clone()).expect("reopen");
+        let mut engine = Engine::new(storage).expect("engine");
+        assert_eq!(
+            sql_error_number(&mut engine, "INSERT INTO items VALUES (5, -9, 10)"),
+            547
+        );
+        // sys.check_constraints lists both (the auto-named column check and the
+        // explicitly named table check).
+        let (_, rows) = sql_rows(
+            &mut engine,
+            "SELECT name FROM sys.check_constraints ORDER BY name",
+        );
+        assert_eq!(
+            rows,
+            vec![
+                vec![Some("CK__items__1".into())],
+                vec![Some("ck_price".into())],
+            ]
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn sql_check_constraint_rejects_unknown_column_and_duplicate_name() {
+        let path = unique_temp_path("sql-check-invalid");
+        let mut engine = new_engine(&path);
+        // A CHECK referencing a non-existent column is rejected at CREATE (207).
+        assert_eq!(
+            sql_error_number(
+                &mut engine,
+                "CREATE TABLE t (id INT NOT NULL PRIMARY KEY, CHECK (missing > 0))",
+            ),
+            207
+        );
+        // Two constraints with the same explicit name collide (2714).
+        assert_eq!(
+            sql_error_number(
+                &mut engine,
+                "CREATE TABLE t (id INT NOT NULL PRIMARY KEY, \
+                   CONSTRAINT c CHECK (id > 0), CONSTRAINT c CHECK (id < 100))",
+            ),
+            2714
+        );
+        // A multi-part (qualified) identifier in a CHECK is rejected at CREATE
+        // (4104) rather than producing a table that rejects every INSERT.
+        assert_eq!(
+            sql_error_number(&mut engine, "CREATE TABLE t (col INT, CHECK (t.col > 0))",),
+            4104
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
     #[test]
     fn sql_decimal_arithmetic_and_rendering() {
         let path = unique_temp_path("sql-decimal");

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -13,9 +13,9 @@ mod plan;
 mod value;
 
 use truthdb_sql::ast::{
-    ColumnDef, CreateIndex, CreateTable, DataType, Delete, DropIndex, DropTable, Expr, ExprKind,
-    Insert, IsolationLevel, JoinKind, Name, OrderItem, Select, SelectItem, SetStatement, Statement,
-    TableRef, Update,
+    CheckConstraint, ColumnDef, CreateIndex, CreateTable, DataType, Delete, DropIndex, DropTable,
+    Expr, ExprKind, Insert, IsolationLevel, JoinKind, Name, OrderItem, Select, SelectItem,
+    SetStatement, Statement, TableRef, Update,
 };
 use truthdb_sql::error::SqlError;
 use truthdb_sql::eval::EvalContext;
@@ -586,10 +586,213 @@ fn exec_create_table(
         });
     }
 
+    // CHECK constraints (column-level + table-level): validate, name, and
+    // fold into the catalog. Validation needs the bound columns.
+    let check_constraints = build_check_defs(create, &columns, table_name)?;
+
     storage
-        .rel_create_table(table_name, columns, &key_names, defaults, identity)
+        .rel_create_table(
+            table_name,
+            columns,
+            &key_names,
+            defaults,
+            identity,
+            check_constraints,
+        )
         .map_err(|err| map_storage_err(err, table_name))?;
     Ok(StatementResult::Done)
+}
+
+/// Collects a table's CHECK constraints (column-level, then table-level),
+/// validates each predicate parses and references only real columns, assigns
+/// a name to unnamed constraints, and rejects duplicate names.
+fn build_check_defs(
+    create: &CreateTable,
+    columns: &[Column],
+    table_name: &str,
+) -> Result<Vec<catalog::CheckDef>, SqlError> {
+    let raw: Vec<&CheckConstraint> = create
+        .columns
+        .iter()
+        .flat_map(|c| c.checks.iter())
+        .chain(create.check_constraints.iter())
+        .collect();
+
+    // Explicit names must be unique within the table (case-insensitive).
+    let mut names: Vec<String> = Vec::new();
+    for check in &raw {
+        if let Some(name) = &check.name {
+            if names.iter().any(|n| n.eq_ignore_ascii_case(&name.value)) {
+                return Err(SqlError::new(
+                    2714,
+                    16,
+                    5,
+                    format!(
+                        "There is already an object named '{}' in the database.",
+                        name.value
+                    ),
+                )
+                .at(name.span));
+            }
+            names.push(name.value.clone());
+        }
+    }
+
+    let mut defs = Vec::with_capacity(raw.len());
+    let mut auto_seq = 0u32;
+    for check in raw {
+        let expr = truthdb_sql::parse_expr(&check.predicate)?;
+        validate_check_columns(&expr, columns)?;
+        let name = match &check.name {
+            Some(n) => n.value.clone(),
+            None => loop {
+                auto_seq += 1;
+                let candidate = format!("CK__{table_name}__{auto_seq}");
+                if !names.iter().any(|n| n.eq_ignore_ascii_case(&candidate)) {
+                    names.push(candidate.clone());
+                    break candidate;
+                }
+            },
+        };
+        defs.push(catalog::CheckDef {
+            name,
+            predicate: check.predicate.clone(),
+        });
+    }
+    Ok(defs)
+}
+
+/// Rejects a CHECK predicate that references a column the table does not have
+/// (error 207). Only column existence is checked here; type/boolean validity
+/// is left to per-row evaluation.
+fn validate_check_columns(expr: &Expr, columns: &[Column]) -> Result<(), SqlError> {
+    match &expr.kind {
+        ExprKind::Column(name) => {
+            // A CHECK may only reference columns of its own table by their bare
+            // name. A multi-part identifier (`t.col`) can't be resolved by the
+            // bare-name enforcement resolver, so reject it here (4104) rather
+            // than accept a table that then rejects every INSERT with 207.
+            if name.value.contains('.') {
+                return Err(SqlError::new(
+                    4104,
+                    16,
+                    1,
+                    format!(
+                        "The multi-part identifier \"{}\" could not be bound.",
+                        name.value
+                    ),
+                )
+                .at(name.span));
+            }
+            if columns
+                .iter()
+                .any(|c| c.name.eq_ignore_ascii_case(&name.value))
+            {
+                Ok(())
+            } else {
+                Err(SqlError::invalid_column(&name.value).at(name.span))
+            }
+        }
+        ExprKind::Unary { expr, .. }
+        | ExprKind::Cast { expr, .. }
+        | ExprKind::IsNull { expr, .. } => validate_check_columns(expr, columns),
+        ExprKind::Binary { left, right, .. } => {
+            validate_check_columns(left, columns)?;
+            validate_check_columns(right, columns)
+        }
+        ExprKind::Like { expr, pattern, .. } => {
+            validate_check_columns(expr, columns)?;
+            validate_check_columns(pattern, columns)
+        }
+        ExprKind::InList { expr, list, .. } => {
+            validate_check_columns(expr, columns)?;
+            list.iter()
+                .try_for_each(|e| validate_check_columns(e, columns))
+        }
+        ExprKind::Between {
+            expr, low, high, ..
+        } => {
+            validate_check_columns(expr, columns)?;
+            validate_check_columns(low, columns)?;
+            validate_check_columns(high, columns)
+        }
+        ExprKind::Case {
+            operand,
+            branches,
+            else_result,
+        } => {
+            if let Some(op) = operand {
+                validate_check_columns(op, columns)?;
+            }
+            for (when, then) in branches {
+                validate_check_columns(when, columns)?;
+                validate_check_columns(then, columns)?;
+            }
+            if let Some(e) = else_result {
+                validate_check_columns(e, columns)?;
+            }
+            Ok(())
+        }
+        ExprKind::Function { args, .. } => args
+            .iter()
+            .try_for_each(|a| validate_check_columns(a, columns)),
+        ExprKind::Aggregate { arg, .. } => arg
+            .as_ref()
+            .map_or(Ok(()), |a| validate_check_columns(a, columns)),
+        ExprKind::Null
+        | ExprKind::Int(_)
+        | ExprKind::Number(_)
+        | ExprKind::Str(_)
+        | ExprKind::Bool(_)
+        | ExprKind::GlobalVar(_) => Ok(()),
+    }
+}
+
+/// Parses a table's stored CHECK predicates once (per statement) for row
+/// enforcement, pairing each with its constraint name.
+fn parse_checks(def: &TableDef) -> Result<Vec<(String, Expr)>, SqlError> {
+    def.check_constraints
+        .iter()
+        .map(|c| Ok((c.name.clone(), truthdb_sql::parse_expr(&c.predicate)?)))
+        .collect()
+}
+
+/// Enforces CHECK constraints against a fully-built row (schema order). A
+/// constraint passes on TRUE or UNKNOWN (NULL); FALSE is error 547.
+fn enforce_checks(
+    checks: &[(String, Expr)],
+    row: &[SqlValue],
+    resolver: &Vec<String>,
+    eval_ctx: &EvalContext,
+    verb: &str,
+    table: &str,
+) -> Result<(), SqlError> {
+    for (name, expr) in checks {
+        match eval::eval(expr, row, resolver, eval_ctx)? {
+            SqlValue::Bool(false) => {
+                return Err(SqlError::new(
+                    547,
+                    16,
+                    0,
+                    format!(
+                        "The {verb} statement conflicted with the CHECK constraint \"{name}\". The conflict occurred in database \"truthdb\", table \"dbo.{table}\".",
+                    ),
+                ));
+            }
+            SqlValue::Bool(true) | SqlValue::Null => {}
+            _ => {
+                return Err(SqlError::new(
+                    4145,
+                    15,
+                    1,
+                    format!(
+                        "An expression of non-boolean type specified in a context where a condition is expected, near the CHECK constraint \"{name}\"."
+                    ),
+                ));
+            }
+        }
+    }
+    Ok(())
 }
 
 fn bind_column(column: &ColumnDef) -> Result<Column, SqlError> {
@@ -747,6 +950,11 @@ fn exec_insert(
     let identity_col = def.identity.map(|s| s.column);
     let increment = def.identity.map(|s| s.increment).unwrap_or(0);
 
+    // CHECK constraints are parsed once and evaluated against each built row.
+    let checks = parse_checks(&def)?;
+    let check_resolver = schema_names(&schema);
+    let check_types = schema_types(&schema);
+
     // Target column indices. An explicit list may not name the identity column
     // (8101) or repeat a column (264); an omitted list targets every
     // non-identity column in order (identity is server-generated).
@@ -845,6 +1053,17 @@ fn exec_insert(
                 ));
             }
         }
+        if !checks.is_empty() {
+            let scope = row_values(&values, &check_types);
+            enforce_checks(
+                &checks,
+                &scope,
+                &check_resolver,
+                eval_ctx,
+                "INSERT",
+                &def.name,
+            )?;
+        }
         rows.push(values);
     }
 
@@ -900,6 +1119,7 @@ fn exec_update(
     let schema = def.schema().map_err(|e| map_storage_err(e, &def.name))?;
     let resolver = schema_names(&schema);
     let identity_col = def.identity.map(|s| s.column);
+    let checks = parse_checks(&def)?;
 
     // Resolve each SET target once; an IDENTITY column cannot be updated.
     let mut assignments: Vec<(usize, &Expr)> = Vec::with_capacity(update.assignments.len());
@@ -960,6 +1180,10 @@ fn exec_update(
                 ));
             }
             new_row[*index] = value::sql_to_datum(&sql_value, &column.column_type, &column.name)?;
+        }
+        if !checks.is_empty() {
+            let scope = row_values(&new_row, &types);
+            enforce_checks(&checks, &scope, &resolver, eval_ctx, "UPDATE", &def.name)?;
         }
         updates.push((locator, old_values, new_row));
     }
@@ -1590,6 +1814,7 @@ fn build_table_source(
         "sys.tables" => sys_tables(storage),
         "sys.columns" => sys_columns(storage),
         "sys.indexes" => sys_indexes(storage),
+        "sys.check_constraints" => sys_check_constraints(storage),
         _ => {
             let def = resolve_table(storage, &name.value)
                 .ok_or_else(|| SqlError::invalid_object(&name.value).at(name.span))?;
@@ -1867,6 +2092,32 @@ fn sys_indexes(storage: &Storage) -> Source {
                 Datum::Int(index.object_id as i32),
                 Datum::NVarChar(index.name.clone()),
                 Datum::Bit(index.unique),
+            ]);
+        }
+    }
+    let collations = vec![None; columns.len()];
+    let qualifiers = vec![None; columns.len()];
+    Source {
+        columns,
+        qualifiers,
+        collations,
+        rows,
+    }
+}
+
+fn sys_check_constraints(storage: &Storage) -> Source {
+    let columns = vec![
+        nvarchar("name", 128),
+        int_col("parent_object_id"),
+        nvarchar("definition", 4000),
+    ];
+    let mut rows = Vec::new();
+    for def in storage.rel_tables() {
+        for check in &def.check_constraints {
+            rows.push(vec![
+                Datum::NVarChar(check.name.clone()),
+                Datum::Int(def.object_id as i32),
+                Datum::NVarChar(format!("({})", check.predicate)),
             ]);
         }
     }

--- a/crates/truthdb-core/src/relstore/catalog.rs
+++ b/crates/truthdb-core/src/relstore/catalog.rs
@@ -47,6 +47,15 @@ pub struct IndexDef {
     pub root_page: u64,
 }
 
+/// A `CHECK` constraint. The predicate is stored as source text (re-parsed and
+/// evaluated per row at INSERT/UPDATE, like a column `DEFAULT`) so the catalog
+/// row need not carry a serialized AST.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CheckDef {
+    pub name: String,
+    pub predicate: String,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TableDef {
     pub object_id: u32,
@@ -69,6 +78,9 @@ pub struct TableDef {
     /// Secondary indexes over this table.
     #[serde(default)]
     pub indexes: Vec<IndexDef>,
+    /// `CHECK` constraints enforced on INSERT/UPDATE.
+    #[serde(default)]
+    pub check_constraints: Vec<CheckDef>,
 }
 
 impl TableDef {

--- a/crates/truthdb-core/src/relstore/tests.rs
+++ b/crates/truthdb-core/src/relstore/tests.rs
@@ -80,6 +80,7 @@ fn create_tree_table(storage: &mut Storage, name: &str) {
             &["id".to_string()],
             Vec::new(),
             None,
+            Vec::new(),
         )
         .expect("create tree table");
 }
@@ -92,6 +93,7 @@ fn create_heap_table(storage: &mut Storage, name: &str) {
             &[],
             Vec::new(),
             None,
+            Vec::new(),
         )
         .expect("create heap table");
 }
@@ -617,6 +619,7 @@ fn heap_update_on_stub_starved_page_fails_cleanly() {
             &[],
             Vec::new(),
             None,
+            Vec::new(),
         )
         .expect("create heap");
     // Fill page 1 to exactly 2 free bytes: 336 null-v rows (12 bytes each

--- a/crates/truthdb-core/src/storage.rs
+++ b/crates/truthdb-core/src/storage.rs
@@ -210,6 +210,7 @@ impl Storage {
         key_names: &[String],
         defaults: Vec<Option<String>>,
         identity: Option<catalog::IdentitySpec>,
+        check_constraints: Vec<catalog::CheckDef>,
     ) -> Result<(), StorageError> {
         self.file.ensure_rel_usable()?;
         if self.file.rel.tables.contains_key(name) {
@@ -274,6 +275,7 @@ impl Storage {
                 collations,
                 identity,
                 indexes: Vec::new(),
+                check_constraints,
             };
             catalog::insert_table(ctx, &mut OpMode::Txn(txn), catalog_root, &def)?;
             Ok(def)

--- a/crates/truthdb-core/tests/slt/check_constraints.slt
+++ b/crates/truthdb-core/tests/slt/check_constraints.slt
@@ -1,0 +1,51 @@
+# CHECK constraints (Stage 10 part 1)
+
+statement ok
+CREATE TABLE items (id INT NOT NULL PRIMARY KEY, qty INT CHECK (qty >= 0), price INT, CONSTRAINT ck_price CHECK ((price - qty) > 0))
+
+statement ok
+INSERT INTO items VALUES (1, 5, 10)
+
+# Column check violation (qty < 0).
+statement error
+INSERT INTO items VALUES (2, -1, 10)
+
+# Table check violation (price <= qty).
+statement error
+INSERT INTO items VALUES (3, 5, 5)
+
+# NULL in a checked column yields UNKNOWN, which passes.
+statement ok
+INSERT INTO items VALUES (4, NULL, 10)
+
+# UPDATE is checked against the new row.
+statement error
+UPDATE items SET qty = -3 WHERE id = 1
+
+statement ok
+UPDATE items SET qty = 2 WHERE id = 1
+
+query I
+SELECT id FROM items ORDER BY id
+----
+1
+4
+
+# Both constraints are visible: the auto-named column check and the named one.
+query T
+SELECT name FROM sys.check_constraints ORDER BY name
+----
+CK__items__1
+ck_price
+
+# A CHECK referencing an unknown column is rejected at CREATE.
+statement error
+CREATE TABLE bad (id INT NOT NULL PRIMARY KEY, CHECK (missing > 0))
+
+# Duplicate explicit constraint names collide.
+statement error
+CREATE TABLE dup (id INT NOT NULL PRIMARY KEY, CONSTRAINT c CHECK (id > 0), CONSTRAINT c CHECK (id < 9))
+
+# A qualified column reference in a CHECK is rejected at CREATE.
+statement error
+CREATE TABLE qual (col INT, CHECK (qual.col > 0))

--- a/crates/truthdb-sql/src/ast.rs
+++ b/crates/truthdb-sql/src/ast.rs
@@ -79,6 +79,18 @@ pub struct CreateTable {
     /// Column names named in a table-level `PRIMARY KEY (...)`, or the single
     /// column that carried an inline `PRIMARY KEY`.
     pub primary_key: Vec<Name>,
+    /// Table-level `[CONSTRAINT name] CHECK (expr)` constraints.
+    pub check_constraints: Vec<CheckConstraint>,
+    pub span: Span,
+}
+
+/// A `[CONSTRAINT name] CHECK (predicate)` constraint (table- or column-level).
+/// The predicate is kept as source text (re-parsed at bind/enforcement time,
+/// like a column `DEFAULT`) so the catalog need not serialize an AST.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CheckConstraint {
+    pub name: Option<Name>,
+    pub predicate: String,
     pub span: Span,
 }
 
@@ -95,6 +107,8 @@ pub struct ColumnDef {
     pub identity: Option<Identity>,
     /// `COLLATE <name>` on a character column.
     pub collation: Option<String>,
+    /// Column-level `[CONSTRAINT name] CHECK (expr)` constraints.
+    pub checks: Vec<CheckConstraint>,
     pub span: Span,
 }
 

--- a/crates/truthdb-sql/src/parser.rs
+++ b/crates/truthdb-sql/src/parser.rs
@@ -333,36 +333,50 @@ impl Parser {
 
         let mut columns = Vec::new();
         let mut primary_key: Vec<Name> = Vec::new();
+        let mut check_constraints: Vec<CheckConstraint> = Vec::new();
         loop {
-            if self.peek_keyword().as_deref() == Some("PRIMARY") {
-                if !primary_key.is_empty() {
-                    return Err(SqlError::message_only(
-                        8110,
-                        "Cannot add multiple PRIMARY KEY constraints to a table.",
-                    ));
-                }
-                self.bump();
-                self.expect_keyword("KEY")?;
-                self.expect(&TokenKind::LParen)?;
-                loop {
-                    primary_key.push(self.parse_name()?);
-                    if !self.eat(&TokenKind::Comma) {
-                        break;
-                    }
-                }
-                self.expect(&TokenKind::RParen)?;
-            } else {
-                let column = self.parse_column_def()?;
-                if column.primary_key {
+            // A leading `CONSTRAINT name` introduces a named table constraint.
+            let constraint_name = self.parse_optional_constraint_name()?;
+            match self.peek_keyword().as_deref() {
+                Some("PRIMARY") => {
                     if !primary_key.is_empty() {
                         return Err(SqlError::message_only(
                             8110,
                             "Cannot add multiple PRIMARY KEY constraints to a table.",
                         ));
                     }
-                    primary_key.push(column.name.clone());
+                    self.bump();
+                    self.expect_keyword("KEY")?;
+                    self.expect(&TokenKind::LParen)?;
+                    loop {
+                        primary_key.push(self.parse_name()?);
+                        if !self.eat(&TokenKind::Comma) {
+                            break;
+                        }
+                    }
+                    self.expect(&TokenKind::RParen)?;
                 }
-                columns.push(column);
+                Some("CHECK") => {
+                    check_constraints.push(self.parse_check_constraint(constraint_name)?);
+                }
+                _ if constraint_name.is_some() => {
+                    // `CONSTRAINT name` must be followed by a table constraint.
+                    let token = self.peek().clone();
+                    return Err(SqlError::syntax(self.token_text(&token), token.span));
+                }
+                _ => {
+                    let column = self.parse_column_def()?;
+                    if column.primary_key {
+                        if !primary_key.is_empty() {
+                            return Err(SqlError::message_only(
+                                8110,
+                                "Cannot add multiple PRIMARY KEY constraints to a table.",
+                            ));
+                        }
+                        primary_key.push(column.name.clone());
+                    }
+                    columns.push(column);
+                }
             }
             if !self.eat(&TokenKind::Comma) {
                 break;
@@ -373,8 +387,41 @@ impl Parser {
             table,
             columns,
             primary_key,
+            check_constraints,
             span: start.to(end),
         }))
+    }
+
+    /// Consumes an optional `CONSTRAINT name` prefix, returning the name.
+    fn parse_optional_constraint_name(&mut self) -> SqlResult<Option<Name>> {
+        if self.peek_keyword().as_deref() == Some("CONSTRAINT") {
+            self.bump();
+            Ok(Some(self.parse_name()?))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Parses `CHECK (predicate)` (the `CONSTRAINT name` prefix, if any, is
+    /// already consumed). The predicate is kept as source text.
+    fn parse_check_constraint(&mut self, name: Option<Name>) -> SqlResult<CheckConstraint> {
+        let start = self.expect_keyword("CHECK")?;
+        let lparen = self.expect(&TokenKind::LParen)?;
+        self.parse_expr()?;
+        let end = self.expect(&TokenKind::RParen)?;
+        // Slice the exact source between the CHECK's own parentheses. An
+        // expression node's span drops any outer parentheses of a boundary
+        // subexpression, so `self.slice(expr.span)` would capture unbalanced
+        // parens (e.g. `(a + b) > 0` -> `a + b) > 0`); slicing between our own
+        // parens keeps nested parentheses balanced.
+        Ok(CheckConstraint {
+            name,
+            predicate: self
+                .slice(Span::new(lparen.end, end.start))
+                .trim()
+                .to_string(),
+            span: start.to(end),
+        })
     }
 
     fn parse_column_def(&mut self) -> SqlResult<ColumnDef> {
@@ -385,9 +432,21 @@ impl Parser {
         let mut default = None;
         let mut identity = None;
         let mut collation = None;
+        let mut checks = Vec::new();
         let mut end = type_span;
         loop {
             match self.peek_keyword().as_deref() {
+                Some("CHECK") => {
+                    let check = self.parse_check_constraint(None)?;
+                    end = check.span;
+                    checks.push(check);
+                }
+                Some("CONSTRAINT") => {
+                    let constraint_name = self.parse_optional_constraint_name()?;
+                    let check = self.parse_check_constraint(constraint_name)?;
+                    end = check.span;
+                    checks.push(check);
+                }
                 Some("NOT") => {
                     self.bump();
                     end = self.expect_keyword("NULL")?;
@@ -436,6 +495,7 @@ impl Parser {
             default,
             identity,
             collation,
+            checks,
         })
     }
 

--- a/crates/truthdb-sql/tests/corpus/ok/check_constraints.ast
+++ b/crates/truthdb-sql/tests/corpus/ok/check_constraints.ast
@@ -1,0 +1,158 @@
+[
+    CreateTable(
+        CreateTable {
+            table: Name {
+                value: "items",
+                quoted: false,
+                span: Span {
+                    start: 13,
+                    end: 18,
+                },
+            },
+            columns: [
+                ColumnDef {
+                    name: Name {
+                        value: "id",
+                        quoted: false,
+                        span: Span {
+                            start: 25,
+                            end: 27,
+                        },
+                    },
+                    data_type: Int,
+                    nullable: Some(
+                        false,
+                    ),
+                    primary_key: true,
+                    default: None,
+                    identity: None,
+                    collation: None,
+                    checks: [],
+                    span: Span {
+                        start: 25,
+                        end: 52,
+                    },
+                },
+                ColumnDef {
+                    name: Name {
+                        value: "qty",
+                        quoted: false,
+                        span: Span {
+                            start: 58,
+                            end: 61,
+                        },
+                    },
+                    data_type: Int,
+                    nullable: None,
+                    primary_key: false,
+                    default: None,
+                    identity: None,
+                    collation: None,
+                    checks: [
+                        CheckConstraint {
+                            name: None,
+                            predicate: "qty >= 0",
+                            span: Span {
+                                start: 66,
+                                end: 82,
+                            },
+                        },
+                    ],
+                    span: Span {
+                        start: 58,
+                        end: 82,
+                    },
+                },
+                ColumnDef {
+                    name: Name {
+                        value: "price",
+                        quoted: false,
+                        span: Span {
+                            start: 88,
+                            end: 93,
+                        },
+                    },
+                    data_type: Int,
+                    nullable: None,
+                    primary_key: false,
+                    default: None,
+                    identity: None,
+                    collation: None,
+                    checks: [
+                        CheckConstraint {
+                            name: Some(
+                                Name {
+                                    value: "ck_pos",
+                                    quoted: false,
+                                    span: Span {
+                                        start: 109,
+                                        end: 115,
+                                    },
+                                },
+                            ),
+                            predicate: "price > 0",
+                            span: Span {
+                                start: 116,
+                                end: 133,
+                            },
+                        },
+                    ],
+                    span: Span {
+                        start: 88,
+                        end: 133,
+                    },
+                },
+            ],
+            primary_key: [
+                Name {
+                    value: "id",
+                    quoted: false,
+                    span: Span {
+                        start: 25,
+                        end: 27,
+                    },
+                },
+            ],
+            check_constraints: [
+                CheckConstraint {
+                    name: Some(
+                        Name {
+                            value: "ck_price",
+                            quoted: false,
+                            span: Span {
+                                start: 150,
+                                end: 158,
+                            },
+                        },
+                    ),
+                    predicate: "(price - qty) > 0",
+                    span: Span {
+                        start: 159,
+                        end: 184,
+                    },
+                },
+                CheckConstraint {
+                    name: Some(
+                        Name {
+                            value: "ck_range",
+                            quoted: false,
+                            span: Span {
+                                start: 201,
+                                end: 209,
+                            },
+                        },
+                    ),
+                    predicate: "qty > 0 AND (price < 100 OR price > 200)",
+                    span: Span {
+                        start: 210,
+                        end: 258,
+                    },
+                },
+            ],
+            span: Span {
+                start: 0,
+                end: 260,
+            },
+        },
+    ),
+]

--- a/crates/truthdb-sql/tests/corpus/ok/check_constraints.sql
+++ b/crates/truthdb-sql/tests/corpus/ok/check_constraints.sql
@@ -1,0 +1,7 @@
+CREATE TABLE items (
+    id INT NOT NULL PRIMARY KEY,
+    qty INT CHECK (qty >= 0),
+    price INT CONSTRAINT ck_pos CHECK (price > 0),
+    CONSTRAINT ck_price CHECK ((price - qty) > 0),
+    CONSTRAINT ck_range CHECK (qty > 0 AND (price < 100 OR price > 200))
+);

--- a/crates/truthdb-sql/tests/corpus/ok/create_table.ast
+++ b/crates/truthdb-sql/tests/corpus/ok/create_table.ast
@@ -27,6 +27,7 @@
                     default: None,
                     identity: None,
                     collation: None,
+                    checks: [],
                     span: Span {
                         start: 28,
                         end: 55,
@@ -51,6 +52,7 @@
                     default: None,
                     identity: None,
                     collation: None,
+                    checks: [],
                     span: Span {
                         start: 61,
                         end: 87,
@@ -73,6 +75,7 @@
                     default: None,
                     identity: None,
                     collation: None,
+                    checks: [],
                     span: Span {
                         start: 93,
                         end: 109,
@@ -93,6 +96,7 @@
                     default: None,
                     identity: None,
                     collation: None,
+                    checks: [],
                     span: Span {
                         start: 115,
                         end: 127,
@@ -109,6 +113,7 @@
                     },
                 },
             ],
+            check_constraints: [],
             span: Span {
                 start: 0,
                 end: 129,

--- a/crates/truthdb-sql/tests/corpus/ok/create_table_composite_pk.ast
+++ b/crates/truthdb-sql/tests/corpus/ok/create_table_composite_pk.ast
@@ -27,6 +27,7 @@
                     default: None,
                     identity: None,
                     collation: None,
+                    checks: [],
                     span: Span {
                         start: 31,
                         end: 52,
@@ -49,6 +50,7 @@
                     default: None,
                     identity: None,
                     collation: None,
+                    checks: [],
                     span: Span {
                         start: 58,
                         end: 83,
@@ -69,6 +71,7 @@
                     default: None,
                     identity: None,
                     collation: None,
+                    checks: [],
                     span: Span {
                         start: 89,
                         end: 96,
@@ -93,6 +96,7 @@
                     },
                 },
             ],
+            check_constraints: [],
             span: Span {
                 start: 0,
                 end: 135,

--- a/crates/truthdb-sql/tests/corpus/ok/create_table_stage5.ast
+++ b/crates/truthdb-sql/tests/corpus/ok/create_table_stage5.ast
@@ -32,6 +32,7 @@
                         },
                     ),
                     collation: None,
+                    checks: [],
                     span: Span {
                         start: 25,
                         end: 67,
@@ -56,6 +57,7 @@
                     collation: Some(
                         "Finnish_Swedish_CI_AS",
                     ),
+                    checks: [],
                     span: Span {
                         start: 73,
                         end: 119,
@@ -81,6 +83,7 @@
                     ),
                     identity: None,
                     collation: None,
+                    checks: [],
                     span: Span {
                         start: 125,
                         end: 155,
@@ -101,6 +104,7 @@
                     default: None,
                     identity: None,
                     collation: None,
+                    checks: [],
                     span: Span {
                         start: 161,
                         end: 178,
@@ -121,6 +125,7 @@
                     default: None,
                     identity: None,
                     collation: None,
+                    checks: [],
                     span: Span {
                         start: 184,
                         end: 204,
@@ -137,6 +142,7 @@
                     },
                 },
             ],
+            check_constraints: [],
             span: Span {
                 start: 0,
                 end: 206,


### PR DESCRIPTION
First slice of **Stage 10 (Constraints & ALTER TABLE)**: SQL `CHECK` constraints. FOREIGN KEY, ALTER TABLE, and `INSERT ... SELECT` land in later PRs; `sys.default_constraints` and persisting a PRIMARY KEY's constraint name are also deferred.

## What's in
- **Parser** — `[CONSTRAINT name]` prefix on table constraints; table-level and column-level `CHECK (predicate)`, named or unnamed. The predicate is stored as source text (re-parsed at bind/enforcement, like a column `DEFAULT`).
- **Catalog** — `CheckDef { name, predicate }` on `TableDef`, additive `#[serde(default)]` so pre-Stage-10 catalog rows still load; checks survive restart/replay.
- **CREATE TABLE** — validates each predicate parses and references only real columns (207), auto-names unnamed checks `CK__<table>__<n>`, rejects duplicate explicit names (2714) and multi-part identifiers (4104).
- **Enforcement** — INSERT (after defaults/identity/NOT NULL) and UPDATE (post-assignment row). Passes on TRUE or UNKNOWN, **error 547** on FALSE with the constraint name in the message.
- **`sys.check_constraints`** virtual view.

## Adversarial review (4 dimensions × find→verify) — 2 confirmed bugs, both fixed
- **HIGH** — predicate text was sliced from the expression's span, which drops the outer parens of a boundary subexpression, capturing unbalanced text (`(a + b) > 0` → `a + b) > 0`); any such CHECK failed to re-parse at CREATE (102). Now slices the exact source between the CHECK's own parentheses. Regression: parenthesized checks in the parser corpus + engine + slt tests.
- **MED** — a qualified column ref (`t.col`) passed create-time validation (qualifier stripped) but the bare-name enforcement resolver couldn't bind it, making the table reject every INSERT with 207. Now rejects multi-part identifiers in a CHECK at CREATE (4104) so the two paths agree.

**Noted, not touched (pre-existing):** the column `DEFAULT` path slices predicate text the same way and shares the latent unbalanced-paren flaw for a non-fully-parenthesized parenthesized default.

## Tests
Engine unit tests (error numbers, message, restart durability, `sys.check_constraints`, 207/2714/4104 rejections), an slt matrix, and a parser corpus case with parenthesized checks. `cargo fmt`, `clippy -D warnings`, and `cargo test --workspace` all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)