### PR TITLE
ALTER TABLE ADD/DROP CONSTRAINT + INSERT...SELECT [Stage 10, part 2]

### DIFF
--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -1366,6 +1366,19 @@ mod tests {
         Engine::new(storage).expect("engine")
     }
 
+    /// A table's catalog object id (via `sys.tables`).
+    fn table_object_id(engine: &mut Engine, name: &str) -> u32 {
+        let (_, rows) = sql_rows(
+            engine,
+            &format!("SELECT object_id FROM sys.tables WHERE name = '{name}'"),
+        );
+        rows[0][0]
+            .as_ref()
+            .expect("object_id")
+            .parse()
+            .expect("u32")
+    }
+
     #[test]
     fn sql_create_insert_select_survive_restart() {
         let path = unique_temp_path("sql-roundtrip");
@@ -1667,6 +1680,207 @@ mod tests {
             sql_error_number(&mut engine, "CREATE TABLE t (col INT, CHECK (t.col > 0))",),
             4104
         );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn sql_insert_select_copies_rows() {
+        let path = unique_temp_path("sql-insert-select");
+        let mut engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE src (id INT NOT NULL PRIMARY KEY, name NVARCHAR(20), keep BIT)")
+            .expect("create src");
+        engine
+            .execute("INSERT INTO src VALUES (1, 'a', 1), (2, 'b', 0), (3, 'c', 1)")
+            .expect("seed src");
+        // Target has an IDENTITY and a DEFAULT; the SELECT feeds the two named
+        // columns and the rest are server-generated / defaulted.
+        engine
+            .execute(
+                "CREATE TABLE dst (rid INT NOT NULL PRIMARY KEY IDENTITY(1,1), \
+                   id INT, label NVARCHAR(20), note NVARCHAR(10) DEFAULT 'copied')",
+            )
+            .expect("create dst");
+        engine
+            .execute(
+                "INSERT INTO dst (id, label) SELECT id, name FROM src WHERE keep = 1 ORDER BY id",
+            )
+            .expect("insert select");
+        let (_, rows) = sql_rows(
+            &mut engine,
+            "SELECT rid, id, label, note FROM dst ORDER BY rid",
+        );
+        assert_eq!(
+            rows,
+            vec![
+                vec![
+                    Some("1".into()),
+                    Some("1".into()),
+                    Some("a".into()),
+                    Some("copied".into())
+                ],
+                vec![
+                    Some("2".into()),
+                    Some("3".into()),
+                    Some("c".into()),
+                    Some("copied".into())
+                ],
+            ]
+        );
+
+        // Column-count mismatch between SELECT list and insert list.
+        assert_eq!(
+            sql_error_number(&mut engine, "INSERT INTO dst (id) SELECT id, name FROM src"),
+            121
+        );
+        assert_eq!(
+            sql_error_number(
+                &mut engine,
+                "INSERT INTO dst (id, label) SELECT id FROM src"
+            ),
+            120
+        );
+
+        // Self-insert is Halloween-safe: the SELECT is fully materialized
+        // before any row is inserted, so it doubles the table exactly once.
+        engine
+            .execute("INSERT INTO dst (id, label) SELECT id, label FROM dst")
+            .expect("self insert select");
+        let (_, rows) = sql_rows(&mut engine, "SELECT COUNT(*) FROM dst");
+        assert_eq!(rows, vec![vec![Some("4".into())]]);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn insert_select_locks_source_table_shared() {
+        use crate::lock::{LockMode, Resource};
+        use crate::rel::Isolation;
+        let path = unique_temp_path("insert-select-locks");
+        let mut engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY, v INT NOT NULL)")
+            .expect("t1");
+        engine
+            .execute("CREATE TABLE t2 (v INT NOT NULL)")
+            .expect("t2");
+        let t1 = table_object_id(&mut engine, "t1");
+        let t2 = table_object_id(&mut engine, "t2");
+
+        // The SELECT's source table must be read-locked (Shared) and the target
+        // write-locked (Exclusive); without the Shared lock this INSERT could
+        // read another transaction's uncommitted rows.
+        let locks = engine.analyze_locks(
+            "INSERT INTO t2 (v) SELECT v FROM t1",
+            Isolation::ReadCommitted,
+        );
+        assert!(
+            locks.contains(&(Resource::Table(t1), LockMode::Shared)),
+            "source t1 must be Shared: {locks:?}"
+        );
+        assert!(
+            locks.contains(&(Resource::Table(t2), LockMode::Exclusive)),
+            "target t2 must be Exclusive: {locks:?}"
+        );
+
+        // A self-insert combines the read and write into a single Exclusive lock.
+        let self_locks = engine.analyze_locks(
+            "INSERT INTO t1 (id, v) SELECT id, v FROM t1",
+            Isolation::ReadCommitted,
+        );
+        let t1_locks: Vec<_> = self_locks
+            .iter()
+            .filter(|(r, _)| *r == Resource::Table(t1))
+            .collect();
+        assert_eq!(
+            t1_locks,
+            vec![&(Resource::Table(t1), LockMode::Exclusive)],
+            "self-insert takes a single Exclusive lock on t1"
+        );
+
+        // READ UNCOMMITTED takes no read lock on the source.
+        let ru = engine.analyze_locks(
+            "INSERT INTO t2 (v) SELECT v FROM t1",
+            Isolation::ReadUncommitted,
+        );
+        assert!(
+            !ru.iter()
+                .any(|(r, m)| *r == Resource::Table(t1) && *m == LockMode::Shared),
+            "READ UNCOMMITTED takes no shared lock: {ru:?}"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn sql_alter_table_add_drop_check() {
+        let path = unique_temp_path("sql-alter-check");
+        let mut engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE t (id INT NOT NULL PRIMARY KEY, qty INT)")
+            .expect("create");
+        engine
+            .execute("INSERT INTO t VALUES (1, 5), (2, 10)")
+            .expect("seed");
+
+        // ADD CONSTRAINT validates existing rows: a constraint every row
+        // satisfies is accepted and then enforced on new writes.
+        engine
+            .execute("ALTER TABLE t ADD CONSTRAINT ck_qty CHECK (qty >= 0)")
+            .expect("add check");
+        assert_eq!(
+            sql_error_number(&mut engine, "INSERT INTO t VALUES (3, -1)"),
+            547
+        );
+
+        // ADD CONSTRAINT that an existing row violates is rejected (547) and
+        // not persisted (a later insert violating it still succeeds after DROP).
+        assert_eq!(
+            sql_error_number(
+                &mut engine,
+                "ALTER TABLE t ADD CONSTRAINT ck_big CHECK (qty > 8)"
+            ),
+            547
+        );
+        // ck_big was not added, so it is not enforced.
+        engine
+            .execute("INSERT INTO t VALUES (4, 1)")
+            .expect("insert allowed (ck_big not added)");
+
+        // DROP CONSTRAINT removes enforcement.
+        engine
+            .execute("ALTER TABLE t DROP CONSTRAINT ck_qty")
+            .expect("drop check");
+        engine
+            .execute("INSERT INTO t VALUES (5, -7)")
+            .expect("insert allowed after drop");
+
+        // Dropping an unknown constraint errors.
+        assert_eq!(
+            sql_error_number(&mut engine, "ALTER TABLE t DROP CONSTRAINT nope"),
+            3728
+        );
+        // ALTER TABLE is DDL and is not allowed inside an explicit transaction
+        // (needs a persistent txn context, so run it as one batch).
+        let mut ctx = TxnContext::default();
+        let out = batch(
+            &mut engine,
+            &mut ctx,
+            "BEGIN TRANSACTION; ALTER TABLE t ADD CHECK (qty < 100)",
+        );
+        assert_eq!(out.error.as_ref().map(|e| e.number), Some(226));
+        batch(&mut engine, &mut ctx, "ROLLBACK");
+
+        // A constraint added via ALTER survives a restart.
+        engine
+            .execute("ALTER TABLE t ADD CONSTRAINT ck_id CHECK (id > 0)")
+            .expect("add ck_id");
+        drop(engine);
+        let storage = Storage::open(path.clone()).expect("reopen");
+        let mut engine = Engine::new(storage).expect("engine");
+        let (_, rows) = sql_rows(
+            &mut engine,
+            "SELECT name FROM sys.check_constraints ORDER BY name",
+        );
+        assert_eq!(rows, vec![vec![Some("ck_id".into())]]);
         let _ = std::fs::remove_file(path);
     }
 

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -13,9 +13,9 @@ mod plan;
 mod value;
 
 use truthdb_sql::ast::{
-    CheckConstraint, ColumnDef, CreateIndex, CreateTable, DataType, Delete, DropIndex, DropTable,
-    Expr, ExprKind, Insert, IsolationLevel, JoinKind, Name, OrderItem, Select, SelectItem,
-    SetStatement, Statement, TableRef, Update,
+    AlterAction, AlterTable, CheckConstraint, ColumnDef, CreateIndex, CreateTable, DataType,
+    Delete, DropIndex, DropTable, Expr, ExprKind, Insert, InsertSource, IsolationLevel, JoinKind,
+    Name, OrderItem, Select, SelectItem, SetStatement, Statement, TableRef, Update,
 };
 use truthdb_sql::error::SqlError;
 use truthdb_sql::eval::EvalContext;
@@ -212,9 +212,32 @@ pub fn analyze_locks(
                     }
                 }
             }
-            Statement::Insert(Insert { table, .. })
-            | Statement::Update(Update { table, .. })
-            | Statement::Delete(Delete { table, .. }) => {
+            Statement::Insert(insert) => {
+                if let Some(def) = resolve_table(storage, &insert.table.value) {
+                    add(Resource::Database, LockMode::IntentExclusive);
+                    add(Resource::Table(def.object_id), LockMode::Exclusive);
+                }
+                // INSERT ... SELECT also reads its source tables; lock them
+                // like a SELECT so it cannot read another txn's uncommitted
+                // rows (they combine to SIX on the target if it is a source).
+                if reads_lock
+                    && let InsertSource::Select(select) = &insert.source
+                    && let Some(from) = &select.from
+                {
+                    let mut tables = Vec::new();
+                    collect_table_names(from, &mut tables);
+                    for name in tables {
+                        if name.value.to_ascii_lowercase().starts_with("sys.") {
+                            continue;
+                        }
+                        if let Some(def) = resolve_table(storage, &name.value) {
+                            add(Resource::Database, LockMode::IntentShared);
+                            add(Resource::Table(def.object_id), LockMode::Shared);
+                        }
+                    }
+                }
+            }
+            Statement::Update(Update { table, .. }) | Statement::Delete(Delete { table, .. }) => {
                 if let Some(def) = resolve_table(storage, &table.value) {
                     add(Resource::Database, LockMode::IntentExclusive);
                     add(Resource::Table(def.object_id), LockMode::Exclusive);
@@ -225,7 +248,8 @@ pub fn analyze_locks(
             Statement::CreateTable(_)
             | Statement::DropTable(_)
             | Statement::CreateIndex(_)
-            | Statement::DropIndex(_) => {
+            | Statement::DropIndex(_)
+            | Statement::AlterTable(_) => {
                 add(Resource::Database, LockMode::Exclusive);
             }
             // Transaction control and SET take no data locks.
@@ -302,6 +326,13 @@ fn exec_statement(
                 return Err(ddl_in_txn_err());
             }
             exec_drop_index(storage, drop)
+        }
+        Statement::AlterTable(alter) => {
+            if txn_ctx.in_txn() {
+                return Err(ddl_in_txn_err());
+            }
+            let eval_ctx = txn_ctx.eval_context();
+            exec_alter_table(storage, alter, &eval_ctx)
         }
         Statement::Insert(insert) => {
             let eval_ctx = txn_ctx.eval_context();
@@ -603,63 +634,79 @@ fn exec_create_table(
     Ok(StatementResult::Done)
 }
 
-/// Collects a table's CHECK constraints (column-level, then table-level),
-/// validates each predicate parses and references only real columns, assigns
-/// a name to unnamed constraints, and rejects duplicate names.
+/// Collects a table's CHECK constraints (column-level, then table-level) and
+/// binds each ([`bind_check`]), threading the running name list so unnamed
+/// constraints get unique auto names and duplicate explicit names are caught.
 fn build_check_defs(
     create: &CreateTable,
     columns: &[Column],
     table_name: &str,
 ) -> Result<Vec<catalog::CheckDef>, SqlError> {
-    let raw: Vec<&CheckConstraint> = create
+    let raw = create
         .columns
         .iter()
         .flat_map(|c| c.checks.iter())
-        .chain(create.check_constraints.iter())
-        .collect();
+        .chain(create.check_constraints.iter());
 
-    // Explicit names must be unique within the table (case-insensitive).
     let mut names: Vec<String> = Vec::new();
-    for check in &raw {
-        if let Some(name) = &check.name {
-            if names.iter().any(|n| n.eq_ignore_ascii_case(&name.value)) {
+    let mut defs = Vec::new();
+    for check in raw {
+        let def = bind_check(check, columns, table_name, &names)?;
+        names.push(def.name.clone());
+        defs.push(def);
+    }
+    Ok(defs)
+}
+
+/// Validates one CHECK constraint against a table's columns and its existing
+/// constraint names: the predicate must parse and reference only real columns
+/// (207/4104); an explicit name must not collide (2714); an unnamed check is
+/// assigned the first free `CK__<table>__<n>`.
+fn bind_check(
+    check: &CheckConstraint,
+    columns: &[Column],
+    table_name: &str,
+    existing_names: &[String],
+) -> Result<catalog::CheckDef, SqlError> {
+    let expr = truthdb_sql::parse_expr(&check.predicate)?;
+    validate_check_columns(&expr, columns)?;
+    let name = match &check.name {
+        Some(n) => {
+            if existing_names
+                .iter()
+                .any(|e| e.eq_ignore_ascii_case(&n.value))
+            {
                 return Err(SqlError::new(
                     2714,
                     16,
                     5,
                     format!(
                         "There is already an object named '{}' in the database.",
-                        name.value
+                        n.value
                     ),
                 )
-                .at(name.span));
+                .at(n.span));
             }
-            names.push(name.value.clone());
+            n.value.clone()
         }
-    }
-
-    let mut defs = Vec::with_capacity(raw.len());
-    let mut auto_seq = 0u32;
-    for check in raw {
-        let expr = truthdb_sql::parse_expr(&check.predicate)?;
-        validate_check_columns(&expr, columns)?;
-        let name = match &check.name {
-            Some(n) => n.value.clone(),
-            None => loop {
-                auto_seq += 1;
-                let candidate = format!("CK__{table_name}__{auto_seq}");
-                if !names.iter().any(|n| n.eq_ignore_ascii_case(&candidate)) {
-                    names.push(candidate.clone());
+        None => {
+            let mut seq = 0u32;
+            loop {
+                seq += 1;
+                let candidate = format!("CK__{table_name}__{seq}");
+                if !existing_names
+                    .iter()
+                    .any(|e| e.eq_ignore_ascii_case(&candidate))
+                {
                     break candidate;
                 }
-            },
-        };
-        defs.push(catalog::CheckDef {
-            name,
-            predicate: check.predicate.clone(),
-        });
-    }
-    Ok(defs)
+            }
+        }
+    };
+    Ok(catalog::CheckDef {
+        name,
+        predicate: check.predicate.clone(),
+    })
 }
 
 /// Rejects a CHECK predicate that references a column the table does not have
@@ -935,6 +982,96 @@ fn exec_drop_index(storage: &mut Storage, drop: &DropIndex) -> Result<StatementR
     Ok(StatementResult::Done)
 }
 
+// ---- ALTER TABLE --------------------------------------------------------
+
+fn exec_alter_table(
+    storage: &mut Storage,
+    alter: &AlterTable,
+    eval_ctx: &EvalContext,
+) -> Result<StatementResult, SqlError> {
+    let def = resolve_table(storage, &alter.table.value)
+        .ok_or_else(|| SqlError::invalid_object(&alter.table.value).at(alter.table.span))?;
+    match &alter.action {
+        AlterAction::AddCheck(check) => alter_add_check(storage, &def, check, eval_ctx),
+        AlterAction::DropConstraint(name) => alter_drop_constraint(storage, &def, name),
+    }
+}
+
+/// `ALTER TABLE ... ADD [CONSTRAINT name] CHECK (expr)`. Validates the new
+/// constraint against every existing row (SQL Server's default WITH CHECK); a
+/// violating row is error 547 and the constraint is not added.
+fn alter_add_check(
+    storage: &mut Storage,
+    def: &TableDef,
+    check: &CheckConstraint,
+    eval_ctx: &EvalContext,
+) -> Result<StatementResult, SqlError> {
+    let schema = def.schema().map_err(|e| map_storage_err(e, &def.name))?;
+    let existing: Vec<String> = def
+        .check_constraints
+        .iter()
+        .map(|c| c.name.clone())
+        .collect();
+    let new_def = bind_check(check, &schema.columns, &def.name, &existing)?;
+
+    // WITH CHECK: no existing row may violate the new constraint.
+    let compiled = vec![(
+        new_def.name.clone(),
+        truthdb_sql::parse_expr(&new_def.predicate)?,
+    )];
+    let resolver = schema_names(&schema);
+    let types = schema_types(&schema);
+    let rows = storage
+        .rel_scan(&def.name)
+        .map_err(|e| map_storage_err(e, &def.name))?;
+    for row in &rows {
+        let scope = row_values(row, &types);
+        enforce_checks(
+            &compiled,
+            &scope,
+            &resolver,
+            eval_ctx,
+            "ALTER TABLE",
+            &def.name,
+        )?;
+    }
+
+    let mut checks = def.check_constraints.clone();
+    checks.push(new_def);
+    storage
+        .rel_set_check_constraints(&def.name, checks)
+        .map_err(|e| map_storage_err(e, &def.name))?;
+    Ok(StatementResult::Done)
+}
+
+/// `ALTER TABLE ... DROP CONSTRAINT name`. Removes a CHECK constraint by name
+/// (case-insensitive); an unknown name is error 3728.
+fn alter_drop_constraint(
+    storage: &mut Storage,
+    def: &TableDef,
+    name: &Name,
+) -> Result<StatementResult, SqlError> {
+    let checks: Vec<catalog::CheckDef> = def
+        .check_constraints
+        .iter()
+        .filter(|c| !c.name.eq_ignore_ascii_case(&name.value))
+        .cloned()
+        .collect();
+    if checks.len() == def.check_constraints.len() {
+        return Err(SqlError::new(
+            3728,
+            16,
+            1,
+            format!("'{}' is not a constraint.", name.value),
+        )
+        .at(name.span));
+    }
+    storage
+        .rel_set_check_constraints(&def.name, checks)
+        .map_err(|e| map_storage_err(e, &def.name))?;
+    Ok(StatementResult::Done)
+}
+
 // ---- INSERT -------------------------------------------------------------
 
 fn exec_insert(
@@ -995,39 +1132,35 @@ fn exec_insert(
         None => (0..ncols).filter(|i| Some(*i) != identity_col).collect(),
     };
 
+    // Gather the input rows (each of length `target.len()`) from either the
+    // VALUES tuples or a SELECT. A SELECT is fully materialized before any
+    // insert, so `INSERT INTO t SELECT ... FROM t` is Halloween-safe.
+    let input_rows = insert_input_rows(storage, &insert.source, target.len(), eval_ctx)?;
+
     // Reserve identity values for the whole batch up front. A failed insert
     // consumes them (a gap), but a value is never reused (SQL Server-faithful).
     let identity_first = if identity_col.is_some() {
         storage
-            .rel_reserve_identity(&def.name, insert.rows.len())
+            .rel_reserve_identity(&def.name, input_rows.len())
             .map_err(|e| map_storage_err(e, &def.name))?
     } else {
         None
     };
 
     // Build every row up front; insert them as one atomic statement.
-    let mut rows = Vec::with_capacity(insert.rows.len());
-    for (row_no, row_exprs) in insert.rows.iter().enumerate() {
-        if row_exprs.len() != target.len() {
-            return Err(SqlError::new(
-                110,
-                15,
-                1,
-                "There are fewer or more columns in the INSERT statement than values specified in the VALUES clause.",
-            ));
-        }
+    let mut rows = Vec::with_capacity(input_rows.len());
+    for (row_no, input) in input_rows.iter().enumerate() {
         // Full row in schema order: unspecified columns start NULL.
         let mut values = vec![Datum::Null; ncols];
-        for (position, expr) in target.iter().zip(row_exprs) {
+        for (position, sql_value) in target.iter().zip(input) {
             let column = &schema.columns[*position];
-            let sql_value = eval_constant(expr, eval_ctx)?;
             if sql_value.is_null() && !column.nullable {
                 return Err(SqlError::null_into_not_null(
                     &column.name,
                     &insert.table.value,
                 ));
             }
-            values[*position] = value::sql_to_datum(&sql_value, &column.column_type, &column.name)?;
+            values[*position] = value::sql_to_datum(sql_value, &column.column_type, &column.name)?;
         }
         // Server-generated identity value for this row.
         if let (Some(col), Some(first)) = (identity_col, identity_first) {
@@ -1072,6 +1205,63 @@ fn exec_insert(
         .rel_insert_many(&def.name, rows, scope)
         .map_err(|err| map_storage_err(err, &def.name))?;
     Ok(StatementResult::RowsAffected(inserted))
+}
+
+/// Produces the input rows an INSERT supplies, each already in target-column
+/// order and as [`SqlValue`]s: `VALUES` tuples are evaluated as constants; a
+/// `SELECT` is executed and its rows converted. Rejects an arity mismatch
+/// against the target column count (110 for VALUES, 120/121 for SELECT).
+fn insert_input_rows(
+    storage: &mut Storage,
+    source: &InsertSource,
+    target_len: usize,
+    eval_ctx: &EvalContext,
+) -> Result<Vec<Vec<SqlValue>>, SqlError> {
+    match source {
+        InsertSource::Values(rows) => {
+            let mut out = Vec::with_capacity(rows.len());
+            for exprs in rows {
+                if exprs.len() != target_len {
+                    return Err(SqlError::new(
+                        110,
+                        15,
+                        1,
+                        "There are fewer or more columns in the INSERT statement than values specified in the VALUES clause.",
+                    ));
+                }
+                let mut vals = Vec::with_capacity(target_len);
+                for expr in exprs {
+                    vals.push(eval_constant(expr, eval_ctx)?);
+                }
+                out.push(vals);
+            }
+            Ok(out)
+        }
+        InsertSource::Select(select) => {
+            let rowset = exec_select(storage, select, eval_ctx)?;
+            if rowset.columns.len() != target_len {
+                let (number, more_or_fewer) = if rowset.columns.len() < target_len {
+                    (120, "fewer")
+                } else {
+                    (121, "more")
+                };
+                return Err(SqlError::new(
+                    number,
+                    15,
+                    1,
+                    format!(
+                        "The select list for the INSERT statement contains {more_or_fewer} items than the insert list. The number of SELECT values must match the number of INSERT columns."
+                    ),
+                ));
+            }
+            let types: Vec<ColumnType> = rowset.columns.iter().map(|c| c.column_type).collect();
+            Ok(rowset
+                .rows
+                .iter()
+                .map(|row| row_values(row, &types))
+                .collect())
+        }
+    }
 }
 
 /// Evaluates a column DEFAULT (re-parsed from its stored source text).

--- a/crates/truthdb-core/src/storage.rs
+++ b/crates/truthdb-core/src/storage.rs
@@ -1027,6 +1027,35 @@ impl Storage {
         Ok(Some(first))
     }
 
+    /// Replaces a table's CHECK constraints (ALTER TABLE ADD/DROP CONSTRAINT)
+    /// and persists the mutated catalog row. Undoable within its own statement.
+    pub(crate) fn rel_set_check_constraints(
+        &mut self,
+        name: &str,
+        check_constraints: Vec<catalog::CheckDef>,
+    ) -> Result<(), StorageError> {
+        self.file.ensure_rel_usable()?;
+        let mut def = self
+            .file
+            .rel
+            .tables
+            .get(name)
+            .cloned()
+            .ok_or_else(|| StorageError::InvalidConfig(format!("unknown table '{name}'")))?;
+        def.check_constraints = check_constraints;
+        let catalog_root = self
+            .file
+            .rel
+            .catalog_root
+            .ok_or_else(|| StorageError::InvalidConfig("catalog root missing".to_string()))?;
+        let persisted = def.clone();
+        self.file.rel_statement(move |ctx, txn| {
+            catalog::update_table(ctx, &mut OpMode::Txn(txn), catalog_root, &persisted)
+        })?;
+        self.file.rel.tables.insert(name.to_string(), def);
+        Ok(())
+    }
+
     /// Test hook: run an insert's ops durably but never commit — the state a
     /// crash mid-statement leaves behind (loser transaction for recovery).
     #[cfg(test)]

--- a/crates/truthdb-core/tests/slt/alter_insert_select.slt
+++ b/crates/truthdb-core/tests/slt/alter_insert_select.slt
@@ -1,0 +1,46 @@
+# ALTER TABLE ADD/DROP CONSTRAINT + INSERT ... SELECT (Stage 10 part 2)
+
+statement ok
+CREATE TABLE src (id INT NOT NULL PRIMARY KEY, name NVARCHAR(20), keep BIT)
+
+statement ok
+INSERT INTO src VALUES (1, 'a', 1), (2, 'b', 0), (3, 'c', 1)
+
+statement ok
+CREATE TABLE dst (id INT NOT NULL PRIMARY KEY, label NVARCHAR(20))
+
+# INSERT ... SELECT with a WHERE filter and projection.
+statement ok
+INSERT INTO dst (id, label) SELECT id, name FROM src WHERE keep = 1
+
+query IT
+SELECT id, label FROM dst ORDER BY id
+----
+1 a
+3 c
+
+# Column-count mismatch between the SELECT list and the insert list.
+statement error
+INSERT INTO dst (id) SELECT id, name FROM src
+
+# ADD CONSTRAINT validates existing rows and then enforces on new rows.
+statement ok
+ALTER TABLE dst ADD CONSTRAINT ck_id CHECK (id > 0)
+
+statement error
+INSERT INTO dst VALUES (-5, 'z')
+
+# ADD CONSTRAINT that an existing row violates is rejected.
+statement error
+ALTER TABLE dst ADD CONSTRAINT ck_big CHECK (id > 100)
+
+# DROP CONSTRAINT removes enforcement.
+statement ok
+ALTER TABLE dst DROP CONSTRAINT ck_id
+
+statement ok
+INSERT INTO dst VALUES (-5, 'z')
+
+# Dropping an unknown constraint errors.
+statement error
+ALTER TABLE dst DROP CONSTRAINT nope

--- a/crates/truthdb-sql/src/ast.rs
+++ b/crates/truthdb-sql/src/ast.rs
@@ -28,6 +28,24 @@ pub enum Statement {
     },
     /// `SET` session option (XACT_ABORT / TRANSACTION ISOLATION LEVEL).
     Set(SetStatement),
+    /// `ALTER TABLE ...`.
+    AlterTable(AlterTable),
+}
+
+/// `ALTER TABLE <table> <action>`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct AlterTable {
+    pub table: Name,
+    pub action: AlterAction,
+    pub span: Span,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum AlterAction {
+    /// `ADD [CONSTRAINT name] CHECK (expr)`.
+    AddCheck(CheckConstraint),
+    /// `DROP CONSTRAINT <name>`.
+    DropConstraint(Name),
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -150,8 +168,15 @@ pub struct Insert {
     pub table: Name,
     /// Explicit column list, or None for "all columns in table order".
     pub columns: Option<Vec<Name>>,
-    pub rows: Vec<Vec<Expr>>,
+    pub source: InsertSource,
     pub span: Span,
+}
+
+/// The rows an `INSERT` supplies: literal `VALUES` tuples or a `SELECT`.
+#[derive(Debug, Clone, PartialEq)]
+pub enum InsertSource {
+    Values(Vec<Vec<Expr>>),
+    Select(Box<Select>),
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/crates/truthdb-sql/src/parser.rs
+++ b/crates/truthdb-sql/src/parser.rs
@@ -106,6 +106,7 @@ impl Parser {
     fn parse_statement(&mut self) -> SqlResult<Statement> {
         match self.peek_keyword().as_deref() {
             Some("CREATE") => self.parse_create(),
+            Some("ALTER") => self.parse_alter(),
             Some("DROP") => self.parse_drop(),
             Some("INSERT") => self.parse_insert(),
             Some("UPDATE") => self.parse_update(),
@@ -600,6 +601,41 @@ impl Parser {
         Ok((precision as u8, scale as u8, end))
     }
 
+    // ---- ALTER TABLE ----------------------------------------------------
+
+    fn parse_alter(&mut self) -> SqlResult<Statement> {
+        let start = self.expect_keyword("ALTER")?;
+        self.expect_keyword("TABLE")?;
+        let table = self.parse_name()?;
+        let (action, end) = match self.peek_keyword().as_deref() {
+            Some("ADD") => {
+                self.bump();
+                // Stage 10 part 2: only `ADD [CONSTRAINT name] CHECK (expr)`.
+                // ADD column arrives in a later part.
+                let name = self.parse_optional_constraint_name()?;
+                let check = self.parse_check_constraint(name)?;
+                let end = check.span;
+                (AlterAction::AddCheck(check), end)
+            }
+            Some("DROP") => {
+                self.bump();
+                self.expect_keyword("CONSTRAINT")?;
+                let name = self.parse_name()?;
+                let end = name.span;
+                (AlterAction::DropConstraint(name), end)
+            }
+            _ => {
+                let token = self.peek().clone();
+                return Err(SqlError::syntax(self.token_text(&token), token.span));
+            }
+        };
+        Ok(Statement::AlterTable(AlterTable {
+            table,
+            action,
+            span: start.to(end),
+        }))
+    }
+
     // ---- DROP TABLE -----------------------------------------------------
 
     /// Dispatches `DROP TABLE` vs `DROP INDEX`.
@@ -669,30 +705,35 @@ impl Parser {
         } else {
             None
         };
-        self.expect_keyword("VALUES")?;
-        let mut rows = Vec::new();
-        loop {
-            self.expect(&TokenKind::LParen)?;
-            let mut values = Vec::new();
+        // The row source is either a SELECT or literal VALUES tuples.
+        let source = if self.peek_keyword().as_deref() == Some("SELECT") {
+            InsertSource::Select(Box::new(self.parse_select()?))
+        } else {
+            self.expect_keyword("VALUES")?;
+            let mut rows = Vec::new();
             loop {
-                values.push(self.parse_expr()?);
+                self.expect(&TokenKind::LParen)?;
+                let mut values = Vec::new();
+                loop {
+                    values.push(self.parse_expr()?);
+                    if !self.eat(&TokenKind::Comma) {
+                        break;
+                    }
+                }
+                self.expect(&TokenKind::RParen)?;
+                rows.push(values);
                 if !self.eat(&TokenKind::Comma) {
                     break;
                 }
             }
-            let end = self.expect(&TokenKind::RParen)?;
-            rows.push(values);
-            let _ = end;
-            if !self.eat(&TokenKind::Comma) {
-                break;
-            }
-        }
+            InsertSource::Values(rows)
+        };
         let end = self.prev_span();
         Ok(Statement::Insert(Insert {
             span: start.to(end),
             table,
             columns,
-            rows,
+            source,
         }))
     }
 

--- a/crates/truthdb-sql/tests/corpus/ok/alter_table.ast
+++ b/crates/truthdb-sql/tests/corpus/ok/alter_table.ast
@@ -1,0 +1,89 @@
+[
+    AlterTable(
+        AlterTable {
+            table: Name {
+                value: "items",
+                quoted: false,
+                span: Span {
+                    start: 12,
+                    end: 17,
+                },
+            },
+            action: AddCheck(
+                CheckConstraint {
+                    name: Some(
+                        Name {
+                            value: "ck_qty",
+                            quoted: false,
+                            span: Span {
+                                start: 33,
+                                end: 39,
+                            },
+                        },
+                    ),
+                    predicate: "qty >= 0",
+                    span: Span {
+                        start: 40,
+                        end: 56,
+                    },
+                },
+            ),
+            span: Span {
+                start: 0,
+                end: 56,
+            },
+        },
+    ),
+    AlterTable(
+        AlterTable {
+            table: Name {
+                value: "items",
+                quoted: false,
+                span: Span {
+                    start: 70,
+                    end: 75,
+                },
+            },
+            action: AddCheck(
+                CheckConstraint {
+                    name: None,
+                    predicate: "(price - qty) > 0",
+                    span: Span {
+                        start: 80,
+                        end: 105,
+                    },
+                },
+            ),
+            span: Span {
+                start: 58,
+                end: 105,
+            },
+        },
+    ),
+    AlterTable(
+        AlterTable {
+            table: Name {
+                value: "items",
+                quoted: false,
+                span: Span {
+                    start: 119,
+                    end: 124,
+                },
+            },
+            action: DropConstraint(
+                Name {
+                    value: "ck_qty",
+                    quoted: false,
+                    span: Span {
+                        start: 141,
+                        end: 147,
+                    },
+                },
+            ),
+            span: Span {
+                start: 107,
+                end: 147,
+            },
+        },
+    ),
+]

--- a/crates/truthdb-sql/tests/corpus/ok/alter_table.sql
+++ b/crates/truthdb-sql/tests/corpus/ok/alter_table.sql
@@ -1,0 +1,3 @@
+ALTER TABLE items ADD CONSTRAINT ck_qty CHECK (qty >= 0);
+ALTER TABLE items ADD CHECK ((price - qty) > 0);
+ALTER TABLE items DROP CONSTRAINT ck_qty;

--- a/crates/truthdb-sql/tests/corpus/ok/insert_multi_row.ast
+++ b/crates/truthdb-sql/tests/corpus/ok/insert_multi_row.ast
@@ -37,93 +37,95 @@
                     },
                 ],
             ),
-            rows: [
+            source: Values(
                 [
-                    Expr {
-                        kind: Int(
-                            1,
-                        ),
-                        span: Span {
-                            start: 51,
-                            end: 52,
+                    [
+                        Expr {
+                            kind: Int(
+                                1,
+                            ),
+                            span: Span {
+                                start: 51,
+                                end: 52,
+                            },
                         },
-                    },
-                    Expr {
-                        kind: Str(
-                            "Skor",
-                        ),
-                        span: Span {
-                            start: 54,
-                            end: 60,
+                        Expr {
+                            kind: Str(
+                                "Skor",
+                            ),
+                            span: Span {
+                                start: 54,
+                                end: 60,
+                            },
                         },
-                    },
-                    Expr {
-                        kind: Number(
-                            "79.99",
-                        ),
-                        span: Span {
-                            start: 62,
-                            end: 67,
+                        Expr {
+                            kind: Number(
+                                "79.99",
+                            ),
+                            span: Span {
+                                start: 62,
+                                end: 67,
+                            },
                         },
-                    },
+                    ],
+                    [
+                        Expr {
+                            kind: Int(
+                                2,
+                            ),
+                            span: Span {
+                                start: 75,
+                                end: 76,
+                            },
+                        },
+                        Expr {
+                            kind: Str(
+                                "Kangor",
+                            ),
+                            span: Span {
+                                start: 78,
+                                end: 86,
+                            },
+                        },
+                        Expr {
+                            kind: Number(
+                                "129.50",
+                            ),
+                            span: Span {
+                                start: 88,
+                                end: 94,
+                            },
+                        },
+                    ],
+                    [
+                        Expr {
+                            kind: Int(
+                                3,
+                            ),
+                            span: Span {
+                                start: 102,
+                                end: 103,
+                            },
+                        },
+                        Expr {
+                            kind: Str(
+                                "Sockar",
+                            ),
+                            span: Span {
+                                start: 105,
+                                end: 113,
+                            },
+                        },
+                        Expr {
+                            kind: Null,
+                            span: Span {
+                                start: 115,
+                                end: 119,
+                            },
+                        },
+                    ],
                 ],
-                [
-                    Expr {
-                        kind: Int(
-                            2,
-                        ),
-                        span: Span {
-                            start: 75,
-                            end: 76,
-                        },
-                    },
-                    Expr {
-                        kind: Str(
-                            "Kangor",
-                        ),
-                        span: Span {
-                            start: 78,
-                            end: 86,
-                        },
-                    },
-                    Expr {
-                        kind: Number(
-                            "129.50",
-                        ),
-                        span: Span {
-                            start: 88,
-                            end: 94,
-                        },
-                    },
-                ],
-                [
-                    Expr {
-                        kind: Int(
-                            3,
-                        ),
-                        span: Span {
-                            start: 102,
-                            end: 103,
-                        },
-                    },
-                    Expr {
-                        kind: Str(
-                            "Sockar",
-                        ),
-                        span: Span {
-                            start: 105,
-                            end: 113,
-                        },
-                    },
-                    Expr {
-                        kind: Null,
-                        span: Span {
-                            start: 115,
-                            end: 119,
-                        },
-                    },
-                ],
-            ],
+            ),
             span: Span {
                 start: 0,
                 end: 120,

--- a/crates/truthdb-sql/tests/corpus/ok/insert_select.ast
+++ b/crates/truthdb-sql/tests/corpus/ok/insert_select.ast
@@ -1,0 +1,140 @@
+[
+    Insert(
+        Insert {
+            table: Name {
+                value: "archive",
+                quoted: false,
+                span: Span {
+                    start: 12,
+                    end: 19,
+                },
+            },
+            columns: Some(
+                [
+                    Name {
+                        value: "id",
+                        quoted: false,
+                        span: Span {
+                            start: 21,
+                            end: 23,
+                        },
+                    },
+                    Name {
+                        value: "name",
+                        quoted: false,
+                        span: Span {
+                            start: 25,
+                            end: 29,
+                        },
+                    },
+                ],
+            ),
+            source: Select(
+                Select {
+                    top: None,
+                    distinct: false,
+                    items: [
+                        Expr {
+                            expr: Expr {
+                                kind: Column(
+                                    Name {
+                                        value: "id",
+                                        quoted: false,
+                                        span: Span {
+                                            start: 38,
+                                            end: 40,
+                                        },
+                                    },
+                                ),
+                                span: Span {
+                                    start: 38,
+                                    end: 40,
+                                },
+                            },
+                            alias: None,
+                        },
+                        Expr {
+                            expr: Expr {
+                                kind: Column(
+                                    Name {
+                                        value: "name",
+                                        quoted: false,
+                                        span: Span {
+                                            start: 42,
+                                            end: 46,
+                                        },
+                                    },
+                                ),
+                                span: Span {
+                                    start: 42,
+                                    end: 46,
+                                },
+                            },
+                            alias: None,
+                        },
+                    ],
+                    from: Some(
+                        Table {
+                            name: Name {
+                                value: "users",
+                                quoted: false,
+                                span: Span {
+                                    start: 52,
+                                    end: 57,
+                                },
+                            },
+                            alias: None,
+                        },
+                    ),
+                    where_clause: Some(
+                        Expr {
+                            kind: Binary {
+                                op: Eq,
+                                left: Expr {
+                                    kind: Column(
+                                        Name {
+                                            value: "active",
+                                            quoted: false,
+                                            span: Span {
+                                                start: 64,
+                                                end: 70,
+                                            },
+                                        },
+                                    ),
+                                    span: Span {
+                                        start: 64,
+                                        end: 70,
+                                    },
+                                },
+                                right: Expr {
+                                    kind: Int(
+                                        1,
+                                    ),
+                                    span: Span {
+                                        start: 73,
+                                        end: 74,
+                                    },
+                                },
+                            },
+                            span: Span {
+                                start: 64,
+                                end: 74,
+                            },
+                        },
+                    ),
+                    group_by: [],
+                    having: None,
+                    order_by: [],
+                    span: Span {
+                        start: 31,
+                        end: 74,
+                    },
+                },
+            ),
+            span: Span {
+                start: 0,
+                end: 74,
+            },
+        },
+    ),
+]

--- a/crates/truthdb-sql/tests/corpus/ok/insert_select.sql
+++ b/crates/truthdb-sql/tests/corpus/ok/insert_select.sql
@@ -1,0 +1,1 @@
+INSERT INTO archive (id, name) SELECT id, name FROM users WHERE active = 1;


### PR DESCRIPTION
Second slice of **Stage 10 (Constraints & ALTER TABLE)**. FOREIGN KEY, ALTER ADD column, and `sys.default_constraints` follow in later parts.

## What's in
- **`INSERT ... SELECT`** — `INSERT INTO t [(cols)] SELECT ...`. The SELECT is fully materialized (as a `RowSet`) before any insert, so `INSERT INTO t SELECT ... FROM t` is Halloween-safe. Output columns map positionally to the target columns and are coerced to target types; identity / `DEFAULT` / `NOT NULL` / `CHECK` are applied exactly as for `VALUES`. Arity mismatch is **120** (fewer) / **121** (more). `Insert.rows` became `Insert.source: InsertSource::{Values, Select}`.
- **`ALTER TABLE ADD [CONSTRAINT name] CHECK (expr)`** — validates the predicate (columns 207/4104, name 2714, auto-name `CK__<table>__<n>`) and **every existing row** (WITH CHECK); a violating row is **547** and the constraint is not added.
- **`ALTER TABLE DROP CONSTRAINT name`** — removes a CHECK by name (case-insensitive); unknown name is **3728**.
- ALTER is autocommit-only (blocked in an explicit txn → **226**) and takes the Database-exclusive DDL lock. Constraints persist across restart. Shared `bind_check` helper for CREATE + ALTER; `rel_set_check_constraints` persists the mutated catalog row.

## Adversarial review (4 dimensions × find→verify) — 1 confirmed bug, fixed
- **HIGH** — `analyze_locks` ignored INSERT's source, so `INSERT ... SELECT` took no read lock on the SELECT's tables. Under READ COMMITTED it could read another session's uncommitted rows and persist them (a dirty read that survives the other txn's rollback). The engine's in-place WAL/undo storage relies entirely on 2PL for isolation, so the missing Shared lock is a real hole. Now the Insert arm walks the SELECT's FROM and takes `IntentShared`/`Shared` on each source table (combining to SIX when a source is also the target). Regression test asserts source=Shared, target=Exclusive, self-insert collapses to one Exclusive, and READ UNCOMMITTED takes no read lock.

## Tests
Engine tests (INSERT…SELECT copy with identity/default/filter, 120/121, self-insert; ALTER add/drop, WITH CHECK existing-row rejection, 3728, 226-in-txn, restart durability; the lock regression), an slt matrix, and parser corpus cases. `cargo fmt`, `clippy -D warnings`, `cargo test --workspace` all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)