### PR TITLE
FOREIGN KEY constraints (NO ACTION) + sys.foreign_keys [Stage 10, part 3]

### DIFF
--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -1885,6 +1885,306 @@ mod tests {
     }
 
     #[test]
+    fn sql_foreign_key_child_and_parent_enforcement() {
+        let path = unique_temp_path("sql-fk");
+        let mut engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE parent (id INT NOT NULL PRIMARY KEY, name NVARCHAR(20))")
+            .expect("parent");
+        engine
+            .execute(
+                "CREATE TABLE child (id INT NOT NULL PRIMARY KEY, pid INT REFERENCES parent (id))",
+            )
+            .expect("child");
+        engine
+            .execute("INSERT INTO parent VALUES (1, 'a'), (2, 'b')")
+            .expect("seed parent");
+
+        // Child side: a referenced parent must exist; NULL skips enforcement.
+        engine
+            .execute("INSERT INTO child VALUES (10, 1)")
+            .expect("child -> parent 1");
+        engine
+            .execute("INSERT INTO child VALUES (11, NULL)")
+            .expect("NULL fk allowed");
+        assert_eq!(
+            sql_error_number(&mut engine, "INSERT INTO child VALUES (12, 99)"),
+            547
+        );
+
+        // Parent side (DELETE, NO ACTION): a referenced parent cannot be deleted.
+        assert_eq!(
+            sql_error_number(&mut engine, "DELETE FROM parent WHERE id = 1"),
+            547
+        );
+        engine
+            .execute("DELETE FROM parent WHERE id = 2")
+            .expect("unreferenced parent deletes");
+
+        // Parent side (UPDATE of the PK): cannot vacate a referenced key; a
+        // non-key update is fine.
+        assert_eq!(
+            sql_error_number(&mut engine, "UPDATE parent SET id = 5 WHERE id = 1"),
+            547
+        );
+        engine
+            .execute("UPDATE parent SET name = 'z' WHERE id = 1")
+            .expect("non-key parent update");
+
+        // Child UPDATE re-checks the new value.
+        assert_eq!(
+            sql_error_number(&mut engine, "UPDATE child SET pid = 42 WHERE id = 10"),
+            547
+        );
+        engine
+            .execute("UPDATE child SET pid = NULL WHERE id = 10")
+            .expect("child update to NULL");
+        // With no child referencing parent 1, it can now be deleted.
+        engine
+            .execute("DELETE FROM parent WHERE id = 1")
+            .expect("now-unreferenced parent deletes");
+
+        // The constraint is enforced again after a restart.
+        drop(engine);
+        let storage = Storage::open(path.clone()).expect("reopen");
+        let mut engine = Engine::new(storage).expect("engine");
+        assert_eq!(
+            sql_error_number(&mut engine, "INSERT INTO child VALUES (20, 7)"),
+            547
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn sql_foreign_key_self_reference() {
+        let path = unique_temp_path("sql-fk-self");
+        let mut engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE emp (id INT NOT NULL PRIMARY KEY, mgr INT REFERENCES emp (id))")
+            .expect("emp");
+        // A root has a NULL manager; a subordinate references an existing row.
+        engine
+            .execute("INSERT INTO emp VALUES (1, NULL)")
+            .expect("root");
+        engine
+            .execute("INSERT INTO emp VALUES (2, 1)")
+            .expect("sub");
+        assert_eq!(
+            sql_error_number(&mut engine, "INSERT INTO emp VALUES (3, 99)"),
+            547
+        );
+        // A batch may reference a sibling row inserted in the same statement
+        // (row 4 references 5, which is created alongside it).
+        engine
+            .execute("INSERT INTO emp VALUES (4, 5), (5, 1)")
+            .expect("self-ref batch");
+        // A referenced row cannot be deleted while a subordinate remains.
+        assert_eq!(
+            sql_error_number(&mut engine, "DELETE FROM emp WHERE id = 1"),
+            547
+        );
+
+        // A primary-key change that would orphan a self-reference is rejected
+        // (row 4 references row 5, so changing id 5 dangles mgr=5). This must be
+        // validated against the post-update state, not the stale pre-update row.
+        assert_eq!(
+            sql_error_number(&mut engine, "UPDATE emp SET id = 50 WHERE id = 5"),
+            547
+        );
+        // A primary-key change with no dependents is allowed (nothing points at
+        // row 2, and its own mgr=1 still exists).
+        engine
+            .execute("UPDATE emp SET id = 6 WHERE id = 2")
+            .expect("unreferenced self-ref pk change");
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn sql_constraint_name_unique_across_kinds() {
+        let path = unique_temp_path("sql-constraint-names");
+        let mut engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE p (id INT NOT NULL PRIMARY KEY)")
+            .expect("p");
+        // A CHECK and a FOREIGN KEY cannot share a name within one CREATE.
+        assert_eq!(
+            sql_error_number(
+                &mut engine,
+                "CREATE TABLE c (x INT, CONSTRAINT dup CHECK (x > 0), \
+                   CONSTRAINT dup FOREIGN KEY (x) REFERENCES p (id))",
+            ),
+            2714
+        );
+        // Nor across ALTER, in either order.
+        engine.execute("CREATE TABLE c (x INT)").expect("c");
+        engine
+            .execute("ALTER TABLE c ADD CONSTRAINT dup CHECK (x > 0)")
+            .expect("add check");
+        assert_eq!(
+            sql_error_number(
+                &mut engine,
+                "ALTER TABLE c ADD CONSTRAINT dup FOREIGN KEY (x) REFERENCES p (id)",
+            ),
+            2714
+        );
+        engine
+            .execute("ALTER TABLE c ADD CONSTRAINT fk1 FOREIGN KEY (x) REFERENCES p (id)")
+            .expect("add fk");
+        assert_eq!(
+            sql_error_number(
+                &mut engine,
+                "ALTER TABLE c ADD CONSTRAINT fk1 CHECK (x < 100)"
+            ),
+            2714
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn sql_foreign_key_alter_drop_and_catalog() {
+        let path = unique_temp_path("sql-fk-alter");
+        let mut engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE p (id INT NOT NULL PRIMARY KEY)")
+            .expect("p");
+        engine
+            .execute("CREATE TABLE c (id INT NOT NULL PRIMARY KEY, pid INT)")
+            .expect("c");
+        engine.execute("INSERT INTO p VALUES (1)").expect("seed p");
+        // Row 11 references a missing parent (no FK yet, so it is allowed).
+        engine
+            .execute("INSERT INTO c VALUES (10, 1), (11, 99)")
+            .expect("seed c");
+
+        // ADD FOREIGN KEY validates existing rows: row 11 orphans -> 547.
+        assert_eq!(
+            sql_error_number(
+                &mut engine,
+                "ALTER TABLE c ADD CONSTRAINT fk FOREIGN KEY (pid) REFERENCES p (id)",
+            ),
+            547
+        );
+        // Fix the orphan, then the constraint is added and enforced.
+        engine
+            .execute("UPDATE c SET pid = 1 WHERE id = 11")
+            .expect("fix orphan");
+        engine
+            .execute("ALTER TABLE c ADD CONSTRAINT fk FOREIGN KEY (pid) REFERENCES p (id)")
+            .expect("add fk");
+        assert_eq!(
+            sql_error_number(&mut engine, "INSERT INTO c VALUES (12, 77)"),
+            547
+        );
+
+        // sys.foreign_keys lists it, referencing p.
+        let p_oid = table_object_id(&mut engine, "p");
+        let (cols, rows) = sql_rows(
+            &mut engine,
+            "SELECT name, referenced_object_id FROM sys.foreign_keys",
+        );
+        assert_eq!(cols, vec!["name", "referenced_object_id"]);
+        assert_eq!(rows, vec![vec![Some("fk".into()), Some(p_oid.to_string())]]);
+
+        // A referenced parent cannot be dropped.
+        assert_eq!(sql_error_number(&mut engine, "DROP TABLE p"), 3726);
+
+        // DROP CONSTRAINT removes enforcement; the FK survives a restart until
+        // then. Confirm durability first.
+        drop(engine);
+        let storage = Storage::open(path.clone()).expect("reopen");
+        let mut engine = Engine::new(storage).expect("engine");
+        assert_eq!(
+            sql_error_number(&mut engine, "INSERT INTO c VALUES (13, 55)"),
+            547
+        );
+        engine
+            .execute("ALTER TABLE c DROP CONSTRAINT fk")
+            .expect("drop fk");
+        engine
+            .execute("INSERT INTO c VALUES (14, 55)")
+            .expect("insert allowed after drop");
+        // Now p can be dropped.
+        engine.execute("DROP TABLE p").expect("drop unref parent");
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn sql_foreign_key_validation_errors() {
+        let path = unique_temp_path("sql-fk-invalid");
+        let mut engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE p (id INT NOT NULL PRIMARY KEY, other INT)")
+            .expect("p");
+        engine
+            .execute("CREATE TABLE bignum (id BIGINT NOT NULL PRIMARY KEY)")
+            .expect("bignum");
+        // Referencing a non-primary-key column of the parent.
+        assert_eq!(
+            sql_error_number(
+                &mut engine,
+                "CREATE TABLE r1 (id INT NOT NULL PRIMARY KEY, pid INT REFERENCES p (other))",
+            ),
+            1776
+        );
+        // Type mismatch between child (INT) and parent PK (BIGINT).
+        assert_eq!(
+            sql_error_number(
+                &mut engine,
+                "CREATE TABLE r2 (id INT NOT NULL PRIMARY KEY, bid INT REFERENCES bignum (id))",
+            ),
+            1778
+        );
+        // Referencing a table that does not exist.
+        assert_eq!(
+            sql_error_number(
+                &mut engine,
+                "CREATE TABLE r3 (id INT NOT NULL PRIMARY KEY, x INT REFERENCES nope (id))",
+            ),
+            208
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn foreign_key_insert_locks_parent_shared() {
+        use crate::lock::{LockMode, Resource};
+        use crate::rel::Isolation;
+        let path = unique_temp_path("fk-locks");
+        let mut engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE p (id INT NOT NULL PRIMARY KEY)")
+            .expect("p");
+        engine
+            .execute("CREATE TABLE c (id INT NOT NULL PRIMARY KEY, pid INT REFERENCES p (id))")
+            .expect("c");
+        let p = table_object_id(&mut engine, "p");
+        let c = table_object_id(&mut engine, "c");
+
+        // INSERT into the child reads the parent, so it must take a Shared lock
+        // on the parent (else it could read an uncommitted parent row).
+        let locks = engine.analyze_locks("INSERT INTO c VALUES (1, 1)", Isolation::ReadCommitted);
+        assert!(
+            locks.contains(&(Resource::Table(c), LockMode::Exclusive)),
+            "child Exclusive: {locks:?}"
+        );
+        assert!(
+            locks.contains(&(Resource::Table(p), LockMode::Shared)),
+            "parent Shared: {locks:?}"
+        );
+        // DELETE of the parent reads the child (NO ACTION check) -> child Shared.
+        let del = engine.analyze_locks("DELETE FROM p WHERE id = 1", Isolation::ReadCommitted);
+        assert!(
+            del.contains(&(Resource::Table(p), LockMode::Exclusive)),
+            "parent Exclusive: {del:?}"
+        );
+        assert!(
+            del.contains(&(Resource::Table(c), LockMode::Shared)),
+            "child Shared: {del:?}"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
     fn sql_decimal_arithmetic_and_rendering() {
         let path = unique_temp_path("sql-decimal");
         let mut engine = new_engine(&path);

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -14,8 +14,8 @@ mod value;
 
 use truthdb_sql::ast::{
     AlterAction, AlterTable, CheckConstraint, ColumnDef, CreateIndex, CreateTable, DataType,
-    Delete, DropIndex, DropTable, Expr, ExprKind, Insert, InsertSource, IsolationLevel, JoinKind,
-    Name, OrderItem, Select, SelectItem, SetStatement, Statement, TableRef, Update,
+    Delete, DropIndex, DropTable, Expr, ExprKind, ForeignKey, Insert, InsertSource, IsolationLevel,
+    JoinKind, Name, OrderItem, Select, SelectItem, SetStatement, Statement, TableRef, Update,
 };
 use truthdb_sql::error::SqlError;
 use truthdb_sql::eval::EvalContext;
@@ -163,6 +163,28 @@ pub fn execute_batch(storage: &mut Storage, sql: &str, txn_ctx: &mut TxnContext)
 /// A parse error yields no locks — execution re-parses and surfaces it.
 /// `sys.*` views and unresolved tables take no lock (catalog reads are
 /// unlocked; missing tables error at execution).
+/// Object ids of the parent tables a table's foreign keys reference.
+fn fk_parent_object_ids(storage: &Storage, def: &TableDef) -> Vec<u32> {
+    def.foreign_keys
+        .iter()
+        .filter_map(|fk| resolve_table(storage, &fk.parent).map(|p| p.object_id))
+        .collect()
+}
+
+/// Object ids of the tables whose foreign keys reference `parent_name`.
+fn fk_child_object_ids(storage: &Storage, parent_name: &str) -> Vec<u32> {
+    storage
+        .rel_tables()
+        .into_iter()
+        .filter(|t| {
+            t.foreign_keys
+                .iter()
+                .any(|fk| fk.parent.eq_ignore_ascii_case(parent_name))
+        })
+        .map(|t| t.object_id)
+        .collect()
+}
+
 pub fn analyze_locks(
     storage: &Storage,
     sql: &str,
@@ -216,6 +238,11 @@ pub fn analyze_locks(
                 if let Some(def) = resolve_table(storage, &insert.table.value) {
                     add(Resource::Database, LockMode::IntentExclusive);
                     add(Resource::Table(def.object_id), LockMode::Exclusive);
+                    // A child INSERT reads its FK parents (integrity read).
+                    for oid in fk_parent_object_ids(storage, &def) {
+                        add(Resource::Database, LockMode::IntentShared);
+                        add(Resource::Table(oid), LockMode::Shared);
+                    }
                 }
                 // INSERT ... SELECT also reads its source tables; lock them
                 // like a SELECT so it cannot read another txn's uncommitted
@@ -237,10 +264,31 @@ pub fn analyze_locks(
                     }
                 }
             }
-            Statement::Update(Update { table, .. }) | Statement::Delete(Delete { table, .. }) => {
+            Statement::Update(Update { table, .. }) => {
                 if let Some(def) = resolve_table(storage, &table.value) {
                     add(Resource::Database, LockMode::IntentExclusive);
                     add(Resource::Table(def.object_id), LockMode::Exclusive);
+                    // UPDATE reads FK parents (new values) and referencing
+                    // children (a changed PK must not orphan them).
+                    for oid in fk_parent_object_ids(storage, &def) {
+                        add(Resource::Database, LockMode::IntentShared);
+                        add(Resource::Table(oid), LockMode::Shared);
+                    }
+                    for oid in fk_child_object_ids(storage, &def.name) {
+                        add(Resource::Database, LockMode::IntentShared);
+                        add(Resource::Table(oid), LockMode::Shared);
+                    }
+                }
+            }
+            Statement::Delete(Delete { table, .. }) => {
+                if let Some(def) = resolve_table(storage, &table.value) {
+                    add(Resource::Database, LockMode::IntentExclusive);
+                    add(Resource::Table(def.object_id), LockMode::Exclusive);
+                    // DELETE reads referencing children (NO ACTION check).
+                    for oid in fk_child_object_ids(storage, &def.name) {
+                        add(Resource::Database, LockMode::IntentShared);
+                        add(Resource::Table(oid), LockMode::Shared);
+                    }
                 }
             }
             // DDL serializes against every active transaction via a
@@ -620,6 +668,11 @@ fn exec_create_table(
     // CHECK constraints (column-level + table-level): validate, name, and
     // fold into the catalog. Validation needs the bound columns.
     let check_constraints = build_check_defs(create, &columns, table_name)?;
+    // FOREIGN KEY constraints: validate against the (possibly self-)referenced
+    // table's primary key and order each child column to the parent's PK.
+    // Constraint names are unique across kinds, so seed with the check names.
+    let check_names: Vec<String> = check_constraints.iter().map(|c| c.name.clone()).collect();
+    let foreign_keys = build_foreign_key_defs(storage, create, &columns, table_name, &check_names)?;
 
     storage
         .rel_create_table(
@@ -629,9 +682,200 @@ fn exec_create_table(
             defaults,
             identity,
             check_constraints,
+            foreign_keys,
         )
         .map_err(|err| map_storage_err(err, table_name))?;
     Ok(StatementResult::Done)
+}
+
+/// Collects and validates a table's FOREIGN KEY constraints (column-level, then
+/// table-level), assigning a name to unnamed ones. `check_names` are the names
+/// already taken by the table's CHECK constraints so a FK cannot reuse one
+/// (constraint names are unique across kinds).
+fn build_foreign_key_defs(
+    storage: &Storage,
+    create: &CreateTable,
+    columns: &[Column],
+    table_name: &str,
+    check_names: &[String],
+) -> Result<Vec<catalog::ForeignKeyDef>, SqlError> {
+    let raw = create
+        .columns
+        .iter()
+        .flat_map(|c| c.foreign_keys.iter())
+        .chain(create.foreign_keys.iter());
+
+    // The parent's primary key (name, type) per PK column, in PK order. A
+    // self-reference reads it from this CREATE; otherwise from the catalog.
+    let self_pk = || -> Result<Vec<(String, ColumnType)>, SqlError> {
+        create
+            .primary_key
+            .iter()
+            .map(|k| {
+                let col = columns
+                    .iter()
+                    .find(|c| c.name.eq_ignore_ascii_case(&k.value))
+                    .expect("primary key column bound");
+                Ok((col.name.clone(), col.column_type))
+            })
+            .collect()
+    };
+
+    let mut names: Vec<String> = check_names.to_vec();
+    let mut defs = Vec::new();
+    for fk in raw {
+        let parent_bare = strip_schema(&fk.parent.value);
+        let is_self = parent_bare.eq_ignore_ascii_case(table_name);
+        // Parent primary key: (column name, type) in PK order.
+        let parent_pk: Vec<(String, ColumnType)> = if is_self {
+            self_pk()?
+        } else {
+            let parent = resolve_table(storage, &fk.parent.value)
+                .ok_or_else(|| SqlError::invalid_object(&fk.parent.value).at(fk.parent.span))?;
+            let schema = parent
+                .schema()
+                .map_err(|e| map_storage_err(e, &parent.name))?;
+            parent
+                .key_columns
+                .iter()
+                .map(|&i| {
+                    (
+                        schema.columns[i].name.clone(),
+                        schema.columns[i].column_type,
+                    )
+                })
+                .collect()
+        };
+        let def = bind_foreign_key(fk, columns, table_name, &parent_pk, parent_bare, &names)?;
+        names.push(def.name.clone());
+        defs.push(def);
+    }
+    Ok(defs)
+}
+
+/// Validates one FOREIGN KEY against the parent's primary key and produces a
+/// [`catalog::ForeignKeyDef`] whose child column indices are ordered to match
+/// the parent's PK. Referenced columns must be exactly the parent PK (SQL
+/// Server requires a unique/PK target); child and parent column types and
+/// counts must match.
+fn bind_foreign_key(
+    fk: &ForeignKey,
+    columns: &[Column],
+    table_name: &str,
+    parent_pk: &[(String, ColumnType)],
+    parent_bare: &str,
+    existing_names: &[String],
+) -> Result<catalog::ForeignKeyDef, SqlError> {
+    let no_key = || {
+        SqlError::new(
+            1776,
+            16,
+            0,
+            format!(
+                "There are no primary or candidate keys in the referenced table '{parent_bare}' that match the referencing column list in the foreign key."
+            ),
+        )
+        .at(fk.parent.span)
+    };
+    if parent_pk.is_empty() {
+        return Err(no_key());
+    }
+    // Referenced parent columns (defaulting to the whole PK) paired with the
+    // child columns positionally.
+    let parent_cols: Vec<String> = if fk.parent_columns.is_empty() {
+        parent_pk.iter().map(|(n, _)| n.clone()).collect()
+    } else {
+        fk.parent_columns.iter().map(|n| n.value.clone()).collect()
+    };
+    if fk.columns.len() != parent_cols.len() {
+        return Err(SqlError::new(
+            1776,
+            16,
+            0,
+            "The number of referencing columns differs from the number of referenced columns.",
+        )
+        .at(fk.span));
+    }
+    // The referenced set must be exactly the parent PK (order-independent).
+    if parent_cols.len() != parent_pk.len()
+        || !parent_pk
+            .iter()
+            .all(|(pk, _)| parent_cols.iter().any(|c| c.eq_ignore_ascii_case(pk)))
+    {
+        return Err(no_key());
+    }
+
+    // Resolve child column indices and check each child/parent type matches.
+    let child_index = |name: &Name| -> Result<usize, SqlError> {
+        columns
+            .iter()
+            .position(|c| c.name.eq_ignore_ascii_case(&name.value))
+            .ok_or_else(|| SqlError::invalid_column(&name.value).at(name.span))
+    };
+    // For each parent PK column (in PK order), find the child column mapped to
+    // it and record its index — so the stored order matches the parent PK.
+    let mut ordered = Vec::with_capacity(parent_pk.len());
+    for (pk_name, pk_type) in parent_pk {
+        // Which referenced position names this PK column?
+        let pos = parent_cols
+            .iter()
+            .position(|c| c.eq_ignore_ascii_case(pk_name))
+            .ok_or_else(no_key)?;
+        let child_col = &fk.columns[pos];
+        let idx = child_index(child_col)?;
+        if columns[idx].column_type != *pk_type {
+            return Err(SqlError::new(
+                1778,
+                16,
+                0,
+                format!(
+                    "Column '{table_name}.{}' is not the same data type as referencing column '{parent_bare}.{pk_name}' in the foreign key.",
+                    columns[idx].name
+                ),
+            )
+            .at(child_col.span));
+        }
+        ordered.push(idx);
+    }
+
+    let name = match &fk.name {
+        Some(n) => {
+            if existing_names
+                .iter()
+                .any(|e| e.eq_ignore_ascii_case(&n.value))
+            {
+                return Err(SqlError::new(
+                    2714,
+                    16,
+                    5,
+                    format!(
+                        "There is already an object named '{}' in the database.",
+                        n.value
+                    ),
+                )
+                .at(n.span));
+            }
+            n.value.clone()
+        }
+        None => {
+            let mut seq = 0u32;
+            loop {
+                seq += 1;
+                let candidate = format!("FK__{table_name}__{parent_bare}__{seq}");
+                if !existing_names
+                    .iter()
+                    .any(|e| e.eq_ignore_ascii_case(&candidate))
+                {
+                    break candidate;
+                }
+            }
+        }
+    };
+    Ok(catalog::ForeignKeyDef {
+        name,
+        columns: ordered,
+        parent: parent_bare.to_string(),
+    })
 }
 
 /// Collects a table's CHECK constraints (column-level, then table-level) and
@@ -842,6 +1086,154 @@ fn enforce_checks(
     Ok(())
 }
 
+/// A child row's referencing key for one foreign key (the FK columns in parent
+/// primary-key order). `None` if any FK column is NULL — MATCH SIMPLE, which
+/// skips enforcement (the NULL-FK trap).
+fn fk_key(fk: &catalog::ForeignKeyDef, row: &[Datum]) -> Option<Vec<Datum>> {
+    let key: Vec<Datum> = fk.columns.iter().map(|&i| row[i].clone()).collect();
+    if key.iter().any(|d| matches!(d, Datum::Null)) {
+        None
+    } else {
+        Some(key)
+    }
+}
+
+/// Whether a referencing `key` (parent PK order) exists in the parent — either
+/// a committed parent row, or, for a self-reference, a sibling row in `batch`
+/// (whose PK columns are `child.key_columns`).
+fn fk_parent_exists(
+    storage: &mut Storage,
+    fk: &catalog::ForeignKeyDef,
+    key: &[Datum],
+    child: &TableDef,
+    batch: &[Vec<Datum>],
+) -> Result<bool, SqlError> {
+    if storage
+        .rel_get(&fk.parent, key)
+        .map_err(|e| map_storage_err(e, &fk.parent))?
+        .is_some()
+    {
+        return Ok(true);
+    }
+    if fk.parent.eq_ignore_ascii_case(&child.name) && child.key_columns.len() == key.len() {
+        return Ok(batch
+            .iter()
+            .any(|r| child.key_columns.iter().zip(key).all(|(&i, k)| &r[i] == k)));
+    }
+    Ok(false)
+}
+
+fn fk_child_violation(name: &str, verb: &str, parent: &str) -> SqlError {
+    SqlError::new(
+        547,
+        16,
+        0,
+        format!(
+            "The {verb} statement conflicted with the FOREIGN KEY constraint \"{name}\". The conflict occurred in database \"truthdb\", table \"dbo.{parent}\".",
+        ),
+    )
+}
+
+/// Enforces this table's FOREIGN KEY constraints against a built child row:
+/// each non-NULL referencing key must exist in the parent's primary key. For a
+/// self-reference, a sibling row in the same statement (`batch`) also satisfies
+/// it. A missing parent is error 547. `check_self_ref` skips self-referencing
+/// foreign keys (an UPDATE validates those against its post-update snapshot,
+/// since a pre-mutation probe would see stale rows).
+fn enforce_child_fks(
+    storage: &mut Storage,
+    def: &TableDef,
+    row: &[Datum],
+    batch: &[Vec<Datum>],
+    verb: &str,
+    check_self_ref: bool,
+) -> Result<(), SqlError> {
+    for fk in &def.foreign_keys {
+        if !check_self_ref && fk.parent.eq_ignore_ascii_case(&def.name) {
+            continue;
+        }
+        let Some(key) = fk_key(fk, row) else {
+            continue; // NULL referencing column: not enforced
+        };
+        if !fk_parent_exists(storage, fk, &key, def, batch)? {
+            return Err(fk_child_violation(&fk.name, verb, &fk.parent));
+        }
+    }
+    Ok(())
+}
+
+/// Enforces NO ACTION on the parent side: no surviving child row may reference
+/// any of `removed_keys` (parent primary-key values being deleted or vacated by
+/// an UPDATE). A referencing child is error 547. Referencing children are found
+/// by scanning every table's foreign keys (FK-index optimization deferred).
+fn enforce_parent_fks(
+    storage: &mut Storage,
+    parent: &TableDef,
+    removed_keys: &[Vec<Datum>],
+    verb: &str,
+    check_self_ref: bool,
+) -> Result<(), SqlError> {
+    if removed_keys.is_empty() {
+        return Ok(());
+    }
+    let children: Vec<TableDef> = storage
+        .rel_tables()
+        .into_iter()
+        .filter(|t| {
+            t.foreign_keys
+                .iter()
+                .any(|fk| fk.parent.eq_ignore_ascii_case(&parent.name))
+        })
+        .collect();
+    for child in &children {
+        let self_ref = child.name.eq_ignore_ascii_case(&parent.name);
+        // A self-referencing table's own FKs are validated against the
+        // post-update snapshot, not the pre-mutation child scan.
+        if self_ref && !check_self_ref {
+            continue;
+        }
+        let child_rows = storage
+            .rel_scan(&child.name)
+            .map_err(|e| map_storage_err(e, &child.name))?;
+        for fk in &child.foreign_keys {
+            if !fk.parent.eq_ignore_ascii_case(&parent.name) {
+                continue;
+            }
+            for row in &child_rows {
+                // A self-referencing row that is itself being removed does not
+                // count as a surviving reference.
+                if self_ref {
+                    let pk: Vec<Datum> =
+                        parent.key_columns.iter().map(|&i| row[i].clone()).collect();
+                    if removed_keys.contains(&pk) {
+                        continue;
+                    }
+                }
+                let Some(key) = fk_key(fk, row) else {
+                    continue;
+                };
+                if removed_keys.contains(&key) {
+                    return Err(SqlError::new(
+                        547,
+                        16,
+                        0,
+                        format!(
+                            "The {verb} statement conflicted with the REFERENCE constraint \"{}\". The conflict occurred in database \"truthdb\", table \"dbo.{}\".",
+                            fk.name, child.name
+                        ),
+                    ));
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// The primary-key values of a row (in key-column order).
+fn pk_of(def: &TableDef, row: &[Datum]) -> Vec<Datum> {
+    def.key_columns.iter().map(|&i| row[i].clone()).collect()
+}
+
 fn bind_column(column: &ColumnDef) -> Result<Column, SqlError> {
     let column_type = match &column.data_type {
         DataType::TinyInt => ColumnType::TinyInt,
@@ -918,6 +1310,29 @@ fn exec_drop_table(storage: &mut Storage, drop: &DropTable) -> Result<StatementR
     let name = resolve_table(storage, &drop.table.value).map(|d| d.name);
     match name {
         Some(name) => {
+            // A table still referenced by another table's foreign key cannot be
+            // dropped (SQL Server 3726) — it would leave a dangling reference.
+            if let Some(child) = storage.rel_tables().into_iter().find(|t| {
+                !t.name.eq_ignore_ascii_case(&name)
+                    && t.foreign_keys
+                        .iter()
+                        .any(|fk| fk.parent.eq_ignore_ascii_case(&name))
+            }) {
+                let referencing = child
+                    .foreign_keys
+                    .iter()
+                    .find(|fk| fk.parent.eq_ignore_ascii_case(&name))
+                    .map(|fk| fk.name.clone())
+                    .unwrap_or_default();
+                return Err(SqlError::new(
+                    3726,
+                    16,
+                    1,
+                    format!(
+                        "Could not drop object '{name}' because it is referenced by a FOREIGN KEY constraint '{referencing}'."
+                    ),
+                ));
+            }
             storage
                 .rel_drop_table(&name)
                 .map_err(|err| map_storage_err(err, &drop.table.value))?;
@@ -993,8 +1408,86 @@ fn exec_alter_table(
         .ok_or_else(|| SqlError::invalid_object(&alter.table.value).at(alter.table.span))?;
     match &alter.action {
         AlterAction::AddCheck(check) => alter_add_check(storage, &def, check, eval_ctx),
+        AlterAction::AddForeignKey(fk) => alter_add_foreign_key(storage, &def, fk),
         AlterAction::DropConstraint(name) => alter_drop_constraint(storage, &def, name),
     }
+}
+
+/// `ALTER TABLE ... ADD [CONSTRAINT name] FOREIGN KEY (...) REFERENCES ...`.
+/// Validates the constraint and every existing row (WITH CHECK): a child row
+/// referencing a missing parent is 547 and the constraint is not added.
+fn alter_add_foreign_key(
+    storage: &mut Storage,
+    def: &TableDef,
+    fk: &ForeignKey,
+) -> Result<StatementResult, SqlError> {
+    let schema = def.schema().map_err(|e| map_storage_err(e, &def.name))?;
+    let parent_bare = strip_schema(&fk.parent.value);
+    let parent_pk: Vec<(String, ColumnType)> = if parent_bare.eq_ignore_ascii_case(&def.name) {
+        def.key_columns
+            .iter()
+            .map(|&i| {
+                (
+                    schema.columns[i].name.clone(),
+                    schema.columns[i].column_type,
+                )
+            })
+            .collect()
+    } else {
+        let parent = resolve_table(storage, &fk.parent.value)
+            .ok_or_else(|| SqlError::invalid_object(&fk.parent.value).at(fk.parent.span))?;
+        let pschema = parent
+            .schema()
+            .map_err(|e| map_storage_err(e, &parent.name))?;
+        parent
+            .key_columns
+            .iter()
+            .map(|&i| {
+                (
+                    pschema.columns[i].name.clone(),
+                    pschema.columns[i].column_type,
+                )
+            })
+            .collect()
+    };
+    let existing_names: Vec<String> = def
+        .check_constraints
+        .iter()
+        .map(|c| c.name.clone())
+        .chain(def.foreign_keys.iter().map(|f| f.name.clone()))
+        .collect();
+    let new_def = bind_foreign_key(
+        fk,
+        &schema.columns,
+        &def.name,
+        &parent_pk,
+        parent_bare,
+        &existing_names,
+    )?;
+
+    // WITH CHECK: every existing child row must satisfy the new foreign key
+    // (its sibling rows count for a self-reference).
+    let rows = storage
+        .rel_scan(&def.name)
+        .map_err(|e| map_storage_err(e, &def.name))?;
+    for row in &rows {
+        if let Some(key) = fk_key(&new_def, row)
+            && !fk_parent_exists(storage, &new_def, &key, def, &rows)?
+        {
+            return Err(fk_child_violation(
+                &new_def.name,
+                "ALTER TABLE",
+                &new_def.parent,
+            ));
+        }
+    }
+
+    let mut fks = def.foreign_keys.clone();
+    fks.push(new_def);
+    storage
+        .rel_set_foreign_keys(&def.name, fks)
+        .map_err(|e| map_storage_err(e, &def.name))?;
+    Ok(StatementResult::Done)
 }
 
 /// `ALTER TABLE ... ADD [CONSTRAINT name] CHECK (expr)`. Validates the new
@@ -1007,10 +1500,12 @@ fn alter_add_check(
     eval_ctx: &EvalContext,
 ) -> Result<StatementResult, SqlError> {
     let schema = def.schema().map_err(|e| map_storage_err(e, &def.name))?;
+    // Constraint names are unique across kinds (CHECK and FOREIGN KEY).
     let existing: Vec<String> = def
         .check_constraints
         .iter()
         .map(|c| c.name.clone())
+        .chain(def.foreign_keys.iter().map(|f| f.name.clone()))
         .collect();
     let new_def = bind_check(check, &schema.columns, &def.name, &existing)?;
 
@@ -1044,32 +1539,52 @@ fn alter_add_check(
     Ok(StatementResult::Done)
 }
 
-/// `ALTER TABLE ... DROP CONSTRAINT name`. Removes a CHECK constraint by name
-/// (case-insensitive); an unknown name is error 3728.
+/// `ALTER TABLE ... DROP CONSTRAINT name`. Removes a CHECK or FOREIGN KEY
+/// constraint by name (case-insensitive); an unknown name is error 3728.
 fn alter_drop_constraint(
     storage: &mut Storage,
     def: &TableDef,
     name: &Name,
 ) -> Result<StatementResult, SqlError> {
-    let checks: Vec<catalog::CheckDef> = def
+    if def
         .check_constraints
         .iter()
-        .filter(|c| !c.name.eq_ignore_ascii_case(&name.value))
-        .cloned()
-        .collect();
-    if checks.len() == def.check_constraints.len() {
-        return Err(SqlError::new(
-            3728,
-            16,
-            1,
-            format!("'{}' is not a constraint.", name.value),
-        )
-        .at(name.span));
+        .any(|c| c.name.eq_ignore_ascii_case(&name.value))
+    {
+        let checks: Vec<catalog::CheckDef> = def
+            .check_constraints
+            .iter()
+            .filter(|c| !c.name.eq_ignore_ascii_case(&name.value))
+            .cloned()
+            .collect();
+        storage
+            .rel_set_check_constraints(&def.name, checks)
+            .map_err(|e| map_storage_err(e, &def.name))?;
+        return Ok(StatementResult::Done);
     }
-    storage
-        .rel_set_check_constraints(&def.name, checks)
-        .map_err(|e| map_storage_err(e, &def.name))?;
-    Ok(StatementResult::Done)
+    if def
+        .foreign_keys
+        .iter()
+        .any(|f| f.name.eq_ignore_ascii_case(&name.value))
+    {
+        let fks: Vec<catalog::ForeignKeyDef> = def
+            .foreign_keys
+            .iter()
+            .filter(|f| !f.name.eq_ignore_ascii_case(&name.value))
+            .cloned()
+            .collect();
+        storage
+            .rel_set_foreign_keys(&def.name, fks)
+            .map_err(|e| map_storage_err(e, &def.name))?;
+        return Ok(StatementResult::Done);
+    }
+    Err(SqlError::new(
+        3728,
+        16,
+        1,
+        format!("'{}' is not a constraint.", name.value),
+    )
+    .at(name.span))
 }
 
 // ---- INSERT -------------------------------------------------------------
@@ -1198,6 +1713,14 @@ fn exec_insert(
             )?;
         }
         rows.push(values);
+    }
+
+    // FOREIGN KEY (child side): each new row must reference an existing parent
+    // (a sibling row in this batch counts for a self-reference).
+    if !def.foreign_keys.is_empty() {
+        for row in &rows {
+            enforce_child_fks(storage, &def, row, &rows, "INSERT", true)?;
+        }
     }
 
     let inserted = rows.len() as u64;
@@ -1377,6 +1900,61 @@ fn exec_update(
         }
         updates.push((locator, old_values, new_row));
     }
+
+    // FOREIGN KEY (child side): each updated row must still reference a valid
+    // parent. Self-referencing FKs are validated separately below.
+    if !def.foreign_keys.is_empty() {
+        for (_, _, new_row) in &updates {
+            enforce_child_fks(storage, &def, new_row, &[], "UPDATE", false)?;
+        }
+    }
+    // FOREIGN KEY (parent side, other tables): a row whose primary key changes
+    // vacates its old key; no surviving child in ANOTHER table may still
+    // reference it (NO ACTION). Self-references are handled by the snapshot.
+    if def.is_tree() {
+        let removed: Vec<Vec<Datum>> = updates
+            .iter()
+            .filter_map(|(_, old, new)| {
+                let old_pk = pk_of(&def, old);
+                (old_pk != pk_of(&def, new)).then_some(old_pk)
+            })
+            .collect();
+        enforce_parent_fks(storage, &def, &removed, "UPDATE", false)?;
+    }
+    // FOREIGN KEY (self-reference): a self-referencing table's own foreign keys
+    // must hold against the state the UPDATE produces — a pre-mutation probe
+    // sees stale rows. Every surviving row's non-NULL self-FK key must match a
+    // surviving primary key.
+    if def.is_tree()
+        && def
+            .foreign_keys
+            .iter()
+            .any(|fk| fk.parent.eq_ignore_ascii_case(&def.name))
+    {
+        let old_pks: Vec<Vec<Datum>> = updates.iter().map(|(_, old, _)| pk_of(&def, old)).collect();
+        let mut post_rows: Vec<Vec<Datum>> = storage
+            .rel_scan(&def.name)
+            .map_err(|e| map_storage_err(e, &def.name))?
+            .into_iter()
+            .filter(|r| !old_pks.contains(&pk_of(&def, r)))
+            .collect();
+        post_rows.extend(updates.iter().map(|(_, _, new)| new.clone()));
+        let post_pks: Vec<Vec<Datum>> = post_rows.iter().map(|r| pk_of(&def, r)).collect();
+        for r in &post_rows {
+            for fk in def
+                .foreign_keys
+                .iter()
+                .filter(|fk| fk.parent.eq_ignore_ascii_case(&def.name))
+            {
+                if let Some(key) = fk_key(fk, r)
+                    && !post_pks.contains(&key)
+                {
+                    return Err(fk_child_violation(&fk.name, "UPDATE", &fk.parent));
+                }
+            }
+        }
+    }
+
     let count = storage
         .rel_update_located(&def.name, updates, scope)
         .map_err(|e| map_storage_err(e, &def.name))?;
@@ -1405,6 +1983,14 @@ fn exec_delete(
             targets.push((locator, row));
         }
     }
+
+    // FOREIGN KEY (parent side): no surviving child may reference a deleted row
+    // (a self-referencing row that is itself deleted does not count).
+    if def.is_tree() {
+        let removed: Vec<Vec<Datum>> = targets.iter().map(|(_, row)| pk_of(&def, row)).collect();
+        enforce_parent_fks(storage, &def, &removed, "DELETE", true)?;
+    }
+
     let count = storage
         .rel_delete_located(&def.name, targets, scope)
         .map_err(|e| map_storage_err(e, &def.name))?;
@@ -2005,6 +2591,7 @@ fn build_table_source(
         "sys.columns" => sys_columns(storage),
         "sys.indexes" => sys_indexes(storage),
         "sys.check_constraints" => sys_check_constraints(storage),
+        "sys.foreign_keys" => sys_foreign_keys(storage),
         _ => {
             let def = resolve_table(storage, &name.value)
                 .ok_or_else(|| SqlError::invalid_object(&name.value).at(name.span))?;
@@ -2308,6 +2895,42 @@ fn sys_check_constraints(storage: &Storage) -> Source {
                 Datum::NVarChar(check.name.clone()),
                 Datum::Int(def.object_id as i32),
                 Datum::NVarChar(format!("({})", check.predicate)),
+            ]);
+        }
+    }
+    let collations = vec![None; columns.len()];
+    let qualifiers = vec![None; columns.len()];
+    Source {
+        columns,
+        qualifiers,
+        collations,
+        rows,
+    }
+}
+
+fn sys_foreign_keys(storage: &Storage) -> Source {
+    let columns = vec![
+        nvarchar("name", 128),
+        int_col("parent_object_id"),
+        int_col("referenced_object_id"),
+    ];
+    // Resolve parent (referenced) table names to object ids.
+    let tables = storage.rel_tables();
+    let oid_of = |name: &str| {
+        tables
+            .iter()
+            .find(|t| t.name.eq_ignore_ascii_case(name))
+            .map(|t| t.object_id)
+    };
+    let mut rows = Vec::new();
+    for def in &tables {
+        for fk in &def.foreign_keys {
+            rows.push(vec![
+                Datum::NVarChar(fk.name.clone()),
+                Datum::Int(def.object_id as i32),
+                oid_of(&fk.parent)
+                    .map(|o| Datum::Int(o as i32))
+                    .unwrap_or(Datum::Null),
             ]);
         }
     }

--- a/crates/truthdb-core/src/relstore/catalog.rs
+++ b/crates/truthdb-core/src/relstore/catalog.rs
@@ -56,6 +56,19 @@ pub struct CheckDef {
     pub predicate: String,
 }
 
+/// A `FOREIGN KEY` constraint (NO ACTION). Referenced columns are always the
+/// parent's primary key, so only the child columns are stored — ordered to
+/// match the parent's primary-key column order, so a child row's key can be
+/// probed against the parent directly.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ForeignKeyDef {
+    pub name: String,
+    /// Child column indices, in parent primary-key order.
+    pub columns: Vec<usize>,
+    /// Referenced parent table (bare name).
+    pub parent: String,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TableDef {
     pub object_id: u32,
@@ -81,6 +94,9 @@ pub struct TableDef {
     /// `CHECK` constraints enforced on INSERT/UPDATE.
     #[serde(default)]
     pub check_constraints: Vec<CheckDef>,
+    /// `FOREIGN KEY` constraints (this table is the referencing child).
+    #[serde(default)]
+    pub foreign_keys: Vec<ForeignKeyDef>,
 }
 
 impl TableDef {

--- a/crates/truthdb-core/src/relstore/tests.rs
+++ b/crates/truthdb-core/src/relstore/tests.rs
@@ -81,6 +81,7 @@ fn create_tree_table(storage: &mut Storage, name: &str) {
             Vec::new(),
             None,
             Vec::new(),
+            Vec::new(),
         )
         .expect("create tree table");
 }
@@ -93,6 +94,7 @@ fn create_heap_table(storage: &mut Storage, name: &str) {
             &[],
             Vec::new(),
             None,
+            Vec::new(),
             Vec::new(),
         )
         .expect("create heap table");
@@ -619,6 +621,7 @@ fn heap_update_on_stub_starved_page_fails_cleanly() {
             &[],
             Vec::new(),
             None,
+            Vec::new(),
             Vec::new(),
         )
         .expect("create heap");

--- a/crates/truthdb-core/src/storage.rs
+++ b/crates/truthdb-core/src/storage.rs
@@ -203,6 +203,7 @@ impl Storage {
 
     /// Creates a table: with `key_names` it becomes a clustered B+ tree on
     /// those columns, without it a heap.
+    #[allow(clippy::too_many_arguments)]
     pub fn rel_create_table(
         &mut self,
         name: &str,
@@ -211,6 +212,7 @@ impl Storage {
         defaults: Vec<Option<String>>,
         identity: Option<catalog::IdentitySpec>,
         check_constraints: Vec<catalog::CheckDef>,
+        foreign_keys: Vec<catalog::ForeignKeyDef>,
     ) -> Result<(), StorageError> {
         self.file.ensure_rel_usable()?;
         if self.file.rel.tables.contains_key(name) {
@@ -276,6 +278,7 @@ impl Storage {
                 identity,
                 indexes: Vec::new(),
                 check_constraints,
+                foreign_keys,
             };
             catalog::insert_table(ctx, &mut OpMode::Txn(txn), catalog_root, &def)?;
             Ok(def)
@@ -1043,6 +1046,35 @@ impl Storage {
             .cloned()
             .ok_or_else(|| StorageError::InvalidConfig(format!("unknown table '{name}'")))?;
         def.check_constraints = check_constraints;
+        let catalog_root = self
+            .file
+            .rel
+            .catalog_root
+            .ok_or_else(|| StorageError::InvalidConfig("catalog root missing".to_string()))?;
+        let persisted = def.clone();
+        self.file.rel_statement(move |ctx, txn| {
+            catalog::update_table(ctx, &mut OpMode::Txn(txn), catalog_root, &persisted)
+        })?;
+        self.file.rel.tables.insert(name.to_string(), def);
+        Ok(())
+    }
+
+    /// Replaces a table's FOREIGN KEY constraints (ALTER TABLE ADD/DROP
+    /// CONSTRAINT) and persists the mutated catalog row.
+    pub(crate) fn rel_set_foreign_keys(
+        &mut self,
+        name: &str,
+        foreign_keys: Vec<catalog::ForeignKeyDef>,
+    ) -> Result<(), StorageError> {
+        self.file.ensure_rel_usable()?;
+        let mut def = self
+            .file
+            .rel
+            .tables
+            .get(name)
+            .cloned()
+            .ok_or_else(|| StorageError::InvalidConfig(format!("unknown table '{name}'")))?;
+        def.foreign_keys = foreign_keys;
         let catalog_root = self
             .file
             .rel

--- a/crates/truthdb-core/tests/slt/foreign_keys.slt
+++ b/crates/truthdb-core/tests/slt/foreign_keys.slt
@@ -1,0 +1,61 @@
+# FOREIGN KEY constraints (Stage 10 part 3)
+
+statement ok
+CREATE TABLE parent (id INT NOT NULL PRIMARY KEY, label NVARCHAR(20))
+
+statement ok
+CREATE TABLE child (id INT NOT NULL PRIMARY KEY, pid INT REFERENCES parent (id))
+
+statement ok
+INSERT INTO parent VALUES (1, 'a'), (2, 'b')
+
+# Child referencing an existing parent.
+statement ok
+INSERT INTO child VALUES (10, 1)
+
+# NULL-FK trap: a NULL referencing column skips enforcement (no parent needed).
+statement ok
+INSERT INTO child VALUES (11, NULL)
+
+# Referencing a missing parent is rejected.
+statement error
+INSERT INTO child VALUES (12, 99)
+
+# A referenced parent cannot be deleted (NO ACTION).
+statement error
+DELETE FROM parent WHERE id = 1
+
+# An unreferenced parent deletes fine.
+statement ok
+DELETE FROM parent WHERE id = 2
+
+# Changing a referenced parent's primary key is rejected.
+statement error
+UPDATE parent SET id = 5 WHERE id = 1
+
+# Composite foreign key.
+statement ok
+CREATE TABLE region (country NVARCHAR(2) NOT NULL, code INT NOT NULL, PRIMARY KEY (country, code))
+
+statement ok
+CREATE TABLE city (id INT NOT NULL PRIMARY KEY, country NVARCHAR(2), code INT, CONSTRAINT fk_region FOREIGN KEY (country, code) REFERENCES region (country, code))
+
+statement ok
+INSERT INTO region VALUES ('US', 1), ('CA', 2)
+
+statement ok
+INSERT INTO city VALUES (1, 'US', 1)
+
+statement error
+INSERT INTO city VALUES (2, 'US', 9)
+
+# A partially-NULL composite key skips enforcement.
+statement ok
+INSERT INTO city VALUES (3, 'US', NULL)
+
+# sys.foreign_keys lists both foreign keys.
+query T
+SELECT name FROM sys.foreign_keys ORDER BY name
+----
+FK__child__parent__1
+fk_region

--- a/crates/truthdb-sql/src/ast.rs
+++ b/crates/truthdb-sql/src/ast.rs
@@ -44,6 +44,8 @@ pub struct AlterTable {
 pub enum AlterAction {
     /// `ADD [CONSTRAINT name] CHECK (expr)`.
     AddCheck(CheckConstraint),
+    /// `ADD [CONSTRAINT name] FOREIGN KEY (...) REFERENCES ...`.
+    AddForeignKey(ForeignKey),
     /// `DROP CONSTRAINT <name>`.
     DropConstraint(Name),
 }
@@ -99,6 +101,8 @@ pub struct CreateTable {
     pub primary_key: Vec<Name>,
     /// Table-level `[CONSTRAINT name] CHECK (expr)` constraints.
     pub check_constraints: Vec<CheckConstraint>,
+    /// Table-level `[CONSTRAINT name] FOREIGN KEY (...) REFERENCES ...`.
+    pub foreign_keys: Vec<ForeignKey>,
     pub span: Span,
 }
 
@@ -109,6 +113,19 @@ pub struct CreateTable {
 pub struct CheckConstraint {
     pub name: Option<Name>,
     pub predicate: String,
+    pub span: Span,
+}
+
+/// A `[CONSTRAINT name] FOREIGN KEY (cols) REFERENCES parent [(pcols)]`
+/// constraint. A column-level `col ... REFERENCES parent [(pcol)]` desugars to
+/// a single-column foreign key. `parent_columns` empty means "the parent's
+/// primary key".
+#[derive(Debug, Clone, PartialEq)]
+pub struct ForeignKey {
+    pub name: Option<Name>,
+    pub columns: Vec<Name>,
+    pub parent: Name,
+    pub parent_columns: Vec<Name>,
     pub span: Span,
 }
 
@@ -127,6 +144,8 @@ pub struct ColumnDef {
     pub collation: Option<String>,
     /// Column-level `[CONSTRAINT name] CHECK (expr)` constraints.
     pub checks: Vec<CheckConstraint>,
+    /// Column-level `[CONSTRAINT name] REFERENCES parent [(pcol)]` foreign keys.
+    pub foreign_keys: Vec<ForeignKey>,
     pub span: Span,
 }
 

--- a/crates/truthdb-sql/src/parser.rs
+++ b/crates/truthdb-sql/src/parser.rs
@@ -335,6 +335,7 @@ impl Parser {
         let mut columns = Vec::new();
         let mut primary_key: Vec<Name> = Vec::new();
         let mut check_constraints: Vec<CheckConstraint> = Vec::new();
+        let mut foreign_keys: Vec<ForeignKey> = Vec::new();
         loop {
             // A leading `CONSTRAINT name` introduces a named table constraint.
             let constraint_name = self.parse_optional_constraint_name()?;
@@ -359,6 +360,9 @@ impl Parser {
                 }
                 Some("CHECK") => {
                     check_constraints.push(self.parse_check_constraint(constraint_name)?);
+                }
+                Some("FOREIGN") => {
+                    foreign_keys.push(self.parse_foreign_key(constraint_name)?);
                 }
                 _ if constraint_name.is_some() => {
                     // `CONSTRAINT name` must be followed by a table constraint.
@@ -389,6 +393,7 @@ impl Parser {
             columns,
             primary_key,
             check_constraints,
+            foreign_keys,
             span: start.to(end),
         }))
     }
@@ -425,6 +430,69 @@ impl Parser {
         })
     }
 
+    /// Parses `FOREIGN KEY (cols) REFERENCES parent [(pcols)]` (the
+    /// `CONSTRAINT name` prefix, if any, is already consumed).
+    fn parse_foreign_key(&mut self, name: Option<Name>) -> SqlResult<ForeignKey> {
+        let start = self.expect_keyword("FOREIGN")?;
+        self.expect_keyword("KEY")?;
+        let columns = self.parse_name_list()?;
+        self.expect_keyword("REFERENCES")?;
+        let parent = self.parse_name()?;
+        let (parent_columns, end) = self.parse_optional_reference_columns(parent.span)?;
+        Ok(ForeignKey {
+            name,
+            columns,
+            parent,
+            parent_columns,
+            span: start.to(end),
+        })
+    }
+
+    /// Parses a column-level `REFERENCES parent [(pcol)]` into a single-column
+    /// foreign key over `column`.
+    fn parse_column_reference(
+        &mut self,
+        name: Option<Name>,
+        column: &Name,
+    ) -> SqlResult<ForeignKey> {
+        let start = self.expect_keyword("REFERENCES")?;
+        let parent = self.parse_name()?;
+        let (parent_columns, end) = self.parse_optional_reference_columns(parent.span)?;
+        Ok(ForeignKey {
+            name,
+            columns: vec![column.clone()],
+            parent,
+            parent_columns,
+            span: start.to(end),
+        })
+    }
+
+    /// Parses a parenthesized comma-separated name list.
+    fn parse_name_list(&mut self) -> SqlResult<Vec<Name>> {
+        self.expect(&TokenKind::LParen)?;
+        let mut names = Vec::new();
+        loop {
+            names.push(self.parse_name()?);
+            if !self.eat(&TokenKind::Comma) {
+                break;
+            }
+        }
+        self.expect(&TokenKind::RParen)?;
+        Ok(names)
+    }
+
+    /// Parses an optional `(cols)` after `REFERENCES parent`; absent means the
+    /// parent's primary key. Returns the columns and the end span.
+    fn parse_optional_reference_columns(&mut self, fallback: Span) -> SqlResult<(Vec<Name>, Span)> {
+        if self.check(&TokenKind::LParen) {
+            let cols = self.parse_name_list()?;
+            let end = cols.last().map(|n| n.span).unwrap_or(fallback);
+            Ok((cols, end))
+        } else {
+            Ok((Vec::new(), fallback))
+        }
+    }
+
     fn parse_column_def(&mut self) -> SqlResult<ColumnDef> {
         let name = self.parse_name()?;
         let (data_type, type_span) = self.parse_data_type()?;
@@ -434,6 +502,7 @@ impl Parser {
         let mut identity = None;
         let mut collation = None;
         let mut checks = Vec::new();
+        let mut foreign_keys = Vec::new();
         let mut end = type_span;
         loop {
             match self.peek_keyword().as_deref() {
@@ -442,11 +511,23 @@ impl Parser {
                     end = check.span;
                     checks.push(check);
                 }
+                Some("REFERENCES") => {
+                    let fk = self.parse_column_reference(None, &name)?;
+                    end = fk.span;
+                    foreign_keys.push(fk);
+                }
                 Some("CONSTRAINT") => {
                     let constraint_name = self.parse_optional_constraint_name()?;
-                    let check = self.parse_check_constraint(constraint_name)?;
-                    end = check.span;
-                    checks.push(check);
+                    // A named column constraint is CHECK or REFERENCES.
+                    if self.peek_keyword().as_deref() == Some("REFERENCES") {
+                        let fk = self.parse_column_reference(constraint_name, &name)?;
+                        end = fk.span;
+                        foreign_keys.push(fk);
+                    } else {
+                        let check = self.parse_check_constraint(constraint_name)?;
+                        end = check.span;
+                        checks.push(check);
+                    }
                 }
                 Some("NOT") => {
                     self.bump();
@@ -497,6 +578,7 @@ impl Parser {
             identity,
             collation,
             checks,
+            foreign_keys,
         })
     }
 
@@ -610,12 +692,18 @@ impl Parser {
         let (action, end) = match self.peek_keyword().as_deref() {
             Some("ADD") => {
                 self.bump();
-                // Stage 10 part 2: only `ADD [CONSTRAINT name] CHECK (expr)`.
-                // ADD column arrives in a later part.
+                // `ADD [CONSTRAINT name] (CHECK | FOREIGN KEY ...)`. ADD column
+                // arrives in a later part.
                 let name = self.parse_optional_constraint_name()?;
-                let check = self.parse_check_constraint(name)?;
-                let end = check.span;
-                (AlterAction::AddCheck(check), end)
+                if self.peek_keyword().as_deref() == Some("FOREIGN") {
+                    let fk = self.parse_foreign_key(name)?;
+                    let end = fk.span;
+                    (AlterAction::AddForeignKey(fk), end)
+                } else {
+                    let check = self.parse_check_constraint(name)?;
+                    let end = check.span;
+                    (AlterAction::AddCheck(check), end)
+                }
             }
             Some("DROP") => {
                 self.bump();

--- a/crates/truthdb-sql/tests/corpus/ok/check_constraints.ast
+++ b/crates/truthdb-sql/tests/corpus/ok/check_constraints.ast
@@ -28,6 +28,7 @@
                     identity: None,
                     collation: None,
                     checks: [],
+                    foreign_keys: [],
                     span: Span {
                         start: 25,
                         end: 52,
@@ -58,6 +59,7 @@
                             },
                         },
                     ],
+                    foreign_keys: [],
                     span: Span {
                         start: 58,
                         end: 82,
@@ -97,6 +99,7 @@
                             },
                         },
                     ],
+                    foreign_keys: [],
                     span: Span {
                         start: 88,
                         end: 133,
@@ -149,6 +152,7 @@
                     },
                 },
             ],
+            foreign_keys: [],
             span: Span {
                 start: 0,
                 end: 260,

--- a/crates/truthdb-sql/tests/corpus/ok/create_table.ast
+++ b/crates/truthdb-sql/tests/corpus/ok/create_table.ast
@@ -28,6 +28,7 @@
                     identity: None,
                     collation: None,
                     checks: [],
+                    foreign_keys: [],
                     span: Span {
                         start: 28,
                         end: 55,
@@ -53,6 +54,7 @@
                     identity: None,
                     collation: None,
                     checks: [],
+                    foreign_keys: [],
                     span: Span {
                         start: 61,
                         end: 87,
@@ -76,6 +78,7 @@
                     identity: None,
                     collation: None,
                     checks: [],
+                    foreign_keys: [],
                     span: Span {
                         start: 93,
                         end: 109,
@@ -97,6 +100,7 @@
                     identity: None,
                     collation: None,
                     checks: [],
+                    foreign_keys: [],
                     span: Span {
                         start: 115,
                         end: 127,
@@ -114,6 +118,7 @@
                 },
             ],
             check_constraints: [],
+            foreign_keys: [],
             span: Span {
                 start: 0,
                 end: 129,

--- a/crates/truthdb-sql/tests/corpus/ok/create_table_composite_pk.ast
+++ b/crates/truthdb-sql/tests/corpus/ok/create_table_composite_pk.ast
@@ -28,6 +28,7 @@
                     identity: None,
                     collation: None,
                     checks: [],
+                    foreign_keys: [],
                     span: Span {
                         start: 31,
                         end: 52,
@@ -51,6 +52,7 @@
                     identity: None,
                     collation: None,
                     checks: [],
+                    foreign_keys: [],
                     span: Span {
                         start: 58,
                         end: 83,
@@ -72,6 +74,7 @@
                     identity: None,
                     collation: None,
                     checks: [],
+                    foreign_keys: [],
                     span: Span {
                         start: 89,
                         end: 96,
@@ -97,6 +100,7 @@
                 },
             ],
             check_constraints: [],
+            foreign_keys: [],
             span: Span {
                 start: 0,
                 end: 135,

--- a/crates/truthdb-sql/tests/corpus/ok/create_table_stage5.ast
+++ b/crates/truthdb-sql/tests/corpus/ok/create_table_stage5.ast
@@ -33,6 +33,7 @@
                     ),
                     collation: None,
                     checks: [],
+                    foreign_keys: [],
                     span: Span {
                         start: 25,
                         end: 67,
@@ -58,6 +59,7 @@
                         "Finnish_Swedish_CI_AS",
                     ),
                     checks: [],
+                    foreign_keys: [],
                     span: Span {
                         start: 73,
                         end: 119,
@@ -84,6 +86,7 @@
                     identity: None,
                     collation: None,
                     checks: [],
+                    foreign_keys: [],
                     span: Span {
                         start: 125,
                         end: 155,
@@ -105,6 +108,7 @@
                     identity: None,
                     collation: None,
                     checks: [],
+                    foreign_keys: [],
                     span: Span {
                         start: 161,
                         end: 178,
@@ -126,6 +130,7 @@
                     identity: None,
                     collation: None,
                     checks: [],
+                    foreign_keys: [],
                     span: Span {
                         start: 184,
                         end: 204,
@@ -143,6 +148,7 @@
                 },
             ],
             check_constraints: [],
+            foreign_keys: [],
             span: Span {
                 start: 0,
                 end: 206,

--- a/crates/truthdb-sql/tests/corpus/ok/foreign_keys.ast
+++ b/crates/truthdb-sql/tests/corpus/ok/foreign_keys.ast
@@ -1,0 +1,323 @@
+[
+    CreateTable(
+        CreateTable {
+            table: Name {
+                value: "orders",
+                quoted: false,
+                span: Span {
+                    start: 13,
+                    end: 19,
+                },
+            },
+            columns: [
+                ColumnDef {
+                    name: Name {
+                        value: "id",
+                        quoted: false,
+                        span: Span {
+                            start: 26,
+                            end: 28,
+                        },
+                    },
+                    data_type: Int,
+                    nullable: Some(
+                        false,
+                    ),
+                    primary_key: true,
+                    default: None,
+                    identity: None,
+                    collation: None,
+                    checks: [],
+                    foreign_keys: [],
+                    span: Span {
+                        start: 26,
+                        end: 53,
+                    },
+                },
+                ColumnDef {
+                    name: Name {
+                        value: "cust_id",
+                        quoted: false,
+                        span: Span {
+                            start: 59,
+                            end: 66,
+                        },
+                    },
+                    data_type: Int,
+                    nullable: None,
+                    primary_key: false,
+                    default: None,
+                    identity: None,
+                    collation: None,
+                    checks: [],
+                    foreign_keys: [
+                        ForeignKey {
+                            name: None,
+                            columns: [
+                                Name {
+                                    value: "cust_id",
+                                    quoted: false,
+                                    span: Span {
+                                        start: 59,
+                                        end: 66,
+                                    },
+                                },
+                            ],
+                            parent: Name {
+                                value: "customers",
+                                quoted: false,
+                                span: Span {
+                                    start: 82,
+                                    end: 91,
+                                },
+                            },
+                            parent_columns: [],
+                            span: Span {
+                                start: 71,
+                                end: 91,
+                            },
+                        },
+                    ],
+                    span: Span {
+                        start: 59,
+                        end: 91,
+                    },
+                },
+                ColumnDef {
+                    name: Name {
+                        value: "prod_id",
+                        quoted: false,
+                        span: Span {
+                            start: 97,
+                            end: 104,
+                        },
+                    },
+                    data_type: Int,
+                    nullable: None,
+                    primary_key: false,
+                    default: None,
+                    identity: None,
+                    collation: None,
+                    checks: [],
+                    foreign_keys: [
+                        ForeignKey {
+                            name: Some(
+                                Name {
+                                    value: "fk_prod",
+                                    quoted: false,
+                                    span: Span {
+                                        start: 120,
+                                        end: 127,
+                                    },
+                                },
+                            ),
+                            columns: [
+                                Name {
+                                    value: "prod_id",
+                                    quoted: false,
+                                    span: Span {
+                                        start: 97,
+                                        end: 104,
+                                    },
+                                },
+                            ],
+                            parent: Name {
+                                value: "products",
+                                quoted: false,
+                                span: Span {
+                                    start: 139,
+                                    end: 147,
+                                },
+                            },
+                            parent_columns: [
+                                Name {
+                                    value: "id",
+                                    quoted: false,
+                                    span: Span {
+                                        start: 149,
+                                        end: 151,
+                                    },
+                                },
+                            ],
+                            span: Span {
+                                start: 128,
+                                end: 151,
+                            },
+                        },
+                    ],
+                    span: Span {
+                        start: 97,
+                        end: 151,
+                    },
+                },
+            ],
+            primary_key: [
+                Name {
+                    value: "id",
+                    quoted: false,
+                    span: Span {
+                        start: 26,
+                        end: 28,
+                    },
+                },
+            ],
+            check_constraints: [],
+            foreign_keys: [
+                ForeignKey {
+                    name: Some(
+                        Name {
+                            value: "fk_cust",
+                            quoted: false,
+                            span: Span {
+                                start: 169,
+                                end: 176,
+                            },
+                        },
+                    ),
+                    columns: [
+                        Name {
+                            value: "cust_id",
+                            quoted: false,
+                            span: Span {
+                                start: 190,
+                                end: 197,
+                            },
+                        },
+                    ],
+                    parent: Name {
+                        value: "customers",
+                        quoted: false,
+                        span: Span {
+                            start: 210,
+                            end: 219,
+                        },
+                    },
+                    parent_columns: [
+                        Name {
+                            value: "id",
+                            quoted: false,
+                            span: Span {
+                                start: 221,
+                                end: 223,
+                            },
+                        },
+                    ],
+                    span: Span {
+                        start: 177,
+                        end: 223,
+                    },
+                },
+            ],
+            span: Span {
+                start: 0,
+                end: 226,
+            },
+        },
+    ),
+    AlterTable(
+        AlterTable {
+            table: Name {
+                value: "orders",
+                quoted: false,
+                span: Span {
+                    start: 240,
+                    end: 246,
+                },
+            },
+            action: AddForeignKey(
+                ForeignKey {
+                    name: Some(
+                        Name {
+                            value: "fk2",
+                            quoted: false,
+                            span: Span {
+                                start: 262,
+                                end: 265,
+                            },
+                        },
+                    ),
+                    columns: [
+                        Name {
+                            value: "prod_id",
+                            quoted: false,
+                            span: Span {
+                                start: 279,
+                                end: 286,
+                            },
+                        },
+                    ],
+                    parent: Name {
+                        value: "products",
+                        quoted: false,
+                        span: Span {
+                            start: 299,
+                            end: 307,
+                        },
+                    },
+                    parent_columns: [
+                        Name {
+                            value: "id",
+                            quoted: false,
+                            span: Span {
+                                start: 309,
+                                end: 311,
+                            },
+                        },
+                    ],
+                    span: Span {
+                        start: 266,
+                        end: 311,
+                    },
+                },
+            ),
+            span: Span {
+                start: 228,
+                end: 311,
+            },
+        },
+    ),
+    AlterTable(
+        AlterTable {
+            table: Name {
+                value: "orders",
+                quoted: false,
+                span: Span {
+                    start: 326,
+                    end: 332,
+                },
+            },
+            action: AddForeignKey(
+                ForeignKey {
+                    name: None,
+                    columns: [
+                        Name {
+                            value: "cust_id",
+                            quoted: false,
+                            span: Span {
+                                start: 350,
+                                end: 357,
+                            },
+                        },
+                    ],
+                    parent: Name {
+                        value: "customers",
+                        quoted: false,
+                        span: Span {
+                            start: 370,
+                            end: 379,
+                        },
+                    },
+                    parent_columns: [],
+                    span: Span {
+                        start: 337,
+                        end: 379,
+                    },
+                },
+            ),
+            span: Span {
+                start: 314,
+                end: 379,
+            },
+        },
+    ),
+]

--- a/crates/truthdb-sql/tests/corpus/ok/foreign_keys.sql
+++ b/crates/truthdb-sql/tests/corpus/ok/foreign_keys.sql
@@ -1,0 +1,8 @@
+CREATE TABLE orders (
+    id INT NOT NULL PRIMARY KEY,
+    cust_id INT REFERENCES customers,
+    prod_id INT CONSTRAINT fk_prod REFERENCES products (id),
+    CONSTRAINT fk_cust FOREIGN KEY (cust_id) REFERENCES customers (id)
+);
+ALTER TABLE orders ADD CONSTRAINT fk2 FOREIGN KEY (prod_id) REFERENCES products (id);
+ALTER TABLE orders ADD FOREIGN KEY (cust_id) REFERENCES customers;


### PR DESCRIPTION
Third slice of **Stage 10 (Constraints & ALTER TABLE)**. A foreign key always references the parent's **PRIMARY KEY** (SQL Server requires a unique/PK target). Only `ALTER TABLE ADD` column and `sys.default_constraints` remain (part 4).

## What's in
- **Syntax** — column-level `col ... REFERENCES parent [(pcol)]`, table-level `[CONSTRAINT n] FOREIGN KEY (cols) REFERENCES parent [(pcols)]`, and `ALTER TABLE ... ADD [CONSTRAINT n] FOREIGN KEY ...`.
- **Catalog** — `ForeignKeyDef { name, columns, parent }` (additive `#[serde(default)]`); `columns` are child indices ordered to the parent's PK so a child key probes the parent directly.
- **CREATE/ALTER validation** — referenced columns must be exactly the parent PK (**1776**); counts must match (1776); child/parent column types must be equal (**1778**, required so the key probe byte-matches); missing parent **208**; unnamed FK auto-named `FK__<child>__<parent>__<n>`; self-reference reads the PK from the CREATE.
- **Child enforcement** (INSERT/UPDATE) — non-NULL referencing key must exist in the parent via a PK point lookup; any NULL referencing column skips (MATCH SIMPLE — the NULL-FK trap). A self-reference may be satisfied by a sibling row in the same INSERT batch. **547**.
- **Parent enforcement** (DELETE / UPDATE that changes a PK) — NO ACTION: no surviving child may reference a removed/vacated key. Referencing children found by scanning every table's FKs (FK-index optimization deferred = documented cliff).
- **ALTER ADD FK** validates every existing row (WITH CHECK). **DROP CONSTRAINT** now drops a CHECK or FK by name. **DROP TABLE** of a referenced parent is **3726**.
- **Locks** — `analyze_locks` takes Shared on FK parents (child writes) and referencing children (parent writes) so integrity reads can't observe uncommitted rows (the engine is 2PL-only, no MVCC read view). **`sys.foreign_keys`** view.

## Adversarial review (5 dimensions × find→verify) — 2 confirmed bugs, both fixed
- **HIGH** — a self-referencing UPDATE that changed a primary key admitted an orphan (no 547): both the child-side `rel_get` and the parent-side self-ref exclusion looked at stale pre-mutation rows. Self-referencing tables are now validated against the **post-update snapshot** — every surviving row's non-NULL self-FK key must match a surviving PK. Regression: `emp(id PK, mgr→emp)`, `(1,1)` then `UPDATE ... SET id=2` → 547.
- **LOW** — constraint names weren't unique across CHECK and FOREIGN KEY at CREATE (and `ALTER ADD CHECK` ignored FK names). All add sites now check both kinds (2714).

## Tests
Engine tests (child/parent enforcement, NULL skip, self-reference incl. the orphan-on-pk-change repro, ALTER add/drop + 3726 + restart durability, `sys.foreign_keys`, 1776/1778/208 validation, cross-kind name uniqueness, FK lock analysis), an slt matrix with a composite key + NULL-FK trap, and a parser corpus case. `cargo fmt`, `clippy -D warnings`, `cargo test --workspace` all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)