### PR TITLE
sys.default_constraints view [Stage 10, part 4a]

### DIFF
--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -2185,6 +2185,40 @@ mod tests {
     }
 
     #[test]
+    fn sql_sys_default_constraints() {
+        let path = unique_temp_path("sql-default-constraints");
+        let mut engine = new_engine(&path);
+        engine
+            .execute(
+                "CREATE TABLE t (id INT NOT NULL PRIMARY KEY, \
+                   qty INT DEFAULT 0, note NVARCHAR(10) DEFAULT 'n/a', plain INT)",
+            )
+            .expect("create");
+        // One row per column that carries a DEFAULT (plain has none).
+        let (cols, rows) = sql_rows(
+            &mut engine,
+            "SELECT name, parent_column_id, definition FROM sys.default_constraints ORDER BY parent_column_id",
+        );
+        assert_eq!(cols, vec!["name", "parent_column_id", "definition"]);
+        assert_eq!(
+            rows,
+            vec![
+                vec![
+                    Some("DF__t__qty".into()),
+                    Some("2".into()),
+                    Some("(0)".into())
+                ],
+                vec![
+                    Some("DF__t__note".into()),
+                    Some("3".into()),
+                    Some("('n/a')".into()),
+                ],
+            ]
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
     fn sql_decimal_arithmetic_and_rendering() {
         let path = unique_temp_path("sql-decimal");
         let mut engine = new_engine(&path);

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -2592,6 +2592,7 @@ fn build_table_source(
         "sys.indexes" => sys_indexes(storage),
         "sys.check_constraints" => sys_check_constraints(storage),
         "sys.foreign_keys" => sys_foreign_keys(storage),
+        "sys.default_constraints" => sys_default_constraints(storage),
         _ => {
             let def = resolve_table(storage, &name.value)
                 .ok_or_else(|| SqlError::invalid_object(&name.value).at(name.span))?;
@@ -2931,6 +2932,38 @@ fn sys_foreign_keys(storage: &Storage) -> Source {
                 oid_of(&fk.parent)
                     .map(|o| Datum::Int(o as i32))
                     .unwrap_or(Datum::Null),
+            ]);
+        }
+    }
+    let collations = vec![None; columns.len()];
+    let qualifiers = vec![None; columns.len()];
+    Source {
+        columns,
+        qualifiers,
+        collations,
+        rows,
+    }
+}
+
+fn sys_default_constraints(storage: &Storage) -> Source {
+    let columns = vec![
+        nvarchar("name", 128),
+        int_col("parent_object_id"),
+        int_col("parent_column_id"),
+        nvarchar("definition", 4000),
+    ];
+    // Inline column DEFAULTs are unnamed; SQL Server auto-names them
+    // `DF__<table>__<column>__...`. We synthesize a stable `DF__<table>__<col>`.
+    let mut rows = Vec::new();
+    for def in storage.rel_tables() {
+        for (index, text) in def.defaults.iter().enumerate() {
+            let Some(text) = text else { continue };
+            let column = &def.columns[index].0;
+            rows.push(vec![
+                Datum::NVarChar(format!("DF__{}__{}", def.name, column)),
+                Datum::Int(def.object_id as i32),
+                Datum::Int(index as i32 + 1),
+                Datum::NVarChar(format!("({text})")),
             ]);
         }
     }


### PR DESCRIPTION
Small final safe slice of **Stage 10**: the `sys.default_constraints` catalog view.

- Each column's inline `DEFAULT` becomes a row: `name` (synthesized `DF__<table>__<column>`), `parent_object_id`, `parent_column_id`, `definition` (`(text)`).
- Defaults are already stored per column as source text, so this is a read-only view — **no catalog change**. Completes the catalog-view surface of Stage 10 (`sys.check_constraints`, `sys.foreign_keys`, `sys.default_constraints`).

## Deferred
The remaining Stage 10 item, `ALTER TABLE ADD` column, is **deferred to supervised work**. The row codec is schema-position-dependent (null bitmap / fixed section / var offsets are all sized to the current schema), so adding a column can't be metadata-only without a per-row column count — it needs a storage-layer table rewrite with WAL/undo integration. That's a format change with recovery implications best not merged unsupervised.

## Tests
An engine test asserting the view lists exactly the columns that carry a default, with the right column ids and definitions. `cargo fmt`, `clippy -D warnings`, `cargo test --workspace` all green locally. (No adversarial review — a read-only view over existing data is a trivial mechanical change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)