### PR TITLE
Derived tables (subquery in FROM) [Stage 11, part 1]

### DIFF
--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -2185,6 +2185,76 @@ mod tests {
     }
 
     #[test]
+    fn sql_derived_tables() {
+        let path = unique_temp_path("sql-derived");
+        let mut engine = new_engine(&path);
+        engine
+            .execute(
+                "CREATE TABLE sales (id INT NOT NULL PRIMARY KEY, dept NVARCHAR(4), amount INT)",
+            )
+            .expect("create");
+        engine
+            .execute("INSERT INTO sales VALUES (1,'a',10),(2,'a',20),(3,'b',5),(4,'b',50)")
+            .expect("seed");
+
+        // A derived table filtered further by the outer query; columns resolve
+        // by the derived alias.
+        let (cols, rows) = sql_rows(
+            &mut engine,
+            "SELECT s.id, s.amount FROM (SELECT id, amount FROM sales WHERE amount >= 10) s \
+               WHERE s.id < 3 ORDER BY s.id",
+        );
+        assert_eq!(cols, vec!["id", "amount"]);
+        assert_eq!(
+            rows,
+            vec![
+                vec![Some("1".into()), Some("10".into())],
+                vec![Some("2".into()), Some("20".into())],
+            ]
+        );
+
+        // A derived table may aggregate; the outer query filters on the alias.
+        let (_, rows) = sql_rows(
+            &mut engine,
+            "SELECT d.dept, d.total FROM (SELECT dept, SUM(amount) AS total FROM sales GROUP BY dept) d \
+               WHERE d.total > 30 ORDER BY d.dept",
+        );
+        assert_eq!(rows, vec![vec![Some("b".into()), Some("55".into())]]);
+
+        // A derived table joined to a base table.
+        let (_, rows) = sql_rows(
+            &mut engine,
+            "SELECT t.dept, d.total FROM sales t \
+               JOIN (SELECT dept, SUM(amount) AS total FROM sales GROUP BY dept) d ON t.dept = d.dept \
+               WHERE t.id = 1",
+        );
+        assert_eq!(rows, vec![vec![Some("a".into()), Some("30".into())]]);
+
+        // A derived table must have an alias.
+        assert_eq!(
+            sql_error_number(&mut engine, "SELECT * FROM (SELECT id FROM sales)"),
+            102
+        );
+        // Every derived column must be named.
+        assert_eq!(
+            sql_error_number(
+                &mut engine,
+                "SELECT * FROM (SELECT amount + 1 FROM sales) x"
+            ),
+            8155
+        );
+        // Duplicate derived column names are rejected.
+        assert_eq!(
+            sql_error_number(
+                &mut engine,
+                "SELECT * FROM (SELECT id, amount AS id FROM sales) x",
+            ),
+            8156
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
     fn sql_sys_default_constraints() {
         let path = unique_temp_path("sql-default-constraints");
         let mut engine = new_engine(&path);

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -2487,13 +2487,19 @@ fn bare_column_index(expr: &Expr, scope: &JoinScope) -> Option<usize> {
     }
 }
 
-/// Collects every base-table name referenced in a FROM join tree.
+/// Collects every base-table name referenced in a FROM join tree, recursing
+/// into derived-table subqueries so their tables are locked too.
 fn collect_table_names<'a>(tref: &'a TableRef, out: &mut Vec<&'a Name>) {
     match tref {
         TableRef::Table { name, .. } => out.push(name),
         TableRef::Join { left, right, .. } => {
             collect_table_names(left, out);
             collect_table_names(right, out);
+        }
+        TableRef::Derived { subquery, .. } => {
+            if let Some(from) = &subquery.from {
+                collect_table_names(from, out);
+            }
         }
     }
 }
@@ -2505,7 +2511,9 @@ fn exposed_name(name: &Name, alias: Option<&Name>) -> String {
         .unwrap_or_else(|| strip_schema(&name.value).to_string())
 }
 
-/// Collects the exposed names of every table in a FROM tree.
+/// Collects the exposed names of every table in a FROM tree. A derived table's
+/// exposed name is its alias (its inner tables are not exposed to the outer
+/// query).
 fn collect_exposed_names(tref: &TableRef, out: &mut Vec<String>) {
     match tref {
         TableRef::Table { name, alias } => out.push(exposed_name(name, alias.as_ref())),
@@ -2513,6 +2521,7 @@ fn collect_exposed_names(tref: &TableRef, out: &mut Vec<String>) {
             collect_exposed_names(left, out);
             collect_exposed_names(right, out);
         }
+        TableRef::Derived { alias, .. } => out.push(alias.value.clone()),
     }
 }
 
@@ -2657,7 +2666,62 @@ fn build_join(
             let right = build_join(storage, right, eval_ctx)?;
             join_sources(left, right, *kind, on.as_ref(), eval_ctx)
         }
+        TableRef::Derived { subquery, alias } => {
+            build_derived_source(storage, subquery, alias, eval_ctx)
+        }
     }
+}
+
+/// Builds a derived table's row source by executing its subquery and stamping
+/// every output column with the derived-table alias. Every column must be named
+/// (8155) and names must be unique within the derived table (8156).
+fn build_derived_source(
+    storage: &mut Storage,
+    subquery: &Select,
+    alias: &Name,
+    eval_ctx: &EvalContext,
+) -> Result<Source, SqlError> {
+    let rowset = exec_select(storage, subquery, eval_ctx)?;
+    for (index, column) in rowset.columns.iter().enumerate() {
+        if column.name.is_empty() {
+            return Err(SqlError::new(
+                8155,
+                16,
+                2,
+                format!(
+                    "No column name was specified for column {} of '{}'.",
+                    index + 1,
+                    alias.value
+                ),
+            ));
+        }
+        if rowset.columns[..index]
+            .iter()
+            .any(|c| c.name.eq_ignore_ascii_case(&column.name))
+        {
+            return Err(SqlError::new(
+                8156,
+                16,
+                1,
+                format!(
+                    "The column '{}' was specified multiple times for '{}'.",
+                    column.name, alias.value
+                ),
+            ));
+        }
+    }
+    let count = rowset.columns.len();
+    Ok(Source {
+        columns: rowset.columns,
+        qualifiers: vec![Some(alias.value.clone()); count],
+        // KNOWN LIMITATION: a RowSet carries no per-column collation, so a
+        // derived character column loses its source collation and an outer
+        // ORDER BY sorts it under the database default rather than the base
+        // column's COLLATE. Fixing this needs collation threaded through the
+        // project/RowSet boundary; deferred (narrow, non-default-collation only).
+        collations: vec![None; count],
+        rows: rowset.rows,
+    })
 }
 
 /// Nested-loop join of two materialized sources. The ON predicate (absent for

--- a/crates/truthdb-core/tests/slt/derived_tables.slt
+++ b/crates/truthdb-core/tests/slt/derived_tables.slt
@@ -1,0 +1,37 @@
+# Derived tables (Stage 11 part 1)
+
+statement ok
+CREATE TABLE sales (id INT NOT NULL PRIMARY KEY, dept NVARCHAR(4), amount INT)
+
+statement ok
+INSERT INTO sales VALUES (1, 'a', 10), (2, 'a', 20), (3, 'b', 5), (4, 'b', 50)
+
+# A derived table filtered further by the outer query.
+query II
+SELECT s.id, s.amount FROM (SELECT id, amount FROM sales WHERE amount >= 10) s WHERE s.id < 3 ORDER BY s.id
+----
+1 10
+2 20
+
+# A derived table that aggregates; the outer query filters on the alias.
+query TI
+SELECT d.dept, d.total FROM (SELECT dept, SUM(amount) AS total FROM sales GROUP BY dept) d WHERE d.total > 30 ORDER BY d.dept
+----
+b 55
+
+# A derived table joined to a base table.
+query TI
+SELECT t.dept, d.total FROM sales t JOIN (SELECT dept, SUM(amount) AS total FROM sales GROUP BY dept) d ON t.dept = d.dept ORDER BY t.id
+----
+a 30
+a 30
+b 55
+b 55
+
+# A derived table must have an alias.
+statement error
+SELECT * FROM (SELECT id FROM sales)
+
+# Every derived column must be named.
+statement error
+SELECT * FROM (SELECT amount + 1 FROM sales) x

--- a/crates/truthdb-sql/src/ast.rs
+++ b/crates/truthdb-sql/src/ast.rs
@@ -252,6 +252,11 @@ pub enum TableRef {
         /// The `ON` predicate (absent for `CROSS JOIN`).
         on: Option<Expr>,
     },
+    /// A derived table: `(SELECT ...) AS alias`. The alias is required.
+    Derived {
+        subquery: Box<Select>,
+        alias: Name,
+    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/truthdb-sql/src/parser.rs
+++ b/crates/truthdb-sql/src/parser.rs
@@ -1107,7 +1107,43 @@ impl Parser {
     }
 
     fn parse_table_primary(&mut self) -> SqlResult<TableRef> {
-        // Derived tables (subqueries) arrive in Stage 11.
+        // A derived table or a parenthesized group re-enters parse_select /
+        // parse_from, so bound the FROM nesting the same way expressions are
+        // bounded — otherwise a deeply nested `((( ... )))` overflows the stack
+        // and aborts the process. Shares the expression depth budget.
+        self.depth += 1;
+        if self.depth > MAX_EXPR_DEPTH {
+            return Err(Self::too_deep());
+        }
+        let tref = self.parse_table_primary_body()?;
+        self.depth -= 1;
+        Ok(tref)
+    }
+
+    fn parse_table_primary_body(&mut self) -> SqlResult<TableRef> {
+        if self.check(&TokenKind::LParen) {
+            // `(SELECT ...)` is a derived table (required alias); any other
+            // parenthesized form is a grouped table reference / join.
+            if self.peek_keyword_at(1).as_deref() == Some("SELECT") {
+                self.bump(); // (
+                let subquery = self.parse_select()?;
+                self.expect(&TokenKind::RParen)?;
+                let alias = self.parse_optional_table_alias()?.ok_or_else(|| {
+                    SqlError::message_only(
+                        102,
+                        "Incorrect syntax: a derived table must have an alias.",
+                    )
+                })?;
+                return Ok(TableRef::Derived {
+                    subquery: Box::new(subquery),
+                    alias,
+                });
+            }
+            self.bump(); // (
+            let inner = self.parse_from()?;
+            self.expect(&TokenKind::RParen)?;
+            return Ok(inner);
+        }
         let name = self.parse_name()?;
         let alias = self.parse_optional_table_alias()?;
         Ok(TableRef::Table { name, alias })
@@ -1834,6 +1870,20 @@ mod tests {
         let sql = format!("SELECT {}1{}", "(".repeat(5000), ")".repeat(5000));
         let err = Parser::parse_str(&sql).expect_err("must reject, not overflow");
         assert_eq!(err.number, 191);
+    }
+
+    #[test]
+    fn deeply_nested_from_error_not_overflow() {
+        // Nested parenthesized-group FROM: must reject cleanly, not overflow.
+        let group = format!("SELECT 1 FROM {}t{}", "(".repeat(5000), ")".repeat(5000));
+        assert_eq!(Parser::parse_str(&group).unwrap_err().number, 191);
+        // Nested derived tables likewise.
+        let derived = format!(
+            "SELECT * FROM {}SELECT * FROM t{} x",
+            "(SELECT * FROM ".repeat(2000),
+            ") y".repeat(2000),
+        );
+        assert_eq!(Parser::parse_str(&derived).unwrap_err().number, 191);
     }
 
     #[test]

--- a/crates/truthdb-sql/tests/corpus/ok/derived_tables.ast
+++ b/crates/truthdb-sql/tests/corpus/ok/derived_tables.ast
@@ -1,0 +1,485 @@
+[
+    Select(
+        Select {
+            top: None,
+            distinct: false,
+            items: [
+                Expr {
+                    expr: Expr {
+                        kind: Column(
+                            Name {
+                                value: "s.id",
+                                quoted: false,
+                                span: Span {
+                                    start: 7,
+                                    end: 11,
+                                },
+                            },
+                        ),
+                        span: Span {
+                            start: 7,
+                            end: 11,
+                        },
+                    },
+                    alias: None,
+                },
+                Expr {
+                    expr: Expr {
+                        kind: Column(
+                            Name {
+                                value: "s.total",
+                                quoted: false,
+                                span: Span {
+                                    start: 13,
+                                    end: 20,
+                                },
+                            },
+                        ),
+                        span: Span {
+                            start: 13,
+                            end: 20,
+                        },
+                    },
+                    alias: None,
+                },
+            ],
+            from: Some(
+                Derived {
+                    subquery: Select {
+                        top: None,
+                        distinct: false,
+                        items: [
+                            Expr {
+                                expr: Expr {
+                                    kind: Column(
+                                        Name {
+                                            value: "id",
+                                            quoted: false,
+                                            span: Span {
+                                                start: 34,
+                                                end: 36,
+                                            },
+                                        },
+                                    ),
+                                    span: Span {
+                                        start: 34,
+                                        end: 36,
+                                    },
+                                },
+                                alias: None,
+                            },
+                            Expr {
+                                expr: Expr {
+                                    kind: Binary {
+                                        op: Add,
+                                        left: Expr {
+                                            kind: Column(
+                                                Name {
+                                                    value: "amount",
+                                                    quoted: false,
+                                                    span: Span {
+                                                        start: 38,
+                                                        end: 44,
+                                                    },
+                                                },
+                                            ),
+                                            span: Span {
+                                                start: 38,
+                                                end: 44,
+                                            },
+                                        },
+                                        right: Expr {
+                                            kind: Int(
+                                                1,
+                                            ),
+                                            span: Span {
+                                                start: 47,
+                                                end: 48,
+                                            },
+                                        },
+                                    },
+                                    span: Span {
+                                        start: 38,
+                                        end: 48,
+                                    },
+                                },
+                                alias: Some(
+                                    Name {
+                                        value: "total",
+                                        quoted: false,
+                                        span: Span {
+                                            start: 52,
+                                            end: 57,
+                                        },
+                                    },
+                                ),
+                            },
+                        ],
+                        from: Some(
+                            Table {
+                                name: Name {
+                                    value: "sales",
+                                    quoted: false,
+                                    span: Span {
+                                        start: 63,
+                                        end: 68,
+                                    },
+                                },
+                                alias: None,
+                            },
+                        ),
+                        where_clause: Some(
+                            Expr {
+                                kind: Binary {
+                                    op: Gt,
+                                    left: Expr {
+                                        kind: Column(
+                                            Name {
+                                                value: "amount",
+                                                quoted: false,
+                                                span: Span {
+                                                    start: 75,
+                                                    end: 81,
+                                                },
+                                            },
+                                        ),
+                                        span: Span {
+                                            start: 75,
+                                            end: 81,
+                                        },
+                                    },
+                                    right: Expr {
+                                        kind: Int(
+                                            0,
+                                        ),
+                                        span: Span {
+                                            start: 84,
+                                            end: 85,
+                                        },
+                                    },
+                                },
+                                span: Span {
+                                    start: 75,
+                                    end: 85,
+                                },
+                            },
+                        ),
+                        group_by: [],
+                        having: None,
+                        order_by: [],
+                        span: Span {
+                            start: 27,
+                            end: 85,
+                        },
+                    },
+                    alias: Name {
+                        value: "s",
+                        quoted: false,
+                        span: Span {
+                            start: 87,
+                            end: 88,
+                        },
+                    },
+                },
+            ),
+            where_clause: Some(
+                Expr {
+                    kind: Binary {
+                        op: Lt,
+                        left: Expr {
+                            kind: Column(
+                                Name {
+                                    value: "s.id",
+                                    quoted: false,
+                                    span: Span {
+                                        start: 95,
+                                        end: 99,
+                                    },
+                                },
+                            ),
+                            span: Span {
+                                start: 95,
+                                end: 99,
+                            },
+                        },
+                        right: Expr {
+                            kind: Int(
+                                10,
+                            ),
+                            span: Span {
+                                start: 102,
+                                end: 104,
+                            },
+                        },
+                    },
+                    span: Span {
+                        start: 95,
+                        end: 104,
+                    },
+                },
+            ),
+            group_by: [],
+            having: None,
+            order_by: [
+                OrderItem {
+                    expr: Expr {
+                        kind: Column(
+                            Name {
+                                value: "s.id",
+                                quoted: false,
+                                span: Span {
+                                    start: 114,
+                                    end: 118,
+                                },
+                            },
+                        ),
+                        span: Span {
+                            start: 114,
+                            end: 118,
+                        },
+                    },
+                    descending: false,
+                },
+            ],
+            span: Span {
+                start: 0,
+                end: 118,
+            },
+        },
+    ),
+    Select(
+        Select {
+            top: None,
+            distinct: false,
+            items: [
+                Expr {
+                    expr: Expr {
+                        kind: Column(
+                            Name {
+                                value: "t.dept",
+                                quoted: false,
+                                span: Span {
+                                    start: 127,
+                                    end: 133,
+                                },
+                            },
+                        ),
+                        span: Span {
+                            start: 127,
+                            end: 133,
+                        },
+                    },
+                    alias: None,
+                },
+                Expr {
+                    expr: Expr {
+                        kind: Column(
+                            Name {
+                                value: "d.total",
+                                quoted: false,
+                                span: Span {
+                                    start: 135,
+                                    end: 142,
+                                },
+                            },
+                        ),
+                        span: Span {
+                            start: 135,
+                            end: 142,
+                        },
+                    },
+                    alias: None,
+                },
+            ],
+            from: Some(
+                Join {
+                    left: Table {
+                        name: Name {
+                            value: "sales",
+                            quoted: false,
+                            span: Span {
+                                start: 148,
+                                end: 153,
+                            },
+                        },
+                        alias: Some(
+                            Name {
+                                value: "t",
+                                quoted: false,
+                                span: Span {
+                                    start: 154,
+                                    end: 155,
+                                },
+                            },
+                        ),
+                    },
+                    right: Derived {
+                        subquery: Select {
+                            top: None,
+                            distinct: false,
+                            items: [
+                                Expr {
+                                    expr: Expr {
+                                        kind: Column(
+                                            Name {
+                                                value: "dept",
+                                                quoted: false,
+                                                span: Span {
+                                                    start: 169,
+                                                    end: 173,
+                                                },
+                                            },
+                                        ),
+                                        span: Span {
+                                            start: 169,
+                                            end: 173,
+                                        },
+                                    },
+                                    alias: None,
+                                },
+                                Expr {
+                                    expr: Expr {
+                                        kind: Aggregate {
+                                            func: Sum,
+                                            distinct: false,
+                                            arg: Some(
+                                                Expr {
+                                                    kind: Column(
+                                                        Name {
+                                                            value: "amount",
+                                                            quoted: false,
+                                                            span: Span {
+                                                                start: 179,
+                                                                end: 185,
+                                                            },
+                                                        },
+                                                    ),
+                                                    span: Span {
+                                                        start: 179,
+                                                        end: 185,
+                                                    },
+                                                },
+                                            ),
+                                        },
+                                        span: Span {
+                                            start: 175,
+                                            end: 186,
+                                        },
+                                    },
+                                    alias: Some(
+                                        Name {
+                                            value: "total",
+                                            quoted: false,
+                                            span: Span {
+                                                start: 190,
+                                                end: 195,
+                                            },
+                                        },
+                                    ),
+                                },
+                            ],
+                            from: Some(
+                                Table {
+                                    name: Name {
+                                        value: "sales",
+                                        quoted: false,
+                                        span: Span {
+                                            start: 201,
+                                            end: 206,
+                                        },
+                                    },
+                                    alias: None,
+                                },
+                            ),
+                            where_clause: None,
+                            group_by: [
+                                Expr {
+                                    kind: Column(
+                                        Name {
+                                            value: "dept",
+                                            quoted: false,
+                                            span: Span {
+                                                start: 216,
+                                                end: 220,
+                                            },
+                                        },
+                                    ),
+                                    span: Span {
+                                        start: 216,
+                                        end: 220,
+                                    },
+                                },
+                            ],
+                            having: None,
+                            order_by: [],
+                            span: Span {
+                                start: 162,
+                                end: 220,
+                            },
+                        },
+                        alias: Name {
+                            value: "d",
+                            quoted: false,
+                            span: Span {
+                                start: 222,
+                                end: 223,
+                            },
+                        },
+                    },
+                    kind: Inner,
+                    on: Some(
+                        Expr {
+                            kind: Binary {
+                                op: Eq,
+                                left: Expr {
+                                    kind: Column(
+                                        Name {
+                                            value: "t.dept",
+                                            quoted: false,
+                                            span: Span {
+                                                start: 227,
+                                                end: 233,
+                                            },
+                                        },
+                                    ),
+                                    span: Span {
+                                        start: 227,
+                                        end: 233,
+                                    },
+                                },
+                                right: Expr {
+                                    kind: Column(
+                                        Name {
+                                            value: "d.dept",
+                                            quoted: false,
+                                            span: Span {
+                                                start: 236,
+                                                end: 242,
+                                            },
+                                        },
+                                    ),
+                                    span: Span {
+                                        start: 236,
+                                        end: 242,
+                                    },
+                                },
+                            },
+                            span: Span {
+                                start: 227,
+                                end: 242,
+                            },
+                        },
+                    ),
+                },
+            ),
+            where_clause: None,
+            group_by: [],
+            having: None,
+            order_by: [],
+            span: Span {
+                start: 120,
+                end: 242,
+            },
+        },
+    ),
+]

--- a/crates/truthdb-sql/tests/corpus/ok/derived_tables.sql
+++ b/crates/truthdb-sql/tests/corpus/ok/derived_tables.sql
@@ -1,0 +1,2 @@
+SELECT s.id, s.total FROM (SELECT id, amount + 1 AS total FROM sales WHERE amount > 0) s WHERE s.id < 10 ORDER BY s.id;
+SELECT t.dept, d.total FROM sales t JOIN (SELECT dept, SUM(amount) AS total FROM sales GROUP BY dept) d ON t.dept = d.dept;


### PR DESCRIPTION
First slice of **Stage 11 (subqueries, views, variables)**: derived tables — `SELECT … FROM (SELECT …) AS alias`. Scalar/IN/EXISTS subqueries, CTEs, views, and variables follow in later parts.

## What's in
- **Parser** — a FROM primary starting with `(SELECT …)` is a derived table (alias **required**, else 102); any other `(` is a parenthesized table/join group. New `TableRef::Derived { subquery, alias }`.
- **Executor** — `build_derived_source` runs the subquery via `exec_select` and stamps every output column with the alias qualifier; column resolution reuses the existing `JoinScope` (`alias.col` / bare `col`). Rejects an unnamed derived column (**8155**) or a duplicate output name (**8156**). Works top-level and on either side of a JOIN; may aggregate/filter/order internally.
- **Locks / binding** — `analyze_locks` recurses into a derived subquery's FROM so its base tables are locked; a derived table's exposed name is its alias (duplicate exposed names still **1013**). Non-lateral: a derived subquery executes independently, so an outer-column reference errors as invalid (correlation is a later part).

## Adversarial review (4 dimensions × find→verify) — 2 findings
- **HIGH (fixed)** — the new `parse_table_primary` recursion (into `parse_select` / `parse_from`) had no depth guard, so a deeply nested `FROM ((( … )))` or nested derived tables **overflowed the stack and aborted the whole process** (uncatchable). Now bounded by the existing expression depth limit → clean error 191, with a regression test asserting no overflow.
- **LOW (documented, deferred)** — a derived character column loses its source collation (a `RowSet` carries none), so an outer `ORDER BY` sorts it under the database default rather than the base column's `COLLATE`. Narrow (non-default collations only); a proper fix needs collation threaded through the `project`/`RowSet` boundary.

## Tests
Engine tests (resolution, aggregate-derived, join-with-derived, 102/8155/8156), an slt matrix, a parser corpus case, and the deep-nesting overflow guard. `cargo fmt`, `clippy -D warnings`, `cargo test --workspace` all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)