### PR TITLE
Scalar / IN / EXISTS subqueries (uncorrelated) [Stage 11, part 2]

### DIFF
--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -2185,6 +2185,167 @@ mod tests {
     }
 
     #[test]
+    fn sql_scalar_in_exists_subqueries() {
+        let path = unique_temp_path("sql-subquery");
+        let mut engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE nums (id INT NOT NULL PRIMARY KEY, v INT)")
+            .expect("nums");
+        engine
+            .execute("INSERT INTO nums VALUES (1, 10), (2, 20), (3, 30)")
+            .expect("seed");
+        engine
+            .execute("CREATE TABLE picks (id INT NOT NULL PRIMARY KEY, target INT)")
+            .expect("picks");
+        engine
+            .execute("INSERT INTO picks VALUES (1, 2), (2, 3)")
+            .expect("seed2");
+
+        // Scalar subquery in WHERE.
+        let (_, rows) = sql_rows(
+            &mut engine,
+            "SELECT id FROM nums WHERE v = (SELECT MAX(v) FROM nums)",
+        );
+        assert_eq!(rows, vec![vec![Some("3".into())]]);
+
+        // Scalar subquery in the SELECT list (evaluated once).
+        let (cols, rows) = sql_rows(
+            &mut engine,
+            "SELECT id, (SELECT COUNT(*) FROM picks) AS pc FROM nums ORDER BY id",
+        );
+        assert_eq!(cols, vec!["id", "pc"]);
+        assert_eq!(
+            rows,
+            vec![
+                vec![Some("1".into()), Some("2".into())],
+                vec![Some("2".into()), Some("2".into())],
+                vec![Some("3".into()), Some("2".into())],
+            ]
+        );
+
+        // IN (SELECT) and NOT IN (SELECT).
+        let (_, rows) = sql_rows(
+            &mut engine,
+            "SELECT id FROM nums WHERE id IN (SELECT target FROM picks) ORDER BY id",
+        );
+        assert_eq!(rows, vec![vec![Some("2".into())], vec![Some("3".into())]]);
+        let (_, rows) = sql_rows(
+            &mut engine,
+            "SELECT id FROM nums WHERE id NOT IN (SELECT target FROM picks)",
+        );
+        assert_eq!(rows, vec![vec![Some("1".into())]]);
+
+        // EXISTS / NOT EXISTS (uncorrelated).
+        let (_, rows) = sql_rows(
+            &mut engine,
+            "SELECT id FROM nums WHERE EXISTS (SELECT 1 FROM picks WHERE target = 3) ORDER BY id",
+        );
+        assert_eq!(
+            rows,
+            vec![
+                vec![Some("1".into())],
+                vec![Some("2".into())],
+                vec![Some("3".into())],
+            ]
+        );
+        let (_, rows) = sql_rows(
+            &mut engine,
+            "SELECT id FROM nums WHERE NOT EXISTS (SELECT 1 FROM picks WHERE target = 99)",
+        );
+        assert_eq!(rows.len(), 3);
+
+        // A scalar subquery with no rows is NULL (so the `=` is unknown).
+        let (_, rows) = sql_rows(
+            &mut engine,
+            "SELECT id FROM nums WHERE v = (SELECT v FROM nums WHERE id = 99)",
+        );
+        assert!(rows.is_empty());
+
+        // More than one row from a scalar subquery is 512; more than one column
+        // is 116.
+        assert_eq!(
+            sql_error_number(
+                &mut engine,
+                "SELECT id FROM nums WHERE v = (SELECT v FROM nums)"
+            ),
+            512
+        );
+        assert_eq!(
+            sql_error_number(
+                &mut engine,
+                "SELECT id FROM nums WHERE v = (SELECT id, v FROM nums WHERE id = 1)",
+            ),
+            116
+        );
+        // A correlated subquery (references an outer column) is not yet
+        // supported; it errors as an invalid column rather than mis-resolving.
+        assert_eq!(
+            sql_error_number(
+                &mut engine,
+                "SELECT id FROM nums WHERE v = (SELECT target FROM picks WHERE picks.target = nums.id)",
+            ),
+            207
+        );
+
+        // `NOT IN (empty subquery)` is TRUE for every row, including a NULL
+        // outer value — the comparison set is empty, so nothing is unknown.
+        engine
+            .execute("INSERT INTO nums VALUES (4, NULL)")
+            .expect("null row");
+        let (_, rows) = sql_rows(
+            &mut engine,
+            "SELECT id FROM nums WHERE v NOT IN (SELECT target FROM picks WHERE target > 1000) ORDER BY id",
+        );
+        assert_eq!(
+            rows,
+            vec![
+                vec![Some("1".into())],
+                vec![Some("2".into())],
+                vec![Some("3".into())],
+                vec![Some("4".into())],
+            ]
+        );
+        // `IN (empty subquery)` is FALSE for every row (no rows returned).
+        let (_, rows) = sql_rows(
+            &mut engine,
+            "SELECT id FROM nums WHERE v IN (SELECT target FROM picks WHERE target > 1000)",
+        );
+        assert!(rows.is_empty());
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn subquery_locks_referenced_tables_shared() {
+        use crate::lock::{LockMode, Resource};
+        use crate::rel::Isolation;
+        let path = unique_temp_path("subquery-locks");
+        let mut engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE a (id INT NOT NULL PRIMARY KEY)")
+            .expect("a");
+        engine
+            .execute("CREATE TABLE b (id INT NOT NULL PRIMARY KEY)")
+            .expect("b");
+        let a = table_object_id(&mut engine, "a");
+        let b = table_object_id(&mut engine, "b");
+        // A subquery over `b` inside `a`'s WHERE reads `b`, so it must take a
+        // Shared lock on `b` (else it could read `b`'s uncommitted rows).
+        let locks = engine.analyze_locks(
+            "SELECT id FROM a WHERE id IN (SELECT id FROM b)",
+            Isolation::ReadCommitted,
+        );
+        assert!(
+            locks.contains(&(Resource::Table(a), LockMode::Shared)),
+            "a Shared: {locks:?}"
+        );
+        assert!(
+            locks.contains(&(Resource::Table(b), LockMode::Shared)),
+            "b Shared (subquery): {locks:?}"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
     fn sql_derived_tables() {
         let path = unique_temp_path("sql-derived");
         let mut engine = new_engine(&path);

--- a/crates/truthdb-core/src/rel/aggregate.rs
+++ b/crates/truthdb-core/src/rel/aggregate.rs
@@ -319,7 +319,13 @@ fn rewrite(expr: &Expr, group_by: &[Expr], aggs: &mut Vec<AggSpec>) -> Result<Ex
         | ExprKind::Number(_)
         | ExprKind::Str(_)
         | ExprKind::Bool(_)
+        | ExprKind::Literal(_)
         | ExprKind::GlobalVar(_) => expr.kind.clone(),
+        // Subqueries are rewritten to literals before aggregation runs; clone
+        // defensively (evaluation would reject any that slipped through).
+        ExprKind::Subquery(_) | ExprKind::Exists(_) | ExprKind::InSubquery { .. } => {
+            expr.kind.clone()
+        }
         ExprKind::Unary { op, expr: inner } => ExprKind::Unary {
             op: *op,
             expr: Box::new(rewrite(inner, group_by, aggs)?),

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -220,17 +220,17 @@ pub fn analyze_locks(
                 if !reads_lock {
                     continue;
                 }
-                if let Some(from) = &select.from {
-                    let mut tables = Vec::new();
-                    collect_table_names(from, &mut tables);
-                    for name in tables {
-                        if name.value.to_ascii_lowercase().starts_with("sys.") {
-                            continue; // catalog view: unlocked
-                        }
-                        if let Some(def) = resolve_table(storage, &name.value) {
-                            add(Resource::Database, LockMode::IntentShared);
-                            add(Resource::Table(def.object_id), LockMode::Shared);
-                        }
+                // Lock every base table the query reads — the FROM clause AND
+                // any subqueries in its expressions (WHERE/SELECT/HAVING/...).
+                let mut tables = Vec::new();
+                collect_locked_tables(select, &mut tables);
+                for name in tables {
+                    if name.value.to_ascii_lowercase().starts_with("sys.") {
+                        continue; // catalog view: unlocked
+                    }
+                    if let Some(def) = resolve_table(storage, &name.value) {
+                        add(Resource::Database, LockMode::IntentShared);
+                        add(Resource::Table(def.object_id), LockMode::Shared);
                     }
                 }
             }
@@ -244,15 +244,13 @@ pub fn analyze_locks(
                         add(Resource::Table(oid), LockMode::Shared);
                     }
                 }
-                // INSERT ... SELECT also reads its source tables; lock them
-                // like a SELECT so it cannot read another txn's uncommitted
-                // rows (they combine to SIX on the target if it is a source).
-                if reads_lock
-                    && let InsertSource::Select(select) = &insert.source
-                    && let Some(from) = &select.from
-                {
+                // INSERT ... SELECT also reads its source tables (and any
+                // subqueries in the SELECT); lock them like a SELECT so it
+                // cannot read another txn's uncommitted rows (they combine to
+                // SIX on the target if it is a source).
+                if reads_lock && let InsertSource::Select(select) = &insert.source {
                     let mut tables = Vec::new();
-                    collect_table_names(from, &mut tables);
+                    collect_locked_tables(select, &mut tables);
                     for name in tables {
                         if name.value.to_ascii_lowercase().starts_with("sys.") {
                             continue;
@@ -1035,7 +1033,17 @@ fn validate_check_columns(expr: &Expr, columns: &[Column]) -> Result<(), SqlErro
         | ExprKind::Number(_)
         | ExprKind::Str(_)
         | ExprKind::Bool(_)
+        | ExprKind::Literal(_)
         | ExprKind::GlobalVar(_) => Ok(()),
+        // Subqueries are not allowed in a CHECK constraint (SQL Server 1046).
+        ExprKind::Subquery(_) | ExprKind::Exists(_) | ExprKind::InSubquery { .. } => {
+            Err(SqlError::new(
+                1046,
+                15,
+                1,
+                "Subqueries are not allowed in this context. Only scalar expressions are allowed.",
+            ))
+        }
     }
 }
 
@@ -2136,11 +2144,267 @@ fn row_values(row: &[Datum], types: &[ColumnType]) -> Vec<SqlValue> {
         .collect()
 }
 
+// ---- subquery resolution ------------------------------------------------
+
+/// Returns a copy of a SELECT with every subquery in its expressions
+/// (WHERE/HAVING/SELECT list/GROUP BY/ORDER BY) evaluated and replaced by a
+/// precomputed literal. Subqueries in a FROM-clause join `ON` are not rewritten
+/// here (they are rare and error at evaluation). Only uncorrelated subqueries
+/// are supported; a correlated one references an outer column and fails to
+/// resolve when executed independently.
+fn rewrite_select_subqueries(
+    storage: &mut Storage,
+    select: &Select,
+    eval_ctx: &EvalContext,
+) -> Result<Select, SqlError> {
+    let items = select
+        .items
+        .iter()
+        .map(|item| match item {
+            SelectItem::Expr { expr, alias } => Ok(SelectItem::Expr {
+                expr: rewrite_subqueries(storage, expr, eval_ctx)?,
+                alias: alias.clone(),
+            }),
+            other => Ok(other.clone()),
+        })
+        .collect::<Result<Vec<_>, SqlError>>()?;
+    let rewrite_opt = |storage: &mut Storage, e: &Option<Expr>| -> Result<Option<Expr>, SqlError> {
+        e.as_ref()
+            .map(|e| rewrite_subqueries(storage, e, eval_ctx))
+            .transpose()
+    };
+    let where_clause = rewrite_opt(storage, &select.where_clause)?;
+    let having = rewrite_opt(storage, &select.having)?;
+    let group_by = select
+        .group_by
+        .iter()
+        .map(|e| rewrite_subqueries(storage, e, eval_ctx))
+        .collect::<Result<Vec<_>, SqlError>>()?;
+    let order_by = select
+        .order_by
+        .iter()
+        .map(|o| {
+            Ok(OrderItem {
+                expr: rewrite_subqueries(storage, &o.expr, eval_ctx)?,
+                descending: o.descending,
+            })
+        })
+        .collect::<Result<Vec<_>, SqlError>>()?;
+    Ok(Select {
+        top: select.top,
+        distinct: select.distinct,
+        items,
+        from: select.from.clone(),
+        where_clause,
+        group_by,
+        having,
+        order_by,
+        span: select.span,
+    })
+}
+
+/// Recursively replaces each subquery node in an expression with its evaluated
+/// result: a scalar `(SELECT ...)` -> a literal, `EXISTS (...)` -> a boolean,
+/// `expr IN (SELECT ...)` -> an `InList` of the subquery's values.
+fn rewrite_subqueries(
+    storage: &mut Storage,
+    expr: &Expr,
+    eval_ctx: &EvalContext,
+) -> Result<Expr, SqlError> {
+    let recur = |storage: &mut Storage, e: &Expr| rewrite_subqueries(storage, e, eval_ctx);
+    let recur_box = |storage: &mut Storage, e: &Expr| -> Result<Box<Expr>, SqlError> {
+        Ok(Box::new(recur(storage, e)?))
+    };
+    let recur_opt =
+        |storage: &mut Storage, e: &Option<Box<Expr>>| -> Result<Option<Box<Expr>>, SqlError> {
+            e.as_ref().map(|e| recur_box(storage, e)).transpose()
+        };
+    let kind = match &expr.kind {
+        ExprKind::Subquery(select) => {
+            ExprKind::Literal(eval_scalar_subquery(storage, select, eval_ctx)?)
+        }
+        ExprKind::Exists(select) => {
+            let rowset = exec_select(storage, select, eval_ctx)?;
+            ExprKind::Bool(!rowset.rows.is_empty())
+        }
+        ExprKind::InSubquery {
+            expr: lhs,
+            subquery,
+            negated,
+        } => {
+            let lhs = recur_box(storage, lhs)?;
+            let list = eval_in_subquery(storage, subquery, eval_ctx)?
+                .into_iter()
+                .map(|v| Expr {
+                    kind: ExprKind::Literal(v),
+                    span: expr.span,
+                })
+                .collect();
+            ExprKind::InList {
+                expr: lhs,
+                list,
+                negated: *negated,
+            }
+        }
+        ExprKind::Unary { op, expr: e } => ExprKind::Unary {
+            op: *op,
+            expr: recur_box(storage, e)?,
+        },
+        ExprKind::Binary { op, left, right } => ExprKind::Binary {
+            op: *op,
+            left: recur_box(storage, left)?,
+            right: recur_box(storage, right)?,
+        },
+        ExprKind::IsNull { expr: e, negated } => ExprKind::IsNull {
+            expr: recur_box(storage, e)?,
+            negated: *negated,
+        },
+        ExprKind::Like {
+            expr: e,
+            pattern,
+            escape,
+            negated,
+        } => ExprKind::Like {
+            expr: recur_box(storage, e)?,
+            pattern: recur_box(storage, pattern)?,
+            escape: *escape,
+            negated: *negated,
+        },
+        ExprKind::InList {
+            expr: e,
+            list,
+            negated,
+        } => ExprKind::InList {
+            expr: recur_box(storage, e)?,
+            list: list
+                .iter()
+                .map(|x| recur(storage, x))
+                .collect::<Result<_, _>>()?,
+            negated: *negated,
+        },
+        ExprKind::Between {
+            expr: e,
+            low,
+            high,
+            negated,
+        } => ExprKind::Between {
+            expr: recur_box(storage, e)?,
+            low: recur_box(storage, low)?,
+            high: recur_box(storage, high)?,
+            negated: *negated,
+        },
+        ExprKind::Case {
+            operand,
+            branches,
+            else_result,
+        } => ExprKind::Case {
+            operand: recur_opt(storage, operand)?,
+            branches: branches
+                .iter()
+                .map(|(w, r)| Ok((recur(storage, w)?, recur(storage, r)?)))
+                .collect::<Result<_, SqlError>>()?,
+            else_result: recur_opt(storage, else_result)?,
+        },
+        ExprKind::Cast { expr: e, target } => ExprKind::Cast {
+            expr: recur_box(storage, e)?,
+            target: target.clone(),
+        },
+        ExprKind::Function { name, args } => ExprKind::Function {
+            name: name.clone(),
+            args: args
+                .iter()
+                .map(|a| recur(storage, a))
+                .collect::<Result<_, _>>()?,
+        },
+        ExprKind::Aggregate {
+            func,
+            distinct,
+            arg,
+        } => ExprKind::Aggregate {
+            func: *func,
+            distinct: *distinct,
+            arg: recur_opt(storage, arg)?,
+        },
+        ExprKind::Null
+        | ExprKind::Int(_)
+        | ExprKind::Number(_)
+        | ExprKind::Str(_)
+        | ExprKind::Bool(_)
+        | ExprKind::Literal(_)
+        | ExprKind::Column(_)
+        | ExprKind::GlobalVar(_) => expr.kind.clone(),
+    };
+    Ok(Expr {
+        kind,
+        span: expr.span,
+    })
+}
+
+/// Evaluates a scalar subquery to a single value: NULL for 0 rows, the value
+/// for 1 row, error 512 for more than 1 row; error 116 if it is not exactly one
+/// column wide.
+fn eval_scalar_subquery(
+    storage: &mut Storage,
+    select: &Select,
+    eval_ctx: &EvalContext,
+) -> Result<SqlValue, SqlError> {
+    let rowset = exec_select(storage, select, eval_ctx)?;
+    if rowset.columns.len() != 1 {
+        return Err(scalar_subquery_shape_err());
+    }
+    match rowset.rows.len() {
+        0 => Ok(SqlValue::Null),
+        1 => Ok(value::datum_to_sql(
+            &rowset.rows[0][0],
+            &rowset.columns[0].column_type,
+        )),
+        _ => Err(SqlError::new(
+            512,
+            16,
+            1,
+            "Subquery returned more than 1 value. This is not permitted when the subquery follows =, !=, <, <=, >, >= or when the subquery is used as an expression.",
+        )),
+    }
+}
+
+/// Evaluates an `IN (SELECT ...)` subquery to its list of values (one column,
+/// else error 116).
+fn eval_in_subquery(
+    storage: &mut Storage,
+    select: &Select,
+    eval_ctx: &EvalContext,
+) -> Result<Vec<SqlValue>, SqlError> {
+    let rowset = exec_select(storage, select, eval_ctx)?;
+    if rowset.columns.len() != 1 {
+        return Err(scalar_subquery_shape_err());
+    }
+    let column_type = rowset.columns[0].column_type;
+    Ok(rowset
+        .rows
+        .iter()
+        .map(|r| value::datum_to_sql(&r[0], &column_type))
+        .collect())
+}
+
+fn scalar_subquery_shape_err() -> SqlError {
+    SqlError::new(
+        116,
+        16,
+        1,
+        "Only one expression can be specified in the select list when the subquery is not introduced with EXISTS.",
+    )
+}
+
 fn exec_select(
     storage: &mut Storage,
     select: &Select,
     eval_ctx: &EvalContext,
 ) -> Result<RowSet, SqlError> {
+    // Resolve each (uncorrelated) subquery once, up front, replacing it with a
+    // literal / boolean / value-list so the rest of execution is subquery-free.
+    let rewritten = rewrite_select_subqueries(storage, select, eval_ctx)?;
+    let select = &rewritten;
+
     let source = build_source(
         storage,
         select.from.as_ref(),
@@ -2488,7 +2752,8 @@ fn bare_column_index(expr: &Expr, scope: &JoinScope) -> Option<usize> {
 }
 
 /// Collects every base-table name referenced in a FROM join tree, recursing
-/// into derived-table subqueries so their tables are locked too.
+/// into derived-table subqueries so their tables are locked too. (Used for the
+/// SHOWPLAN table list; [`collect_locked_tables`] is the lock-set collector.)
 fn collect_table_names<'a>(tref: &'a TableRef, out: &mut Vec<&'a Name>) {
     match tref {
         TableRef::Table { name, .. } => out.push(name),
@@ -2501,6 +2766,111 @@ fn collect_table_names<'a>(tref: &'a TableRef, out: &mut Vec<&'a Name>) {
                 collect_table_names(from, out);
             }
         }
+    }
+}
+
+/// Collects every base table a SELECT reads for the lock set: its FROM tree
+/// (including derived-table subqueries and join `ON` clauses) plus every
+/// subquery embedded in its expressions (WHERE/SELECT list/HAVING/GROUP BY/
+/// ORDER BY). Recurses through nested subqueries.
+fn collect_locked_tables<'a>(select: &'a Select, out: &mut Vec<&'a Name>) {
+    if let Some(from) = &select.from {
+        collect_from_tables(from, out);
+    }
+    for item in &select.items {
+        if let SelectItem::Expr { expr, .. } = item {
+            collect_expr_tables(expr, out);
+        }
+    }
+    for expr in select.where_clause.iter().chain(select.having.iter()) {
+        collect_expr_tables(expr, out);
+    }
+    for expr in &select.group_by {
+        collect_expr_tables(expr, out);
+    }
+    for item in &select.order_by {
+        collect_expr_tables(&item.expr, out);
+    }
+}
+
+/// Collects base tables from a FROM tree, recursing into derived subqueries and
+/// join `ON` predicates (which may contain their own subqueries).
+fn collect_from_tables<'a>(tref: &'a TableRef, out: &mut Vec<&'a Name>) {
+    match tref {
+        TableRef::Table { name, .. } => out.push(name),
+        TableRef::Join {
+            left, right, on, ..
+        } => {
+            collect_from_tables(left, out);
+            collect_from_tables(right, out);
+            if let Some(on) = on {
+                collect_expr_tables(on, out);
+            }
+        }
+        TableRef::Derived { subquery, .. } => collect_locked_tables(subquery, out),
+    }
+}
+
+/// Collects base tables from every subquery embedded in an expression.
+fn collect_expr_tables<'a>(expr: &'a Expr, out: &mut Vec<&'a Name>) {
+    match &expr.kind {
+        ExprKind::Subquery(select) | ExprKind::Exists(select) => collect_locked_tables(select, out),
+        ExprKind::InSubquery { expr, subquery, .. } => {
+            collect_expr_tables(expr, out);
+            collect_locked_tables(subquery, out);
+        }
+        ExprKind::Unary { expr, .. }
+        | ExprKind::IsNull { expr, .. }
+        | ExprKind::Cast { expr, .. } => collect_expr_tables(expr, out),
+        ExprKind::Binary { left, right, .. } => {
+            collect_expr_tables(left, out);
+            collect_expr_tables(right, out);
+        }
+        ExprKind::Like { expr, pattern, .. } => {
+            collect_expr_tables(expr, out);
+            collect_expr_tables(pattern, out);
+        }
+        ExprKind::InList { expr, list, .. } => {
+            collect_expr_tables(expr, out);
+            list.iter().for_each(|e| collect_expr_tables(e, out));
+        }
+        ExprKind::Between {
+            expr, low, high, ..
+        } => {
+            collect_expr_tables(expr, out);
+            collect_expr_tables(low, out);
+            collect_expr_tables(high, out);
+        }
+        ExprKind::Case {
+            operand,
+            branches,
+            else_result,
+        } => {
+            if let Some(o) = operand {
+                collect_expr_tables(o, out);
+            }
+            for (when, then) in branches {
+                collect_expr_tables(when, out);
+                collect_expr_tables(then, out);
+            }
+            if let Some(e) = else_result {
+                collect_expr_tables(e, out);
+            }
+        }
+        ExprKind::Function { args, .. } => args.iter().for_each(|a| collect_expr_tables(a, out)),
+        ExprKind::Aggregate { arg, .. } => {
+            if let Some(a) = arg {
+                collect_expr_tables(a, out);
+            }
+        }
+        ExprKind::Null
+        | ExprKind::Int(_)
+        | ExprKind::Number(_)
+        | ExprKind::Str(_)
+        | ExprKind::Bool(_)
+        | ExprKind::Literal(_)
+        | ExprKind::Column(_)
+        | ExprKind::GlobalVar(_) => {}
     }
 }
 

--- a/crates/truthdb-core/tests/slt/subqueries.slt
+++ b/crates/truthdb-core/tests/slt/subqueries.slt
@@ -1,0 +1,52 @@
+# Scalar / IN / EXISTS subqueries (Stage 11 part 2, uncorrelated)
+
+statement ok
+CREATE TABLE nums (id INT NOT NULL PRIMARY KEY, v INT)
+
+statement ok
+INSERT INTO nums VALUES (1, 10), (2, 20), (3, 30)
+
+statement ok
+CREATE TABLE picks (id INT NOT NULL PRIMARY KEY, target INT)
+
+statement ok
+INSERT INTO picks VALUES (1, 2), (2, 3)
+
+# Scalar subquery in WHERE.
+query I
+SELECT id FROM nums WHERE v = (SELECT MAX(v) FROM nums)
+----
+3
+
+# Scalar subquery in the SELECT list (evaluated once, same for every row).
+query II
+SELECT id, (SELECT COUNT(*) FROM picks) AS pc FROM nums ORDER BY id
+----
+1 2
+2 2
+3 2
+
+# IN (SELECT).
+query I
+SELECT id FROM nums WHERE id IN (SELECT target FROM picks) ORDER BY id
+----
+2
+3
+
+# NOT IN (SELECT).
+query I
+SELECT id FROM nums WHERE id NOT IN (SELECT target FROM picks)
+----
+1
+
+# EXISTS (uncorrelated true) keeps all rows.
+query I
+SELECT id FROM nums WHERE EXISTS (SELECT 1 FROM picks WHERE target = 3) ORDER BY id
+----
+1
+2
+3
+
+# A scalar subquery returning more than one row is an error.
+statement error
+SELECT id FROM nums WHERE v = (SELECT v FROM nums)

--- a/crates/truthdb-sql/src/ast.rs
+++ b/crates/truthdb-sql/src/ast.rs
@@ -382,6 +382,22 @@ pub enum ExprKind {
     /// A `@@`-prefixed global/session variable (e.g. `@@TRANCOUNT`), evaluated
     /// from the session's [`EvalContext`](crate::eval::EvalContext).
     GlobalVar(String),
+    /// A precomputed value. Not produced by the parser — the executor rewrites
+    /// each evaluated subquery to a `Literal` so scalar evaluation stays free of
+    /// storage access.
+    Literal(crate::value::SqlValue),
+    /// A scalar subquery `(SELECT ...)`. Rewritten to a [`Literal`] (its single
+    /// value; 512 if it returns more than one row) before evaluation.
+    Subquery(Box<Select>),
+    /// `EXISTS (SELECT ...)`. Rewritten to a boolean before evaluation.
+    Exists(Box<Select>),
+    /// `expr [NOT] IN (SELECT ...)`. Rewritten to an [`InList`] of the
+    /// subquery's values before evaluation.
+    InSubquery {
+        expr: Box<Expr>,
+        subquery: Box<Select>,
+        negated: bool,
+    },
 }
 
 /// The five standard aggregate functions.

--- a/crates/truthdb-sql/src/eval.rs
+++ b/crates/truthdb-sql/src/eval.rs
@@ -74,6 +74,14 @@ fn eval_at(
         ExprKind::Number(text) => eval_number_literal(text),
         ExprKind::Str(s) => Ok(SqlValue::Str(s.clone())),
         ExprKind::Bool(b) => Ok(SqlValue::Bool(*b)),
+        // A precomputed value (a rewritten subquery).
+        ExprKind::Literal(value) => Ok(value.clone()),
+        // Subqueries must be rewritten to literals by the executor before
+        // evaluation; reaching here means one appeared in an unsupported
+        // context (e.g. a join ON clause).
+        ExprKind::Subquery(_) | ExprKind::Exists(_) | ExprKind::InSubquery { .. } => Err(
+            SqlError::message_only(1015, "A subquery is not supported in this context."),
+        ),
         ExprKind::Column(name) => eval_column(name, row, resolver),
         ExprKind::GlobalVar(name) => eval_global_var(name, ctx),
         ExprKind::Unary { op, expr: inner } => {
@@ -223,6 +231,13 @@ fn eval_in_expr<R: ColumnResolver>(
     ctx: &EvalContext,
     depth: usize,
 ) -> SqlResult<SqlValue> {
+    // An empty list is definite regardless of the operand: `x IN ()` is FALSE
+    // and `x NOT IN ()` is TRUE, even when `x` is NULL (the comparison set is
+    // empty, so there is nothing unknown). Only reachable via an IN-subquery
+    // that returned no rows — a written value list always has at least one item.
+    if list.is_empty() {
+        return Ok(SqlValue::Bool(negated));
+    }
     let value = eval_at(expr, row, resolver, ctx, depth + 1)?;
     if value.is_null() {
         return Ok(SqlValue::Null);

--- a/crates/truthdb-sql/src/parser.rs
+++ b/crates/truthdb-sql/src/parser.rs
@@ -1314,6 +1314,20 @@ impl Parser {
     fn parse_in(&mut self, left: Expr, negated: bool) -> SqlResult<Expr> {
         self.bump(); // IN
         self.expect(&TokenKind::LParen)?;
+        // `expr IN (SELECT ...)` is a subquery; otherwise a value list.
+        if self.peek_keyword().as_deref() == Some("SELECT") {
+            let subquery = self.parse_select()?;
+            let end = self.expect(&TokenKind::RParen)?;
+            self.node()?;
+            return Ok(Expr {
+                span: left.span.to(end),
+                kind: ExprKind::InSubquery {
+                    expr: Box::new(left),
+                    subquery: Box::new(subquery),
+                    negated,
+                },
+            });
+        }
         let mut list = Vec::new();
         loop {
             list.push(self.parse_expr()?);
@@ -1592,10 +1606,21 @@ impl Parser {
                 })
             }
             TokenKind::LParen => {
-                self.bump();
-                let inner = self.parse_expr()?;
-                self.expect(&TokenKind::RParen)?;
-                Ok(inner)
+                // `(SELECT ...)` is a scalar subquery; otherwise a grouping paren.
+                if self.peek_keyword_at(1).as_deref() == Some("SELECT") {
+                    let start = self.bump().span; // (
+                    let subquery = self.parse_select()?;
+                    let end = self.expect(&TokenKind::RParen)?;
+                    Ok(Expr {
+                        kind: ExprKind::Subquery(Box::new(subquery)),
+                        span: start.to(end),
+                    })
+                } else {
+                    self.bump();
+                    let inner = self.parse_expr()?;
+                    self.expect(&TokenKind::RParen)?;
+                    Ok(inner)
+                }
             }
             TokenKind::Word { quoted, .. } => {
                 let keyword = token.keyword();
@@ -1624,6 +1649,17 @@ impl Parser {
                     Some("CASE") if !quoted => self.parse_case(),
                     Some("CAST") if !quoted => self.parse_cast(),
                     Some("CONVERT") if !quoted => self.parse_convert(),
+                    Some("EXISTS") if !quoted => {
+                        // `EXISTS (SELECT ...)`; `NOT EXISTS` is parse_not over this.
+                        let start = self.bump().span;
+                        self.expect(&TokenKind::LParen)?;
+                        let subquery = self.parse_select()?;
+                        let end = self.expect(&TokenKind::RParen)?;
+                        Ok(Expr {
+                            kind: ExprKind::Exists(Box::new(subquery)),
+                            span: start.to(end),
+                        })
+                    }
                     Some(kw) if !quoted && is_reserved(kw) => {
                         Err(SqlError::syntax(self.token_text(&token), token.span))
                     }

--- a/crates/truthdb-sql/tests/corpus/ok/subqueries.ast
+++ b/crates/truthdb-sql/tests/corpus/ok/subqueries.ast
@@ -1,0 +1,534 @@
+[
+    Select(
+        Select {
+            top: None,
+            distinct: false,
+            items: [
+                Expr {
+                    expr: Expr {
+                        kind: Column(
+                            Name {
+                                value: "id",
+                                quoted: false,
+                                span: Span {
+                                    start: 7,
+                                    end: 9,
+                                },
+                            },
+                        ),
+                        span: Span {
+                            start: 7,
+                            end: 9,
+                        },
+                    },
+                    alias: None,
+                },
+            ],
+            from: Some(
+                Table {
+                    name: Name {
+                        value: "nums",
+                        quoted: false,
+                        span: Span {
+                            start: 15,
+                            end: 19,
+                        },
+                    },
+                    alias: None,
+                },
+            ),
+            where_clause: Some(
+                Expr {
+                    kind: Binary {
+                        op: Eq,
+                        left: Expr {
+                            kind: Column(
+                                Name {
+                                    value: "v",
+                                    quoted: false,
+                                    span: Span {
+                                        start: 26,
+                                        end: 27,
+                                    },
+                                },
+                            ),
+                            span: Span {
+                                start: 26,
+                                end: 27,
+                            },
+                        },
+                        right: Expr {
+                            kind: Subquery(
+                                Select {
+                                    top: None,
+                                    distinct: false,
+                                    items: [
+                                        Expr {
+                                            expr: Expr {
+                                                kind: Aggregate {
+                                                    func: Max,
+                                                    distinct: false,
+                                                    arg: Some(
+                                                        Expr {
+                                                            kind: Column(
+                                                                Name {
+                                                                    value: "v",
+                                                                    quoted: false,
+                                                                    span: Span {
+                                                                        start: 42,
+                                                                        end: 43,
+                                                                    },
+                                                                },
+                                                            ),
+                                                            span: Span {
+                                                                start: 42,
+                                                                end: 43,
+                                                            },
+                                                        },
+                                                    ),
+                                                },
+                                                span: Span {
+                                                    start: 38,
+                                                    end: 44,
+                                                },
+                                            },
+                                            alias: None,
+                                        },
+                                    ],
+                                    from: Some(
+                                        Table {
+                                            name: Name {
+                                                value: "nums",
+                                                quoted: false,
+                                                span: Span {
+                                                    start: 50,
+                                                    end: 54,
+                                                },
+                                            },
+                                            alias: None,
+                                        },
+                                    ),
+                                    where_clause: None,
+                                    group_by: [],
+                                    having: None,
+                                    order_by: [],
+                                    span: Span {
+                                        start: 31,
+                                        end: 54,
+                                    },
+                                },
+                            ),
+                            span: Span {
+                                start: 30,
+                                end: 55,
+                            },
+                        },
+                    },
+                    span: Span {
+                        start: 26,
+                        end: 55,
+                    },
+                },
+            ),
+            group_by: [],
+            having: None,
+            order_by: [],
+            span: Span {
+                start: 0,
+                end: 55,
+            },
+        },
+    ),
+    Select(
+        Select {
+            top: None,
+            distinct: false,
+            items: [
+                Expr {
+                    expr: Expr {
+                        kind: Column(
+                            Name {
+                                value: "id",
+                                quoted: false,
+                                span: Span {
+                                    start: 64,
+                                    end: 66,
+                                },
+                            },
+                        ),
+                        span: Span {
+                            start: 64,
+                            end: 66,
+                        },
+                    },
+                    alias: None,
+                },
+                Expr {
+                    expr: Expr {
+                        kind: Subquery(
+                            Select {
+                                top: None,
+                                distinct: false,
+                                items: [
+                                    Expr {
+                                        expr: Expr {
+                                            kind: Aggregate {
+                                                func: Count,
+                                                distinct: false,
+                                                arg: None,
+                                            },
+                                            span: Span {
+                                                start: 76,
+                                                end: 84,
+                                            },
+                                        },
+                                        alias: None,
+                                    },
+                                ],
+                                from: Some(
+                                    Table {
+                                        name: Name {
+                                            value: "picks",
+                                            quoted: false,
+                                            span: Span {
+                                                start: 90,
+                                                end: 95,
+                                            },
+                                        },
+                                        alias: None,
+                                    },
+                                ),
+                                where_clause: None,
+                                group_by: [],
+                                having: None,
+                                order_by: [],
+                                span: Span {
+                                    start: 69,
+                                    end: 95,
+                                },
+                            },
+                        ),
+                        span: Span {
+                            start: 68,
+                            end: 96,
+                        },
+                    },
+                    alias: Some(
+                        Name {
+                            value: "pc",
+                            quoted: false,
+                            span: Span {
+                                start: 100,
+                                end: 102,
+                            },
+                        },
+                    ),
+                },
+            ],
+            from: Some(
+                Table {
+                    name: Name {
+                        value: "nums",
+                        quoted: false,
+                        span: Span {
+                            start: 108,
+                            end: 112,
+                        },
+                    },
+                    alias: None,
+                },
+            ),
+            where_clause: Some(
+                Expr {
+                    kind: Binary {
+                        op: And,
+                        left: Expr {
+                            kind: InSubquery {
+                                expr: Expr {
+                                    kind: Column(
+                                        Name {
+                                            value: "id",
+                                            quoted: false,
+                                            span: Span {
+                                                start: 119,
+                                                end: 121,
+                                            },
+                                        },
+                                    ),
+                                    span: Span {
+                                        start: 119,
+                                        end: 121,
+                                    },
+                                },
+                                subquery: Select {
+                                    top: None,
+                                    distinct: false,
+                                    items: [
+                                        Expr {
+                                            expr: Expr {
+                                                kind: Column(
+                                                    Name {
+                                                        value: "target",
+                                                        quoted: false,
+                                                        span: Span {
+                                                            start: 133,
+                                                            end: 139,
+                                                        },
+                                                    },
+                                                ),
+                                                span: Span {
+                                                    start: 133,
+                                                    end: 139,
+                                                },
+                                            },
+                                            alias: None,
+                                        },
+                                    ],
+                                    from: Some(
+                                        Table {
+                                            name: Name {
+                                                value: "picks",
+                                                quoted: false,
+                                                span: Span {
+                                                    start: 145,
+                                                    end: 150,
+                                                },
+                                            },
+                                            alias: None,
+                                        },
+                                    ),
+                                    where_clause: None,
+                                    group_by: [],
+                                    having: None,
+                                    order_by: [],
+                                    span: Span {
+                                        start: 126,
+                                        end: 150,
+                                    },
+                                },
+                                negated: false,
+                            },
+                            span: Span {
+                                start: 119,
+                                end: 151,
+                            },
+                        },
+                        right: Expr {
+                            kind: Exists(
+                                Select {
+                                    top: None,
+                                    distinct: false,
+                                    items: [
+                                        Expr {
+                                            expr: Expr {
+                                                kind: Int(
+                                                    1,
+                                                ),
+                                                span: Span {
+                                                    start: 171,
+                                                    end: 172,
+                                                },
+                                            },
+                                            alias: None,
+                                        },
+                                    ],
+                                    from: Some(
+                                        Table {
+                                            name: Name {
+                                                value: "picks",
+                                                quoted: false,
+                                                span: Span {
+                                                    start: 178,
+                                                    end: 183,
+                                                },
+                                            },
+                                            alias: None,
+                                        },
+                                    ),
+                                    where_clause: None,
+                                    group_by: [],
+                                    having: None,
+                                    order_by: [],
+                                    span: Span {
+                                        start: 164,
+                                        end: 183,
+                                    },
+                                },
+                            ),
+                            span: Span {
+                                start: 156,
+                                end: 184,
+                            },
+                        },
+                    },
+                    span: Span {
+                        start: 119,
+                        end: 184,
+                    },
+                },
+            ),
+            group_by: [],
+            having: None,
+            order_by: [],
+            span: Span {
+                start: 57,
+                end: 184,
+            },
+        },
+    ),
+    Select(
+        Select {
+            top: None,
+            distinct: false,
+            items: [
+                Expr {
+                    expr: Expr {
+                        kind: Column(
+                            Name {
+                                value: "id",
+                                quoted: false,
+                                span: Span {
+                                    start: 193,
+                                    end: 195,
+                                },
+                            },
+                        ),
+                        span: Span {
+                            start: 193,
+                            end: 195,
+                        },
+                    },
+                    alias: None,
+                },
+            ],
+            from: Some(
+                Table {
+                    name: Name {
+                        value: "nums",
+                        quoted: false,
+                        span: Span {
+                            start: 201,
+                            end: 205,
+                        },
+                    },
+                    alias: None,
+                },
+            ),
+            where_clause: Some(
+                Expr {
+                    kind: InSubquery {
+                        expr: Expr {
+                            kind: Column(
+                                Name {
+                                    value: "id",
+                                    quoted: false,
+                                    span: Span {
+                                        start: 212,
+                                        end: 214,
+                                    },
+                                },
+                            ),
+                            span: Span {
+                                start: 212,
+                                end: 214,
+                            },
+                        },
+                        subquery: Select {
+                            top: None,
+                            distinct: false,
+                            items: [
+                                Expr {
+                                    expr: Expr {
+                                        kind: Column(
+                                            Name {
+                                                value: "target",
+                                                quoted: false,
+                                                span: Span {
+                                                    start: 230,
+                                                    end: 236,
+                                                },
+                                            },
+                                        ),
+                                        span: Span {
+                                            start: 230,
+                                            end: 236,
+                                        },
+                                    },
+                                    alias: None,
+                                },
+                            ],
+                            from: Some(
+                                Table {
+                                    name: Name {
+                                        value: "picks",
+                                        quoted: false,
+                                        span: Span {
+                                            start: 242,
+                                            end: 247,
+                                        },
+                                    },
+                                    alias: None,
+                                },
+                            ),
+                            where_clause: Some(
+                                Expr {
+                                    kind: Binary {
+                                        op: Gt,
+                                        left: Expr {
+                                            kind: Column(
+                                                Name {
+                                                    value: "target",
+                                                    quoted: false,
+                                                    span: Span {
+                                                        start: 254,
+                                                        end: 260,
+                                                    },
+                                                },
+                                            ),
+                                            span: Span {
+                                                start: 254,
+                                                end: 260,
+                                            },
+                                        },
+                                        right: Expr {
+                                            kind: Int(
+                                                0,
+                                            ),
+                                            span: Span {
+                                                start: 263,
+                                                end: 264,
+                                            },
+                                        },
+                                    },
+                                    span: Span {
+                                        start: 254,
+                                        end: 264,
+                                    },
+                                },
+                            ),
+                            group_by: [],
+                            having: None,
+                            order_by: [],
+                            span: Span {
+                                start: 223,
+                                end: 264,
+                            },
+                        },
+                        negated: true,
+                    },
+                    span: Span {
+                        start: 212,
+                        end: 265,
+                    },
+                },
+            ),
+            group_by: [],
+            having: None,
+            order_by: [],
+            span: Span {
+                start: 186,
+                end: 265,
+            },
+        },
+    ),
+]

--- a/crates/truthdb-sql/tests/corpus/ok/subqueries.sql
+++ b/crates/truthdb-sql/tests/corpus/ok/subqueries.sql
@@ -1,0 +1,3 @@
+SELECT id FROM nums WHERE v = (SELECT MAX(v) FROM nums);
+SELECT id, (SELECT COUNT(*) FROM picks) AS pc FROM nums WHERE id IN (SELECT target FROM picks) AND EXISTS (SELECT 1 FROM picks);
+SELECT id FROM nums WHERE id NOT IN (SELECT target FROM picks WHERE target > 0);


### PR DESCRIPTION
Adds subqueries in expressions: a scalar `(SELECT …)`, `expr [NOT] IN (SELECT …)`, and `[NOT] EXISTS (SELECT …)` — **uncorrelated** only. Correlated subqueries, CTEs, views, and variables follow in later parts.

## Architecture
`eval` has no `Storage` handle, so subqueries can't run inside it. The executor does a **rewrite pass**: `exec_select` first calls `rewrite_select_subqueries`, replacing each subquery in `WHERE`/`HAVING`/`SELECT`-list/`GROUP BY`/`ORDER BY` with a precomputed node — a scalar → `Literal` (0 rows → NULL, 1 → value, >1 → **512**, not one column → **116**); `EXISTS` → `Bool`; `IN (SELECT)` → an `InList` of values. `eval` gains only a trivial `Literal` arm (and errors **1015** if a subquery reaches it unrewritten, e.g. a join `ON` clause). The rewrite runs **once, before `build_source`**, so an uncorrelated subquery evaluates independently and a **correlated** one (references an outer column) errors as invalid-column (**207**) — honest, real support comes in a later part. Nested subqueries and subqueries inside derived tables / `INSERT … SELECT` all compose.

## Locks
`collect_locked_tables` now walks the FROM (incl. derived + join `ON`) **and** every subquery in the query's expressions, so a `WHERE`/`SELECT`-list subquery Shared-locks its base tables — closing the same dirty-read hole as `INSERT…SELECT` (the engine is 2PL-only, no MVCC).

## Adversarial review (4 dimensions × find→verify) — 1 confirmed bug, fixed
- **MEDIUM** — `NOT IN (empty subquery)` dropped rows whose left operand is NULL. The rewrite can now produce an **empty** `InList` (unreachable from a written value list, which requires ≥1 item), and `eval_in_expr` short-circuited on a NULL operand *before* checking the empty list. `x NOT IN ()` is TRUE and `x IN ()` is FALSE regardless of `x`, so the empty-list case is now handled first. Regression test added.

## Tests
Engine tests (scalar in WHERE/SELECT-list, IN/NOT IN, EXISTS/NOT EXISTS, 0-row→NULL, 512/116, correlated→207, empty-subquery IN/NOT IN, subquery lock analysis), an slt matrix, and a parser corpus case. `cargo fmt`, `clippy -D warnings`, `cargo test --workspace` all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)