### PR TITLE
Batch variables: DECLARE / SET / @v [Stage 11, part 3]

### DIFF
--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -2185,6 +2185,85 @@ mod tests {
     }
 
     #[test]
+    fn sql_batch_variables() {
+        let path = unique_temp_path("sql-vars");
+        let mut engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+
+        // DECLARE, SET, and read a variable within one batch.
+        let out = batch(
+            &mut engine,
+            &mut ctx,
+            "DECLARE @n INT; SET @n = 42; SELECT @n",
+        );
+        assert!(out.error.is_none(), "{:?}", out.error);
+        assert_eq!(ids(&out), vec![42]);
+
+        // An initializer may reference an earlier variable in the same DECLARE.
+        let out = batch(
+            &mut engine,
+            &mut ctx,
+            "DECLARE @a INT = 5, @b INT = @a + 1; SELECT @b",
+        );
+        assert!(out.error.is_none(), "{:?}", out.error);
+        assert_eq!(ids(&out), vec![6]);
+
+        // A variable used in a WHERE clause.
+        batch(
+            &mut engine,
+            &mut ctx,
+            "CREATE TABLE t (id INT NOT NULL PRIMARY KEY, v INT)",
+        );
+        batch(
+            &mut engine,
+            &mut ctx,
+            "INSERT INTO t VALUES (1,10),(2,20),(3,30)",
+        );
+        let out = batch(
+            &mut engine,
+            &mut ctx,
+            "DECLARE @min INT; SET @min = 20; SELECT id FROM t WHERE v >= @min ORDER BY id",
+        );
+        assert_eq!(ids(&out), vec![2, 3]);
+
+        // Using an undeclared variable is error 137 (SET and read).
+        assert_eq!(
+            batch(&mut engine, &mut ctx, "SET @nope = 1")
+                .error
+                .as_ref()
+                .map(|e| e.number),
+            Some(137)
+        );
+        assert_eq!(
+            batch(&mut engine, &mut ctx, "SELECT @nope")
+                .error
+                .as_ref()
+                .map(|e| e.number),
+            Some(137)
+        );
+
+        // Redeclaring within the same batch is error 134.
+        assert_eq!(
+            batch(&mut engine, &mut ctx, "DECLARE @d INT; DECLARE @d INT")
+                .error
+                .as_ref()
+                .map(|e| e.number),
+            Some(134)
+        );
+
+        // Variables are batch-scoped: one declared in a prior batch is gone.
+        batch(&mut engine, &mut ctx, "DECLARE @scoped INT");
+        assert_eq!(
+            batch(&mut engine, &mut ctx, "SELECT @scoped")
+                .error
+                .as_ref()
+                .map(|e| e.number),
+            Some(137)
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
     fn sql_scalar_in_exists_subqueries() {
         let path = unique_temp_path("sql-subquery");
         let mut engine = new_engine(&path);

--- a/crates/truthdb-core/src/rel/aggregate.rs
+++ b/crates/truthdb-core/src/rel/aggregate.rs
@@ -320,7 +320,8 @@ fn rewrite(expr: &Expr, group_by: &[Expr], aggs: &mut Vec<AggSpec>) -> Result<Ex
         | ExprKind::Str(_)
         | ExprKind::Bool(_)
         | ExprKind::Literal(_)
-        | ExprKind::GlobalVar(_) => expr.kind.clone(),
+        | ExprKind::GlobalVar(_)
+        | ExprKind::LocalVar(_) => expr.kind.clone(),
         // Subqueries are rewritten to literals before aggregation runs; clone
         // defensively (evaluation would reject any that slipped through).
         ExprKind::Subquery(_) | ExprKind::Exists(_) | ExprKind::InSubquery { .. } => {

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -14,8 +14,9 @@ mod value;
 
 use truthdb_sql::ast::{
     AlterAction, AlterTable, CheckConstraint, ColumnDef, CreateIndex, CreateTable, DataType,
-    Delete, DropIndex, DropTable, Expr, ExprKind, ForeignKey, Insert, InsertSource, IsolationLevel,
-    JoinKind, Name, OrderItem, Select, SelectItem, SetStatement, Statement, TableRef, Update,
+    Declaration, Delete, DropIndex, DropTable, Expr, ExprKind, ForeignKey, Insert, InsertSource,
+    IsolationLevel, JoinKind, Name, OrderItem, Select, SelectItem, SetStatement, Statement,
+    TableRef, Update,
 };
 use truthdb_sql::error::SqlError;
 use truthdb_sql::eval::EvalContext;
@@ -43,6 +44,9 @@ pub struct TxnContext {
     isolation: Isolation,
     /// `SET SHOWPLAN_TEXT ON` — a SELECT returns its plan text, not results.
     showplan_text: bool,
+    /// Declared batch variables (name without `@`, lowercased) to their type
+    /// and current value. Cleared at the start of each batch.
+    variables: std::collections::HashMap<String, (ColumnType, SqlValue)>,
 }
 
 /// Session isolation level (defaults to READ COMMITTED, like SQL Server).
@@ -63,7 +67,17 @@ impl TxnContext {
     fn eval_context(&self) -> EvalContext {
         EvalContext {
             trancount: self.trancount as i32,
+            variables: self
+                .variables
+                .iter()
+                .map(|(name, (_, value))| (name.clone(), value.clone()))
+                .collect(),
         }
+    }
+
+    /// Clears batch-scoped variables (called at the start of each batch).
+    pub fn clear_variables(&mut self) {
+        self.variables.clear();
     }
 
     /// True if a transaction is open (used by the session to decide whether a
@@ -123,6 +137,8 @@ pub struct BatchOutcome {
 /// Parses and executes a SQL batch. A parse error yields an empty batch with
 /// the error; a runtime error stops the batch but keeps earlier results.
 pub fn execute_batch(storage: &mut Storage, sql: &str, txn_ctx: &mut TxnContext) -> BatchOutcome {
+    // Variables are batch-scoped: each batch starts with none.
+    txn_ctx.clear_variables();
     let statements = match truthdb_sql::parse(sql) {
         Ok(statements) => statements,
         Err(error) => {
@@ -298,11 +314,12 @@ pub fn analyze_locks(
             | Statement::AlterTable(_) => {
                 add(Resource::Database, LockMode::Exclusive);
             }
-            // Transaction control and SET take no data locks.
+            // Transaction control, SET, and DECLARE take no data locks.
             Statement::BeginTransaction { .. }
             | Statement::Commit { .. }
             | Statement::Rollback { .. }
-            | Statement::Set(_) => {}
+            | Statement::Set(_)
+            | Statement::Declare(_) => {}
         }
     }
     needs.into_iter().collect()
@@ -349,6 +366,7 @@ fn exec_statement(
         Statement::Commit { .. } => exec_commit(storage, txn_ctx),
         Statement::Rollback { .. } => exec_rollback(storage, txn_ctx),
         Statement::Set(set) => exec_set(txn_ctx, set),
+        Statement::Declare(decls) => exec_declare(txn_ctx, decls),
         Statement::CreateTable(create) => {
             if txn_ctx.in_txn() {
                 return Err(ddl_in_txn_err());
@@ -532,8 +550,70 @@ fn exec_set(ctx: &mut TxnContext, set: &SetStatement) -> Result<StatementResult,
             }
         }
         SetStatement::ShowplanText(on) => ctx.showplan_text = *on,
+        SetStatement::Variable { name, value } => {
+            let column_type = ctx
+                .variables
+                .get(name)
+                .map(|(t, _)| *t)
+                .ok_or_else(|| undeclared_variable_err(name))?;
+            let eval_ctx = ctx.eval_context();
+            let coerced = coerce_variable(value, &column_type, name, &eval_ctx)?;
+            ctx.variables.insert(name.clone(), (column_type, coerced));
+        }
     }
     Ok(StatementResult::Done)
+}
+
+/// `DECLARE @a TYPE [= expr], ...`. Each variable is added to the batch (error
+/// 134 if already declared); an initializer (which may reference an earlier
+/// variable) is coerced to the declared type, else the value starts NULL.
+fn exec_declare(ctx: &mut TxnContext, decls: &[Declaration]) -> Result<StatementResult, SqlError> {
+    for decl in decls {
+        if ctx.variables.contains_key(&decl.name) {
+            return Err(SqlError::new(
+                134,
+                15,
+                2,
+                format!(
+                    "The variable name '@{}' has already been declared. Variable names must be unique within a query batch.",
+                    decl.name
+                ),
+            ));
+        }
+        let column_type = data_type_to_column_type(&decl.data_type, &decl.name)?;
+        let value = match &decl.initializer {
+            Some(expr) => {
+                let eval_ctx = ctx.eval_context();
+                coerce_variable(expr, &column_type, &decl.name, &eval_ctx)?
+            }
+            None => SqlValue::Null,
+        };
+        ctx.variables
+            .insert(decl.name.clone(), (column_type, value));
+    }
+    Ok(StatementResult::Done)
+}
+
+fn undeclared_variable_err(name: &str) -> SqlError {
+    SqlError::new(
+        137,
+        15,
+        2,
+        format!("Must declare the scalar variable \"@{name}\"."),
+    )
+}
+
+/// Evaluates a variable initializer/assignment (a constant expression that may
+/// reference already-declared variables) and coerces it to the declared type.
+fn coerce_variable(
+    expr: &Expr,
+    column_type: &ColumnType,
+    name: &str,
+    eval_ctx: &EvalContext,
+) -> Result<SqlValue, SqlError> {
+    let sql_value = eval_constant(expr, eval_ctx)?;
+    let datum = value::sql_to_datum(&sql_value, column_type, name)?;
+    Ok(value::datum_to_sql(&datum, column_type))
 }
 
 // ---- CREATE TABLE -------------------------------------------------------
@@ -1034,7 +1114,8 @@ fn validate_check_columns(expr: &Expr, columns: &[Column]) -> Result<(), SqlErro
         | ExprKind::Str(_)
         | ExprKind::Bool(_)
         | ExprKind::Literal(_)
-        | ExprKind::GlobalVar(_) => Ok(()),
+        | ExprKind::GlobalVar(_)
+        | ExprKind::LocalVar(_) => Ok(()),
         // Subqueries are not allowed in a CHECK constraint (SQL Server 1046).
         ExprKind::Subquery(_) | ExprKind::Exists(_) | ExprKind::InSubquery { .. } => {
             Err(SqlError::new(
@@ -1242,8 +1323,10 @@ fn pk_of(def: &TableDef, row: &[Datum]) -> Vec<Datum> {
     def.key_columns.iter().map(|&i| row[i].clone()).collect()
 }
 
-fn bind_column(column: &ColumnDef) -> Result<Column, SqlError> {
-    let column_type = match &column.data_type {
+/// Maps a parsed [`DataType`] to a storage [`ColumnType`], validating length
+/// bounds. `name` is only used for the length-overflow error message.
+fn data_type_to_column_type(data_type: &DataType, name: &str) -> Result<ColumnType, SqlError> {
+    Ok(match data_type {
         DataType::TinyInt => ColumnType::TinyInt,
         DataType::SmallInt => ColumnType::SmallInt,
         DataType::Int => ColumnType::Int,
@@ -1260,15 +1343,19 @@ fn bind_column(column: &ColumnDef) -> Result<Column, SqlError> {
         DataType::DateTime2 => ColumnType::DateTime2,
         DataType::UniqueIdentifier => ColumnType::UniqueIdentifier,
         DataType::VarChar(n) => ColumnType::VarChar {
-            max_len: length(*n, column)?,
+            max_len: length(*n, name)?,
         },
         DataType::NVarChar(n) => ColumnType::NVarChar {
-            max_len: length(*n, column)?,
+            max_len: length(*n, name)?,
         },
         DataType::VarBinary(n) => ColumnType::VarBinary {
-            max_len: length(*n, column)?,
+            max_len: length(*n, name)?,
         },
-    };
+    })
+}
+
+fn bind_column(column: &ColumnDef) -> Result<Column, SqlError> {
+    let column_type = data_type_to_column_type(&column.data_type, &column.name.value)?;
     // A COLLATE clause is only meaningful on character columns.
     if column.collation.is_some()
         && !matches!(
@@ -1298,16 +1385,13 @@ fn bind_column(column: &ColumnDef) -> Result<Column, SqlError> {
     })
 }
 
-fn length(n: u32, column: &ColumnDef) -> Result<u16, SqlError> {
+fn length(n: u32, name: &str) -> Result<u16, SqlError> {
     u16::try_from(n).map_err(|_| {
         SqlError::new(
             131,
             15,
             2,
-            format!(
-                "The size for column '{}' exceeds the maximum.",
-                column.name.value
-            ),
+            format!("The size for column '{name}' exceeds the maximum."),
         )
     })
 }
@@ -2332,7 +2416,8 @@ fn rewrite_subqueries(
         | ExprKind::Bool(_)
         | ExprKind::Literal(_)
         | ExprKind::Column(_)
-        | ExprKind::GlobalVar(_) => expr.kind.clone(),
+        | ExprKind::GlobalVar(_)
+        | ExprKind::LocalVar(_) => expr.kind.clone(),
     };
     Ok(Expr {
         kind,
@@ -2870,7 +2955,8 @@ fn collect_expr_tables<'a>(expr: &'a Expr, out: &mut Vec<&'a Name>) {
         | ExprKind::Bool(_)
         | ExprKind::Literal(_)
         | ExprKind::Column(_)
-        | ExprKind::GlobalVar(_) => {}
+        | ExprKind::GlobalVar(_)
+        | ExprKind::LocalVar(_) => {}
     }
 }
 

--- a/crates/truthdb-sql/src/ast.rs
+++ b/crates/truthdb-sql/src/ast.rs
@@ -26,10 +26,23 @@ pub enum Statement {
     Rollback {
         span: Span,
     },
-    /// `SET` session option (XACT_ABORT / TRANSACTION ISOLATION LEVEL).
+    /// `SET` session option (XACT_ABORT / TRANSACTION ISOLATION LEVEL) or a
+    /// `SET @v = expr` variable assignment.
     Set(SetStatement),
     /// `ALTER TABLE ...`.
     AlterTable(AlterTable),
+    /// `DECLARE @a TYPE [= expr], ...` — batch variable declarations.
+    Declare(Vec<Declaration>),
+}
+
+/// One `@name TYPE [= initializer]` in a `DECLARE`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Declaration {
+    /// Variable name without the `@`, lowercased.
+    pub name: String,
+    pub data_type: DataType,
+    pub initializer: Option<Expr>,
+    pub span: Span,
 }
 
 /// `ALTER TABLE <table> <action>`.
@@ -57,6 +70,11 @@ pub enum SetStatement {
     /// `SET SHOWPLAN_TEXT ON|OFF` — when on, statements return their plan text
     /// instead of executing.
     ShowplanText(bool),
+    /// `SET @v = expr` — assigns a batch variable.
+    Variable {
+        name: String,
+        value: Expr,
+    },
 }
 
 /// `CREATE [UNIQUE] INDEX <name> ON <table> (<col> [ASC|DESC], ...)`.
@@ -382,6 +400,9 @@ pub enum ExprKind {
     /// A `@@`-prefixed global/session variable (e.g. `@@TRANCOUNT`), evaluated
     /// from the session's [`EvalContext`](crate::eval::EvalContext).
     GlobalVar(String),
+    /// A `@`-prefixed local/batch variable (name without the `@`, lowercased),
+    /// resolved from the batch's declared variables.
+    LocalVar(String),
     /// A precomputed value. Not produced by the parser — the executor rewrites
     /// each evaluated subquery to a `Literal` so scalar evaluation stays free of
     /// storage access.

--- a/crates/truthdb-sql/src/eval.rs
+++ b/crates/truthdb-sql/src/eval.rs
@@ -37,12 +37,17 @@ impl ColumnResolver for Vec<String> {
 /// kept small (heavy arms delegate to out-of-line helpers) so this is safe.
 const MAX_EVAL_DEPTH: usize = 500;
 
-/// Session context available to expression evaluation: `@@`-variables (and,
-/// in later stages, the current time / SCOPE_IDENTITY). `Default` is a
-/// no-transaction context, used where no session is in scope.
-#[derive(Debug, Clone, Copy, Default)]
+/// Session context available to expression evaluation: `@@`-variables, the
+/// batch's `@`-variables, and (in later stages) the current time /
+/// SCOPE_IDENTITY. `Default` is a no-transaction, no-variable context, used
+/// where no session is in scope.
+#[derive(Debug, Clone, Default)]
 pub struct EvalContext {
     pub trancount: i32,
+    /// Declared batch variables (name without `@`, lowercased) to their current
+    /// value. Present but NULL for a declared-but-unset variable; absent means
+    /// undeclared.
+    pub variables: std::collections::HashMap<String, SqlValue>,
 }
 
 /// Evaluates `expr` against `row`, resolving columns via `resolver`.
@@ -84,6 +89,12 @@ fn eval_at(
         ),
         ExprKind::Column(name) => eval_column(name, row, resolver),
         ExprKind::GlobalVar(name) => eval_global_var(name, ctx),
+        ExprKind::LocalVar(name) => ctx.variables.get(name).cloned().ok_or_else(|| {
+            SqlError::message_only(
+                137,
+                format!("Must declare the scalar variable \"@{name}\"."),
+            )
+        }),
         ExprKind::Unary { op, expr: inner } => {
             let value = eval_at(inner, row, resolver, ctx, depth + 1)?;
             eval_unary(*op, value)

--- a/crates/truthdb-sql/src/lexer.rs
+++ b/crates/truthdb-sql/src/lexer.rs
@@ -38,6 +38,8 @@ pub enum TokenKind {
     String(String),
     /// A `@@`-prefixed global variable name (without the `@@`), lowercased.
     GlobalVar(String),
+    /// A `@`-prefixed local/batch variable name (without the `@`), lowercased.
+    LocalVar(String),
     // Operators / punctuation.
     Comma,
     Semicolon,
@@ -269,10 +271,23 @@ impl<'a> Lexer<'a> {
                     span: Span::new(start, self.pos),
                 })
             }
-            b'@' => Err(
-                SqlError::message_only(102, "Variables are not supported yet.")
-                    .at(Span::new(start, start + 1)),
-            ),
+            b'@' => {
+                // `@name` — a local/batch variable.
+                self.pos += 1;
+                let name_start = self.pos;
+                while self.peek().is_some_and(is_ident_cont) {
+                    self.pos += 1;
+                }
+                if self.pos == name_start {
+                    return Err(SqlError::syntax('@', Span::new(start, start + 1)));
+                }
+                let name =
+                    String::from_utf8_lossy(&self.src[name_start..self.pos]).to_ascii_lowercase();
+                Ok(Token {
+                    kind: TokenKind::LocalVar(name),
+                    span: Span::new(start, self.pos),
+                })
+            }
             _ if b.is_ascii_digit() => self.lex_number(start),
             _ if is_ident_start(b) => self.lex_word(start),
             _ => {

--- a/crates/truthdb-sql/src/parser.rs
+++ b/crates/truthdb-sql/src/parser.rs
@@ -116,6 +116,7 @@ impl Parser {
             Some("COMMIT") => self.parse_commit(),
             Some("ROLLBACK") => self.parse_rollback(),
             Some("SET") => self.parse_set(),
+            Some("DECLARE") => self.parse_declare(),
             _ => {
                 let token = self.peek().clone();
                 Err(SqlError::syntax(self.token_text(&token), token.span))
@@ -191,8 +192,49 @@ impl Parser {
         None
     }
 
+    /// `DECLARE @a TYPE [= expr], @b TYPE ...`.
+    fn parse_declare(&mut self) -> SqlResult<Statement> {
+        self.expect_keyword("DECLARE")?;
+        let mut decls = Vec::new();
+        loop {
+            let token = self.peek().clone();
+            let TokenKind::LocalVar(name) = &token.kind else {
+                return Err(SqlError::syntax(self.token_text(&token), token.span));
+            };
+            let name = name.clone();
+            self.bump();
+            let _ = self.eat_keyword("AS"); // `DECLARE @v AS INT` — AS optional
+            let (data_type, type_span) = self.parse_data_type()?;
+            let (initializer, end) = if self.eat(&TokenKind::Eq) {
+                let expr = self.parse_expr()?;
+                let end = expr.span;
+                (Some(expr), end)
+            } else {
+                (None, type_span)
+            };
+            decls.push(Declaration {
+                name,
+                data_type,
+                initializer,
+                span: token.span.to(end),
+            });
+            if !self.eat(&TokenKind::Comma) {
+                break;
+            }
+        }
+        Ok(Statement::Declare(decls))
+    }
+
     fn parse_set(&mut self) -> SqlResult<Statement> {
         self.expect_keyword("SET")?;
+        // `SET @v = expr` — a variable assignment.
+        if let TokenKind::LocalVar(name) = &self.peek().kind {
+            let name = name.clone();
+            self.bump();
+            self.expect(&TokenKind::Eq)?;
+            let value = self.parse_expr()?;
+            return Ok(Statement::Set(SetStatement::Variable { name, value }));
+        }
         match self.peek_keyword().as_deref() {
             Some("XACT_ABORT") => {
                 self.bump();
@@ -1602,6 +1644,13 @@ impl Parser {
                 self.bump();
                 Ok(Expr {
                     kind: ExprKind::GlobalVar(name.clone()),
+                    span: token.span,
+                })
+            }
+            TokenKind::LocalVar(name) => {
+                self.bump();
+                Ok(Expr {
+                    kind: ExprKind::LocalVar(name.clone()),
                     span: token.span,
                 })
             }

--- a/crates/truthdb-sql/tests/corpus/ok/variables.ast
+++ b/crates/truthdb-sql/tests/corpus/ok/variables.ast
@@ -1,0 +1,209 @@
+[
+    Declare(
+        [
+            Declaration {
+                name: "a",
+                data_type: Int,
+                initializer: None,
+                span: Span {
+                    start: 8,
+                    end: 14,
+                },
+            },
+            Declaration {
+                name: "b",
+                data_type: NVarChar(
+                    10,
+                ),
+                initializer: Some(
+                    Expr {
+                        kind: Str(
+                            "hi",
+                        ),
+                        span: Span {
+                            start: 34,
+                            end: 38,
+                        },
+                    },
+                ),
+                span: Span {
+                    start: 16,
+                    end: 38,
+                },
+            },
+            Declaration {
+                name: "c",
+                data_type: Int,
+                initializer: Some(
+                    Expr {
+                        kind: Binary {
+                            op: Add,
+                            left: Expr {
+                                kind: LocalVar(
+                                    "a",
+                                ),
+                                span: Span {
+                                    start: 49,
+                                    end: 51,
+                                },
+                            },
+                            right: Expr {
+                                kind: Int(
+                                    1,
+                                ),
+                                span: Span {
+                                    start: 54,
+                                    end: 55,
+                                },
+                            },
+                        },
+                        span: Span {
+                            start: 49,
+                            end: 55,
+                        },
+                    },
+                ),
+                span: Span {
+                    start: 40,
+                    end: 55,
+                },
+            },
+        ],
+    ),
+    Set(
+        Variable {
+            name: "a",
+            value: Expr {
+                kind: Binary {
+                    op: Mul,
+                    left: Expr {
+                        kind: Int(
+                            5,
+                        ),
+                        span: Span {
+                            start: 66,
+                            end: 67,
+                        },
+                    },
+                    right: Expr {
+                        kind: Int(
+                            2,
+                        ),
+                        span: Span {
+                            start: 70,
+                            end: 71,
+                        },
+                    },
+                },
+                span: Span {
+                    start: 66,
+                    end: 71,
+                },
+            },
+        },
+    ),
+    Select(
+        Select {
+            top: None,
+            distinct: false,
+            items: [
+                Expr {
+                    expr: Expr {
+                        kind: LocalVar(
+                            "a",
+                        ),
+                        span: Span {
+                            start: 80,
+                            end: 82,
+                        },
+                    },
+                    alias: Some(
+                        Name {
+                            value: "doubled",
+                            quoted: false,
+                            span: Span {
+                                start: 86,
+                                end: 93,
+                            },
+                        },
+                    ),
+                },
+                Expr {
+                    expr: Expr {
+                        kind: Column(
+                            Name {
+                                value: "id",
+                                quoted: false,
+                                span: Span {
+                                    start: 95,
+                                    end: 97,
+                                },
+                            },
+                        ),
+                        span: Span {
+                            start: 95,
+                            end: 97,
+                        },
+                    },
+                    alias: None,
+                },
+            ],
+            from: Some(
+                Table {
+                    name: Name {
+                        value: "t",
+                        quoted: false,
+                        span: Span {
+                            start: 103,
+                            end: 104,
+                        },
+                    },
+                    alias: None,
+                },
+            ),
+            where_clause: Some(
+                Expr {
+                    kind: Binary {
+                        op: Ge,
+                        left: Expr {
+                            kind: Column(
+                                Name {
+                                    value: "v",
+                                    quoted: false,
+                                    span: Span {
+                                        start: 111,
+                                        end: 112,
+                                    },
+                                },
+                            ),
+                            span: Span {
+                                start: 111,
+                                end: 112,
+                            },
+                        },
+                        right: Expr {
+                            kind: LocalVar(
+                                "a",
+                            ),
+                            span: Span {
+                                start: 116,
+                                end: 118,
+                            },
+                        },
+                    },
+                    span: Span {
+                        start: 111,
+                        end: 118,
+                    },
+                },
+            ),
+            group_by: [],
+            having: None,
+            order_by: [],
+            span: Span {
+                start: 73,
+                end: 118,
+            },
+        },
+    ),
+]

--- a/crates/truthdb-sql/tests/corpus/ok/variables.sql
+++ b/crates/truthdb-sql/tests/corpus/ok/variables.sql
@@ -1,0 +1,3 @@
+DECLARE @a INT, @b NVARCHAR(10) = 'hi', @c INT = @a + 1;
+SET @a = 5 * 2;
+SELECT @a AS doubled, id FROM t WHERE v >= @a;


### PR DESCRIPTION
Adds batch-scoped local variables: `DECLARE @a TYPE [= expr], …`, `SET @v = expr`, and `@v` references in expressions. The `SELECT @v = expr` assignment form is deferred.

## What's in
- **Lexer** — `@name` → a `LocalVar` token (name lowercased); `@@name` stays a global variable; a bare `@` is a syntax error.
- **Parser** — `DECLARE` (`@name [AS] TYPE [= expr]`, comma-separated), `SET @v = expr` (disambiguated from SET options by the `LocalVar` token), and `@v` in any expression.
- **eval** — `EvalContext` gained a `variables` map (and lost `Copy` — it's cloned per statement, which is cheap). `@v` resolves from it; an undeclared variable is error **137**.
- **Executor** — `TxnContext` holds the typed variable store; `eval_context()` projects it into the `EvalContext`. `DECLARE` rejects a redeclaration (**134**) and coerces an initializer to the declared type (an initializer may reference an earlier variable in the same `DECLARE`); `SET` coerces to the declared type. Variables are **batch-scoped** — `execute_batch` clears them at the start of every batch — and are **not** rolled back by `ROLLBACK` (matching SQL Server). `data_type_to_column_type` was extracted from `bind_column` and shared.

## Adversarial review — clean
4 dimensions (typing/coercion, batch-scope + transactions, lexer/parser, integration across DML/subquery/derived contexts), find→verify. **No confirmed findings.**

## Tests
Engine tests (DECLARE/SET/read, cross-variable initializer, variable in a WHERE, 137/134, batch scoping) and a parser corpus case. `cargo fmt`, `clippy -D warnings`, `cargo test --workspace` all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)