### PR TITLE
Non-recursive common table expressions (WITH) [Stage 11, part 4]

### DIFF
--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -2425,6 +2425,91 @@ mod tests {
     }
 
     #[test]
+    fn sql_common_table_expressions() {
+        let path = unique_temp_path("sql-cte");
+        let mut engine = new_engine(&path);
+        engine
+            .execute(
+                "CREATE TABLE sales (id INT NOT NULL PRIMARY KEY, dept NVARCHAR(4), amount INT)",
+            )
+            .expect("create");
+        engine
+            .execute("INSERT INTO sales VALUES (1,'a',10),(2,'a',20),(3,'b',5),(4,'b',50)")
+            .expect("seed");
+
+        // A basic CTE referenced in FROM.
+        let (cols, rows) = sql_rows(
+            &mut engine,
+            "WITH big AS (SELECT id, amount FROM sales WHERE amount >= 20) SELECT id FROM big ORDER BY id",
+        );
+        assert_eq!(cols, vec!["id"]);
+        assert_eq!(rows, vec![vec![Some("2".into())], vec![Some("4".into())]]);
+
+        // A CTE that aggregates, filtered by the outer query.
+        let (_, rows) = sql_rows(
+            &mut engine,
+            "WITH s AS (SELECT dept, SUM(amount) AS total FROM sales GROUP BY dept) \
+               SELECT dept FROM s WHERE total > 30 ORDER BY dept",
+        );
+        assert_eq!(rows, vec![vec![Some("b".into())]]);
+
+        // A later CTE references an earlier one.
+        let (_, rows) = sql_rows(
+            &mut engine,
+            "WITH a AS (SELECT id, amount FROM sales WHERE amount >= 10), \
+                  b AS (SELECT id FROM a WHERE amount >= 20) \
+               SELECT id FROM b ORDER BY id",
+        );
+        assert_eq!(rows, vec![vec![Some("2".into())], vec![Some("4".into())]]);
+
+        // A CTE joined to a base table.
+        let (_, rows) = sql_rows(
+            &mut engine,
+            "WITH s AS (SELECT dept, SUM(amount) AS total FROM sales GROUP BY dept) \
+               SELECT t.id, s.total FROM sales t JOIN s ON t.dept = s.dept WHERE t.id = 3",
+        );
+        assert_eq!(rows, vec![vec![Some("3".into()), Some("55".into())]]);
+
+        // The optional column-rename list is not supported yet.
+        assert_eq!(
+            sql_error_number(
+                &mut engine,
+                "WITH c(x) AS (SELECT id FROM sales) SELECT x FROM c",
+            ),
+            102
+        );
+        // A recursive / self-reference resolves as a (non-existent) base table.
+        assert_eq!(
+            sql_error_number(&mut engine, "WITH r AS (SELECT id FROM r) SELECT id FROM r"),
+            208
+        );
+
+        // A CTE is visible to a subquery in the WHERE clause, not just the FROM.
+        let (_, rows) = sql_rows(
+            &mut engine,
+            "WITH s AS (SELECT dept, SUM(amount) AS total FROM sales GROUP BY dept) \
+               SELECT id FROM sales WHERE dept IN (SELECT dept FROM s WHERE total > 30) ORDER BY id",
+        );
+        assert_eq!(rows, vec![vec![Some("3".into())], vec![Some("4".into())]]);
+
+        // Duplicate CTE names are rejected.
+        assert_eq!(
+            sql_error_number(
+                &mut engine,
+                "WITH a AS (SELECT 1 AS x), a AS (SELECT 2 AS x) SELECT x FROM a",
+            ),
+            460
+        );
+        // A schema-qualified reference does not match a CTE (dbo.s is a base
+        // table name, which here does not exist).
+        assert_eq!(
+            sql_error_number(&mut engine, "WITH s AS (SELECT 1 AS v) SELECT v FROM dbo.s"),
+            208
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
     fn sql_derived_tables() {
         let path = unique_temp_path("sql-derived");
         let mut engine = new_engine(&path);

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -238,8 +238,10 @@ pub fn analyze_locks(
                 }
                 // Lock every base table the query reads — the FROM clause AND
                 // any subqueries in its expressions (WHERE/SELECT/HAVING/...).
+                // CTEs are inlined first so their base tables are counted.
+                let expanded = expand_ctes(select);
                 let mut tables = Vec::new();
-                collect_locked_tables(select, &mut tables);
+                collect_locked_tables(&expanded, &mut tables);
                 for name in tables {
                     if name.value.to_ascii_lowercase().starts_with("sys.") {
                         continue; // catalog view: unlocked
@@ -265,8 +267,9 @@ pub fn analyze_locks(
                 // cannot read another txn's uncommitted rows (they combine to
                 // SIX on the target if it is a source).
                 if reads_lock && let InsertSource::Select(select) = &insert.source {
+                    let expanded = expand_ctes(select);
                     let mut tables = Vec::new();
-                    collect_locked_tables(select, &mut tables);
+                    collect_locked_tables(&expanded, &mut tables);
                     for name in tables {
                         if name.value.to_ascii_lowercase().starts_with("sys.") {
                             continue;
@@ -2228,6 +2231,215 @@ fn row_values(row: &[Datum], types: &[ColumnType]) -> Vec<SqlValue> {
         .collect()
 }
 
+// ---- common table expressions -------------------------------------------
+
+/// Inlines a SELECT's `WITH` common table expressions: each FROM reference to a
+/// CTE name becomes a derived table over the CTE's query. CTEs are expanded in
+/// order, so a later CTE may reference an earlier one; non-recursive (a self- or
+/// forward-reference is left as a base-table name and errors at bind). Returns a
+/// CTE-free SELECT.
+type CteMap = std::collections::HashMap<String, Select>;
+
+fn expand_ctes(select: &Select) -> Select {
+    if select.ctes.is_empty() {
+        return select.clone();
+    }
+    let mut resolved: CteMap = std::collections::HashMap::new();
+    for cte in &select.ctes {
+        let body = expand_select_ctes(&cte.query, &resolved);
+        resolved.insert(cte.name.value.to_ascii_lowercase(), body);
+    }
+    let mut out = expand_select_ctes(select, &resolved);
+    out.ctes = Vec::new();
+    out
+}
+
+/// A copy of `select` with its FROM references and its embedded subqueries'
+/// references to `resolved` CTEs replaced by derived tables. (The CTE is visible
+/// to the whole statement, not just the top-level FROM.) The select's own `ctes`
+/// field is left intact — a nested `WITH` keeps its own scope.
+fn expand_select_ctes(select: &Select, resolved: &CteMap) -> Select {
+    let mut out = select.clone();
+    out.from = out
+        .from
+        .as_ref()
+        .map(|from| expand_from_ctes(from, resolved));
+    out.items = out
+        .items
+        .iter()
+        .map(|item| match item {
+            SelectItem::Expr { expr, alias } => SelectItem::Expr {
+                expr: expand_expr_ctes(expr, resolved),
+                alias: alias.clone(),
+            },
+            other => other.clone(),
+        })
+        .collect();
+    out.where_clause = out
+        .where_clause
+        .as_ref()
+        .map(|e| expand_expr_ctes(e, resolved));
+    out.having = out.having.as_ref().map(|e| expand_expr_ctes(e, resolved));
+    out.group_by = out
+        .group_by
+        .iter()
+        .map(|e| expand_expr_ctes(e, resolved))
+        .collect();
+    out.order_by = out
+        .order_by
+        .iter()
+        .map(|o| OrderItem {
+            expr: expand_expr_ctes(&o.expr, resolved),
+            descending: o.descending,
+        })
+        .collect();
+    out
+}
+
+/// Replaces CTE references in a FROM tree with derived tables (recursing into
+/// joins — including the `ON` predicate's subqueries — and nested derived
+/// tables, which may also reference the CTEs).
+fn expand_from_ctes(tref: &TableRef, resolved: &CteMap) -> TableRef {
+    match tref {
+        TableRef::Table { name, alias } => {
+            // Only an unqualified reference can name a CTE (CTE names are not
+            // schema-qualified); `dbo.s` must resolve to a base table.
+            let cte = (!name.value.contains('.'))
+                .then(|| resolved.get(&name.value.to_ascii_lowercase()))
+                .flatten();
+            match cte {
+                Some(body) => TableRef::Derived {
+                    subquery: Box::new(body.clone()),
+                    // The exposed name is the alias, else the CTE reference name.
+                    alias: alias.clone().unwrap_or_else(|| name.clone()),
+                },
+                None => tref.clone(),
+            }
+        }
+        TableRef::Join {
+            left,
+            right,
+            kind,
+            on,
+        } => TableRef::Join {
+            left: Box::new(expand_from_ctes(left, resolved)),
+            right: Box::new(expand_from_ctes(right, resolved)),
+            kind: *kind,
+            on: on.as_ref().map(|e| expand_expr_ctes(e, resolved)),
+        },
+        TableRef::Derived { subquery, alias } => TableRef::Derived {
+            subquery: Box::new(expand_select_ctes(subquery, resolved)),
+            alias: alias.clone(),
+        },
+    }
+}
+
+/// Replaces CTE references inside a subquery embedded in an expression (so a CTE
+/// is visible to WHERE/SELECT/HAVING subqueries, not only the FROM clause).
+fn expand_expr_ctes(expr: &Expr, resolved: &CteMap) -> Expr {
+    let recur = |e: &Expr| Box::new(expand_expr_ctes(e, resolved));
+    let recur_opt = |e: &Option<Box<Expr>>| e.as_ref().map(|e| recur(e));
+    let kind = match &expr.kind {
+        ExprKind::Subquery(s) => ExprKind::Subquery(Box::new(expand_select_ctes(s, resolved))),
+        ExprKind::Exists(s) => ExprKind::Exists(Box::new(expand_select_ctes(s, resolved))),
+        ExprKind::InSubquery {
+            expr: e,
+            subquery,
+            negated,
+        } => ExprKind::InSubquery {
+            expr: recur(e),
+            subquery: Box::new(expand_select_ctes(subquery, resolved)),
+            negated: *negated,
+        },
+        ExprKind::Unary { op, expr: e } => ExprKind::Unary {
+            op: *op,
+            expr: recur(e),
+        },
+        ExprKind::Binary { op, left, right } => ExprKind::Binary {
+            op: *op,
+            left: recur(left),
+            right: recur(right),
+        },
+        ExprKind::IsNull { expr: e, negated } => ExprKind::IsNull {
+            expr: recur(e),
+            negated: *negated,
+        },
+        ExprKind::Like {
+            expr: e,
+            pattern,
+            escape,
+            negated,
+        } => ExprKind::Like {
+            expr: recur(e),
+            pattern: recur(pattern),
+            escape: *escape,
+            negated: *negated,
+        },
+        ExprKind::InList {
+            expr: e,
+            list,
+            negated,
+        } => ExprKind::InList {
+            expr: recur(e),
+            list: list.iter().map(|x| expand_expr_ctes(x, resolved)).collect(),
+            negated: *negated,
+        },
+        ExprKind::Between {
+            expr: e,
+            low,
+            high,
+            negated,
+        } => ExprKind::Between {
+            expr: recur(e),
+            low: recur(low),
+            high: recur(high),
+            negated: *negated,
+        },
+        ExprKind::Case {
+            operand,
+            branches,
+            else_result,
+        } => ExprKind::Case {
+            operand: recur_opt(operand),
+            branches: branches
+                .iter()
+                .map(|(w, r)| (expand_expr_ctes(w, resolved), expand_expr_ctes(r, resolved)))
+                .collect(),
+            else_result: recur_opt(else_result),
+        },
+        ExprKind::Cast { expr: e, target } => ExprKind::Cast {
+            expr: recur(e),
+            target: target.clone(),
+        },
+        ExprKind::Function { name, args } => ExprKind::Function {
+            name: name.clone(),
+            args: args.iter().map(|a| expand_expr_ctes(a, resolved)).collect(),
+        },
+        ExprKind::Aggregate {
+            func,
+            distinct,
+            arg,
+        } => ExprKind::Aggregate {
+            func: *func,
+            distinct: *distinct,
+            arg: recur_opt(arg),
+        },
+        ExprKind::Null
+        | ExprKind::Int(_)
+        | ExprKind::Number(_)
+        | ExprKind::Str(_)
+        | ExprKind::Bool(_)
+        | ExprKind::Literal(_)
+        | ExprKind::Column(_)
+        | ExprKind::GlobalVar(_)
+        | ExprKind::LocalVar(_) => expr.kind.clone(),
+    };
+    Expr {
+        kind,
+        span: expr.span,
+    }
+}
+
 // ---- subquery resolution ------------------------------------------------
 
 /// Returns a copy of a SELECT with every subquery in its expressions
@@ -2275,6 +2487,7 @@ fn rewrite_select_subqueries(
         })
         .collect::<Result<Vec<_>, SqlError>>()?;
     Ok(Select {
+        ctes: select.ctes.clone(),
         top: select.top,
         distinct: select.distinct,
         items,
@@ -2485,6 +2698,14 @@ fn exec_select(
     select: &Select,
     eval_ctx: &EvalContext,
 ) -> Result<RowSet, SqlError> {
+    // Inline any WITH common table expressions (as derived tables) first.
+    let expanded;
+    let select = if select.ctes.is_empty() {
+        select
+    } else {
+        expanded = expand_ctes(select);
+        &expanded
+    };
     // Resolve each (uncorrelated) subquery once, up front, replacing it with a
     // literal / boolean / value-list so the rest of execution is subquery-free.
     let rewritten = rewrite_select_subqueries(storage, select, eval_ctx)?;

--- a/crates/truthdb-core/tests/slt/ctes.slt
+++ b/crates/truthdb-core/tests/slt/ctes.slt
@@ -1,0 +1,40 @@
+# Common table expressions (Stage 11 part 4, non-recursive)
+
+statement ok
+CREATE TABLE sales (id INT NOT NULL PRIMARY KEY, dept NVARCHAR(4), amount INT)
+
+statement ok
+INSERT INTO sales VALUES (1,'a',10),(2,'a',20),(3,'b',5),(4,'b',50)
+
+# A CTE referenced in FROM.
+query I
+WITH big AS (SELECT id, amount FROM sales WHERE amount >= 20) SELECT id FROM big ORDER BY id
+----
+2
+4
+
+# A CTE that aggregates, filtered by the outer query.
+query TI
+WITH s AS (SELECT dept, SUM(amount) AS total FROM sales GROUP BY dept) SELECT dept, total FROM s WHERE total > 30 ORDER BY dept
+----
+b 55
+
+# A later CTE references an earlier one.
+query I
+WITH a AS (SELECT id, amount FROM sales WHERE amount >= 10), b AS (SELECT id FROM a WHERE amount >= 20) SELECT id FROM b ORDER BY id
+----
+2
+4
+
+# A CTE joined to a base table.
+query II
+WITH s AS (SELECT dept, SUM(amount) AS total FROM sales GROUP BY dept) SELECT t.id, s.total FROM sales t JOIN s ON t.dept = s.dept ORDER BY t.id
+----
+1 30
+2 30
+3 55
+4 55
+
+# A CTE column-rename list is not supported yet.
+statement error
+WITH c(x) AS (SELECT id FROM sales) SELECT x FROM c

--- a/crates/truthdb-sql/src/ast.rs
+++ b/crates/truthdb-sql/src/ast.rs
@@ -240,6 +240,9 @@ pub struct Delete {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Select {
+    /// `WITH name AS (SELECT ...), ...` common table expressions (empty = none).
+    /// Non-recursive; expanded inline (as derived tables) before execution.
+    pub ctes: Vec<Cte>,
     pub top: Option<u64>,
     /// `SELECT DISTINCT` — deduplicate the projected rows.
     pub distinct: bool,
@@ -253,6 +256,14 @@ pub struct Select {
     pub having: Option<Expr>,
     pub order_by: Vec<OrderItem>,
     pub span: Span,
+}
+
+/// A `WITH` common table expression: `name AS (SELECT ...)`. The optional
+/// column-rename list is not yet supported.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Cte {
+    pub name: Name,
+    pub query: Box<Select>,
 }
 
 /// A FROM clause: a base table (with optional alias) or a join of two table

--- a/crates/truthdb-sql/src/parser.rs
+++ b/crates/truthdb-sql/src/parser.rs
@@ -111,7 +111,7 @@ impl Parser {
             Some("INSERT") => self.parse_insert(),
             Some("UPDATE") => self.parse_update(),
             Some("DELETE") => self.parse_delete(),
-            Some("SELECT") => Ok(Statement::Select(self.parse_select()?)),
+            Some("SELECT") | Some("WITH") => Ok(Statement::Select(self.parse_select()?)),
             Some("BEGIN") => self.parse_begin(),
             Some("COMMIT") => self.parse_commit(),
             Some("ROLLBACK") => self.parse_rollback(),
@@ -922,7 +922,60 @@ impl Parser {
 
     // ---- SELECT ---------------------------------------------------------
 
+    /// `WITH name AS (SELECT ...), ... ` — a common-table-expression prefix.
+    fn parse_ctes(&mut self) -> SqlResult<Vec<Cte>> {
+        // Bound WITH-in-WITH nesting like other recursive parse paths.
+        self.depth += 1;
+        if self.depth > MAX_EXPR_DEPTH {
+            return Err(Self::too_deep());
+        }
+        self.expect_keyword("WITH")?;
+        let mut ctes: Vec<Cte> = Vec::new();
+        loop {
+            let name = self.parse_name()?;
+            if self.check(&TokenKind::LParen) {
+                return Err(SqlError::message_only(
+                    102,
+                    "A column list on a common table expression is not supported yet.",
+                ));
+            }
+            if ctes
+                .iter()
+                .any(|c| c.name.value.eq_ignore_ascii_case(&name.value))
+            {
+                return Err(SqlError::new(
+                    460,
+                    15,
+                    1,
+                    format!(
+                        "Duplicate common table expression name '{}' was specified.",
+                        name.value
+                    ),
+                )
+                .at(name.span));
+            }
+            self.expect_keyword("AS")?;
+            self.expect(&TokenKind::LParen)?;
+            let query = self.parse_select()?;
+            self.expect(&TokenKind::RParen)?;
+            ctes.push(Cte {
+                name,
+                query: Box::new(query),
+            });
+            if !self.eat(&TokenKind::Comma) {
+                break;
+            }
+        }
+        self.depth -= 1;
+        Ok(ctes)
+    }
+
     fn parse_select(&mut self) -> SqlResult<Select> {
+        let ctes = if self.peek_keyword().as_deref() == Some("WITH") {
+            self.parse_ctes()?
+        } else {
+            Vec::new()
+        };
         let start = self.expect_keyword("SELECT")?;
         // Optional set quantifier: `SELECT [ALL | DISTINCT]`.
         let distinct = match self.peek_keyword().as_deref() {
@@ -1024,6 +1077,7 @@ impl Parser {
         }
 
         Ok(Select {
+            ctes,
             top,
             distinct,
             items,

--- a/crates/truthdb-sql/tests/corpus/ok/aggregation.ast
+++ b/crates/truthdb-sql/tests/corpus/ok/aggregation.ast
@@ -1,6 +1,7 @@
 [
     Select(
         Select {
+            ctes: [],
             top: None,
             distinct: true,
             items: [

--- a/crates/truthdb-sql/tests/corpus/ok/ctes.ast
+++ b/crates/truthdb-sql/tests/corpus/ok/ctes.ast
@@ -1,0 +1,448 @@
+[
+    Select(
+        Select {
+            ctes: [
+                Cte {
+                    name: Name {
+                        value: "big",
+                        quoted: false,
+                        span: Span {
+                            start: 5,
+                            end: 8,
+                        },
+                    },
+                    query: Select {
+                        ctes: [],
+                        top: None,
+                        distinct: false,
+                        items: [
+                            Expr {
+                                expr: Expr {
+                                    kind: Column(
+                                        Name {
+                                            value: "id",
+                                            quoted: false,
+                                            span: Span {
+                                                start: 20,
+                                                end: 22,
+                                            },
+                                        },
+                                    ),
+                                    span: Span {
+                                        start: 20,
+                                        end: 22,
+                                    },
+                                },
+                                alias: None,
+                            },
+                            Expr {
+                                expr: Expr {
+                                    kind: Column(
+                                        Name {
+                                            value: "amount",
+                                            quoted: false,
+                                            span: Span {
+                                                start: 24,
+                                                end: 30,
+                                            },
+                                        },
+                                    ),
+                                    span: Span {
+                                        start: 24,
+                                        end: 30,
+                                    },
+                                },
+                                alias: None,
+                            },
+                        ],
+                        from: Some(
+                            Table {
+                                name: Name {
+                                    value: "sales",
+                                    quoted: false,
+                                    span: Span {
+                                        start: 36,
+                                        end: 41,
+                                    },
+                                },
+                                alias: None,
+                            },
+                        ),
+                        where_clause: Some(
+                            Expr {
+                                kind: Binary {
+                                    op: Ge,
+                                    left: Expr {
+                                        kind: Column(
+                                            Name {
+                                                value: "amount",
+                                                quoted: false,
+                                                span: Span {
+                                                    start: 48,
+                                                    end: 54,
+                                                },
+                                            },
+                                        ),
+                                        span: Span {
+                                            start: 48,
+                                            end: 54,
+                                        },
+                                    },
+                                    right: Expr {
+                                        kind: Int(
+                                            20,
+                                        ),
+                                        span: Span {
+                                            start: 58,
+                                            end: 60,
+                                        },
+                                    },
+                                },
+                                span: Span {
+                                    start: 48,
+                                    end: 60,
+                                },
+                            },
+                        ),
+                        group_by: [],
+                        having: None,
+                        order_by: [],
+                        span: Span {
+                            start: 13,
+                            end: 60,
+                        },
+                    },
+                },
+            ],
+            top: None,
+            distinct: false,
+            items: [
+                Expr {
+                    expr: Expr {
+                        kind: Column(
+                            Name {
+                                value: "id",
+                                quoted: false,
+                                span: Span {
+                                    start: 69,
+                                    end: 71,
+                                },
+                            },
+                        ),
+                        span: Span {
+                            start: 69,
+                            end: 71,
+                        },
+                    },
+                    alias: None,
+                },
+            ],
+            from: Some(
+                Table {
+                    name: Name {
+                        value: "big",
+                        quoted: false,
+                        span: Span {
+                            start: 77,
+                            end: 80,
+                        },
+                    },
+                    alias: None,
+                },
+            ),
+            where_clause: None,
+            group_by: [],
+            having: None,
+            order_by: [
+                OrderItem {
+                    expr: Expr {
+                        kind: Column(
+                            Name {
+                                value: "id",
+                                quoted: false,
+                                span: Span {
+                                    start: 90,
+                                    end: 92,
+                                },
+                            },
+                        ),
+                        span: Span {
+                            start: 90,
+                            end: 92,
+                        },
+                    },
+                    descending: false,
+                },
+            ],
+            span: Span {
+                start: 62,
+                end: 92,
+            },
+        },
+    ),
+    Select(
+        Select {
+            ctes: [
+                Cte {
+                    name: Name {
+                        value: "a",
+                        quoted: false,
+                        span: Span {
+                            start: 99,
+                            end: 100,
+                        },
+                    },
+                    query: Select {
+                        ctes: [],
+                        top: None,
+                        distinct: false,
+                        items: [
+                            Expr {
+                                expr: Expr {
+                                    kind: Column(
+                                        Name {
+                                            value: "id",
+                                            quoted: false,
+                                            span: Span {
+                                                start: 112,
+                                                end: 114,
+                                            },
+                                        },
+                                    ),
+                                    span: Span {
+                                        start: 112,
+                                        end: 114,
+                                    },
+                                },
+                                alias: None,
+                            },
+                        ],
+                        from: Some(
+                            Table {
+                                name: Name {
+                                    value: "sales",
+                                    quoted: false,
+                                    span: Span {
+                                        start: 120,
+                                        end: 125,
+                                    },
+                                },
+                                alias: None,
+                            },
+                        ),
+                        where_clause: None,
+                        group_by: [],
+                        having: None,
+                        order_by: [],
+                        span: Span {
+                            start: 105,
+                            end: 125,
+                        },
+                    },
+                },
+                Cte {
+                    name: Name {
+                        value: "b",
+                        quoted: false,
+                        span: Span {
+                            start: 128,
+                            end: 129,
+                        },
+                    },
+                    query: Select {
+                        ctes: [],
+                        top: None,
+                        distinct: false,
+                        items: [
+                            Expr {
+                                expr: Expr {
+                                    kind: Column(
+                                        Name {
+                                            value: "id",
+                                            quoted: false,
+                                            span: Span {
+                                                start: 141,
+                                                end: 143,
+                                            },
+                                        },
+                                    ),
+                                    span: Span {
+                                        start: 141,
+                                        end: 143,
+                                    },
+                                },
+                                alias: None,
+                            },
+                        ],
+                        from: Some(
+                            Table {
+                                name: Name {
+                                    value: "a",
+                                    quoted: false,
+                                    span: Span {
+                                        start: 149,
+                                        end: 150,
+                                    },
+                                },
+                                alias: None,
+                            },
+                        ),
+                        where_clause: Some(
+                            Expr {
+                                kind: Binary {
+                                    op: Lt,
+                                    left: Expr {
+                                        kind: Column(
+                                            Name {
+                                                value: "id",
+                                                quoted: false,
+                                                span: Span {
+                                                    start: 157,
+                                                    end: 159,
+                                                },
+                                            },
+                                        ),
+                                        span: Span {
+                                            start: 157,
+                                            end: 159,
+                                        },
+                                    },
+                                    right: Expr {
+                                        kind: Int(
+                                            3,
+                                        ),
+                                        span: Span {
+                                            start: 162,
+                                            end: 163,
+                                        },
+                                    },
+                                },
+                                span: Span {
+                                    start: 157,
+                                    end: 163,
+                                },
+                            },
+                        ),
+                        group_by: [],
+                        having: None,
+                        order_by: [],
+                        span: Span {
+                            start: 134,
+                            end: 163,
+                        },
+                    },
+                },
+            ],
+            top: None,
+            distinct: false,
+            items: [
+                Expr {
+                    expr: Expr {
+                        kind: Column(
+                            Name {
+                                value: "t.id",
+                                quoted: false,
+                                span: Span {
+                                    start: 172,
+                                    end: 176,
+                                },
+                            },
+                        ),
+                        span: Span {
+                            start: 172,
+                            end: 176,
+                        },
+                    },
+                    alias: None,
+                },
+            ],
+            from: Some(
+                Join {
+                    left: Table {
+                        name: Name {
+                            value: "sales",
+                            quoted: false,
+                            span: Span {
+                                start: 182,
+                                end: 187,
+                            },
+                        },
+                        alias: Some(
+                            Name {
+                                value: "t",
+                                quoted: false,
+                                span: Span {
+                                    start: 188,
+                                    end: 189,
+                                },
+                            },
+                        ),
+                    },
+                    right: Table {
+                        name: Name {
+                            value: "b",
+                            quoted: false,
+                            span: Span {
+                                start: 195,
+                                end: 196,
+                            },
+                        },
+                        alias: None,
+                    },
+                    kind: Inner,
+                    on: Some(
+                        Expr {
+                            kind: Binary {
+                                op: Eq,
+                                left: Expr {
+                                    kind: Column(
+                                        Name {
+                                            value: "t.id",
+                                            quoted: false,
+                                            span: Span {
+                                                start: 200,
+                                                end: 204,
+                                            },
+                                        },
+                                    ),
+                                    span: Span {
+                                        start: 200,
+                                        end: 204,
+                                    },
+                                },
+                                right: Expr {
+                                    kind: Column(
+                                        Name {
+                                            value: "b.id",
+                                            quoted: false,
+                                            span: Span {
+                                                start: 207,
+                                                end: 211,
+                                            },
+                                        },
+                                    ),
+                                    span: Span {
+                                        start: 207,
+                                        end: 211,
+                                    },
+                                },
+                            },
+                            span: Span {
+                                start: 200,
+                                end: 211,
+                            },
+                        },
+                    ),
+                },
+            ),
+            where_clause: None,
+            group_by: [],
+            having: None,
+            order_by: [],
+            span: Span {
+                start: 165,
+                end: 211,
+            },
+        },
+    ),
+]

--- a/crates/truthdb-sql/tests/corpus/ok/ctes.sql
+++ b/crates/truthdb-sql/tests/corpus/ok/ctes.sql
@@ -1,0 +1,2 @@
+WITH big AS (SELECT id, amount FROM sales WHERE amount >= 20) SELECT id FROM big ORDER BY id;
+WITH a AS (SELECT id FROM sales), b AS (SELECT id FROM a WHERE id < 3) SELECT t.id FROM sales t JOIN b ON t.id = b.id;

--- a/crates/truthdb-sql/tests/corpus/ok/derived_tables.ast
+++ b/crates/truthdb-sql/tests/corpus/ok/derived_tables.ast
@@ -1,6 +1,7 @@
 [
     Select(
         Select {
+            ctes: [],
             top: None,
             distinct: false,
             items: [
@@ -46,6 +47,7 @@
             from: Some(
                 Derived {
                     subquery: Select {
+                        ctes: [],
                         top: None,
                         distinct: false,
                         items: [
@@ -249,6 +251,7 @@
     ),
     Select(
         Select {
+            ctes: [],
             top: None,
             distinct: false,
             items: [
@@ -315,6 +318,7 @@
                     },
                     right: Derived {
                         subquery: Select {
+                            ctes: [],
                             top: None,
                             distinct: false,
                             items: [

--- a/crates/truthdb-sql/tests/corpus/ok/expression_precedence.ast
+++ b/crates/truthdb-sql/tests/corpus/ok/expression_precedence.ast
@@ -1,6 +1,7 @@
 [
     Select(
         Select {
+            ctes: [],
             top: None,
             distinct: false,
             items: [

--- a/crates/truthdb-sql/tests/corpus/ok/insert_select.ast
+++ b/crates/truthdb-sql/tests/corpus/ok/insert_select.ast
@@ -31,6 +31,7 @@
             ),
             source: Select(
                 Select {
+                    ctes: [],
                     top: None,
                     distinct: false,
                     items: [

--- a/crates/truthdb-sql/tests/corpus/ok/joins.ast
+++ b/crates/truthdb-sql/tests/corpus/ok/joins.ast
@@ -1,6 +1,7 @@
 [
     Select(
         Select {
+            ctes: [],
             top: None,
             distinct: false,
             items: [

--- a/crates/truthdb-sql/tests/corpus/ok/select_expressions.ast
+++ b/crates/truthdb-sql/tests/corpus/ok/select_expressions.ast
@@ -1,6 +1,7 @@
 [
     Select(
         Select {
+            ctes: [],
             top: None,
             distinct: false,
             items: [

--- a/crates/truthdb-sql/tests/corpus/ok/select_star.ast
+++ b/crates/truthdb-sql/tests/corpus/ok/select_star.ast
@@ -1,6 +1,7 @@
 [
     Select(
         Select {
+            ctes: [],
             top: None,
             distinct: false,
             items: [

--- a/crates/truthdb-sql/tests/corpus/ok/select_where_order.ast
+++ b/crates/truthdb-sql/tests/corpus/ok/select_where_order.ast
@@ -1,6 +1,7 @@
 [
     Select(
         Select {
+            ctes: [],
             top: Some(
                 5,
             ),

--- a/crates/truthdb-sql/tests/corpus/ok/subqueries.ast
+++ b/crates/truthdb-sql/tests/corpus/ok/subqueries.ast
@@ -1,6 +1,7 @@
 [
     Select(
         Select {
+            ctes: [],
             top: None,
             distinct: false,
             items: [
@@ -60,6 +61,7 @@
                         right: Expr {
                             kind: Subquery(
                                 Select {
+                                    ctes: [],
                                     top: None,
                                     distinct: false,
                                     items: [
@@ -141,6 +143,7 @@
     ),
     Select(
         Select {
+            ctes: [],
             top: None,
             distinct: false,
             items: [
@@ -167,6 +170,7 @@
                     expr: Expr {
                         kind: Subquery(
                             Select {
+                                ctes: [],
                                 top: None,
                                 distinct: false,
                                 items: [
@@ -261,6 +265,7 @@
                                     },
                                 },
                                 subquery: Select {
+                                    ctes: [],
                                     top: None,
                                     distinct: false,
                                     items: [
@@ -316,6 +321,7 @@
                         right: Expr {
                             kind: Exists(
                                 Select {
+                                    ctes: [],
                                     top: None,
                                     distinct: false,
                                     items: [
@@ -378,6 +384,7 @@
     ),
     Select(
         Select {
+            ctes: [],
             top: None,
             distinct: false,
             items: [
@@ -434,6 +441,7 @@
                             },
                         },
                         subquery: Select {
+                            ctes: [],
                             top: None,
                             distinct: false,
                             items: [

--- a/crates/truthdb-sql/tests/corpus/ok/transactions.ast
+++ b/crates/truthdb-sql/tests/corpus/ok/transactions.ast
@@ -106,6 +106,7 @@
     ),
     Select(
         Select {
+            ctes: [],
             top: None,
             distinct: false,
             items: [

--- a/crates/truthdb-sql/tests/corpus/ok/variables.ast
+++ b/crates/truthdb-sql/tests/corpus/ok/variables.ast
@@ -104,6 +104,7 @@
     ),
     Select(
         Select {
+            ctes: [],
             top: None,
             distinct: false,
             items: [


### PR DESCRIPTION
Adds `WITH name AS (SELECT …), … SELECT … FROM name`. The optional column-rename list and `WITH RECURSIVE` are deferred.

## What's in
- **Parser** — an optional leading `WITH` on any SELECT; `name AS (select)`, comma-separated; a column list `WITH c(a) AS …` errors **102**; a duplicate CTE name errors **460**; `WITH`-in-`WITH` is depth-bounded (no overflow).
- **Executor** — CTEs are inlined as **derived tables** before execution. `expand_ctes` processes CTEs in order (a later CTE may reference an earlier one) into a name→query map, then replaces every FROM reference to a CTE with a derived table over the CTE's query. **Non-recursive**: a self- or forward-reference isn't in scope and resolves as a base table (errors). A CTE **shadows** a same-named real table (SQL Server precedence). `analyze_locks` inlines CTEs first so a CTE body's base tables are Shared-locked.

## Adversarial review (5 dimensions × find→verify) — 3 confirmed, all fixed
- **HIGH** — a CTE was only inlined in the top-level FROM, so a reference from a subquery in `WHERE`/`SELECT`/`HAVING` errored 208 (or, when the CTE shadowed a base table, **silently read the base table** — a wrong-result soundness bug). Expansion now recurses into embedded subqueries and join `ON` predicates, making the CTE visible to the whole statement.
- **LOW** — a duplicate CTE name was silently accepted (last wins) → now **460**.
- **LOW** — a schema-qualified reference (`dbo.s`) matched a CTE named `s` because the schema was stripped before matching → now only an unqualified reference can name a CTE.

## Tests
Engine tests (basic/aggregate/join/cross-CTE, **CTE in a WHERE subquery**, 102/460/208, self-reference), an slt matrix, and a parser corpus case. `cargo fmt`, `clippy -D warnings`, `cargo test --workspace` all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)