### PR TITLE
TDS transport-layer TLS (tunneled handshake) [Stage 9]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,7 +164,8 @@ jobs:
         run: |
           apt-get update
           apt-get install -y --no-install-recommends python3 python3-pip
-          pip install --break-system-packages python-tds==1.17.1
+          # pyOpenSSL is required for pytds's TLS (encrypted) connections.
+          pip install --break-system-packages python-tds==1.17.1 pyOpenSSL
 
       - name: Install Go
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,6 +171,13 @@ jobs:
           curl -fsSL https://go.dev/dl/go1.22.4.linux-amd64.tar.gz | tar -C /usr/local -xz
           echo "/usr/local/go/bin" >> "$GITHUB_PATH"
 
+      - name: Generate a self-signed TLS certificate
+        run: |
+          mkdir -p /etc/truthdb
+          openssl req -x509 -newkey rsa:2048 -nodes -days 1 \
+            -keyout /etc/truthdb/tls.key -out /etc/truthdb/tls.crt \
+            -subj "/CN=localhost"
+
       - name: Configure and start server
         run: |
           mkdir -p /etc/truthdb /var/lib/truthdb
@@ -183,6 +190,8 @@ jobs:
           addr = "127.0.0.1"
           port = 1433
           database = "truthdb"
+          tls_cert = "/etc/truthdb/tls.crt"
+          tls_key = "/etc/truthdb/tls.key"
 
           [tds.auth]
           sa = "secret"
@@ -206,6 +215,9 @@ jobs:
 
       - name: Conformance — pytds (Python)
         run: python3 scripts/tds_conformance.py 127.0.0.1 1433 sa secret
+
+      - name: Conformance — pytds over TLS (tunneled handshake)
+        run: python3 scripts/tds_conformance_tls.py 127.0.0.1 1433 sa secret /etc/truthdb/tls.crt
 
       - name: Conformance — go-mssqldb (Go)
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 
 [[package]]
+name = "cc"
+version = "1.2.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -187,6 +197,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "futures-core"
@@ -650,6 +666,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rstest"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -685,6 +715,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -761,6 +835,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -803,6 +883,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -911,6 +997,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -1131,7 +1227,10 @@ version = "0.1.0"
 name = "truthdb-tds"
 version = "0.1.0"
 dependencies = [
+ "rustls",
+ "rustls-pemfile",
  "tokio",
+ "tokio-rustls",
  "tracing",
  "truthdb-core",
 ]
@@ -1141,6 +1240,12 @@ name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "utf16_iter"
@@ -1189,6 +1294,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
@@ -1222,6 +1336,22 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
@@ -1230,7 +1360,7 @@ dependencies = [
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.53.1",
  "windows_i686_msvc 0.53.1",
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
@@ -1242,6 +1372,12 @@ name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -1257,6 +1393,12 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
@@ -1269,9 +1411,21 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnu"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_gnullvm"
@@ -1287,6 +1441,12 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
@@ -1296,6 +1456,12 @@ name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1311,6 +1477,12 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
@@ -1320,6 +1492,12 @@ name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -1398,6 +1576,12 @@ dependencies = [
  "syn",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerovec"

--- a/crates/truthdb-tds/Cargo.toml
+++ b/crates/truthdb-tds/Cargo.toml
@@ -9,5 +9,8 @@ license = "MIT"
 tokio = { workspace = true }
 tracing = { workspace = true }
 truthdb-core = { path = "../truthdb-core", version = "0.1.0" }
+rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12", "logging"] }
+tokio-rustls = { version = "0.26", default-features = false, features = ["ring", "tls12"] }
+rustls-pemfile = "2"
 
 [dev-dependencies]

--- a/crates/truthdb-tds/src/lib.rs
+++ b/crates/truthdb-tds/src/lib.rs
@@ -1,14 +1,15 @@
 //! TDS (Tabular Data Stream) gateway for TruthDB.
 //!
-//! A plaintext SQL Server-protocol front end so real drivers (pymssql,
-//! go-mssqldb with `encrypt=disable`) can connect to TruthDB. Stage 4 covers
-//! the packet layer, PRELOGIN (encryption not supported), LOGIN7 with
-//! config-file auth, and SQLBatch → token-stream execution over the engine's
-//! typed SQL results. TLS and RPC/prepared statements arrive in Stage 9.
+//! A SQL Server-protocol front end so real drivers (pymssql, go-mssqldb) can
+//! connect to TruthDB. Covers the packet layer, PRELOGIN, optional TLS (the
+//! tunneled handshake of MS-TDS 2.2.6.5; see [`tls`]), LOGIN7 with config-file
+//! auth, and SQLBatch → token-stream execution over the engine's typed SQL
+//! results. RPC/prepared statements arrive later in Stage 9.
 
 pub mod login;
 pub mod packet;
 pub mod server;
+pub mod tls;
 pub mod token;
 pub mod typeinfo;
 

--- a/crates/truthdb-tds/src/login.rs
+++ b/crates/truthdb-tds/src/login.rs
@@ -1,16 +1,22 @@
 //! PRELOGIN response and LOGIN7 parsing (MS-TDS 2.2.6.5, 2.2.6.4).
 
-/// Builds a PRELOGIN response: version, ENCRYPTION = NOT_SUP (plaintext
-/// only), MARS off. The option table is a list of
-/// `token u8 | offset u16 (BE) | length u16 (BE)` entries ended by `0xFF`,
-/// followed by the option data.
-pub fn prelogin_response() -> Vec<u8> {
+// PRELOGIN ENCRYPTION option values (MS-TDS 2.2.6.5).
+pub const ENCRYPT_OFF: u8 = 0x00;
+pub const ENCRYPT_ON: u8 = 0x01;
+pub const ENCRYPT_NOT_SUP: u8 = 0x02;
+pub const ENCRYPT_REQ: u8 = 0x03;
+
+const TOKEN_ENCRYPTION: u8 = 0x01;
+
+/// Builds a PRELOGIN response: version, an ENCRYPTION option, MARS off. When
+/// `offer_tls` is set the server advertises `ENCRYPT_ON` (the whole session is
+/// encrypted after a tunneled TLS handshake); otherwise `ENCRYPT_NOT_SUP`
+/// (plaintext). The option table is a list of `token u8 | offset u16 (BE) |
+/// length u16 (BE)` entries ended by `0xFF`, followed by the option data.
+pub fn prelogin_response(offer_tls: bool) -> Vec<u8> {
     const TOKEN_VERSION: u8 = 0x00;
-    const TOKEN_ENCRYPTION: u8 = 0x01;
     const TOKEN_MARS: u8 = 0x04;
     const TERMINATOR: u8 = 0xff;
-    /// ENCRYPT_NOT_SUP: this server does not support TLS (Stage 4 plaintext).
-    const ENCRYPT_NOT_SUP: u8 = 0x02;
 
     // Three options + terminator: table is 3*5 + 1 = 16 bytes; data follows.
     let table_len = 3 * 5 + 1;
@@ -32,9 +38,32 @@ pub fn prelogin_response() -> Vec<u8> {
     out.push(TERMINATOR);
 
     out.extend_from_slice(&version);
-    out.push(ENCRYPT_NOT_SUP);
+    out.push(if offer_tls {
+        ENCRYPT_ON
+    } else {
+        ENCRYPT_NOT_SUP
+    });
     out.push(0x00); // MARS off
     out
+}
+
+/// Extracts the client's ENCRYPTION option value from a PRELOGIN request
+/// payload; returns `ENCRYPT_NOT_SUP` if the option is absent or malformed.
+pub fn prelogin_client_encryption(payload: &[u8]) -> u8 {
+    let mut i = 0;
+    while i + 5 <= payload.len() {
+        let token = payload[i];
+        if token == 0xff {
+            break;
+        }
+        let offset = u16::from_be_bytes([payload[i + 1], payload[i + 2]]) as usize;
+        let len = u16::from_be_bytes([payload[i + 3], payload[i + 4]]) as usize;
+        if token == TOKEN_ENCRYPTION && len >= 1 && offset < payload.len() {
+            return payload[offset];
+        }
+        i += 5;
+    }
+    ENCRYPT_NOT_SUP
 }
 
 /// The fields a LOGIN7 request carries that Stage 4 uses.
@@ -180,7 +209,7 @@ mod tests {
 
     #[test]
     fn prelogin_response_is_well_formed() {
-        let resp = prelogin_response();
+        let resp = prelogin_response(false);
         // First option token is VERSION with a sane offset.
         assert_eq!(resp[0], 0x00);
         let version_off = u16::from_be_bytes([resp[1], resp[2]]) as usize;
@@ -192,5 +221,30 @@ mod tests {
     #[test]
     fn short_login7_errors() {
         assert!(parse_login7(&[0u8; 10]).is_err());
+    }
+
+    #[test]
+    fn prelogin_response_advertises_encryption() {
+        // The ENCRYPTION option value is the last byte before the MARS byte.
+        let off = prelogin_response(false);
+        assert_eq!(off[off.len() - 2], ENCRYPT_NOT_SUP);
+        let on = prelogin_response(true);
+        assert_eq!(on[on.len() - 2], ENCRYPT_ON);
+    }
+
+    #[test]
+    fn prelogin_client_encryption_parses_option() {
+        // Round-trip: a response built with ENCRYPT_ON is read back as ON.
+        assert_eq!(
+            prelogin_client_encryption(&prelogin_response(true)),
+            ENCRYPT_ON
+        );
+        assert_eq!(
+            prelogin_client_encryption(&prelogin_response(false)),
+            ENCRYPT_NOT_SUP
+        );
+        // A payload without an ENCRYPTION option defaults to NOT_SUP.
+        assert_eq!(prelogin_client_encryption(&[0xff]), ENCRYPT_NOT_SUP);
+        assert_eq!(prelogin_client_encryption(&[]), ENCRYPT_NOT_SUP);
     }
 }

--- a/crates/truthdb-tds/src/server.rs
+++ b/crates/truthdb-tds/src/server.rs
@@ -19,13 +19,18 @@ const TM_BEGIN_XACT: u16 = 5;
 const TM_COMMIT_XACT: u16 = 7;
 const TM_ROLLBACK_XACT: u16 = 8;
 
-/// Server-side TDS configuration: the login users and the reported database.
+/// Server-side TDS configuration: the login users, the reported database, and
+/// optional TLS.
 #[derive(Debug, Clone)]
 pub struct TdsConfig {
     /// username -> password (plaintext config auth for Stage 4).
     pub users: HashMap<String, String>,
     /// The single database name reported to clients.
     pub database: String,
+    /// TLS certificate/key. When present, the server offers encryption to
+    /// clients that request it (a tunneled TLS handshake, then an encrypted
+    /// session).
+    pub tls: Option<crate::tls::TlsConfig>,
 }
 
 /// Handles one TDS connection to completion (or disconnect).
@@ -44,15 +49,29 @@ where
     if prelogin.kind != PKT_PRELOGIN {
         return Err(protocol_err("expected PRELOGIN"));
     }
+    // Offer TLS only when configured AND the client asks to encrypt (ENCRYPT_ON
+    // /REQ). We encrypt the whole session, not the login-only mode.
+    let client_enc = login::prelogin_client_encryption(&prelogin.payload);
+    let offer_tls =
+        config.tls.is_some() && matches!(client_enc, login::ENCRYPT_ON | login::ENCRYPT_REQ);
     // The PRELOGIN *response* is sent as a REPLY (Tabular Result) packet;
     // clients (pytds/go-mssqldb) expect type 0x04 here, not 0x12.
     write_message(
         &mut stream,
         PKT_TABULAR_RESULT,
-        &login::prelogin_response(),
+        &login::prelogin_response(offer_tls),
         packet_size,
     )
     .await?;
+
+    // If encryption was negotiated, complete the tunneled TLS handshake and run
+    // the rest of the session over the encrypted stream.
+    let mut stream = if offer_tls {
+        let tls = config.tls.as_ref().expect("tls configured");
+        crate::tls::MaybeTlsStream::Tls(Box::new(tls.accept(stream).await?))
+    } else {
+        crate::tls::MaybeTlsStream::Plain(stream)
+    };
 
     // --- LOGIN7 ---
     let login_msg = read_message(&mut stream).await?;

--- a/crates/truthdb-tds/src/tls.rs
+++ b/crates/truthdb-tds/src/tls.rs
@@ -1,0 +1,436 @@
+//! TDS transport-layer TLS (MS-TDS 2.2.6.5 / "TLS tunneled in PRELOGIN").
+//!
+//! SQL Server's TLS handshake is not a normal TLS-over-TCP handshake: while the
+//! handshake is in progress, every TLS record is wrapped in a TDS packet of type
+//! `PRELOGIN` (0x12); once the handshake completes, records flow raw and the
+//! encrypted payload is ordinary TDS traffic (LOGIN7, SQL batches, ...).
+//!
+//! [`Detunnel`] is a byte stream that performs exactly this de-framing: while
+//! `raw` is false it reads/writes TLS records inside 0x12 packets; once flipped
+//! to true (right after the handshake finishes) it passes bytes through. We hand
+//! it to `tokio-rustls`, which drives the actual handshake, and flip `raw` the
+//! instant `accept()` resolves — at which point every handshake record has been
+//! exchanged and only application data remains.
+
+use std::io;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::task::{Context, Poll};
+
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use tokio_rustls::TlsAcceptor;
+use tokio_rustls::server::TlsStream;
+
+const HEADER_LEN: usize = 8;
+const PKT_PRELOGIN: u8 = 0x12;
+const STATUS_EOM: u8 = 0x01;
+/// Bounds a single handshake-phase TDS packet's payload (a TLS record is at most
+/// ~16 KiB; this is generous while capping a pre-auth allocation).
+const MAX_HANDSHAKE_PACKET: usize = 32 * 1024;
+/// Max payload per handshake-phase 0x12 packet the server emits: the default
+/// packet size (4096) minus the 8-byte header. A larger handshake flight is
+/// split across packets (the packet size is not yet negotiated during PRELOGIN).
+const HANDSHAKE_PACKET_DATA: usize = 4096 - HEADER_LEN;
+
+/// Server-side TLS configuration built from a PEM certificate chain and key.
+#[derive(Clone)]
+pub struct TlsConfig {
+    acceptor: TlsAcceptor,
+}
+
+impl std::fmt::Debug for TlsConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("TlsConfig(..)")
+    }
+}
+
+/// A client stream that is either plaintext or (after a tunneled handshake) TLS.
+/// Both variants are `AsyncRead + AsyncWrite`, so the LOGIN7/batch loop is
+/// oblivious to encryption.
+pub enum MaybeTlsStream<S> {
+    Plain(S),
+    Tls(Box<TlsStream<Detunnel<S>>>),
+}
+
+impl<S: AsyncRead + AsyncWrite + Unpin> AsyncRead for MaybeTlsStream<S> {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        match self.get_mut() {
+            MaybeTlsStream::Plain(s) => Pin::new(s).poll_read(cx, buf),
+            MaybeTlsStream::Tls(s) => Pin::new(s.as_mut()).poll_read(cx, buf),
+        }
+    }
+}
+
+impl<S: AsyncRead + AsyncWrite + Unpin> AsyncWrite for MaybeTlsStream<S> {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        match self.get_mut() {
+            MaybeTlsStream::Plain(s) => Pin::new(s).poll_write(cx, buf),
+            MaybeTlsStream::Tls(s) => Pin::new(s.as_mut()).poll_write(cx, buf),
+        }
+    }
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        match self.get_mut() {
+            MaybeTlsStream::Plain(s) => Pin::new(s).poll_flush(cx),
+            MaybeTlsStream::Tls(s) => Pin::new(s.as_mut()).poll_flush(cx),
+        }
+    }
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        match self.get_mut() {
+            MaybeTlsStream::Plain(s) => Pin::new(s).poll_shutdown(cx),
+            MaybeTlsStream::Tls(s) => Pin::new(s.as_mut()).poll_shutdown(cx),
+        }
+    }
+}
+
+impl TlsConfig {
+    /// Builds a config from a PEM certificate chain and a PEM private key.
+    pub fn from_pem(cert_pem: &[u8], key_pem: &[u8]) -> io::Result<Self> {
+        let certs = rustls_pemfile::certs(&mut &cert_pem[..])
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| {
+                io::Error::new(io::ErrorKind::InvalidData, format!("bad certificate: {e}"))
+            })?;
+        if certs.is_empty() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "no certificate found in the TLS certificate PEM",
+            ));
+        }
+        let key = rustls_pemfile::private_key(&mut &key_pem[..])
+            .map_err(|e| {
+                io::Error::new(io::ErrorKind::InvalidData, format!("bad private key: {e}"))
+            })?
+            .ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "no private key found in the TLS key PEM",
+                )
+            })?;
+        let config = rustls::ServerConfig::builder_with_provider(Arc::new(
+            rustls::crypto::ring::default_provider(),
+        ))
+        .with_safe_default_protocol_versions()
+        .map_err(|e| io::Error::other(format!("tls config: {e}")))?
+        .with_no_client_auth()
+        .with_single_cert(certs, key)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, format!("tls config: {e}")))?;
+        Ok(Self {
+            acceptor: TlsAcceptor::from(Arc::new(config)),
+        })
+    }
+
+    /// Completes the tunneled TLS handshake over `io` and returns the encrypted
+    /// stream for the rest of the session (LOGIN7 onward).
+    pub async fn accept<S>(&self, io: S) -> io::Result<TlsStream<Detunnel<S>>>
+    where
+        S: AsyncRead + AsyncWrite + Unpin,
+    {
+        let raw = Arc::new(AtomicBool::new(false));
+        let stream = self.acceptor.accept(Detunnel::new(io, raw.clone())).await?;
+        // The handshake is done; every further record is raw application data.
+        raw.store(true, Ordering::SeqCst);
+        Ok(stream)
+    }
+}
+
+/// Reads exactly one TDS packet header/body worth of bytes across polls.
+#[derive(Default)]
+struct PacketReader {
+    header: [u8; HEADER_LEN],
+    header_filled: usize,
+    body: Vec<u8>,
+    body_filled: usize,
+    body_len: usize,
+    have_header: bool,
+}
+
+/// A byte stream that tunnels TLS records inside TDS `PRELOGIN` (0x12) packets
+/// while `raw` is false, and passes bytes through once it is true.
+pub struct Detunnel<S> {
+    io: S,
+    raw: Arc<AtomicBool>,
+    reader: PacketReader,
+    /// Decoded handshake-phase bytes waiting to be delivered upward.
+    read_out: Vec<u8>,
+    read_out_pos: usize,
+    /// Framed handshake-phase bytes waiting to be written to `io`.
+    write_buf: Vec<u8>,
+    write_pos: usize,
+}
+
+impl<S> Detunnel<S> {
+    fn new(io: S, raw: Arc<AtomicBool>) -> Self {
+        Self {
+            io,
+            raw,
+            reader: PacketReader::default(),
+            read_out: Vec::new(),
+            read_out_pos: 0,
+            write_buf: Vec::new(),
+            write_pos: 0,
+        }
+    }
+    fn is_raw(&self) -> bool {
+        self.raw.load(Ordering::SeqCst)
+    }
+}
+
+/// Reads into `dst[*filled..]` from `io`, updating `filled`. Ready(true) once
+/// `dst` is full, Ready(false) on EOF, Pending if the socket would block.
+fn poll_fill<S: AsyncRead + Unpin>(
+    io: &mut S,
+    dst: &mut [u8],
+    filled: &mut usize,
+    cx: &mut Context<'_>,
+) -> Poll<io::Result<bool>> {
+    while *filled < dst.len() {
+        let mut rb = ReadBuf::new(&mut dst[*filled..]);
+        match Pin::new(&mut *io).poll_read(cx, &mut rb) {
+            Poll::Ready(Ok(())) => {
+                let n = rb.filled().len();
+                if n == 0 {
+                    return Poll::Ready(Ok(false)); // EOF
+                }
+                *filled += n;
+            }
+            Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
+            Poll::Pending => return Poll::Pending,
+        }
+    }
+    Poll::Ready(Ok(true))
+}
+
+impl<S: AsyncRead + AsyncWrite + Unpin> AsyncRead for Detunnel<S> {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        let this = self.get_mut();
+        if this.is_raw() {
+            return Pin::new(&mut this.io).poll_read(cx, buf);
+        }
+        loop {
+            // Deliver any buffered decoded bytes first.
+            if this.read_out_pos < this.read_out.len() {
+                let n = buf.remaining().min(this.read_out.len() - this.read_out_pos);
+                buf.put_slice(&this.read_out[this.read_out_pos..this.read_out_pos + n]);
+                this.read_out_pos += n;
+                return Poll::Ready(Ok(()));
+            }
+            this.read_out.clear();
+            this.read_out_pos = 0;
+
+            let r = &mut this.reader;
+            if !r.have_header {
+                match poll_fill(&mut this.io, &mut r.header, &mut r.header_filled, cx)? {
+                    Poll::Ready(true) => {}
+                    Poll::Ready(false) => return Poll::Ready(Ok(())), // EOF -> 0 bytes
+                    Poll::Pending => return Poll::Pending,
+                }
+                let length = u16::from_be_bytes([r.header[2], r.header[3]]) as usize;
+                if length < HEADER_LEN || length - HEADER_LEN > MAX_HANDSHAKE_PACKET {
+                    return Poll::Ready(Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "invalid TDS handshake packet length",
+                    )));
+                }
+                r.body_len = length - HEADER_LEN;
+                r.body = vec![0u8; r.body_len];
+                r.body_filled = 0;
+                r.have_header = true;
+            }
+            match poll_fill(&mut this.io, &mut r.body, &mut r.body_filled, cx)? {
+                Poll::Ready(true) => {}
+                Poll::Ready(false) => {
+                    return Poll::Ready(Err(io::Error::new(
+                        io::ErrorKind::UnexpectedEof,
+                        "EOF within a TDS handshake packet",
+                    )));
+                }
+                Poll::Pending => return Poll::Pending,
+            }
+            // One packet decoded; its body is the TLS record bytes.
+            this.read_out = std::mem::take(&mut r.body);
+            this.read_out_pos = 0;
+            *r = PacketReader::default();
+            // Loop to deliver the freshly decoded bytes.
+        }
+    }
+}
+
+impl<S: AsyncRead + AsyncWrite + Unpin> AsyncWrite for Detunnel<S> {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        data: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        let this = self.get_mut();
+        if this.is_raw() {
+            return Pin::new(&mut this.io).poll_write(cx, data);
+        }
+        // Drain any framed bytes still pending before accepting more.
+        while this.write_pos < this.write_buf.len() {
+            match Pin::new(&mut this.io).poll_write(cx, &this.write_buf[this.write_pos..])? {
+                Poll::Ready(n) => this.write_pos += n,
+                Poll::Pending => return Poll::Pending,
+            }
+        }
+        this.write_buf.clear();
+        this.write_pos = 0;
+        // Frame this write as one or more 0x12 packets no larger than the
+        // handshake-phase packet size (a large handshake flight — e.g. a big
+        // certificate chain — must be split, since the packet size is not yet
+        // negotiated and clients cap it). EOM is set only on the final packet.
+        let mut offset = 0;
+        let mut packet_id: u8 = 1;
+        loop {
+            let end = (offset + HANDSHAKE_PACKET_DATA).min(data.len());
+            let is_last = end == data.len();
+            let chunk = &data[offset..end];
+            let length = (HEADER_LEN + chunk.len()) as u16;
+            this.write_buf.extend_from_slice(&[
+                PKT_PRELOGIN,
+                if is_last { STATUS_EOM } else { 0 },
+                (length >> 8) as u8,
+                (length & 0xff) as u8,
+                0,
+                0,
+                packet_id,
+                0,
+            ]);
+            this.write_buf.extend_from_slice(chunk);
+            packet_id = packet_id.wrapping_add(1);
+            offset = end;
+            if is_last {
+                break;
+            }
+        }
+        while this.write_pos < this.write_buf.len() {
+            match Pin::new(&mut this.io).poll_write(cx, &this.write_buf[this.write_pos..])? {
+                Poll::Ready(n) => this.write_pos += n,
+                Poll::Pending => return Poll::Pending,
+            }
+        }
+        this.write_buf.clear();
+        this.write_pos = 0;
+        Poll::Ready(Ok(data.len()))
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        let this = self.get_mut();
+        while this.write_pos < this.write_buf.len() {
+            match Pin::new(&mut this.io).poll_write(cx, &this.write_buf[this.write_pos..])? {
+                Poll::Ready(n) => this.write_pos += n,
+                Poll::Pending => return Poll::Pending,
+            }
+        }
+        this.write_buf.clear();
+        this.write_pos = 0;
+        Pin::new(&mut this.io).poll_flush(cx)
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.get_mut().io).poll_shutdown(cx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    #[tokio::test]
+    async fn detunnel_frames_handshake_and_passes_raw() {
+        let (mut peer, server) = tokio::io::duplex(4096);
+        let raw = Arc::new(AtomicBool::new(false));
+        let mut det = Detunnel::new(server, raw.clone());
+
+        // Handshake phase: a write is wrapped in one EOM'd 0x12 packet.
+        det.write_all(b"hello").await.unwrap();
+        det.flush().await.unwrap();
+        let mut hdr = [0u8; HEADER_LEN];
+        peer.read_exact(&mut hdr).await.unwrap();
+        assert_eq!(hdr[0], PKT_PRELOGIN);
+        assert_eq!(hdr[1], STATUS_EOM);
+        let len = u16::from_be_bytes([hdr[2], hdr[3]]) as usize;
+        let mut body = vec![0u8; len - HEADER_LEN];
+        peer.read_exact(&mut body).await.unwrap();
+        assert_eq!(body, b"hello");
+
+        // Handshake phase: a 0x12 packet from the peer is de-framed on read.
+        let payload = b"world";
+        let l = (HEADER_LEN + payload.len()) as u16;
+        peer.write_all(&[
+            PKT_PRELOGIN,
+            STATUS_EOM,
+            (l >> 8) as u8,
+            (l & 0xff) as u8,
+            0,
+            0,
+            1,
+            0,
+        ])
+        .await
+        .unwrap();
+        peer.write_all(payload).await.unwrap();
+        peer.flush().await.unwrap();
+        let mut got = [0u8; 5];
+        det.read_exact(&mut got).await.unwrap();
+        assert_eq!(&got, b"world");
+
+        // After the handshake, bytes pass through unframed in both directions.
+        raw.store(true, Ordering::SeqCst);
+        det.write_all(b"raw-out").await.unwrap();
+        det.flush().await.unwrap();
+        let mut r = [0u8; 7];
+        peer.read_exact(&mut r).await.unwrap();
+        assert_eq!(&r, b"raw-out");
+        peer.write_all(b"raw-in").await.unwrap();
+        peer.flush().await.unwrap();
+        let mut r2 = [0u8; 6];
+        det.read_exact(&mut r2).await.unwrap();
+        assert_eq!(&r2, b"raw-in");
+    }
+
+    #[tokio::test]
+    async fn detunnel_splits_a_large_handshake_flight() {
+        // A flight larger than one packet is split; EOM only on the last, and
+        // the peer reassembles the original bytes.
+        let (mut peer, server) = tokio::io::duplex(1 << 16);
+        let raw = Arc::new(AtomicBool::new(false));
+        let mut det = Detunnel::new(server, raw);
+        let flight: Vec<u8> = (0..(HANDSHAKE_PACKET_DATA * 2 + 100))
+            .map(|i| (i % 253) as u8)
+            .collect();
+        det.write_all(&flight).await.unwrap();
+        det.flush().await.unwrap();
+
+        let mut reassembled = Vec::new();
+        let mut packets = 0;
+        loop {
+            let mut hdr = [0u8; HEADER_LEN];
+            peer.read_exact(&mut hdr).await.unwrap();
+            assert_eq!(hdr[0], PKT_PRELOGIN);
+            let len = u16::from_be_bytes([hdr[2], hdr[3]]) as usize;
+            let mut body = vec![0u8; len - HEADER_LEN];
+            peer.read_exact(&mut body).await.unwrap();
+            reassembled.extend_from_slice(&body);
+            packets += 1;
+            if hdr[1] & STATUS_EOM != 0 {
+                break;
+            }
+        }
+        assert_eq!(packets, 3);
+        assert_eq!(reassembled, flight);
+    }
+}

--- a/crates/truthdb-tds/tests/tds_client.rs
+++ b/crates/truthdb-tds/tests/tds_client.rs
@@ -50,6 +50,7 @@ fn config() -> TdsConfig {
     TdsConfig {
         users,
         database: "truthdb".to_string(),
+        tls: None,
     }
 }
 

--- a/scripts/tds_conformance_tls.py
+++ b/scripts/tds_conformance_tls.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""TDS TLS conformance smoke: connect over the tunneled-TLS handshake with an
+independent TDS client (python-tds), then run a create/insert/select round trip.
+
+Usage: tds_conformance_tls.py <host> <port> <user> <password> <ca_pem>
+Exits non-zero on any mismatch.
+"""
+import sys
+
+import pytds
+
+
+def main() -> int:
+    host, port, user, password, ca = (
+        sys.argv[1],
+        int(sys.argv[2]),
+        sys.argv[3],
+        sys.argv[4],
+        sys.argv[5],
+    )
+
+    conn = pytds.connect(
+        host,
+        "truthdb",
+        user,
+        password,
+        port=port,
+        login_timeout=10,
+        autocommit=True,
+        cafile=ca,
+        validate_host=False,
+        disable_connect_retry=True,
+    )
+    cur = conn.cursor()
+    cur.execute(
+        "CREATE TABLE tls_conf (id INT NOT NULL PRIMARY KEY, name NVARCHAR(20))"
+    )
+    cur.execute("INSERT INTO tls_conf VALUES (1, 'encrypted'), (2, 'session')")
+    cur.execute("SELECT id, name FROM tls_conf ORDER BY id")
+    rows = cur.fetchall()
+    expected = [(1, "encrypted"), (2, "session")]
+    if rows != expected:
+        print(f"FAIL: TLS SELECT mismatch\n got: {rows}\n want: {expected}")
+        return 1
+
+    print("tds tls conformance: OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/config.rs
+++ b/src/config.rs
@@ -35,6 +35,14 @@ pub struct TdsConfig {
 
     #[serde(default)]
     pub auth: HashMap<String, String>,
+
+    /// PEM certificate chain path — enables TLS when set (with `tls_key`).
+    #[serde(default)]
+    pub tls_cert: Option<String>,
+
+    /// PEM private key path (paired with `tls_cert`).
+    #[serde(default)]
+    pub tls_key: Option<String>,
 }
 
 impl Default for TdsConfig {
@@ -45,6 +53,8 @@ impl Default for TdsConfig {
             port: default_tds_port(),
             database: default_tds_database(),
             auth: HashMap::new(),
+            tls_cert: None,
+            tls_key: None,
         }
     }
 }
@@ -300,6 +310,8 @@ struct TdsConfigOverride {
     port: Option<u16>,
     database: Option<String>,
     auth: Option<HashMap<String, String>>,
+    tls_cert: Option<String>,
+    tls_key: Option<String>,
 }
 
 fn apply_tds_override(target: &mut TdsConfig, source: TdsConfigOverride) {
@@ -317,6 +329,12 @@ fn apply_tds_override(target: &mut TdsConfig, source: TdsConfigOverride) {
     }
     if let Some(auth) = source.auth {
         target.auth = auth;
+    }
+    if source.tls_cert.is_some() {
+        target.tls_cert = source.tls_cert;
+    }
+    if source.tls_key.is_some() {
+        target.tls_key = source.tls_key;
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -114,9 +114,27 @@ async fn main() {
 
     // Optional TDS (SQL Server protocol) gateway.
     let tds_task = if config.tds.enabled {
+        let tls = match (&config.tds.tls_cert, &config.tds.tls_key) {
+            (Some(cert_path), Some(key_path)) => match load_tds_tls(cert_path, key_path) {
+                Ok(tls) => {
+                    info!("TDS TLS enabled (cert {cert_path})");
+                    Some(tls)
+                }
+                Err(err) => {
+                    eprintln!("Failed to load TDS TLS certificate/key: {err}");
+                    return;
+                }
+            },
+            (None, None) => None,
+            _ => {
+                eprintln!("TDS TLS needs both tls_cert and tls_key");
+                return;
+            }
+        };
         let tds_config = truthdb_tds::TdsConfig {
             users: config.tds.auth.clone(),
             database: config.tds.database.clone(),
+            tls,
         };
         match truthdb_tds::TdsListener::bind(
             &config.tds.addr,
@@ -162,4 +180,11 @@ async fn main() {
     engine.shutdown();
     let _ = tokio::task::spawn_blocking(move || engine_join.join()).await;
     info!("TruthDB exiting");
+}
+
+/// Loads a PEM certificate chain and private key into a TDS TLS config.
+fn load_tds_tls(cert_path: &str, key_path: &str) -> std::io::Result<truthdb_tds::tls::TlsConfig> {
+    let cert = std::fs::read(cert_path)?;
+    let key = std::fs::read(key_path)?;
+    truthdb_tds::tls::TlsConfig::from_pem(&cert, &key)
 }


### PR DESCRIPTION
Adds SQL Server-style **TLS** to the TDS gateway — the plan's single riskiest artifact, which I'd previously deferred. Encryption is negotiated in PRELOGIN, the TLS handshake is **tunneled inside TDS PRELOGIN (0x12) packets** (MS-TDS 2.2.6.5), and the rest of the session runs over the encrypted stream. Verified end-to-end against a real client (**python-tds**) both locally and in CI. RPC/prepared statements + compat shims are the remaining Stage 9 work.

## How the tunneled handshake works
`tls::Detunnel<S>` is a byte stream that wraps/unwraps TLS records in `0x12` packets **while the handshake is in progress** and passes bytes through afterward. `tokio-rustls` drives the actual handshake over it; the raw-mode flag flips the instant `accept()` resolves — at which point every handshake record has been exchanged and only application data remains. A large handshake flight (e.g. a big cert chain) is split across packets (the packet size isn't negotiated yet during PRELOGIN).

- `tls::TlsConfig::from_pem` builds a rustls (**ring** provider) server config from a PEM cert chain + key; `MaybeTlsStream` keeps the LOGIN7/batch loop oblivious to encryption.
- **Negotiation**: the server advertises `ENCRYPT_ON` (and completes the handshake) only when a cert is configured **and** the client requests encryption (`ENCRYPT_ON`/`REQ`); otherwise it stays plaintext — existing plaintext clients (`encrypt=disable`) are unaffected.
- **Config**: `[tds] tls_cert` / `tls_key` PEM paths enable TLS.

## Verification
- Local: pytds connects over TLS (`cafile` + `validate_host=False`), runs create/insert/select, and the existing plaintext conformance still passes against the same TLS-configured server.
- **CI**: a new conformance step generates a self-signed cert, configures TLS, and drives a full tunneled TLS handshake + round trip with pytds (alongside the existing plaintext pytds/go-mssqldb runs).
- Unit tests: PRELOGIN encryption negotiation; `Detunnel` framing (round trip, **large-flight splitting**, raw passthrough after the switch).

`cargo fmt`, `clippy -D warnings`, `cargo test --workspace` all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)