### PR TITLE
Client-compat session options: safe SET no-ops + @@VERSION [Stage 9]

### DIFF
--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -563,6 +563,7 @@ fn exec_set(ctx: &mut TxnContext, set: &SetStatement) -> Result<StatementResult,
             let coerced = coerce_variable(value, &column_type, name, &eval_ctx)?;
             ctx.variables.insert(name.clone(), (column_type, coerced));
         }
+        SetStatement::Ignored => {}
     }
     Ok(StatementResult::Done)
 }

--- a/crates/truthdb-core/tests/slt/session_options.slt
+++ b/crates/truthdb-core/tests/slt/session_options.slt
@@ -1,0 +1,62 @@
+# Client-compatibility session options (Stage 9): SET options that TruthDB
+# accepts but ignores, plus the @@VERSION intrinsic. Drivers and tools (SSMS,
+# sqlcmd) emit these at connection time.
+
+statement ok
+SET QUOTED_IDENTIFIER ON
+
+statement ok
+SET ANSI_NULLS ON
+
+statement ok
+SET NOCOUNT ON
+
+statement ok
+SET ANSI_PADDING OFF
+
+statement ok
+SET TEXTSIZE 2147483647
+
+statement ok
+SET LOCK_TIMEOUT 5000
+
+# A signed numeric argument is accepted.
+statement ok
+SET DEADLOCK_PRIORITY -5
+
+statement ok
+SET DATEFORMAT mdy
+
+# Options whose OFF would change results are rejected, not silently ignored.
+statement error
+SET ANSI_NULLS OFF
+
+statement error
+SET CONCAT_NULL_YIELDS_NULL OFF
+
+# Options that change what/how much runs are rejected, not silently dropped.
+statement error
+SET ROWCOUNT 100
+
+# The no-op options do not disturb a following statement.
+statement ok
+CREATE TABLE opt_probe (id INT NOT NULL PRIMARY KEY)
+
+statement ok
+INSERT INTO opt_probe VALUES (1), (2)
+
+query I
+SELECT id FROM opt_probe ORDER BY id
+----
+1
+2
+
+# @@VERSION leads with TruthDB's identity so tools can display it.
+query T
+SELECT LEFT(@@VERSION, 7)
+----
+TruthDB
+
+# An unrecognized SET option is still a syntax error.
+statement error
+SET WHATSIT ON

--- a/crates/truthdb-sql/src/ast.rs
+++ b/crates/truthdb-sql/src/ast.rs
@@ -75,6 +75,10 @@ pub enum SetStatement {
         name: String,
         value: Expr,
     },
+    /// A recognized session option that TruthDB accepts but ignores (client
+    /// compatibility: `SET QUOTED_IDENTIFIER ON`, `SET NOCOUNT ON`,
+    /// `SET TEXTSIZE 2147483647`, ...).
+    Ignored,
 }
 
 /// `CREATE [UNIQUE] INDEX <name> ON <table> (<col> [ASC|DESC], ...)`.

--- a/crates/truthdb-sql/src/eval.rs
+++ b/crates/truthdb-sql/src/eval.rs
@@ -173,7 +173,12 @@ fn eval_global_var(name: &str, ctx: &EvalContext) -> SqlResult<SqlValue> {
     match name {
         "trancount" => Ok(SqlValue::Int(ctx.trancount as i64)),
         "spid" => Ok(SqlValue::Int(0)),
-        "version" => Ok(SqlValue::Str("TruthDB".to_string())),
+        // Lead with TruthDB's own identity, then a SQL-Server-shaped version
+        // token so tooling that scrapes @@VERSION for a version number keeps
+        // working.
+        "version" => Ok(SqlValue::Str(
+            "TruthDB - 16.0.1000.6\n\tMicrosoft SQL Server 2022 compatible edition".to_string(),
+        )),
         "error" | "rowcount" | "identity" => Ok(SqlValue::Int(0)),
         other => Err(SqlError::message_only(
             102,

--- a/crates/truthdb-sql/src/parser.rs
+++ b/crates/truthdb-sql/src/parser.rs
@@ -253,11 +253,81 @@ impl Parser {
                 let on = self.parse_on_off()?;
                 Ok(Statement::Set(SetStatement::ShowplanText(on)))
             }
+            Some(kw) if Self::set_option_requires_on(kw) => {
+                // The SQL Server default for these is ON, and TruthDB's engine
+                // is hardwired to that ON behaviour. Accept ON as a no-op, but
+                // reject OFF: silently ignoring it would return results that
+                // differ from what the client asked for (e.g. `ANSI_NULLS OFF`
+                // making `col = NULL` match NULL rows).
+                self.bump();
+                if self.parse_on_off()? {
+                    Ok(Statement::Set(SetStatement::Ignored))
+                } else {
+                    Err(SqlError::message_only(
+                        102,
+                        format!("SET {kw} OFF is not supported."),
+                    ))
+                }
+            }
+            Some(kw) if Self::set_option_ignorable(kw) => {
+                // Cosmetic or advisory options that do not change query results
+                // at TruthDB's feature level. Accept any argument as a no-op.
+                // Each takes a single argument (`ON`/`OFF`, a bare word, or a
+                // number that may carry a leading sign), so consume the option
+                // name, an optional sign, and one argument token.
+                self.bump();
+                let _ = self.eat(&TokenKind::Minus) || self.eat(&TokenKind::Plus);
+                if !matches!(self.peek().kind, TokenKind::Semicolon | TokenKind::Eof) {
+                    self.bump();
+                }
+                Ok(Statement::Set(SetStatement::Ignored))
+            }
             _ => {
                 let token = self.peek().clone();
                 Err(SqlError::syntax(self.token_text(&token), token.span))
             }
         }
+    }
+
+    /// Options whose SQL Server ON default matches TruthDB's fixed behaviour.
+    /// Accepting ON is a faithful no-op; OFF must be rejected because TruthDB
+    /// cannot honour it and silently ignoring it would corrupt results.
+    fn set_option_requires_on(kw: &str) -> bool {
+        matches!(
+            kw,
+            "QUOTED_IDENTIFIER" | "ANSI_NULLS" | "CONCAT_NULL_YIELDS_NULL" | "ANSI_DEFAULTS"
+        )
+    }
+
+    /// Cosmetic or advisory session options that clients (SSMS, sqlcmd,
+    /// drivers) set at connection time. TruthDB does not model these, but
+    /// ignoring them does not change query results, so accepting them as
+    /// no-ops keeps those clients working.
+    ///
+    /// Options that change *what* or *how much* runs — `ROWCOUNT`, `NOEXEC`,
+    /// `PARSEONLY`, `FMTONLY`, `IMPLICIT_TRANSACTIONS` — are deliberately absent:
+    /// silently ignoring them would run statements the client meant to limit or
+    /// skip. They stay hard errors until implemented.
+    fn set_option_ignorable(kw: &str) -> bool {
+        matches!(
+            kw,
+            "ANSI_PADDING"
+                | "ANSI_WARNINGS"
+                | "ANSI_NULL_DFLT_ON"
+                | "ANSI_NULL_DFLT_OFF"
+                | "ARITHABORT"
+                | "ARITHIGNORE"
+                | "NUMERIC_ROUNDABORT"
+                | "NOCOUNT"
+                | "CURSOR_CLOSE_ON_COMMIT"
+                | "FORCEPLAN"
+                | "TEXTSIZE"
+                | "LOCK_TIMEOUT"
+                | "DEADLOCK_PRIORITY"
+                | "DATEFIRST"
+                | "DATEFORMAT"
+                | "LANGUAGE"
+        )
     }
 
     fn parse_on_off(&mut self) -> SqlResult<bool> {
@@ -2047,6 +2117,58 @@ mod tests {
         assert!(Parser::parse_str(&sql).is_ok());
         let chain = format!("SELECT 1{}", " + 1".repeat(100));
         assert!(Parser::parse_str(&chain).is_ok());
+    }
+
+    #[test]
+    fn ignorable_set_options_parse_as_noops() {
+        // Cosmetic/advisory options clients send at connection time: ON/OFF
+        // flags, value forms, a signed value, and a required-ON option at ON.
+        let sql = "SET QUOTED_IDENTIFIER ON; SET NOCOUNT ON; SET ANSI_WARNINGS OFF; \
+                   SET TEXTSIZE 2147483647; SET DATEFORMAT mdy; SET LOCK_TIMEOUT -1";
+        let stmts = Parser::parse_str(sql).expect("all recognized as no-ops");
+        assert_eq!(stmts.len(), 6);
+        assert!(
+            stmts
+                .iter()
+                .all(|s| matches!(s, Statement::Set(SetStatement::Ignored))),
+            "every option should parse to SetStatement::Ignored: {stmts:?}",
+        );
+        // An unknown option is still a syntax error, not silently ignored.
+        assert_eq!(Parser::parse_str("SET WHATSIT ON").unwrap_err().number, 102);
+    }
+
+    #[test]
+    fn result_changing_set_options_are_not_silently_ignored() {
+        // OFF for an option TruthDB hardwires to ON must be rejected, never
+        // silently accepted (it would change query results).
+        assert_eq!(
+            Parser::parse_str("SET ANSI_NULLS OFF").unwrap_err().number,
+            102,
+        );
+        assert_eq!(
+            Parser::parse_str("SET CONCAT_NULL_YIELDS_NULL OFF")
+                .unwrap_err()
+                .number,
+            102,
+        );
+        // ...but the matching ON is a faithful no-op.
+        assert!(matches!(
+            Parser::parse_str("SET ANSI_NULLS ON").as_deref(),
+            Ok([Statement::Set(SetStatement::Ignored)]),
+        ));
+        // Options that change what/how much runs stay hard errors, not no-ops,
+        // so we never silently drop a client's row cap or skip flag.
+        for sql in [
+            "SET ROWCOUNT 100",
+            "SET NOEXEC ON",
+            "SET IMPLICIT_TRANSACTIONS ON",
+        ] {
+            assert_eq!(
+                Parser::parse_str(sql).unwrap_err().number,
+                102,
+                "{sql} must not be a silent no-op",
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
Part of Stage 9 (TDS client compatibility). Follows #60 (tunneled TLS).

## What

Clients (SSMS, sqlcmd, ODBC/JDBC/go-mssqldb/pytds) emit a batch of `SET`
options at connection time. Previously any option beyond
`XACT_ABORT`/`ISOLATION LEVEL`/`SHOWPLAN_TEXT` was a syntax error. This accepts
the standard connection-setup options — **but only where doing so is safe** —
and gives `@@VERSION` a client-parseable string.

## The safety split

The key design point (surfaced by an adversarial review of the first cut):
silently ignoring a `SET` option that changes results is *worse* than a loud
error. Options are handled by whether ignoring them can change data/results:

| Class | Examples | Behaviour |
|-------|----------|-----------|
| Cosmetic / advisory | `NOCOUNT`, `ANSI_PADDING`, `TEXTSIZE`, `LOCK_TIMEOUT`, `DATEFORMAT`, `DEADLOCK_PRIORITY` | Accepted as a no-op for any argument |
| Hardwired-ON | `QUOTED_IDENTIFIER`, `ANSI_NULLS`, `CONCAT_NULL_YIELDS_NULL`, `ANSI_DEFAULTS` | `ON` = faithful no-op; **`OFF` rejected** |
| Execution / row-count changing | `ROWCOUNT`, `NOEXEC`, `PARSEONLY`, `FMTONLY`, `IMPLICIT_TRANSACTIONS` | **Not accepted** — stay hard errors |

- The engine hardwires the `ON` behaviour for the middle group (e.g. `col = NULL`
  is `Unknown`, `str + NULL` is `NULL`, `"x"` is an identifier), so ignoring `OFF`
  would silently return results the client didn't ask for. `OFF` is rejected
  instead.
- The last group changes *what* or *how much* runs. Silently ignoring
  `SET ROWCOUNT 1; DELETE FROM t` would delete every row. These stay errors
  until implemented.
- A leading `+`/`-` sign on a value argument is consumed, so `SET LOCK_TIMEOUT -1`
  and `SET DEADLOCK_PRIORITY -5` parse.

`@@VERSION` now returns `"TruthDB - 16.0.1000.6\n\tMicrosoft SQL Server 2022
compatible edition"` — leads with TruthDB's identity, includes a version token
tooling can scrape.

## Tests

- `crates/truthdb-sql/src/parser.rs`: `ignorable_set_options_parse_as_noops`
  (no-op + signed-value forms) and `result_changing_set_options_are_not_silently_ignored`
  (OFF rejected, `ROWCOUNT`/`NOEXEC`/`IMPLICIT_TRANSACTIONS` still error).
- `crates/truthdb-core/tests/slt/session_options.slt`: end-to-end execute of the
  no-op options, `@@VERSION` prefix check, and the rejected forms.

fmt / clippy `-D warnings` / `cargo test --workspace` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)