### PR TITLE
sp_executesql RPC: parameterized queries [Stage 9]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,6 +217,9 @@ jobs:
       - name: Conformance — pytds (Python)
         run: python3 scripts/tds_conformance.py 127.0.0.1 1433 sa secret
 
+      - name: Conformance — pytds parameterized (sp_executesql RPC)
+        run: python3 scripts/tds_conformance_rpc.py 127.0.0.1 1433 sa secret
+
       - name: Conformance — pytds over TLS (tunneled handshake)
         run: python3 scripts/tds_conformance_tls.py 127.0.0.1 1433 sa secret /etc/truthdb/tls.crt
 

--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -144,7 +144,19 @@ impl Engine {
         input: &str,
         txn_ctx: &mut crate::rel::TxnContext,
     ) -> Result<crate::rel::BatchOutcome, EngineError> {
-        let outcome = crate::rel::execute_batch(&mut self.storage, input, txn_ctx);
+        self.sql_batch_with_params(input, txn_ctx, &[])
+    }
+
+    /// Runs a SQL batch with `sp_executesql` parameters seeded as batch
+    /// variables (see [`crate::rel::execute_batch_with_params`]).
+    pub fn sql_batch_with_params(
+        &mut self,
+        input: &str,
+        txn_ctx: &mut crate::rel::TxnContext,
+        params: &[crate::rel::RpcParam],
+    ) -> Result<crate::rel::BatchOutcome, EngineError> {
+        let outcome =
+            crate::rel::execute_batch_with_params(&mut self.storage, input, txn_ctx, params);
         self.maybe_checkpoint()?;
         Ok(outcome)
     }

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -134,11 +134,42 @@ pub struct BatchOutcome {
     pub error: Option<SqlError>,
 }
 
+/// One `sp_executesql` parameter: its `@name` (as it appears in the RPC
+/// stream), declared type, and decoded value. Passed by the TDS layer to
+/// [`execute_batch_with_params`], which seeds them as batch variables the
+/// statement text can read by name.
+#[derive(Debug, Clone)]
+pub struct RpcParam {
+    pub name: String,
+    pub column_type: ColumnType,
+    pub value: Datum,
+}
+
 /// Parses and executes a SQL batch. A parse error yields an empty batch with
 /// the error; a runtime error stops the batch but keeps earlier results.
 pub fn execute_batch(storage: &mut Storage, sql: &str, txn_ctx: &mut TxnContext) -> BatchOutcome {
+    execute_batch_with_params(storage, sql, txn_ctx, &[])
+}
+
+/// Like [`execute_batch`], but seeds `params` as batch variables before running
+/// the statement text — the `sp_executesql` path. Parameters are injected as
+/// already-typed values, never re-rendered into the SQL text, so a parameter
+/// value can never alter the statement's structure (no injection surface).
+pub fn execute_batch_with_params(
+    storage: &mut Storage,
+    sql: &str,
+    txn_ctx: &mut TxnContext,
+    params: &[RpcParam],
+) -> BatchOutcome {
     // Variables are batch-scoped: each batch starts with none.
     txn_ctx.clear_variables();
+    for param in params {
+        // The lexer keys `@p1` as `p1` (leading `@` stripped, lowercased); the
+        // RPC name arrives as `@p1`, so normalise it the same way to match.
+        let key = param.name.trim_start_matches('@').to_ascii_lowercase();
+        let value = value::datum_to_sql(&param.value, &param.column_type);
+        txn_ctx.variables.insert(key, (param.column_type, value));
+    }
     let statements = match truthdb_sql::parse(sql) {
         Ok(statements) => statements,
         Err(error) => {

--- a/crates/truthdb-core/src/session.rs
+++ b/crates/truthdb-core/src/session.rs
@@ -102,10 +102,13 @@ enum EngineCall {
     OpenSession {
         reply: oneshot::Sender<SessionId>,
     },
-    /// A SQL batch on behalf of a session (TDS path): typed results.
+    /// A SQL batch on behalf of a session (TDS path): typed results. `params`
+    /// is empty for a plain batch, or the `sp_executesql` parameters seeded as
+    /// batch variables before the statement runs (RPC path).
     RunBatch {
         session: SessionId,
         sql: String,
+        params: Vec<crate::rel::RpcParam>,
         reply: oneshot::Sender<Result<BatchReply, EngineError>>,
     },
     /// A native-protocol command (ES or SQL): rendered text.
@@ -142,11 +145,23 @@ impl EngineHandle {
         session: SessionId,
         sql: String,
     ) -> Result<BatchReply, EngineError> {
+        self.run_rpc(session, sql, Vec::new()).await
+    }
+
+    /// Runs an `sp_executesql` statement with decoded parameters seeded as
+    /// batch variables. Same lock/parking path as [`Self::run_batch`].
+    pub async fn run_rpc(
+        &self,
+        session: SessionId,
+        sql: String,
+        params: Vec<crate::rel::RpcParam>,
+    ) -> Result<BatchReply, EngineError> {
         let (reply, rx) = oneshot::channel();
         self.tx
             .send(EngineCall::RunBatch {
                 session,
                 sql,
+                params,
                 reply,
             })
             .map_err(|_| EngineError::Unavailable)?;
@@ -204,6 +219,7 @@ fn spawn_engine_with_timeout(engine: Engine, timeout: Duration) -> (EngineHandle
 struct Parked {
     session: SessionId,
     sql: String,
+    params: Vec<crate::rel::RpcParam>,
     reply: oneshot::Sender<Result<BatchReply, EngineError>>,
     needs: Vec<(Resource, LockMode)>,
     deadline: Instant,
@@ -256,8 +272,9 @@ impl EngineLoop {
                 Some(EngineCall::RunBatch {
                     session,
                     sql,
+                    params,
                     reply,
-                }) => self.dispatch_batch(session, sql, reply),
+                }) => self.dispatch_batch(session, sql, params, reply),
                 Some(EngineCall::RunNative { command, reply }) => {
                     let _ = reply.send(self.engine.execute(&command));
                 }
@@ -281,6 +298,7 @@ impl EngineLoop {
         &mut self,
         session: SessionId,
         sql: String,
+        params: Vec<crate::rel::RpcParam>,
         reply: oneshot::Sender<Result<BatchReply, EngineError>>,
     ) {
         let isolation = self
@@ -288,14 +306,17 @@ impl EngineLoop {
             .get(session)
             .map(|s| s.txn_ctx.isolation())
             .unwrap_or_default();
+        // Parameters are values, not statements, so they never change which
+        // locks the batch needs — analyse the statement text as usual.
         let needs = self.engine.analyze_locks(&sql, isolation);
         if self.try_acquire(session.raw(), &needs, true) {
-            self.run_and_reply(session, &sql, reply);
+            self.run_and_reply(session, &sql, &params, reply);
             self.wake_parked();
         } else {
             self.parked.push_back(Parked {
                 session,
                 sql,
+                params,
                 reply,
                 needs,
                 deadline: Instant::now() + self.lock_wait_timeout,
@@ -341,15 +362,18 @@ impl EngineLoop {
         &mut self,
         session: SessionId,
         sql: &str,
+        params: &[crate::rel::RpcParam],
         reply: oneshot::Sender<Result<BatchReply, EngineError>>,
     ) {
         let owner = session.raw();
         let outcome = match self.sessions.get_mut(session) {
-            Some(state) => self.engine.sql_batch(sql, &mut state.txn_ctx),
+            Some(state) => self
+                .engine
+                .sql_batch_with_params(sql, &mut state.txn_ctx, params),
             None => {
                 // Unknown session: one-shot autocommit, hold no locks after.
                 let mut txn_ctx = TxnContext::default();
-                let out = self.engine.sql_batch(sql, &mut txn_ctx);
+                let out = self.engine.sql_batch_with_params(sql, &mut txn_ctx, params);
                 self.engine.abort_session_txn(&mut txn_ctx);
                 out
             }
@@ -407,7 +431,7 @@ impl EngineLoop {
                     for (resource, mode) in &parked.needs {
                         self.locks.grant(owner, *resource, *mode);
                     }
-                    self.run_and_reply(parked.session, &parked.sql, parked.reply);
+                    self.run_and_reply(parked.session, &parked.sql, &parked.params, parked.reply);
                     ran = true;
                     break; // re-scan from the front (locks may have changed)
                 }

--- a/crates/truthdb-tds/src/lib.rs
+++ b/crates/truthdb-tds/src/lib.rs
@@ -3,11 +3,13 @@
 //! A SQL Server-protocol front end so real drivers (pymssql, go-mssqldb) can
 //! connect to TruthDB. Covers the packet layer, PRELOGIN, optional TLS (the
 //! tunneled handshake of MS-TDS 2.2.6.5; see [`tls`]), LOGIN7 with config-file
-//! auth, and SQLBatch → token-stream execution over the engine's typed SQL
-//! results. RPC/prepared statements arrive later in Stage 9.
+//! auth, SQLBatch → token-stream execution over the engine's typed SQL results,
+//! and RPC `sp_executesql` for parameterized queries (see [`rpc`]). Handle-based
+//! prepared statements (`sp_prepare`/`sp_execute`) arrive later in Stage 9.
 
 pub mod login;
 pub mod packet;
+pub mod rpc;
 pub mod server;
 pub mod tls;
 pub mod token;

--- a/crates/truthdb-tds/src/rpc.rs
+++ b/crates/truthdb-tds/src/rpc.rs
@@ -1,0 +1,600 @@
+//! TDS RPC request decoding (MS-TDS 2.2.6.6).
+//!
+//! Covers `sp_executesql` — the RPC every mainstream driver (go-mssqldb, pytds,
+//! JDBC, ODBC) uses to run a parameterized query. The request carries the
+//! statement text, a parameter-declaration string, and the typed parameter
+//! values; this module decodes the values into [`RpcParam`]s the engine seeds
+//! as batch variables. Parameters are decoded as typed values, never spliced
+//! back into SQL text, so a parameter can never change the statement's shape.
+//!
+//! `sp_prepare`/`sp_execute`/`sp_prepexec`/`sp_unprepare` (handle-based prepared
+//! statements) are a later increment; they surface here as [`RpcProc::Other`].
+
+use std::io;
+
+use truthdb_core::rel::RpcParam;
+use truthdb_core::relstore::types::{ColumnType, Datum};
+
+// Data type tokens (MS-TDS 2.2.5.4) — the variable/nullable forms drivers send
+// for parameters, plus DATE/DATETIME2/GUID/DECIMAL.
+const INTN: u8 = 0x26;
+const BITN: u8 = 0x68;
+const FLTN: u8 = 0x6d;
+const DECIMALN: u8 = 0x6a;
+const NUMERICN: u8 = 0x6c;
+const DATEN: u8 = 0x28;
+const DATETIME2N: u8 = 0x2a;
+const GUID: u8 = 0x24;
+const NVARCHAR: u8 = 0xe7;
+const NCHAR: u8 = 0xef;
+const BIGVARCHR: u8 = 0xa7;
+const BIGCHAR: u8 = 0xaf;
+const BIGVARBINARY: u8 = 0xa5;
+
+/// A `USHORT` charbin length that means NVARCHAR(MAX)/VARCHAR(MAX)/VARBINARY(MAX)
+/// — the value arrives PLP-chunked rather than length-prefixed.
+const PLP_MARKER: u16 = 0xffff;
+/// A `USHORT` value length meaning the value is NULL (non-PLP charbin).
+const CHARBIN_NULL: u16 = 0xffff;
+/// A PLP total length meaning the whole value is NULL.
+const PLP_NULL: u64 = 0xffff_ffff_ffff_ffff;
+
+/// The well-known `ProcID` for `sp_executesql` (MS-TDS 2.2.6.6).
+const SP_EXECUTESQL_PROCID: u16 = 10;
+/// Sentinel `NameLenProcID` length selecting a well-known `ProcID` instead of a
+/// procedure name.
+const PROCID_SENTINEL: u16 = 0xffff;
+
+/// Which procedure an RPC targets.
+pub enum RpcProc {
+    /// `sp_executesql` (by ProcID 10 or by name).
+    SpExecuteSql,
+    /// Any other procedure — reported back to the client as unsupported.
+    Other(String),
+}
+
+/// A decoded RPC request: the target procedure and its ordered parameters.
+pub struct RpcRequest {
+    pub proc: RpcProc,
+    pub params: Vec<RpcParam>,
+}
+
+/// Decodes an RPC request body (the bytes *after* the ALL_HEADERS block).
+pub fn parse_rpc_request(body: &[u8]) -> io::Result<RpcRequest> {
+    let mut c = Cursor::new(body);
+    // NameLenProcID: a US_VARCHAR proc name, or 0xFFFF + a well-known ProcID.
+    let name_len = c.u16()?;
+    let proc = if name_len == PROCID_SENTINEL {
+        let procid = c.u16()?;
+        if procid == SP_EXECUTESQL_PROCID {
+            RpcProc::SpExecuteSql
+        } else {
+            RpcProc::Other(format!("ProcID #{procid}"))
+        }
+    } else {
+        let name = c.utf16(name_len as usize * 2)?;
+        if name.eq_ignore_ascii_case("sp_executesql") {
+            RpcProc::SpExecuteSql
+        } else {
+            RpcProc::Other(name)
+        }
+    };
+    let _option_flags = c.u16()?;
+
+    let mut params = Vec::new();
+    while c.remaining() > 0 {
+        // A batch flag (0x80 = fWithRecompile / 0xFF = separator) begins the
+        // next RPC in a multi-RPC request; we run the first and stop there.
+        let lead = c.peek_u8();
+        if lead == 0xff || lead == 0x80 {
+            break;
+        }
+        let name_len = c.u8()? as usize;
+        let name = c.utf16(name_len * 2)?;
+        let _status = c.u8()?; // StatusFlags: fByRefValue / fDefaultValue.
+        let (column_type, value) = decode_param(&mut c)?;
+        params.push(RpcParam {
+            name,
+            column_type,
+            value,
+        });
+    }
+    Ok(RpcRequest { proc, params })
+}
+
+/// Splits an `sp_executesql` parameter list into (statement text, value
+/// parameters). Layout: `@stmt`, optional `@params` declaration, then the
+/// value parameters — which are the only ones seeded as batch variables.
+pub fn split_sp_executesql(mut params: Vec<RpcParam>) -> io::Result<(String, Vec<RpcParam>)> {
+    if params.is_empty() {
+        return Err(protocol_err("sp_executesql: missing statement parameter"));
+    }
+    let values = params.split_off(params.len().min(2));
+    let stmt = match &params[0].value {
+        Datum::NVarChar(s) | Datum::VarChar(s) => s.clone(),
+        Datum::Null => return Err(protocol_err("sp_executesql: NULL statement")),
+        _ => return Err(protocol_err("sp_executesql: statement is not a string")),
+    };
+    Ok((stmt, values))
+}
+
+/// Decodes one parameter's TYPE_INFO and value into a column type + datum.
+fn decode_param(c: &mut Cursor) -> io::Result<(ColumnType, Datum)> {
+    let token = c.u8()?;
+    match token {
+        INTN => {
+            let max_len = c.u8()?;
+            let column_type = int_type(max_len)?;
+            let value = match c.u8()? as usize {
+                0 => Datum::Null,
+                1 => Datum::TinyInt(c.u8()?),
+                2 => Datum::SmallInt(i16::from_le_bytes(c.array::<2>()?)),
+                4 => Datum::Int(i32::from_le_bytes(c.array::<4>()?)),
+                8 => Datum::BigInt(i64::from_le_bytes(c.array::<8>()?)),
+                n => return Err(protocol_err(&format!("INTN bad value length {n}"))),
+            };
+            Ok((column_type, value))
+        }
+        BITN => {
+            let _max_len = c.u8()?;
+            let value = match c.u8()? {
+                0 => Datum::Null,
+                _ => Datum::Bit(c.u8()? != 0),
+            };
+            Ok((ColumnType::Bit, value))
+        }
+        FLTN => {
+            let max_len = c.u8()?;
+            let column_type = match max_len {
+                4 => ColumnType::Real,
+                8 => ColumnType::Float,
+                n => return Err(protocol_err(&format!("FLTN bad max length {n}"))),
+            };
+            let value = match c.u8()? as usize {
+                0 => Datum::Null,
+                4 => Datum::Real(f32::from_le_bytes(c.array::<4>()?)),
+                8 => Datum::Float(f64::from_le_bytes(c.array::<8>()?)),
+                n => return Err(protocol_err(&format!("FLTN bad value length {n}"))),
+            };
+            Ok((column_type, value))
+        }
+        DECIMALN | NUMERICN => {
+            let _max_len = c.u8()?;
+            let precision = c.u8()?;
+            let scale = c.u8()?;
+            let value = match c.u8()? as usize {
+                0 => Datum::Null,
+                // 1 sign byte + at most a 16-byte magnitude (an i128); a longer
+                // length is malformed and would overflow the shift below.
+                len if len <= 17 => {
+                    let sign = c.u8()?;
+                    let mag = c.bytes(len - 1)?;
+                    let mut acc: i128 = 0;
+                    for (i, byte) in mag.iter().enumerate() {
+                        acc |= (*byte as i128) << (8 * i);
+                    }
+                    Datum::Decimal(if sign == 0 { -acc } else { acc })
+                }
+                len => return Err(protocol_err(&format!("DECIMALN bad value length {len}"))),
+            };
+            Ok((ColumnType::Decimal { precision, scale }, value))
+        }
+        DATEN => {
+            let value = match c.u8()? {
+                0 => Datum::Null,
+                _ => Datum::Date(u32::from_le_bytes(c.array_padded::<3, 4>()?)),
+            };
+            Ok((ColumnType::Date, value))
+        }
+        DATETIME2N => {
+            let scale = c.u8()?;
+            let value = match c.u8()? as usize {
+                0 => Datum::Null,
+                // A DATETIME2 body is a 3/4/5-byte time field (by scale) plus a
+                // 3-byte date = total 6..=8. Anything else is malformed; without
+                // this bound `total - 3` and the tick scaling could overflow.
+                total if (6..=8).contains(&total) => {
+                    let raw = c.uint_le(total - 3)?;
+                    // The wire value is in 10^-scale-second units; the datum
+                    // stores 100ns (10^-7-second) ticks. With a valid time field
+                    // (<= 5 bytes) this product cannot overflow, but saturate
+                    // defensively rather than wrap.
+                    let ticks = raw.saturating_mul(10u64.pow(7u32.saturating_sub(scale as u32)));
+                    let days = u32::from_le_bytes(c.array_padded::<3, 4>()?);
+                    Datum::DateTime2(days, ticks)
+                }
+                total => {
+                    return Err(protocol_err(&format!(
+                        "DATETIME2N bad value length {total}"
+                    )));
+                }
+            };
+            Ok((ColumnType::DateTime2, value))
+        }
+        GUID => {
+            let _max_len = c.u8()?;
+            let value = match c.u8()? {
+                0 => Datum::Null,
+                _ => Datum::UniqueIdentifier(c.array::<16>()?),
+            };
+            Ok((ColumnType::UniqueIdentifier, value))
+        }
+        NVARCHAR | NCHAR => {
+            let max_len = c.u16()?;
+            c.skip(5)?; // collation
+            let column_type = ColumnType::NVarChar {
+                max_len: (max_len / 2).max(1),
+            };
+            let value = match charbin_bytes(c, max_len)? {
+                Some(bytes) => Datum::NVarChar(utf16le_to_string(&bytes)),
+                None => Datum::Null,
+            };
+            Ok((column_type, value))
+        }
+        BIGVARCHR | BIGCHAR => {
+            let max_len = c.u16()?;
+            c.skip(5)?; // collation
+            let column_type = ColumnType::VarChar {
+                max_len: max_len.max(1),
+            };
+            let value = match charbin_bytes(c, max_len)? {
+                Some(bytes) => Datum::VarChar(cp1252_to_string(&bytes)),
+                None => Datum::Null,
+            };
+            Ok((column_type, value))
+        }
+        BIGVARBINARY => {
+            let max_len = c.u16()?;
+            let column_type = ColumnType::VarBinary {
+                max_len: max_len.max(1),
+            };
+            let value = match charbin_bytes(c, max_len)? {
+                Some(bytes) => Datum::VarBinary(bytes),
+                None => Datum::Null,
+            };
+            Ok((column_type, value))
+        }
+        other => Err(protocol_err(&format!(
+            "unsupported RPC parameter type token 0x{other:02x}"
+        ))),
+    }
+}
+
+/// The ColumnType for an INTN of the given declared byte width.
+fn int_type(max_len: u8) -> io::Result<ColumnType> {
+    match max_len {
+        1 => Ok(ColumnType::TinyInt),
+        2 => Ok(ColumnType::SmallInt),
+        4 => Ok(ColumnType::Int),
+        8 => Ok(ColumnType::BigInt),
+        n => Err(protocol_err(&format!("INTN bad max length {n}"))),
+    }
+}
+
+/// Reads a charbin (NVARCHAR/VARCHAR/VARBINARY) value body: either a PLP stream
+/// (declared max length 0xFFFF) or a `USHORT`-length-prefixed run. Returns the
+/// raw bytes, or `None` for NULL.
+fn charbin_bytes(c: &mut Cursor, max_len: u16) -> io::Result<Option<Vec<u8>>> {
+    if max_len == PLP_MARKER {
+        return plp_bytes(c);
+    }
+    let len = c.u16()?;
+    if len == CHARBIN_NULL {
+        return Ok(None);
+    }
+    Ok(Some(c.bytes(len as usize)?.to_vec()))
+}
+
+/// Reads a PLP-encoded value (MS-TDS 2.2.5.2.3): an 8-byte total length, then
+/// length-prefixed chunks terminated by a zero-length chunk.
+fn plp_bytes(c: &mut Cursor) -> io::Result<Option<Vec<u8>>> {
+    let total = c.u64()?;
+    if total == PLP_NULL {
+        return Ok(None);
+    }
+    let mut out = Vec::new();
+    loop {
+        let chunk = c.u32()? as usize;
+        if chunk == 0 {
+            break;
+        }
+        out.extend_from_slice(c.bytes(chunk)?);
+    }
+    Ok(Some(out))
+}
+
+fn utf16le_to_string(bytes: &[u8]) -> String {
+    let units: Vec<u16> = bytes
+        .chunks_exact(2)
+        .map(|c| u16::from_le_bytes([c[0], c[1]]))
+        .collect();
+    String::from_utf16_lossy(&units)
+}
+
+/// Decodes Windows-1252 bytes to a string — the inverse of the encoder in
+/// `typeinfo`. 0x00–0x7F and 0xA0–0xFF are Latin-1 (== Unicode); 0x80–0x9F map
+/// to specific punctuation/symbols, with the five unassigned slots replaced.
+fn cp1252_to_string(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| cp1252_char(*b)).collect()
+}
+
+fn cp1252_char(b: u8) -> char {
+    match b {
+        0x80 => '\u{20AC}',
+        0x82 => '\u{201A}',
+        0x83 => '\u{0192}',
+        0x84 => '\u{201E}',
+        0x85 => '\u{2026}',
+        0x86 => '\u{2020}',
+        0x87 => '\u{2021}',
+        0x88 => '\u{02C6}',
+        0x89 => '\u{2030}',
+        0x8A => '\u{0160}',
+        0x8B => '\u{2039}',
+        0x8C => '\u{0152}',
+        0x8E => '\u{017D}',
+        0x91 => '\u{2018}',
+        0x92 => '\u{2019}',
+        0x93 => '\u{201C}',
+        0x94 => '\u{201D}',
+        0x95 => '\u{2022}',
+        0x96 => '\u{2013}',
+        0x97 => '\u{2014}',
+        0x98 => '\u{02DC}',
+        0x99 => '\u{2122}',
+        0x9A => '\u{0161}',
+        0x9B => '\u{203A}',
+        0x9C => '\u{0153}',
+        0x9E => '\u{017E}',
+        0x9F => '\u{0178}',
+        0x81 | 0x8D | 0x8F | 0x90 | 0x9D => '\u{FFFD}',
+        other => other as char,
+    }
+}
+
+fn protocol_err(message: &str) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, message.to_string())
+}
+
+/// A little-endian byte cursor over an RPC body. Every read is bounds-checked
+/// and returns an `InvalidData` error on underflow, so a truncated or malformed
+/// request fails cleanly instead of panicking.
+struct Cursor<'a> {
+    buf: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> Cursor<'a> {
+    fn new(buf: &'a [u8]) -> Self {
+        Cursor { buf, pos: 0 }
+    }
+
+    fn remaining(&self) -> usize {
+        self.buf.len().saturating_sub(self.pos)
+    }
+
+    fn peek_u8(&self) -> u8 {
+        self.buf.get(self.pos).copied().unwrap_or(0)
+    }
+
+    fn bytes(&mut self, n: usize) -> io::Result<&'a [u8]> {
+        let end = self
+            .pos
+            .checked_add(n)
+            .filter(|end| *end <= self.buf.len())
+            .ok_or_else(|| protocol_err("RPC request truncated"))?;
+        let slice = &self.buf[self.pos..end];
+        self.pos = end;
+        Ok(slice)
+    }
+
+    fn skip(&mut self, n: usize) -> io::Result<()> {
+        self.bytes(n).map(|_| ())
+    }
+
+    fn u8(&mut self) -> io::Result<u8> {
+        Ok(self.bytes(1)?[0])
+    }
+
+    fn u16(&mut self) -> io::Result<u16> {
+        Ok(u16::from_le_bytes(self.array::<2>()?))
+    }
+
+    fn u32(&mut self) -> io::Result<u32> {
+        Ok(u32::from_le_bytes(self.array::<4>()?))
+    }
+
+    fn u64(&mut self) -> io::Result<u64> {
+        Ok(u64::from_le_bytes(self.array::<8>()?))
+    }
+
+    /// Reads `n` (<= 8) little-endian bytes into a u64. A wider request is
+    /// rejected rather than shifting past the width of a u64.
+    fn uint_le(&mut self, n: usize) -> io::Result<u64> {
+        if n > 8 {
+            return Err(protocol_err("integer field wider than 8 bytes"));
+        }
+        let mut acc = 0u64;
+        for (i, byte) in self.bytes(n)?.iter().enumerate() {
+            acc |= (*byte as u64) << (8 * i);
+        }
+        Ok(acc)
+    }
+
+    fn array<const N: usize>(&mut self) -> io::Result<[u8; N]> {
+        let mut out = [0u8; N];
+        out.copy_from_slice(self.bytes(N)?);
+        Ok(out)
+    }
+
+    /// Reads `N` bytes into the low bytes of an `M`-byte array (M > N), leaving
+    /// the high bytes zero — for 3-byte DATE/DATETIME2 fields read as a u32.
+    fn array_padded<const N: usize, const M: usize>(&mut self) -> io::Result<[u8; M]> {
+        let mut out = [0u8; M];
+        out[..N].copy_from_slice(self.bytes(N)?);
+        Ok(out)
+    }
+
+    /// Reads `byte_count` bytes as a UTF-16LE string.
+    fn utf16(&mut self, byte_count: usize) -> io::Result<String> {
+        Ok(utf16le_to_string(self.bytes(byte_count)?))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Builds a minimal `sp_executesql` RPC body (ProcID form) with a single
+    /// `@p1 INT` value parameter, and an empty `@params` declaration.
+    fn sample_body() -> Vec<u8> {
+        let mut b = Vec::new();
+        // NameLenProcID: 0xFFFF + ProcID 10.
+        b.extend_from_slice(&PROCID_SENTINEL.to_le_bytes());
+        b.extend_from_slice(&SP_EXECUTESQL_PROCID.to_le_bytes());
+        b.extend_from_slice(&0u16.to_le_bytes()); // OptionFlags
+
+        // Param 0: @stmt = N'SELECT @p1' (NVARCHAR).
+        push_nvarchar_param(&mut b, "", "SELECT @p1");
+        // Param 1: @params = N'@p1 int' (NVARCHAR).
+        push_nvarchar_param(&mut b, "@params", "@p1 int");
+        // Param 2: @p1 = 258 (INTN, 4 bytes).
+        push_name(&mut b, "@p1");
+        b.push(0x00); // status
+        b.push(INTN);
+        b.push(4); // max len
+        b.push(4); // value len
+        b.extend_from_slice(&258i32.to_le_bytes());
+        b
+    }
+
+    fn push_name(b: &mut Vec<u8>, name: &str) {
+        let units: Vec<u16> = name.encode_utf16().collect();
+        b.push(units.len() as u8);
+        for u in units {
+            b.extend_from_slice(&u.to_le_bytes());
+        }
+    }
+
+    fn push_nvarchar_param(b: &mut Vec<u8>, name: &str, value: &str) {
+        push_name(b, name);
+        b.push(0x00); // status
+        b.push(NVARCHAR);
+        b.extend_from_slice(&8000u16.to_le_bytes()); // max len
+        b.extend_from_slice(&[0x09, 0x04, 0xd0, 0x00, 0x34]); // collation
+        let bytes: Vec<u8> = value.encode_utf16().flat_map(|u| u.to_le_bytes()).collect();
+        b.extend_from_slice(&(bytes.len() as u16).to_le_bytes());
+        b.extend_from_slice(&bytes);
+    }
+
+    #[test]
+    fn decodes_sp_executesql_with_int_param() {
+        let req = parse_rpc_request(&sample_body()).expect("parse");
+        assert!(matches!(req.proc, RpcProc::SpExecuteSql));
+        assert_eq!(req.params.len(), 3);
+
+        let (sql, values) = split_sp_executesql(req.params).expect("split");
+        assert_eq!(sql, "SELECT @p1");
+        assert_eq!(values.len(), 1);
+        assert_eq!(values[0].name, "@p1");
+        assert!(matches!(values[0].column_type, ColumnType::Int));
+        assert!(matches!(values[0].value, Datum::Int(258)));
+    }
+
+    #[test]
+    fn decodes_null_and_string_and_bigint_params() {
+        let mut b = Vec::new();
+        b.extend_from_slice(&PROCID_SENTINEL.to_le_bytes());
+        b.extend_from_slice(&SP_EXECUTESQL_PROCID.to_le_bytes());
+        b.extend_from_slice(&0u16.to_le_bytes());
+        push_nvarchar_param(&mut b, "", "stmt");
+        push_nvarchar_param(&mut b, "@params", "decl");
+        // @s = N'café' (NVARCHAR).
+        push_nvarchar_param(&mut b, "@s", "café");
+        // @big = 5_000_000_000 (INTN, 8 bytes).
+        push_name(&mut b, "@big");
+        b.push(0x00);
+        b.push(INTN);
+        b.push(8);
+        b.push(8);
+        b.extend_from_slice(&5_000_000_000i64.to_le_bytes());
+        // @n = NULL INT.
+        push_name(&mut b, "@n");
+        b.push(0x00);
+        b.push(INTN);
+        b.push(4);
+        b.push(0); // NULL
+
+        let req = parse_rpc_request(&b).expect("parse");
+        let (_sql, values) = split_sp_executesql(req.params).expect("split");
+        assert_eq!(values.len(), 3);
+        assert!(matches!(&values[0].value, Datum::NVarChar(s) if s == "café"));
+        assert!(matches!(values[1].value, Datum::BigInt(5_000_000_000)));
+        assert!(matches!(values[2].value, Datum::Null));
+    }
+
+    #[test]
+    fn unknown_proc_reports_other() {
+        let mut b = Vec::new();
+        b.extend_from_slice(&PROCID_SENTINEL.to_le_bytes());
+        b.extend_from_slice(&11u16.to_le_bytes()); // sp_prepare
+        b.extend_from_slice(&0u16.to_le_bytes());
+        let req = parse_rpc_request(&b).expect("parse");
+        assert!(matches!(req.proc, RpcProc::Other(_)));
+    }
+
+    #[test]
+    fn truncated_body_errors_not_panics() {
+        // ProcID form then a param cut off mid-value.
+        let mut b = Vec::new();
+        b.extend_from_slice(&PROCID_SENTINEL.to_le_bytes());
+        b.extend_from_slice(&SP_EXECUTESQL_PROCID.to_le_bytes());
+        b.extend_from_slice(&0u16.to_le_bytes());
+        push_name(&mut b, "@p1");
+        b.push(0x00);
+        b.push(INTN);
+        b.push(4);
+        b.push(4); // claims 4 value bytes...
+        b.extend_from_slice(&[0x01, 0x02]); // ...only 2 present
+        assert!(parse_rpc_request(&b).is_err());
+    }
+
+    /// A malformed value length must yield an error, never an arithmetic-overflow
+    /// panic in the length-driven decoders. These bodies would panic (debug) or
+    /// silently mis-decode (release) without the range checks.
+    #[test]
+    fn malformed_lengths_error_not_panic() {
+        let header = |token: &[u8]| {
+            let mut b = Vec::new();
+            b.extend_from_slice(&PROCID_SENTINEL.to_le_bytes());
+            b.extend_from_slice(&SP_EXECUTESQL_PROCID.to_le_bytes());
+            b.extend_from_slice(&0u16.to_le_bytes());
+            push_name(&mut b, "@p");
+            b.push(0x00); // status
+            b.extend_from_slice(token);
+            b
+        };
+
+        // DATETIME2N with value length 1 (< the minimum 6) — `total - 3` would
+        // underflow.
+        let mut short_dt2 = header(&[DATETIME2N, 0x00]); // scale 0
+        short_dt2.push(1); // value length 1
+        short_dt2.push(0xAA);
+        assert!(parse_rpc_request(&short_dt2).is_err());
+
+        // DATETIME2N with value length 12 (time field 9 bytes) — `uint_le(9)`
+        // would shift past a u64.
+        let mut long_dt2 = header(&[DATETIME2N, 0x00]);
+        long_dt2.push(12);
+        long_dt2.extend_from_slice(&[0xFF; 12]);
+        assert!(parse_rpc_request(&long_dt2).is_err());
+
+        // DECIMALN with value length 18 (17-byte magnitude) — the i128 shift
+        // would reach `<< 128`.
+        let mut big_dec = header(&[DECIMALN, 0x00, 0x00, 0x00]); // max_len, prec, scale
+        big_dec.push(18); // value length
+        big_dec.push(0x01); // sign
+        big_dec.extend_from_slice(&[0x00; 17]);
+        assert!(parse_rpc_request(&big_dec).is_err());
+    }
+}

--- a/crates/truthdb-tds/src/rpc.rs
+++ b/crates/truthdb-tds/src/rpc.rs
@@ -17,6 +17,9 @@ use truthdb_core::relstore::types::{ColumnType, Datum};
 
 // Data type tokens (MS-TDS 2.2.5.4) — the variable/nullable forms drivers send
 // for parameters, plus DATE/DATETIME2/GUID/DECIMAL.
+/// A typeless NULL: no metadata, no value body (go-mssqldb sends a bare `nil`
+/// parameter this way).
+const NULLTYPE: u8 = 0x1f;
 const INTN: u8 = 0x26;
 const BITN: u8 = 0x68;
 const FLTN: u8 = 0x6d;
@@ -122,6 +125,9 @@ pub fn split_sp_executesql(mut params: Vec<RpcParam>) -> io::Result<(String, Vec
 fn decode_param(c: &mut Cursor) -> io::Result<(ColumnType, Datum)> {
     let token = c.u8()?;
     match token {
+        // A typeless NULL carries no metadata and no value. The stored column
+        // type is unused (the value coerces to NULL wherever it is read).
+        NULLTYPE => Ok((ColumnType::Int, Datum::Null)),
         INTN => {
             let max_len = c.u8()?;
             let column_type = int_type(max_len)?;
@@ -531,6 +537,34 @@ mod tests {
         assert!(matches!(&values[0].value, Datum::NVarChar(s) if s == "café"));
         assert!(matches!(values[1].value, Datum::BigInt(5_000_000_000)));
         assert!(matches!(values[2].value, Datum::Null));
+    }
+
+    #[test]
+    fn decodes_bare_nulltype_param() {
+        // go-mssqldb sends a `nil` parameter as a typeless NULL (0x1F): the
+        // token alone, with no metadata and no value body.
+        let mut b = Vec::new();
+        b.extend_from_slice(&PROCID_SENTINEL.to_le_bytes());
+        b.extend_from_slice(&SP_EXECUTESQL_PROCID.to_le_bytes());
+        b.extend_from_slice(&0u16.to_le_bytes());
+        push_nvarchar_param(&mut b, "", "stmt");
+        push_nvarchar_param(&mut b, "@params", "decl");
+        push_name(&mut b, "@p1");
+        b.push(0x00); // status
+        b.push(NULLTYPE); // token, nothing follows
+        // A second param after it must still parse (no over-read of NULLTYPE).
+        push_name(&mut b, "@p2");
+        b.push(0x00);
+        b.push(INTN);
+        b.push(4);
+        b.push(4);
+        b.extend_from_slice(&7i32.to_le_bytes());
+
+        let req = parse_rpc_request(&b).expect("parse");
+        let (_sql, values) = split_sp_executesql(req.params).expect("split");
+        assert_eq!(values.len(), 2);
+        assert!(matches!(values[0].value, Datum::Null));
+        assert!(matches!(values[1].value, Datum::Int(7)));
     }
 
     #[test]

--- a/crates/truthdb-tds/src/server.rs
+++ b/crates/truthdb-tds/src/server.rs
@@ -9,9 +9,10 @@ use truthdb_core::session::{EngineHandle, SessionId};
 
 use crate::login::{self, parse_login7};
 use crate::packet::{
-    self, DEFAULT_PACKET_SIZE, Message, PKT_ATTENTION, PKT_LOGIN7, PKT_PRELOGIN, PKT_SQL_BATCH,
-    PKT_TABULAR_RESULT, PKT_TRANSACTION_MANAGER, read_message, write_message,
+    self, DEFAULT_PACKET_SIZE, Message, PKT_ATTENTION, PKT_LOGIN7, PKT_PRELOGIN, PKT_RPC,
+    PKT_SQL_BATCH, PKT_TABULAR_RESULT, PKT_TRANSACTION_MANAGER, read_message, write_message,
 };
+use crate::rpc::{self, RpcProc};
 use crate::token;
 
 // Transaction Manager request types (MS-TDS 2.2.6.9).
@@ -153,6 +154,10 @@ where
             PKT_SQL_BATCH => {
                 let sql = batch_sql(&message.payload)?;
                 let response = run_batch(engine, session, &sql).await;
+                write_message(stream, PKT_TABULAR_RESULT, &response, packet_size).await?;
+            }
+            PKT_RPC => {
+                let response = run_rpc(engine, session, &message.payload).await;
                 write_message(stream, PKT_TABULAR_RESULT, &response, packet_size).await?;
             }
             PKT_TRANSACTION_MANAGER => {
@@ -301,6 +306,44 @@ async fn run_batch(engine: &EngineHandle, session: SessionId, sql: &str) -> Vec<
             out
         }
     }
+}
+
+/// Handles an RPC request. Supports `sp_executesql` — decode its statement and
+/// typed parameters, run them, and return the same token stream a batch would.
+/// Any other procedure, or a malformed request, is answered with an error token
+/// plus a final DONE so the connection stays usable.
+async fn run_rpc(engine: &EngineHandle, session: SessionId, payload: &[u8]) -> Vec<u8> {
+    let request = match rpc::parse_rpc_request(skip_all_headers(payload)) {
+        Ok(request) => request,
+        Err(err) => return rpc_error(&format!("malformed RPC request: {err}")),
+    };
+    match request.proc {
+        RpcProc::SpExecuteSql => {
+            let (sql, params) = match rpc::split_sp_executesql(request.params) {
+                Ok(split) => split,
+                Err(err) => return rpc_error(&err.to_string()),
+            };
+            match engine.run_rpc(session, sql, params).await {
+                Ok(reply) => build_batch_tokens(&reply.outcome, reply.in_transaction),
+                Err(err) => rpc_error(&err.to_string()),
+            }
+        }
+        // Error 2812 is SQL Server's "Could not find stored procedure".
+        RpcProc::Other(name) => {
+            rpc_error_num(2812, &format!("Could not find stored procedure '{name}'."))
+        }
+    }
+}
+
+fn rpc_error(message: &str) -> Vec<u8> {
+    rpc_error_num(50000, message)
+}
+
+fn rpc_error_num(number: i32, message: &str) -> Vec<u8> {
+    let mut out = Vec::new();
+    token::error(&mut out, number, 1, 16, message);
+    token::done(&mut out, false, true, false, None);
+    out
 }
 
 /// Builds the COLMETADATA/ROW/DONE/ERROR token stream for a batch outcome.

--- a/scripts/tds_conformance.go
+++ b/scripts/tds_conformance.go
@@ -180,9 +180,83 @@ func main() {
 	// 11-13: transactions via the TDS Transaction Manager (db.BeginTx sends
 	// TM_BEGIN_XACT, tx.Commit/Rollback send TM_COMMIT/ROLLBACK_XACT).
 	transactionMatrix(db)
+	parameterizedQueries(db)
 	blockingDemo(db, host, port, user, pass)
 
 	fmt.Println("tds conformance (go-mssqldb): OK")
+}
+
+// parameterizedQueries exercises the sp_executesql RPC path: go-mssqldb sends
+// query arguments as typed RPC parameters (packet type 0x03), never spliced
+// into the SQL text.
+func parameterizedQueries(db *sql.DB) {
+	mustExec(db, "CREATE TABLE param_go (id INT NOT NULL PRIMARY KEY, name NVARCHAR(40), n INT)")
+
+	// Parameterized INSERTs with int, unicode string, and NULL parameters.
+	if _, err := db.Exec("INSERT INTO param_go (id, name, n) VALUES (@p1, @p2, @p3)",
+		sql.Named("p1", 1), sql.Named("p2", "café"), sql.Named("p3", 7)); err != nil {
+		fail("param insert: %v", err)
+	}
+	if _, err := db.Exec("INSERT INTO param_go (id, name, n) VALUES (@p1, @p2, @p3)",
+		sql.Named("p1", 2), sql.Named("p2", "Zürich"), sql.Named("p3", nil)); err != nil {
+		fail("param insert (null): %v", err)
+	}
+
+	// Parameterized SELECT: the predicate value arrives as a typed parameter.
+	var name string
+	var n sql.NullInt64
+	if err := db.QueryRow("SELECT name, n FROM param_go WHERE id = @p1", sql.Named("p1", 1)).
+		Scan(&name, &n); err != nil {
+		fail("param select: %v", err)
+	}
+	if name != "café" || !n.Valid || n.Int64 != 7 {
+		fail("param select mismatch: name=%q n=%v", name, n)
+	}
+
+	// A NULL parameter round-trips as a NULL column.
+	var n2 sql.NullInt64
+	if err := db.QueryRow("SELECT n FROM param_go WHERE id = @p1", sql.Named("p1", 2)).
+		Scan(&n2); err != nil {
+		fail("param select (null): %v", err)
+	}
+	if n2.Valid {
+		fail("NULL parameter did not round-trip: %v", n2)
+	}
+
+	// A long string (> 4000 chars) is sent NVARCHAR(MAX)/PLP-chunked. Measure
+	// its decoded length — echoing a >4000-char NVARCHAR result is a separate,
+	// not-yet-supported MAX case.
+	long := strings.Repeat("λ", 5000)
+	var plen int64
+	if err := db.QueryRow("SELECT LEN(@p1)", sql.Named("p1", long)).Scan(&plen); err != nil {
+		fail("PLP param select: %v", err)
+	}
+	if plen != 5000 {
+		fail("long (PLP) parameter not fully decoded: LEN=%d", plen)
+	}
+
+	// Injection safety: a payload passed as a parameter is stored literally,
+	// not executed — the table must survive.
+	evil := "'); DROP TABLE param_go; --"
+	if _, err := db.Exec("INSERT INTO param_go (id, name) VALUES (@p1, @p2)",
+		sql.Named("p1", 3), sql.Named("p2", evil)); err != nil {
+		fail("param insert (payload): %v", err)
+	}
+	var stored string
+	if err := db.QueryRow("SELECT name FROM param_go WHERE id = @p1", sql.Named("p1", 3)).
+		Scan(&stored); err != nil {
+		fail("payload select: %v", err)
+	}
+	if stored != evil {
+		fail("parameter not stored literally: %q", stored)
+	}
+	var count int64
+	if err := db.QueryRow("SELECT COUNT(*) FROM param_go").Scan(&count); err != nil {
+		fail("count: %v", err)
+	}
+	if count != 3 {
+		fail("table did not survive injection payload: count=%d", count)
+	}
 }
 
 // transactionMatrix exercises db.BeginTx + Commit/Rollback (the TM request

--- a/scripts/tds_conformance_rpc.py
+++ b/scripts/tds_conformance_rpc.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""TDS RPC conformance smoke: parameterized queries over sp_executesql.
+
+pytds sends `cur.execute(sql, params)` as an sp_executesql RPC (packet type
+0x03), so this exercises the RPC parameter decoder end to end — separately from
+the plain-batch path in tds_conformance.py.
+
+Usage: tds_conformance_rpc.py <host> <port> <user> <password>
+Exits non-zero on any mismatch.
+"""
+import datetime
+import decimal
+import sys
+
+import pytds
+
+
+def main() -> int:
+    host, port, user, password = sys.argv[1], int(sys.argv[2]), sys.argv[3], sys.argv[4]
+    conn = pytds.connect(
+        host, "truthdb", user, password, port=port, login_timeout=10, autocommit=True
+    )
+    cur = conn.cursor()
+
+    cur.execute(
+        "CREATE TABLE rpc_conf (id INT NOT NULL PRIMARY KEY, name NVARCHAR(40), "
+        "amount DECIMAL(10,2), n INT)"
+    )
+
+    # Parameterized INSERTs: int, unicode string, decimal, and a NULL parameter.
+    cur.execute(
+        "INSERT INTO rpc_conf (id, name, amount, n) VALUES (%s, %s, %s, %s)",
+        (1, "café", decimal.Decimal("12.34"), 7),
+    )
+    cur.execute(
+        "INSERT INTO rpc_conf (id, name, amount, n) VALUES (%s, %s, %s, %s)",
+        (2, "Zürich", decimal.Decimal("-5.00"), None),
+    )
+
+    # Parameterized SELECT: the predicate value arrives as a typed parameter.
+    cur.execute("SELECT id, name, amount, n FROM rpc_conf WHERE id = %s", (1,))
+    row = cur.fetchone()
+    want = (1, "café", decimal.Decimal("12.34"), 7)
+    if row != want:
+        print(f"FAIL: param SELECT mismatch\n got: {row}\n want: {want}")
+        return 1
+
+    # NULL parameter round-trips as a NULL column.
+    cur.execute("SELECT n FROM rpc_conf WHERE id = %s", (2,))
+    if cur.fetchone()[0] is not None:
+        print("FAIL: NULL parameter did not round-trip")
+        return 1
+
+    # Injection safety: a payload passed as a *parameter* is stored literally,
+    # never executed. If parameters were spliced into SQL text this would drop
+    # the table.
+    evil = "'); DROP TABLE rpc_conf; --"
+    cur.execute("INSERT INTO rpc_conf (id, name) VALUES (%s, %s)", (3, evil))
+    cur.execute("SELECT name FROM rpc_conf WHERE id = %s", (3,))
+    if cur.fetchone()[0] != evil:
+        print("FAIL: parameter was not stored literally")
+        return 1
+    cur.execute("SELECT COUNT(*) FROM rpc_conf")
+    if cur.fetchone()[0] != 3:
+        print("FAIL: table did not survive the injection payload")
+        return 1
+
+    # A long string parameter (> 4000 chars) is sent NVARCHAR(MAX)/PLP-chunked.
+    # Check its decoded length (a >4000-char NVARCHAR result value is a separate,
+    # not-yet-supported MAX case, so measure rather than echo it).
+    long = "λ" * 5000
+    cur.execute("SELECT LEN(%s)", (long,))
+    if cur.fetchone()[0] != 5000:
+        print("FAIL: long (PLP) parameter was not fully decoded")
+        return 1
+
+    # A DATE/DATETIME2 parameter round-trips through the temporal decoders.
+    cur.execute("CREATE TABLE rpc_time (id INT NOT NULL PRIMARY KEY, d DATE, ts DATETIME2)")
+    cur.execute(
+        "INSERT INTO rpc_time (id, d, ts) VALUES (%s, %s, %s)",
+        (1, datetime.date(2021, 3, 9), datetime.datetime(2021, 3, 9, 8, 30, 15, 250000)),
+    )
+    cur.execute("SELECT d, ts FROM rpc_time WHERE id = %s", (1,))
+    d, ts = cur.fetchone()
+    if d != datetime.date(2021, 3, 9):
+        print(f"FAIL: DATE parameter round-trip: {d!r}")
+        return 1
+    if ts != datetime.datetime(2021, 3, 9, 8, 30, 15, 250000):
+        print(f"FAIL: DATETIME2 parameter round-trip: {ts!r}")
+        return 1
+
+    conn.close()
+    print("tds rpc conformance: OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Part of Stage 9 (TDS 2). Follows #60 (TLS) and #61 (compat shims).

## What

Handle the TDS **RPC request** (packet type `0x03`) for `sp_executesql` — the
call every mainstream driver (go-mssqldb, pytds, JDBC, ODBC) uses to run a
**parameterized query**. Before this, an RPC hit the `_ => unexpected message`
arm and closed the connection, so no driver could run a query with bound
parameters.

## How

- **`crates/truthdb-tds/src/rpc.rs`** (new) decodes the RPC wire format
  (MS-TDS 2.2.6.6): the `NameLenProcID` (well-known ProcID **or** procedure
  name), option flags, and for each parameter its `B_VARCHAR` name, status
  byte, `TYPE_INFO`, and value. Supported parameter types: `INTN`, `BITN`,
  `FLTN`, `DECIMAL`/`NUMERIC`, `DATE`, `DATETIME2`, `UNIQUEIDENTIFIER`,
  `NVARCHAR`/`NCHAR`, `VARCHAR`/`CHAR`, `VARBINARY` — including
  `NVARCHAR(MAX)`/PLP-chunked values.
- **Injection-safe by construction**: parameters are decoded to typed values
  and seeded as batch variables (keyed like `@p1`, matching the lexer) via a
  new engine entry point `execute_batch_with_params`; they are **never**
  rendered back into SQL text. Same lock/parking path as a plain batch.
- Non-`sp_executesql` procedures (e.g. `sp_prepare`) get a clear
  "unsupported procedure" error so the connection stays usable — handle-based
  prepared statements are a later increment.

## Safety

`rpc.rs` parses untrusted network bytes. Every read goes through a
bounds-checked cursor, and the length-driven decoders (`DATETIME2`, `DECIMAL`)
range-check their length fields, so a truncated or crafted request fails with a
clean `InvalidData` error rather than panicking or overflowing the tick/
magnitude arithmetic. An adversarial review of the first cut found three
overflow-on-malformed-input panics (all in that arithmetic); all three are
fixed and covered by `malformed_lengths_error_not_panic`.

## Tests

- `crates/truthdb-tds/src/rpc.rs`: unit tests for decode (int/string/bigint/
  null params), unknown-proc handling, truncated-body, and the malformed-length
  regression.
- `scripts/tds_conformance_rpc.py` (new) + a parameterized section in
  `scripts/tds_conformance.go`: two independent drivers exercise the decoder
  end to end — int/string/decimal/null/date/datetime2 params, PLP long
  strings, and injection safety. Both wired into CI.

Verified end to end locally with pytds; fmt / clippy `-D warnings` /
`cargo test --workspace` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)