### PR TITLE
Session-identity intrinsics: DB_NAME(), SUSER_SNAME(), @@SPID [Stage 9]

### DIFF
--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -47,6 +47,11 @@ pub struct TxnContext {
     /// Declared batch variables (name without `@`, lowercased) to their type
     /// and current value. Cleared at the start of each batch.
     variables: std::collections::HashMap<String, (ColumnType, SqlValue)>,
+    /// Connection identity for session intrinsics (`DB_NAME()`,
+    /// `SUSER_SNAME()`, `@@SPID`), set once when the session opens.
+    database: String,
+    login: String,
+    spid: i32,
 }
 
 /// Session isolation level (defaults to READ COMMITTED, like SQL Server).
@@ -72,7 +77,18 @@ impl TxnContext {
                 .iter()
                 .map(|(name, (_, value))| (name.clone(), value.clone()))
                 .collect(),
+            database: self.database.clone(),
+            login: self.login.clone(),
+            spid: self.spid,
         }
+    }
+
+    /// Records the connection identity used by session intrinsics. Called once
+    /// when the session opens.
+    pub fn set_session_identity(&mut self, database: String, login: String, spid: i32) {
+        self.database = database;
+        self.login = login;
+        self.spid = spid;
     }
 
     /// Clears batch-scoped variables (called at the start of each batch).

--- a/crates/truthdb-core/src/session.rs
+++ b/crates/truthdb-core/src/session.rs
@@ -76,10 +76,14 @@ impl SessionManager {
         }
     }
 
-    fn open(&mut self) -> SessionId {
+    fn open(&mut self, database: String, login: String) -> SessionId {
         let id = SessionId(self.next_id);
         self.next_id += 1;
-        self.sessions.insert(id, Session::default());
+        let mut session = Session::default();
+        session
+            .txn_ctx
+            .set_session_identity(database, login, id.0 as i32);
+        self.sessions.insert(id, session);
         id
     }
 
@@ -100,6 +104,8 @@ impl SessionManager {
 /// async caller awaits.
 enum EngineCall {
     OpenSession {
+        database: String,
+        login: String,
         reply: oneshot::Sender<SessionId>,
     },
     /// A SQL batch on behalf of a session (TDS path): typed results. `params`
@@ -129,10 +135,20 @@ pub struct EngineHandle {
 }
 
 impl EngineHandle {
-    /// Opens a session; returns its id (or a placeholder if the engine is gone).
-    pub async fn open_session(&self) -> SessionId {
+    /// Opens a session for a connection, recording its database and login for
+    /// session intrinsics. Returns its id (or a placeholder if the engine is
+    /// gone).
+    pub async fn open_session(&self, database: String, login: String) -> SessionId {
         let (reply, rx) = oneshot::channel();
-        if self.tx.send(EngineCall::OpenSession { reply }).is_err() {
+        if self
+            .tx
+            .send(EngineCall::OpenSession {
+                database,
+                login,
+                reply,
+            })
+            .is_err()
+        {
             return SessionId(0);
         }
         rx.await.unwrap_or(SessionId(0))
@@ -266,8 +282,12 @@ impl EngineLoop {
             };
             self.reap_expired();
             match call {
-                Some(EngineCall::OpenSession { reply }) => {
-                    let _ = reply.send(self.sessions.open());
+                Some(EngineCall::OpenSession {
+                    database,
+                    login,
+                    reply,
+                }) => {
+                    let _ = reply.send(self.sessions.open(database, login));
                 }
                 Some(EngineCall::RunBatch {
                     session,
@@ -577,8 +597,8 @@ mod tests {
     #[tokio::test]
     async fn writer_blocks_reader_until_commit() {
         let h = start(Duration::from_secs(30));
-        let a = h.handle.open_session().await;
-        let b = h.handle.open_session().await;
+        let a = h.handle.open_session(String::new(), String::new()).await;
+        let b = h.handle.open_session(String::new(), String::new()).await;
 
         h.handle
             .run_batch(a, "CREATE TABLE t (id INT NOT NULL PRIMARY KEY)".into())
@@ -616,8 +636,8 @@ mod tests {
     #[tokio::test]
     async fn read_uncommitted_sees_uncommitted_rows_without_blocking() {
         let h = start(Duration::from_secs(30));
-        let a = h.handle.open_session().await;
-        let b = h.handle.open_session().await;
+        let a = h.handle.open_session(String::new(), String::new()).await;
+        let b = h.handle.open_session(String::new(), String::new()).await;
 
         h.handle
             .run_batch(a, "CREATE TABLE t (id INT NOT NULL PRIMARY KEY)".into())
@@ -648,8 +668,8 @@ mod tests {
     #[tokio::test]
     async fn disconnect_releases_locks_and_wakes_waiter() {
         let h = start(Duration::from_secs(30));
-        let a = h.handle.open_session().await;
-        let b = h.handle.open_session().await;
+        let a = h.handle.open_session(String::new(), String::new()).await;
+        let b = h.handle.open_session(String::new(), String::new()).await;
 
         h.handle
             .run_batch(a, "CREATE TABLE t (id INT NOT NULL PRIMARY KEY)".into())
@@ -684,8 +704,8 @@ mod tests {
     async fn deadlock_is_broken_by_timeout_with_1205() {
         // Short timeout so the reaper fires quickly.
         let h = start(Duration::from_millis(300));
-        let a = h.handle.open_session().await;
-        let b = h.handle.open_session().await;
+        let a = h.handle.open_session(String::new(), String::new()).await;
+        let b = h.handle.open_session(String::new(), String::new()).await;
 
         for stmt in [
             "CREATE TABLE a (id INT NOT NULL PRIMARY KEY)",
@@ -736,8 +756,8 @@ mod tests {
     #[tokio::test]
     async fn repeatable_read_holds_shared_lock_and_blocks_a_writer() {
         let h = start(Duration::from_secs(30));
-        let a = h.handle.open_session().await;
-        let b = h.handle.open_session().await;
+        let a = h.handle.open_session(String::new(), String::new()).await;
+        let b = h.handle.open_session(String::new(), String::new()).await;
         h.handle
             .run_batch(a, "CREATE TABLE t (id INT NOT NULL PRIMARY KEY)".into())
             .await
@@ -782,8 +802,8 @@ mod tests {
     #[tokio::test]
     async fn read_committed_releases_shared_lock_so_a_writer_proceeds() {
         let h = start(Duration::from_secs(30));
-        let a = h.handle.open_session().await;
-        let b = h.handle.open_session().await;
+        let a = h.handle.open_session(String::new(), String::new()).await;
+        let b = h.handle.open_session(String::new(), String::new()).await;
         h.handle
             .run_batch(a, "CREATE TABLE t (id INT NOT NULL PRIMARY KEY)".into())
             .await
@@ -816,8 +836,8 @@ mod tests {
     #[tokio::test]
     async fn isolation_escalation_within_a_batch_locks_the_read() {
         let h = start(Duration::from_secs(30));
-        let a = h.handle.open_session().await;
-        let b = h.handle.open_session().await;
+        let a = h.handle.open_session(String::new(), String::new()).await;
+        let b = h.handle.open_session(String::new(), String::new()).await;
         h.handle
             .run_batch(a, "CREATE TABLE t (id INT NOT NULL PRIMARY KEY)".into())
             .await
@@ -866,8 +886,8 @@ mod tests {
     #[tokio::test]
     async fn holder_is_not_blocked_by_a_waiter_on_its_own_lock() {
         let h = start(Duration::from_secs(30));
-        let a = h.handle.open_session().await;
-        let b = h.handle.open_session().await;
+        let a = h.handle.open_session(String::new(), String::new()).await;
+        let b = h.handle.open_session(String::new(), String::new()).await;
         h.handle
             .run_batch(a, "CREATE TABLE t (id INT NOT NULL PRIMARY KEY)".into())
             .await
@@ -914,8 +934,8 @@ mod tests {
     #[tokio::test]
     async fn autocommit_reads_run_concurrently() {
         let h = start(Duration::from_secs(30));
-        let a = h.handle.open_session().await;
-        let b = h.handle.open_session().await;
+        let a = h.handle.open_session(String::new(), String::new()).await;
+        let b = h.handle.open_session(String::new(), String::new()).await;
         h.handle
             .run_batch(a, "CREATE TABLE t (id INT NOT NULL PRIMARY KEY)".into())
             .await

--- a/crates/truthdb-sql/src/eval.rs
+++ b/crates/truthdb-sql/src/eval.rs
@@ -48,6 +48,12 @@ pub struct EvalContext {
     /// value. Present but NULL for a declared-but-unset variable; absent means
     /// undeclared.
     pub variables: std::collections::HashMap<String, SqlValue>,
+    /// The connection's current database name — `DB_NAME()`.
+    pub database: String,
+    /// The authenticated login name — `SUSER_SNAME()`.
+    pub login: String,
+    /// The session process id — `@@SPID`.
+    pub spid: i32,
 }
 
 /// Evaluates `expr` against `row`, resolving columns via `resolver`.
@@ -172,7 +178,7 @@ fn eval_column(
 fn eval_global_var(name: &str, ctx: &EvalContext) -> SqlResult<SqlValue> {
     match name {
         "trancount" => Ok(SqlValue::Int(ctx.trancount as i64)),
-        "spid" => Ok(SqlValue::Int(0)),
+        "spid" => Ok(SqlValue::Int(ctx.spid as i64)),
         // Lead with TruthDB's own identity, then a SQL-Server-shaped version
         // token so tooling that scrapes @@VERSION for a version number keeps
         // working.
@@ -347,11 +353,30 @@ fn eval_call<R: ColumnResolver>(
     ctx: &EvalContext,
     depth: usize,
 ) -> SqlResult<SqlValue> {
+    // Session-context functions read the EvalContext, which the pure
+    // functions::eval_function does not receive.
+    if let Some(value) = eval_session_function(name, args) {
+        return Ok(value(ctx));
+    }
     let mut values = Vec::with_capacity(args.len());
     for arg in args {
         values.push(eval_at(arg, row, resolver, ctx, depth + 1)?);
     }
     functions::eval_function(name, values)
+}
+
+/// Session-identity intrinsics that resolve against the [`EvalContext`] rather
+/// than their arguments. Returns a closure so the (cheap) context read happens
+/// only when the name matches. With a single database, `DB_NAME()` and
+/// `DB_NAME(id)` both report the current database.
+fn eval_session_function(name: &str, args: &[Expr]) -> Option<fn(&EvalContext) -> SqlValue> {
+    match name.to_ascii_uppercase().as_str() {
+        "DB_NAME" if args.len() <= 1 => Some(|ctx| SqlValue::Str(ctx.database.clone())),
+        "SUSER_SNAME" | "SUSER_NAME" if args.is_empty() => {
+            Some(|ctx| SqlValue::Str(ctx.login.clone()))
+        }
+        _ => None,
+    }
 }
 
 /// CAST/CONVERT: converts a value to a target [`DataType`], producing a value
@@ -764,6 +789,32 @@ mod tests {
     #[test]
     fn null_arithmetic_is_null() {
         assert_eq!(eval_predicate("1 + NULL", &[], &[]), SqlValue::Null);
+    }
+
+    #[test]
+    fn session_identity_intrinsics() {
+        let ctx = EvalContext {
+            database: "truthdb".to_string(),
+            login: "sa".to_string(),
+            spid: 53,
+            ..EvalContext::default()
+        };
+        let eval_ctx = |sql: &str| {
+            let statements = Parser::parse_str(&format!("SELECT {sql}")).expect("parse");
+            let crate::ast::Statement::Select(select) = &statements[0] else {
+                panic!("expected select")
+            };
+            let crate::ast::SelectItem::Expr { expr, .. } = &select.items[0] else {
+                panic!("expected expr")
+            };
+            let no_columns: Vec<String> = Vec::new();
+            eval(expr, &[], &no_columns, &ctx).expect("eval")
+        };
+        assert_eq!(eval_ctx("DB_NAME()"), SqlValue::Str("truthdb".to_string()));
+        assert_eq!(eval_ctx("DB_NAME(1)"), SqlValue::Str("truthdb".to_string()));
+        assert_eq!(eval_ctx("SUSER_SNAME()"), SqlValue::Str("sa".to_string()));
+        assert_eq!(eval_ctx("SUSER_NAME()"), SqlValue::Str("sa".to_string()));
+        assert_eq!(eval_ctx("@@SPID"), SqlValue::Int(53));
     }
 
     #[test]

--- a/crates/truthdb-tds/src/server.rs
+++ b/crates/truthdb-tds/src/server.rs
@@ -123,8 +123,11 @@ where
     write_message(&mut stream, PKT_TABULAR_RESULT, &out, packet_size).await?;
 
     // Each connection gets an engine-side session; it is closed (rolling back
-    // any open transaction) whenever the connection ends, cleanly or not.
-    let session = engine.open_session().await;
+    // any open transaction) whenever the connection ends, cleanly or not. The
+    // database and login are recorded for session intrinsics (DB_NAME() etc.).
+    let session = engine
+        .open_session(database.clone(), login.username.clone())
+        .await;
     let result = request_loop(&mut stream, &engine, session, packet_size).await;
     engine.close_session(session);
     result

--- a/scripts/tds_conformance.py
+++ b/scripts/tds_conformance.py
@@ -153,6 +153,13 @@ def main() -> int:
         print("FAIL: rolled-back transaction row was not discarded")
         return 1
 
+    # Session-identity intrinsics reflect the connection's database and login.
+    cur.execute("SELECT DB_NAME(), SUSER_SNAME(), @@SPID")
+    db, login, spid = cur.fetchone()
+    if db != "truthdb" or login != "sa" or not (isinstance(spid, int) and spid > 0):
+        print(f"FAIL: session intrinsics: db={db!r} login={login!r} spid={spid!r}")
+        return 1
+
     conn.close()
     print("tds conformance: OK")
     return 0


### PR DESCRIPTION
Part of Stage 9 (TDS client compatibility). Follows #60 (TLS), #61 (compat shims), #62 (sp_executesql RPC).

## What

Tools (SSMS, sqlcmd) and drivers probe the connection's identity at connect
time. This records the database and login when a session opens and surfaces
them through the standard intrinsics:

- `DB_NAME()` / `DB_NAME(id)` → the current database (single-database model, so
  the id argument is ignored).
- `SUSER_SNAME()` / `SUSER_NAME()` → the authenticated login.
- `@@SPID` → the session id (was hardcoded `0`).

## How

The identity is threaded from the TDS LOGIN7 into the engine session's
`TxnContext` (`open_session` gains `database` + `login`; `@@SPID` is the
session id) and projected into `EvalContext`. `DB_NAME()`/`SUSER_SNAME()`
resolve in `eval_call` — they need the `EvalContext` the pure function table
doesn't receive — and `@@SPID` in `eval_global_var`. An orphan/unknown session
falls back to a default context (empty db/login, spid 0) with no panic.

## Tests

- `crates/truthdb-sql/src/eval.rs`: `session_identity_intrinsics` unit test.
- `scripts/tds_conformance.py`: asserts `SELECT DB_NAME(), SUSER_SNAME(),
  @@SPID` returns the connection's `truthdb` / `sa` / session-id.

Verified end to end locally with pytds; fmt / clippy `-D warnings` /
`cargo test --workspace` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)