### PR TITLE
Assignment SELECT: SELECT @v = expr [Stage 11]

### DIFF
--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -2158,6 +2158,31 @@ mod tests {
     }
 
     #[test]
+    fn assignment_select_locks_base_table_behind_a_cte_value() {
+        // A CTE referenced only inside an assignment SELECT's value subquery
+        // must still lock the real base table, or the read could dirty-read a
+        // concurrent uncommitted write under READ COMMITTED.
+        use crate::lock::{LockMode, Resource};
+        use crate::rel::Isolation;
+        let path = unique_temp_path("assign-cte-locks");
+        let mut engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE secret (x INT NOT NULL PRIMARY KEY)")
+            .expect("secret");
+        let secret = table_object_id(&mut engine, "secret");
+
+        let locks = engine.analyze_locks(
+            "DECLARE @v INT; WITH c AS (SELECT x FROM secret) SELECT @v = (SELECT MAX(x) FROM c)",
+            Isolation::ReadCommitted,
+        );
+        assert!(
+            locks.contains(&(Resource::Table(secret), LockMode::Shared)),
+            "base table behind the CTE-in-value must be Shared-locked: {locks:?}"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
     fn foreign_key_insert_locks_parent_shared() {
         use crate::lock::{LockMode, Resource};
         use crate::rel::Isolation;

--- a/crates/truthdb-core/src/rel/aggregate.rs
+++ b/crates/truthdb-core/src/rel/aggregate.rs
@@ -24,6 +24,7 @@ pub fn is_aggregated(select: &Select) -> bool {
         || select.having.is_some()
         || select.items.iter().any(|item| match item {
             SelectItem::Expr { expr, .. } => contains_aggregate(expr),
+            SelectItem::Assign { value, .. } => contains_aggregate(value),
             SelectItem::Wildcard | SelectItem::QualifiedWildcard(_) => false,
         })
 }
@@ -96,6 +97,10 @@ pub fn execute(
             SelectItem::Expr { expr, alias } => {
                 out_names.push(output_name(expr, alias.as_ref()));
                 out_exprs.push(rewrite(expr, &select.group_by, &mut aggs)?);
+            }
+            // Assignment SELECTs are rewritten to Expr items before execution.
+            SelectItem::Assign { .. } => {
+                unreachable!("assignment SELECT handled before aggregation")
             }
         }
     }

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -464,6 +464,13 @@ fn exec_statement(
             exec_delete(storage, delete, &mut scope, &eval_ctx)
         }
         Statement::Select(select) => {
+            if select
+                .items
+                .iter()
+                .any(|i| matches!(i, SelectItem::Assign { .. }))
+            {
+                return exec_select_assign(storage, select, txn_ctx);
+            }
             let eval_ctx = txn_ctx.eval_context();
             if txn_ctx.showplan_text {
                 Ok(StatementResult::Rows(showplan_rows(
@@ -2320,6 +2327,13 @@ fn expand_select_ctes(select: &Select, resolved: &CteMap) -> Select {
                 expr: expand_expr_ctes(expr, resolved),
                 alias: alias.clone(),
             },
+            // Inline CTE references inside an assignment value too, so lock
+            // analysis (which expands the original assignment SELECT) sees the
+            // real base tables behind a CTE used only in the value expression.
+            SelectItem::Assign { target, value } => SelectItem::Assign {
+                target: target.clone(),
+                value: expand_expr_ctes(value, resolved),
+            },
             other => other.clone(),
         })
         .collect();
@@ -2746,6 +2760,18 @@ fn exec_select(
     select: &Select,
     eval_ctx: &EvalContext,
 ) -> Result<RowSet, SqlError> {
+    // A top-level assignment SELECT is routed to exec_select_assign; one reaching
+    // here has been nested in a subquery / derived table / CTE, which is invalid.
+    if select
+        .items
+        .iter()
+        .any(|i| matches!(i, SelectItem::Assign { .. }))
+    {
+        return Err(SqlError::message_only(
+            141,
+            "A SELECT that assigns to a variable cannot be used inside a query expression.",
+        ));
+    }
     // Inline any WITH common table expressions (as derived tables) first.
     let expanded;
     let select = if select.ctes.is_empty() {
@@ -2848,6 +2874,87 @@ fn exec_select(
         &resolver,
         eval_ctx,
     )
+}
+
+/// `SELECT @a = expr, @b = expr2 [FROM ...]` — an assignment SELECT. The value
+/// expressions are projected as an ordinary result set; each variable then
+/// takes the value from the *last* row the query produces (SQL Server's
+/// documented behaviour for the final value). Zero rows leave the variables
+/// unchanged. A value that reads a variable being assigned in the same
+/// statement (running aggregation, cross-referencing targets) is rejected
+/// rather than evaluated against the pre-statement snapshot, which would give a
+/// result that silently differs from SQL Server's per-row assignment.
+fn exec_select_assign(
+    storage: &mut Storage,
+    select: &Select,
+    txn_ctx: &mut TxnContext,
+) -> Result<StatementResult, SqlError> {
+    // Every target must be a declared variable; capture their declared types.
+    let mut targets: Vec<(String, ColumnType)> = Vec::with_capacity(select.items.len());
+    for item in &select.items {
+        let SelectItem::Assign { target, .. } = item else {
+            // The dispatcher only routes here when every item is an assignment.
+            unreachable!("assignment SELECT has a non-assignment item");
+        };
+        let column_type = txn_ctx
+            .variables
+            .get(target)
+            .map(|(t, _)| *t)
+            .ok_or_else(|| undeclared_variable_err(target))?;
+        targets.push((target.clone(), column_type));
+    }
+
+    // Every value is evaluated against the variables' pre-statement values, so a
+    // value that references a variable being assigned here would silently
+    // diverge from SQL Server's per-row / left-to-right assignment (running
+    // aggregation, cross-referencing targets). Reject those rather than compute
+    // a wrong result; the caller can use SET or a set-based aggregate instead.
+    let target_names: std::collections::HashSet<&str> =
+        targets.iter().map(|(name, _)| name.as_str()).collect();
+    for item in &select.items {
+        let SelectItem::Assign { value, .. } = item else {
+            unreachable!()
+        };
+        if expr_uses_local_var(value, &target_names) {
+            return Err(SqlError::message_only(
+                141,
+                "An assignment SELECT cannot reference a variable it is assigning in the same statement; use SET or a set-based aggregate.",
+            ));
+        }
+    }
+
+    // Project the value expressions as an ordinary result set.
+    let projected = Select {
+        items: select
+            .items
+            .iter()
+            .map(|item| {
+                let SelectItem::Assign { value, .. } = item else {
+                    unreachable!()
+                };
+                SelectItem::Expr {
+                    expr: value.clone(),
+                    alias: None,
+                }
+            })
+            .collect(),
+        ..select.clone()
+    };
+    let rowset = exec_select(storage, &projected, &txn_ctx.eval_context())?;
+
+    // Assign the last row's values (SQL Server: the variable holds the value
+    // from the final row). No rows -> variables keep their current values.
+    if let Some(last) = rowset.rows.last() {
+        for (index, (name, column_type)) in targets.iter().enumerate() {
+            let produced = value::datum_to_sql(&last[index], &rowset.columns[index].column_type);
+            let datum = value::sql_to_datum(&produced, column_type, name)?;
+            let coerced = value::datum_to_sql(&datum, column_type);
+            txn_ctx
+                .variables
+                .insert(name.clone(), (*column_type, coerced));
+        }
+    }
+    Ok(StatementResult::Done)
 }
 
 /// Removes duplicate output rows (SELECT DISTINCT), keeping first occurrence.
@@ -3045,6 +3152,10 @@ fn project(
                     None => projs.push(Proj::Expr { name, expr }),
                 }
             }
+            // Assignment SELECTs are rewritten to Expr items before projection.
+            SelectItem::Assign { .. } => {
+                unreachable!("assignment SELECT handled before projection")
+            }
         }
     }
 
@@ -3132,8 +3243,11 @@ fn collect_locked_tables<'a>(select: &'a Select, out: &mut Vec<&'a Name>) {
         collect_from_tables(from, out);
     }
     for item in &select.items {
-        if let SelectItem::Expr { expr, .. } = item {
-            collect_expr_tables(expr, out);
+        match item {
+            SelectItem::Expr { expr, .. } | SelectItem::Assign { value: expr, .. } => {
+                collect_expr_tables(expr, out)
+            }
+            SelectItem::Wildcard | SelectItem::QualifiedWildcard(_) => {}
         }
     }
     for expr in select.where_clause.iter().chain(select.having.iter()) {
@@ -3166,6 +3280,89 @@ fn collect_from_tables<'a>(tref: &'a TableRef, out: &mut Vec<&'a Name>) {
 }
 
 /// Collects base tables from every subquery embedded in an expression.
+/// True if `expr` references any of the named local variables (`@name`, given
+/// without the leading `@`), descending into subqueries. Used to reject an
+/// assignment SELECT whose value reads a variable it is assigning.
+fn expr_uses_local_var(expr: &Expr, names: &std::collections::HashSet<&str>) -> bool {
+    match &expr.kind {
+        ExprKind::LocalVar(name) => names.contains(name.as_str()),
+        ExprKind::Subquery(select) | ExprKind::Exists(select) => {
+            select_uses_local_var(select, names)
+        }
+        ExprKind::InSubquery { expr, subquery, .. } => {
+            expr_uses_local_var(expr, names) || select_uses_local_var(subquery, names)
+        }
+        ExprKind::Unary { expr, .. }
+        | ExprKind::IsNull { expr, .. }
+        | ExprKind::Cast { expr, .. } => expr_uses_local_var(expr, names),
+        ExprKind::Binary { left, right, .. } => {
+            expr_uses_local_var(left, names) || expr_uses_local_var(right, names)
+        }
+        ExprKind::Like { expr, pattern, .. } => {
+            expr_uses_local_var(expr, names) || expr_uses_local_var(pattern, names)
+        }
+        ExprKind::InList { expr, list, .. } => {
+            expr_uses_local_var(expr, names) || list.iter().any(|e| expr_uses_local_var(e, names))
+        }
+        ExprKind::Between {
+            expr, low, high, ..
+        } => {
+            expr_uses_local_var(expr, names)
+                || expr_uses_local_var(low, names)
+                || expr_uses_local_var(high, names)
+        }
+        ExprKind::Case {
+            operand,
+            branches,
+            else_result,
+        } => {
+            operand
+                .as_ref()
+                .is_some_and(|o| expr_uses_local_var(o, names))
+                || branches
+                    .iter()
+                    .any(|(w, t)| expr_uses_local_var(w, names) || expr_uses_local_var(t, names))
+                || else_result
+                    .as_ref()
+                    .is_some_and(|e| expr_uses_local_var(e, names))
+        }
+        ExprKind::Function { args, .. } => args.iter().any(|a| expr_uses_local_var(a, names)),
+        ExprKind::Aggregate { arg, .. } => {
+            arg.as_ref().is_some_and(|a| expr_uses_local_var(a, names))
+        }
+        ExprKind::Null
+        | ExprKind::Int(_)
+        | ExprKind::Number(_)
+        | ExprKind::Str(_)
+        | ExprKind::Bool(_)
+        | ExprKind::Literal(_)
+        | ExprKind::Column(_)
+        | ExprKind::GlobalVar(_) => false,
+    }
+}
+
+/// True if any expression in `select` references one of the named local
+/// variables (descends the SELECT list, WHERE/HAVING, GROUP BY, and ORDER BY).
+fn select_uses_local_var(select: &Select, names: &std::collections::HashSet<&str>) -> bool {
+    let item_uses = select.items.iter().any(|item| match item {
+        SelectItem::Expr { expr, .. } | SelectItem::Assign { value: expr, .. } => {
+            expr_uses_local_var(expr, names)
+        }
+        SelectItem::Wildcard | SelectItem::QualifiedWildcard(_) => false,
+    });
+    item_uses
+        || select
+            .where_clause
+            .iter()
+            .chain(select.having.iter())
+            .chain(select.group_by.iter())
+            .any(|e| expr_uses_local_var(e, names))
+        || select
+            .order_by
+            .iter()
+            .any(|o| expr_uses_local_var(&o.expr, names))
+}
+
 fn collect_expr_tables<'a>(expr: &'a Expr, out: &mut Vec<&'a Name>) {
     match &expr.kind {
         ExprKind::Subquery(select) | ExprKind::Exists(select) => collect_locked_tables(select, out),

--- a/crates/truthdb-core/tests/slt/assign_select.slt
+++ b/crates/truthdb-core/tests/slt/assign_select.slt
@@ -1,0 +1,79 @@
+# Assignment SELECT: `SELECT @v = expr [, ...] [FROM ...]` (Stage 11).
+# Variables are batch-scoped, so each check declares, assigns, and reads in one
+# batch; only the trailing SELECT produces rows for the runner to compare.
+
+statement ok
+CREATE TABLE nums (id INT NOT NULL PRIMARY KEY, v INT)
+
+statement ok
+INSERT INTO nums VALUES (1, 10), (2, 20), (3, 30)
+
+# Scalar assignment with no FROM.
+query I
+DECLARE @a INT; SELECT @a = 5 + 2; SELECT @a
+----
+7
+
+# Aggregate into a variable.
+query I
+DECLARE @c INT; SELECT @c = COUNT(*) FROM nums; SELECT @c
+----
+3
+
+# Single-row lookup by key.
+query I
+DECLARE @x INT; SELECT @x = v FROM nums WHERE id = 2; SELECT @x
+----
+20
+
+# Many rows: the variable holds the last row's value (ORDER BY makes it stable).
+query I
+DECLARE @x INT; SELECT @x = v FROM nums ORDER BY id; SELECT @x
+----
+30
+
+# Zero rows: the variable keeps its prior value.
+query I
+DECLARE @x INT; SET @x = 99; SELECT @x = v FROM nums WHERE id = 999; SELECT @x
+----
+99
+
+# Multiple assignments in one SELECT.
+query II
+DECLARE @lo INT, @hi INT; SELECT @lo = MIN(v), @hi = MAX(v) FROM nums; SELECT @lo, @hi
+----
+10 30
+
+# A value type is coerced to the variable's declared type.
+query I
+DECLARE @s NVARCHAR(10); SELECT @s = 42; SELECT @s
+----
+42
+
+# Mixing an assignment with a result column is rejected (141).
+statement error
+SELECT @a = 1, v FROM nums
+
+# Assigning to an undeclared variable is rejected (137).
+statement error
+SELECT @undeclared = 1
+
+# A value that reads a variable being assigned is rejected, not silently wrong:
+# self-referential running aggregation (use SET or a set-based aggregate)...
+statement error
+DECLARE @s INT; SET @s = 0; SELECT @s = @s + v FROM nums
+
+# ...and cross-referencing another target in the same SELECT.
+statement error
+DECLARE @a INT, @b INT; SELECT @a = 10, @b = @a
+
+# A value subquery reading a base table only through a CTE still runs (and, at
+# the lock layer, locks that base table).
+query I
+DECLARE @m INT; WITH c AS (SELECT v FROM nums) SELECT @m = (SELECT MAX(v) FROM c); SELECT @m
+----
+30
+
+# An assignment SELECT cannot be nested as a derived table.
+statement error
+SELECT * FROM (SELECT @a = 1) t

--- a/crates/truthdb-sql/src/ast.rs
+++ b/crates/truthdb-sql/src/ast.rs
@@ -311,6 +311,13 @@ pub enum SelectItem {
         expr: Expr,
         alias: Option<Name>,
     },
+    /// `@var = expr` — an assignment SELECT. All items must be assignments (a
+    /// query cannot mix assignments with result columns). `target` is the
+    /// variable name without its leading `@`, lowercased (as the lexer emits it).
+    Assign {
+        target: String,
+        value: Expr,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/crates/truthdb-sql/src/parser.rs
+++ b/crates/truthdb-sql/src/parser.rs
@@ -1077,6 +1077,13 @@ impl Parser {
                 self.expect(&TokenKind::Dot)?;
                 self.expect(&TokenKind::Star)?;
                 items.push(SelectItem::QualifiedWildcard(name));
+            } else if let Some(target) = self.assignment_target() {
+                // `@var = expr` — an assignment SELECT (not the `@var = expr`
+                // comparison a WHERE clause would parse).
+                self.bump(); // @var
+                self.bump(); // =
+                let value = self.parse_expr()?;
+                items.push(SelectItem::Assign { target, value });
             } else {
                 let expr = self.parse_expr()?;
                 let alias = self.parse_optional_alias()?;
@@ -1085,6 +1092,18 @@ impl Parser {
             if !self.eat(&TokenKind::Comma) {
                 break;
             }
+        }
+
+        // A SELECT cannot mix variable assignments with result columns (141).
+        let assigns = items
+            .iter()
+            .filter(|i| matches!(i, SelectItem::Assign { .. }))
+            .count();
+        if assigns != 0 && assigns != items.len() {
+            return Err(SqlError::message_only(
+                141,
+                "A SELECT statement that assigns a value to a variable must not be combined with data-retrieval operations.",
+            ));
         }
 
         let from = if self.peek_keyword().as_deref() == Some("FROM") {
@@ -1176,6 +1195,19 @@ impl Parser {
             return Ok(Some(self.parse_name()?));
         }
         Ok(None)
+    }
+
+    /// If the next two tokens are `@var =`, returns the variable name (the
+    /// start of an assignment SELECT item). Peeks only — does not consume.
+    fn assignment_target(&self) -> Option<String> {
+        let name = match self.tokens.get(self.pos).map(|t| &t.kind) {
+            Some(TokenKind::LocalVar(name)) => name.clone(),
+            _ => return None,
+        };
+        match self.tokens.get(self.pos + 1).map(|t| &t.kind) {
+            Some(TokenKind::Eq) => Some(name),
+            _ => None,
+        }
     }
 
     /// True if the next three tokens are `<word> . *` (a qualified wildcard).
@@ -2117,6 +2149,34 @@ mod tests {
         assert!(Parser::parse_str(&sql).is_ok());
         let chain = format!("SELECT 1{}", " + 1".repeat(100));
         assert!(Parser::parse_str(&chain).is_ok());
+    }
+
+    #[test]
+    fn assignment_select_parses_as_assign_item() {
+        // `SELECT @v = expr` is an assignment item, not a boolean comparison.
+        let stmts = Parser::parse_str("SELECT @v = 1 + 2").expect("parse");
+        let Statement::Select(select) = &stmts[0] else {
+            panic!("expected select")
+        };
+        assert!(
+            matches!(&select.items[0], SelectItem::Assign { target, .. } if target == "v"),
+            "expected an assignment item: {:?}",
+            select.items[0]
+        );
+
+        // `@v = x` inside a WHERE stays a comparison (only the item list assigns).
+        let stmts = Parser::parse_str("SELECT 1 WHERE @v = 5").expect("parse");
+        let Statement::Select(select) = &stmts[0] else {
+            panic!("expected select")
+        };
+        assert!(matches!(&select.items[0], SelectItem::Expr { .. }));
+        assert!(select.where_clause.is_some());
+
+        // Mixing an assignment with a result column is a syntax-level error 141.
+        assert_eq!(
+            Parser::parse_str("SELECT @v = 1, 2").unwrap_err().number,
+            141,
+        );
     }
 
     #[test]


### PR DESCRIPTION
Part of Stage 11 (variables/subqueries). Follows #56–#59.

## What

`SELECT @v = expr [, @w = expr2] [FROM ...]` assigns query results to
variables instead of returning a rowset — a common T-SQL scalar-fetch form and
groundwork for Stage 15 stored procedures.

- **Parser**: a `@var =` at the start of a select item is an assignment
  (distinct from the `@var = x` comparison a WHERE clause parses); mixing
  assignments with result columns is rejected (error 141).
- **Executor**: `exec_select_assign` projects the value expressions as an
  ordinary result set (reusing the whole SELECT pipeline: FROM/WHERE/GROUP/
  aggregates/ORDER/TOP) and assigns each variable the value from the last row,
  coerced to its declared type. Zero rows leave the variables unchanged.
- A nested assignment SELECT (as a derived table / subquery / CTE) is rejected
  cleanly (141).

## Adversarial review fixes

An adversarial review (executor / locking / parser lenses) found:

- **major — dirty read.** A CTE referenced *only* inside an assignment value's
  subquery was not inlined during lock analysis, so its base table went
  unlocked — a READ COMMITTED dirty-read window (lock analysis runs on the raw
  statement, execution inlines the CTE). `expand_select_ctes` now recurses into
  assignment values; a regression test asserts the base table is Shared-locked.
- **silent-wrong → loud error.** A value that reads a variable being assigned in
  the same statement — running aggregation (`@s = @s + v FROM t`) or
  cross-referencing targets (`@a = 10, @b = @a`) — would silently diverge from
  SQL Server's per-row / left-to-right assignment (all RHS see the
  pre-statement snapshot). These are now rejected with a clear error rather than
  computing a wrong value; use `SET` or a set-based aggregate.

## Tests

- `crates/truthdb-core/tests/slt/assign_select.slt`: scalar / aggregate /
  single-row / last-row / zero-row / multi-assign / coercion, and the rejected
  forms (mixing, undeclared, self/cross-reference, nested-derived, CTE-in-value).
- `crates/truthdb-sql/src/parser.rs`: assignment vs comparison parsing + 141.
- `crates/truthdb-core/src/engine.rs`: the CTE-in-value lock regression.

fmt / clippy `-D warnings` / `cargo test --workspace` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)