### PR TITLE
CREATE / DROP VIEW [Stage 11]

### DIFF
--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -2158,6 +2158,133 @@ mod tests {
     }
 
     #[test]
+    fn nested_cte_locks_its_base_table() {
+        // A CTE whose body itself declares a CTE (`WITH c AS (WITH d AS ...)`)
+        // must still Shared-lock the base table the inner CTE reads — directly
+        // and through a view — or it dirty-reads under READ COMMITTED.
+        use crate::lock::{LockMode, Resource};
+        use crate::rel::Isolation;
+        let path = unique_temp_path("nested-cte-locks");
+        let mut engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE secret (z INT NOT NULL PRIMARY KEY)")
+            .expect("secret");
+        let secret = table_object_id(&mut engine, "secret");
+
+        // Plain query with a nested CTE.
+        let direct = engine.analyze_locks(
+            "WITH c AS (WITH d AS (SELECT z FROM secret) SELECT z FROM d) SELECT z FROM c",
+            Isolation::ReadCommitted,
+        );
+        assert!(
+            direct.contains(&(Resource::Table(secret), LockMode::Shared)),
+            "nested-CTE query must lock secret: {direct:?}"
+        );
+
+        // Same through a view.
+        engine
+            .execute(
+                "CREATE VIEW v AS WITH c AS (WITH d AS (SELECT z FROM secret) SELECT z FROM d) SELECT z FROM c",
+            )
+            .expect("view");
+        let via_view = engine.analyze_locks("SELECT z FROM v", Isolation::ReadCommitted);
+        assert!(
+            via_view.contains(&(Resource::Table(secret), LockMode::Shared)),
+            "view over a nested-CTE body must lock secret: {via_view:?}"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn selecting_a_view_locks_its_base_tables() {
+        // A read through a view must Shared-lock the view's base tables (else a
+        // dirty read under READ COMMITTED), including a base table the view body
+        // reaches only through its own CTE.
+        use crate::lock::{LockMode, Resource};
+        use crate::rel::Isolation;
+        let path = unique_temp_path("view-locks");
+        let mut engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE base (x INT NOT NULL PRIMARY KEY)")
+            .expect("base");
+        engine
+            .execute("CREATE VIEW v AS WITH c AS (SELECT x FROM base) SELECT x FROM c")
+            .expect("view");
+        let base = table_object_id(&mut engine, "base");
+
+        let locks = engine.analyze_locks("SELECT x FROM v", Isolation::ReadCommitted);
+        assert!(
+            locks.contains(&(Resource::Table(base), LockMode::Shared)),
+            "a view's base table (via its CTE) must be Shared-locked: {locks:?}"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn view_with_nested_cte_in_exists_locks_both_tables() {
+        // A view whose body has `WHERE EXISTS (WITH d AS (SELECT ... FROM secret)
+        // ...)` reads both `base` and `secret`; both must be Shared-locked.
+        // EXISTS is the only expression position the parser lets a subquery start
+        // with WITH, so it is the nested-CTE-in-expression case for locks.
+        use crate::lock::{LockMode, Resource};
+        use crate::rel::Isolation;
+        let path = unique_temp_path("view-exists-cte-locks");
+        let mut engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE base (x INT NOT NULL PRIMARY KEY)")
+            .expect("base");
+        engine
+            .execute("CREATE TABLE secret (z INT NOT NULL PRIMARY KEY)")
+            .expect("secret");
+        engine
+            .execute("CREATE VIEW v AS SELECT x FROM base WHERE EXISTS (WITH d AS (SELECT z FROM secret) SELECT z FROM d)")
+            .expect("view");
+        let base = table_object_id(&mut engine, "base");
+        let secret = table_object_id(&mut engine, "secret");
+
+        let locks = engine.analyze_locks("SELECT x FROM v", Isolation::ReadCommitted);
+        assert!(
+            locks.contains(&(Resource::Table(base), LockMode::Shared)),
+            "base must be locked: {locks:?}"
+        );
+        assert!(
+            locks.contains(&(Resource::Table(secret), LockMode::Shared)),
+            "secret (behind the EXISTS nested CTE) must be locked: {locks:?}"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn view_definition_survives_restart() {
+        // A view lives in the persisted catalog, so it must be queryable after
+        // the engine is reopened.
+        let path = unique_temp_path("view-persist");
+        let storage =
+            Storage::create(path.clone(), test_storage_options()).expect("storage create");
+        let mut engine = Engine::new(storage).expect("engine create");
+        engine
+            .execute("CREATE TABLE t (id INT NOT NULL PRIMARY KEY, v INT)")
+            .expect("table");
+        engine
+            .execute("INSERT INTO t VALUES (1, 10), (2, 20)")
+            .expect("insert");
+        engine
+            .execute("CREATE VIEW hi AS SELECT id FROM t WHERE v >= 20")
+            .expect("view");
+        drop(engine);
+
+        let storage = Storage::open(path.clone()).expect("reopen");
+        let mut engine = Engine::new(storage).expect("engine restart");
+        let out = engine.execute("SELECT id FROM hi").expect("query view");
+        assert!(out.contains('2'), "view query after restart: {out}");
+        let listed = engine
+            .execute("SELECT name FROM sys.views")
+            .expect("sys.views");
+        assert!(listed.contains("hi"), "sys.views after restart: {listed}");
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
     fn assignment_select_locks_base_table_behind_a_cte_value() {
         // A CTE referenced only inside an assignment SELECT's value subquery
         // must still lock the real base table, or the read could dirty-read a

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -13,10 +13,10 @@ mod plan;
 mod value;
 
 use truthdb_sql::ast::{
-    AlterAction, AlterTable, CheckConstraint, ColumnDef, CreateIndex, CreateTable, DataType,
-    Declaration, Delete, DropIndex, DropTable, Expr, ExprKind, ForeignKey, Insert, InsertSource,
-    IsolationLevel, JoinKind, Name, OrderItem, Select, SelectItem, SetStatement, Statement,
-    TableRef, Update,
+    AlterAction, AlterTable, CheckConstraint, ColumnDef, CreateIndex, CreateTable, CreateView,
+    DataType, Declaration, Delete, DropIndex, DropTable, DropView, Expr, ExprKind, ForeignKey,
+    Insert, InsertSource, IsolationLevel, JoinKind, Name, OrderItem, Select, SelectItem,
+    SetStatement, Statement, TableRef, Update,
 };
 use truthdb_sql::error::SqlError;
 use truthdb_sql::eval::EvalContext;
@@ -290,12 +290,9 @@ pub fn analyze_locks(
                 let mut tables = Vec::new();
                 collect_locked_tables(&expanded, &mut tables);
                 for name in tables {
-                    if name.value.to_ascii_lowercase().starts_with("sys.") {
-                        continue; // catalog view: unlocked
-                    }
-                    if let Some(def) = resolve_table(storage, &name.value) {
+                    for oid in read_lock_object_ids(storage, &name.value) {
                         add(Resource::Database, LockMode::IntentShared);
-                        add(Resource::Table(def.object_id), LockMode::Shared);
+                        add(Resource::Table(oid), LockMode::Shared);
                     }
                 }
             }
@@ -318,12 +315,9 @@ pub fn analyze_locks(
                     let mut tables = Vec::new();
                     collect_locked_tables(&expanded, &mut tables);
                     for name in tables {
-                        if name.value.to_ascii_lowercase().starts_with("sys.") {
-                            continue;
-                        }
-                        if let Some(def) = resolve_table(storage, &name.value) {
+                        for oid in read_lock_object_ids(storage, &name.value) {
                             add(Resource::Database, LockMode::IntentShared);
-                            add(Resource::Table(def.object_id), LockMode::Shared);
+                            add(Resource::Table(oid), LockMode::Shared);
                         }
                     }
                 }
@@ -359,6 +353,8 @@ pub fn analyze_locks(
             // database-exclusive lock (it is disallowed inside a txn anyway).
             Statement::CreateTable(_)
             | Statement::DropTable(_)
+            | Statement::CreateView(_)
+            | Statement::DropView(_)
             | Statement::CreateIndex(_)
             | Statement::DropIndex(_)
             | Statement::AlterTable(_) => {
@@ -428,6 +424,18 @@ fn exec_statement(
                 return Err(ddl_in_txn_err());
             }
             exec_drop_table(storage, drop)
+        }
+        Statement::CreateView(create) => {
+            if txn_ctx.in_txn() {
+                return Err(ddl_in_txn_err());
+            }
+            exec_create_view(storage, create)
+        }
+        Statement::DropView(drop) => {
+            if txn_ctx.in_txn() {
+                return Err(ddl_in_txn_err());
+            }
+            exec_drop_view(storage, drop)
         }
         Statement::CreateIndex(create) => {
             if txn_ctx.in_txn() {
@@ -1457,6 +1465,19 @@ fn length(n: u32, name: &str) -> Result<u16, SqlError> {
 // ---- DROP TABLE ---------------------------------------------------------
 
 fn exec_drop_table(storage: &mut Storage, drop: &DropTable) -> Result<StatementResult, SqlError> {
+    // DROP TABLE does not drop a view (use DROP VIEW). The object exists but is
+    // the wrong type, so error even under IF EXISTS rather than silently no-op.
+    if resolve_table(storage, &drop.table.value).is_some_and(|d| d.is_view()) {
+        return Err(SqlError::new(
+            3701,
+            11,
+            5,
+            format!(
+                "Cannot drop the table '{}', because it does not exist or you do not have permission.",
+                drop.table.value
+            ),
+        ));
+    }
     let name = resolve_table(storage, &drop.table.value).map(|d| d.name);
     match name {
         Some(name) => {
@@ -1501,6 +1522,74 @@ fn exec_drop_table(storage: &mut Storage, drop: &DropTable) -> Result<StatementR
     }
 }
 
+// ---- CREATE / DROP VIEW -------------------------------------------------
+
+/// Parses a stored view definition back into its `SELECT`. The text was
+/// validated at CREATE, so this only fails on catalog corruption.
+fn parse_view_query(text: &str, view_name: &str) -> Result<Select, SqlError> {
+    match truthdb_sql::parse(text)?.into_iter().next() {
+        Some(Statement::Select(select)) => Ok(select),
+        _ => Err(SqlError::message_only(
+            208,
+            format!("The definition of view '{view_name}' is not a SELECT."),
+        )),
+    }
+}
+
+fn exec_create_view(
+    storage: &mut Storage,
+    create: &CreateView,
+) -> Result<StatementResult, SqlError> {
+    let bare = strip_schema(&create.name.value);
+    if resolve_table(storage, &create.name.value).is_some() {
+        return Err(SqlError::new(
+            2714,
+            16,
+            6,
+            format!("There is already an object named '{bare}' in the database."),
+        ));
+    }
+    // Validate the definition parses as a SELECT now; base-table and column
+    // resolution is deferred to query time (SQL Server-style deferred name
+    // resolution — a view over a not-yet-created table is allowed).
+    parse_view_query(&create.query_text, bare)?;
+    storage
+        .rel_create_view(bare, &create.query_text)
+        .map_err(|e| map_storage_err(e, &create.name.value))?;
+    Ok(StatementResult::Done)
+}
+
+fn exec_drop_view(storage: &mut Storage, drop: &DropView) -> Result<StatementResult, SqlError> {
+    match resolve_table(storage, &drop.name.value) {
+        Some(def) if def.is_view() => {
+            storage
+                .rel_drop_table(&def.name)
+                .map_err(|e| map_storage_err(e, &def.name))?;
+            Ok(StatementResult::Done)
+        }
+        // The object exists but is a base table, not a view.
+        Some(_) => Err(SqlError::new(
+            3701,
+            11,
+            5,
+            format!(
+                "Cannot drop the view '{}', because it does not exist or you do not have permission.",
+                drop.name.value
+            ),
+        )),
+        None if drop.if_exists => Ok(StatementResult::Done),
+        None => Err(SqlError::new(
+            3701,
+            11,
+            5,
+            format!(
+                "Cannot drop the view '{}', because it does not exist or you do not have permission.",
+                drop.name.value
+            ),
+        )),
+    }
+}
+
 // ---- CREATE / DROP INDEX ------------------------------------------------
 
 fn exec_create_index(
@@ -1509,6 +1598,7 @@ fn exec_create_index(
 ) -> Result<StatementResult, SqlError> {
     let def = resolve_table(storage, &create.table.value)
         .ok_or_else(|| SqlError::invalid_object(&create.table.value).at(create.table.span))?;
+    reject_view_as_table(&def)?;
     let schema = def.schema().map_err(|e| map_storage_err(e, &def.name))?;
     let mut columns = Vec::with_capacity(create.columns.len());
     for col in &create.columns {
@@ -1556,6 +1646,7 @@ fn exec_alter_table(
 ) -> Result<StatementResult, SqlError> {
     let def = resolve_table(storage, &alter.table.value)
         .ok_or_else(|| SqlError::invalid_object(&alter.table.value).at(alter.table.span))?;
+    reject_view_as_table(&def)?;
     match &alter.action {
         AlterAction::AddCheck(check) => alter_add_check(storage, &def, check, eval_ctx),
         AlterAction::AddForeignKey(fk) => alter_add_foreign_key(storage, &def, fk),
@@ -1747,6 +1838,7 @@ fn exec_insert(
 ) -> Result<StatementResult, SqlError> {
     let def = resolve_table(storage, &insert.table.value)
         .ok_or_else(|| SqlError::invalid_object(&insert.table.value).at(insert.table.span))?;
+    reject_dml_on_view(&def)?;
     let schema = def.schema().map_err(|e| map_storage_err(e, &def.name))?;
     let ncols = schema.columns.len();
     let identity_col = def.identity.map(|s| s.column);
@@ -1979,6 +2071,7 @@ fn exec_update(
 ) -> Result<StatementResult, SqlError> {
     let def = resolve_table(storage, &update.table.value)
         .ok_or_else(|| SqlError::invalid_object(&update.table.value).at(update.table.span))?;
+    reject_dml_on_view(&def)?;
     let schema = def.schema().map_err(|e| map_storage_err(e, &def.name))?;
     let resolver = schema_names(&schema);
     let identity_col = def.identity.map(|s| s.column);
@@ -2119,6 +2212,7 @@ fn exec_delete(
 ) -> Result<StatementResult, SqlError> {
     let def = resolve_table(storage, &delete.table.value)
         .ok_or_else(|| SqlError::invalid_object(&delete.table.value).at(delete.table.span))?;
+    reject_dml_on_view(&def)?;
     let schema = def.schema().map_err(|e| map_storage_err(e, &def.name))?;
     let resolver = schema_names(&schema);
 
@@ -2296,25 +2390,24 @@ fn row_values(row: &[Datum], types: &[ColumnType]) -> Vec<SqlValue> {
 type CteMap = std::collections::HashMap<String, Select>;
 
 fn expand_ctes(select: &Select) -> Select {
-    if select.ctes.is_empty() {
-        return select.clone();
-    }
-    let mut resolved: CteMap = std::collections::HashMap::new();
+    expand_select_ctes(select, &CteMap::new())
+}
+
+/// A copy of `select` with every CTE reference — at this level and nested inside
+/// its subqueries — replaced by a derived table. `outer` is the enclosing CTE
+/// scope; this select's own `WITH` layers on top of it (so a nested `WITH` sees
+/// enclosing CTEs and is itself inlined). The result carries no `ctes` at any
+/// level, so lock analysis, which walks the expanded tree without re-expanding,
+/// still sees every base table the executor reads.
+fn expand_select_ctes(select: &Select, outer: &CteMap) -> Select {
+    let mut resolved = outer.clone();
     for cte in &select.ctes {
         let body = expand_select_ctes(&cte.query, &resolved);
         resolved.insert(cte.name.value.to_ascii_lowercase(), body);
     }
-    let mut out = expand_select_ctes(select, &resolved);
-    out.ctes = Vec::new();
-    out
-}
-
-/// A copy of `select` with its FROM references and its embedded subqueries'
-/// references to `resolved` CTEs replaced by derived tables. (The CTE is visible
-/// to the whole statement, not just the top-level FROM.) The select's own `ctes`
-/// field is left intact — a nested `WITH` keeps its own scope.
-fn expand_select_ctes(select: &Select, resolved: &CteMap) -> Select {
+    let resolved = &resolved;
     let mut out = select.clone();
+    out.ctes = Vec::new();
     out.from = out
         .from
         .as_ref()
@@ -3519,6 +3612,7 @@ fn build_table_source(
         .unwrap_or_else(|| strip_schema(&name.value).to_string());
     let base = match name.value.to_ascii_lowercase().as_str() {
         "sys.tables" => sys_tables(storage),
+        "sys.views" => sys_views(storage),
         "sys.columns" => sys_columns(storage),
         "sys.indexes" => sys_indexes(storage),
         "sys.check_constraints" => sys_check_constraints(storage),
@@ -3527,6 +3621,35 @@ fn build_table_source(
         _ => {
             let def = resolve_table(storage, &name.value)
                 .ok_or_else(|| SqlError::invalid_object(&name.value).at(name.span))?;
+            // A view: run its stored SELECT as a derived table under the view's
+            // qualifier. First cut: a view over another view is rejected here
+            // rather than expanded, which keeps this non-recursive.
+            if let Some(query_text) = &def.view_query {
+                let body = parse_view_query(query_text, &def.name)?;
+                // Inline the body's own CTEs before checking for referenced
+                // views, so a view reached only through a CTE is still caught.
+                let expanded_body = expand_ctes(&body);
+                let mut refs = Vec::new();
+                collect_locked_tables(&expanded_body, &mut refs);
+                if refs
+                    .iter()
+                    .any(|n| resolve_table(storage, &n.value).is_some_and(|d| d.is_view()))
+                {
+                    return Err(SqlError::message_only(
+                        4506,
+                        format!(
+                            "View '{}' references another view, which is not supported yet.",
+                            def.name
+                        ),
+                    ));
+                }
+                let qual = Name {
+                    value: qualifier,
+                    quoted: false,
+                    span: name.span,
+                };
+                return build_derived_source(storage, &body, &qual, eval_ctx);
+            }
             let schema = def.schema().map_err(|e| map_storage_err(e, &def.name))?;
             // An index seek narrows the candidate set; the WHERE filter later
             // re-checks, so results match a full scan.
@@ -3784,7 +3907,38 @@ fn sys_tables(storage: &Storage) -> Source {
     let rows = storage
         .rel_tables()
         .into_iter()
+        .filter(|def| !def.is_view())
         .map(|def| vec![Datum::Int(def.object_id as i32), Datum::NVarChar(def.name)])
+        .collect();
+    let collations = vec![None; columns.len()];
+    let qualifiers = vec![None; columns.len()];
+    Source {
+        columns,
+        qualifiers,
+        collations,
+        rows,
+    }
+}
+
+/// `sys.views` — one row per view, with its stored definition text.
+fn sys_views(storage: &Storage) -> Source {
+    let columns = vec![
+        int_col("object_id"),
+        nvarchar("name", 128),
+        nvarchar("definition", 4000),
+    ];
+    let rows = storage
+        .rel_tables()
+        .into_iter()
+        .filter_map(|def| {
+            def.view_query.map(|q| {
+                vec![
+                    Datum::Int(def.object_id as i32),
+                    Datum::NVarChar(def.name),
+                    Datum::NVarChar(q),
+                ]
+            })
+        })
         .collect();
     let collations = vec![None; columns.len()];
     let qualifiers = vec![None; columns.len()];
@@ -3989,6 +4143,72 @@ fn strip_schema(name: &str) -> &str {
 
 /// Case-insensitive table resolution (single `dbo` schema in Stage 3). An
 /// optional `dbo.` schema prefix is accepted and stripped.
+/// The base-table object ids that a read of `name` must Shared-lock: the table
+/// itself, or — for a view — the base tables its definition reads. `sys.*`
+/// views take no lock. Nested views (a view over a view) are not expanded here
+/// (they error at query time), so they contribute no locks; view expansion is
+/// one level deep, matching the executor.
+fn read_lock_object_ids(storage: &Storage, name: &str) -> Vec<u32> {
+    if name.to_ascii_lowercase().starts_with("sys.") {
+        return Vec::new();
+    }
+    let Some(def) = resolve_table(storage, name) else {
+        return Vec::new();
+    };
+    let Some(text) = &def.view_query else {
+        return vec![def.object_id];
+    };
+    let Ok(body) = parse_view_query(text, &def.name) else {
+        return Vec::new();
+    };
+    // Inline the body's own CTEs so a base table reached only through a CTE is
+    // still locked (matching what the executor reads).
+    let expanded = expand_ctes(&body);
+    let mut names = Vec::new();
+    collect_locked_tables(&expanded, &mut names);
+    names
+        .into_iter()
+        .filter(|n| !n.value.to_ascii_lowercase().starts_with("sys."))
+        .filter_map(|n| resolve_table(storage, &n.value))
+        .filter(|d| !d.is_view())
+        .map(|d| d.object_id)
+        .collect()
+}
+
+/// Views are read-only here; INSERT/UPDATE/DELETE against one is rejected.
+fn reject_dml_on_view(def: &TableDef) -> Result<(), SqlError> {
+    if def.is_view() {
+        return Err(SqlError::new(
+            4406,
+            16,
+            1,
+            format!(
+                "Update or insert of view '{}' is not supported (the view is read-only).",
+                def.name
+            ),
+        ));
+    }
+    Ok(())
+}
+
+/// Table-only DDL (ALTER TABLE, CREATE INDEX) rejects a view. Without this a
+/// view's `root_page = 0` would be heap-scanned — and page 0 is the catalog
+/// root, so a bare `ALTER TABLE view ADD CHECK (1=1)` could corrupt the catalog.
+fn reject_view_as_table(def: &TableDef) -> Result<(), SqlError> {
+    if def.is_view() {
+        return Err(SqlError::new(
+            4928,
+            16,
+            1,
+            format!(
+                "Cannot perform this operation on '{}' because it is a view, not a table.",
+                def.name
+            ),
+        ));
+    }
+    Ok(())
+}
+
 fn resolve_table(storage: &Storage, name: &str) -> Option<TableDef> {
     let bare = strip_schema(name);
     if let Some(def) = storage.rel_table(bare) {

--- a/crates/truthdb-core/src/relstore/catalog.rs
+++ b/crates/truthdb-core/src/relstore/catalog.rs
@@ -97,6 +97,18 @@ pub struct TableDef {
     /// `FOREIGN KEY` constraints (this table is the referencing child).
     #[serde(default)]
     pub foreign_keys: Vec<ForeignKeyDef>,
+    /// For a VIEW: the source text of its `SELECT`, re-parsed and inlined (as a
+    /// derived table) wherever the view is referenced. `None` for a base table.
+    /// A view carries no data pages, columns, or key.
+    #[serde(default)]
+    pub view_query: Option<String>,
+}
+
+impl TableDef {
+    /// True if this catalog entry is a view rather than a base table.
+    pub fn is_view(&self) -> bool {
+        self.view_query.is_some()
+    }
 }
 
 impl TableDef {

--- a/crates/truthdb-core/src/storage.rs
+++ b/crates/truthdb-core/src/storage.rs
@@ -279,6 +279,52 @@ impl Storage {
                 indexes: Vec::new(),
                 check_constraints,
                 foreign_keys,
+                view_query: None,
+            };
+            catalog::insert_table(ctx, &mut OpMode::Txn(txn), catalog_root, &def)?;
+            Ok(def)
+        })?;
+        self.file.rel.next_object_id += 1;
+        self.file.rel.tables.insert(name.to_string(), def);
+        Ok(())
+    }
+
+    /// Creates a VIEW: a catalog entry that stores its `SELECT` source text and
+    /// owns no data pages. The name shares the table namespace (a view and a
+    /// table cannot share a name).
+    pub fn rel_create_view(&mut self, name: &str, query_text: &str) -> Result<(), StorageError> {
+        self.file.ensure_rel_usable()?;
+        if self.file.rel.tables.contains_key(name) {
+            return Err(StorageError::Constraint(format!(
+                "object '{name}' already exists"
+            )));
+        }
+        if self.file.rel.catalog_root.is_none() {
+            let root = {
+                let mut ctx = self.file.rel_ctx();
+                catalog::create_catalog(&mut ctx)?
+            };
+            self.file.rel.catalog_root = Some(root);
+        }
+        let catalog_root = self.file.rel.catalog_root.expect("catalog exists");
+        let object_id = self.file.rel.next_object_id;
+        let view_name = name.to_string();
+        let query = query_text.to_string();
+
+        let def = self.file.rel_statement(move |ctx, txn| {
+            let def = TableDef {
+                object_id,
+                name: view_name,
+                columns: Vec::new(),
+                key_columns: Vec::new(),
+                root_page: 0,
+                defaults: Vec::new(),
+                collations: Vec::new(),
+                identity: None,
+                indexes: Vec::new(),
+                check_constraints: Vec::new(),
+                foreign_keys: Vec::new(),
+                view_query: Some(query),
             };
             catalog::insert_table(ctx, &mut OpMode::Txn(txn), catalog_root, &def)?;
             Ok(def)

--- a/crates/truthdb-core/tests/slt/views.slt
+++ b/crates/truthdb-core/tests/slt/views.slt
@@ -1,0 +1,129 @@
+# CREATE / DROP VIEW (Stage 11). A view stores its SELECT text and is inlined
+# (as a derived table) wherever it is referenced.
+
+statement ok
+CREATE TABLE emp (id INT NOT NULL PRIMARY KEY, name NVARCHAR(20), dept NVARCHAR(4), salary INT)
+
+statement ok
+INSERT INTO emp VALUES (1,'Ada','eng',100),(2,'Bo','eng',90),(3,'Cy','ops',70),(4,'Di','ops',80)
+
+statement ok
+CREATE VIEW eng AS SELECT id, name, salary FROM emp WHERE dept = 'eng'
+
+# Select from a view.
+query IT
+SELECT id, name FROM eng ORDER BY id
+----
+1 Ada
+2 Bo
+
+# A view with aggregation.
+statement ok
+CREATE VIEW dept_pay AS SELECT dept, SUM(salary) AS total FROM emp GROUP BY dept
+
+query TI
+SELECT dept, total FROM dept_pay ORDER BY dept
+----
+eng 190
+ops 150
+
+# A view referenced in a WHERE against the outer query, and joined to a table.
+query TI
+SELECT e.name, d.total FROM eng e JOIN dept_pay d ON d.dept = 'eng' ORDER BY e.id
+----
+Ada 190
+Bo 190
+
+# A view can be filtered and aliased by the outer query.
+query I
+SELECT COUNT(*) FROM eng WHERE salary >= 95
+----
+1
+
+# A view whose body uses a CTE reads the CTE's base table correctly.
+statement ok
+CREATE VIEW top_paid AS WITH ranked AS (SELECT name, salary FROM emp WHERE salary >= 90) SELECT name FROM ranked
+
+query T
+SELECT name FROM top_paid ORDER BY name
+----
+Ada
+Bo
+
+# sys.views lists the view; sys.tables does not.
+query T
+SELECT name FROM sys.views WHERE name = 'eng'
+----
+eng
+
+query I
+SELECT COUNT(*) FROM sys.tables WHERE name IN ('eng', 'dept_pay')
+----
+0
+
+# The base table is still listed by sys.tables.
+query T
+SELECT name FROM sys.tables WHERE name = 'emp'
+----
+emp
+
+# DML against a view is rejected (read-only).
+statement error
+INSERT INTO eng VALUES (9, 'X', 999)
+
+statement error
+UPDATE eng SET salary = 1 WHERE id = 1
+
+statement error
+DELETE FROM eng WHERE id = 1
+
+# Table-only DDL against a view is rejected (a bare ALTER ... ADD CHECK (1=1)
+# would otherwise heap-scan the view's root_page 0 — the catalog root).
+statement error
+ALTER TABLE eng ADD CHECK (1 = 1)
+
+statement error
+CREATE INDEX ix_eng ON eng (id)
+
+# DROP TABLE does not drop a view, even with IF EXISTS (wrong object type).
+statement error
+DROP TABLE IF EXISTS eng
+
+# A view over another view is not supported (rejected at query time).
+statement ok
+CREATE VIEW eng2 AS SELECT id FROM eng
+
+statement error
+SELECT id FROM eng2
+
+# Deferred name resolution: a view over a missing table is created, but querying
+# it fails.
+statement ok
+CREATE VIEW ghost AS SELECT * FROM does_not_exist
+
+statement error
+SELECT * FROM ghost
+
+# Creating an object whose name is taken errors (2714).
+statement error
+CREATE VIEW emp AS SELECT id FROM emp
+
+# DROP TABLE does not drop a view, and DROP VIEW does not drop a table.
+statement error
+DROP TABLE eng
+
+statement error
+DROP VIEW emp
+
+# DROP VIEW removes it; a second drop errors unless IF EXISTS.
+statement ok
+DROP VIEW eng
+
+statement error
+SELECT * FROM eng
+
+statement error
+DROP VIEW eng
+
+statement ok
+DROP VIEW IF EXISTS eng

--- a/crates/truthdb-sql/src/ast.rs
+++ b/crates/truthdb-sql/src/ast.rs
@@ -7,6 +7,8 @@ use crate::lexer::Span;
 pub enum Statement {
     CreateTable(CreateTable),
     DropTable(DropTable),
+    CreateView(CreateView),
+    DropView(DropView),
     CreateIndex(CreateIndex),
     DropIndex(DropIndex),
     Insert(Insert),
@@ -200,6 +202,23 @@ pub enum DataType {
 #[derive(Debug, Clone, PartialEq)]
 pub struct DropTable {
     pub table: Name,
+    pub if_exists: bool,
+    pub span: Span,
+}
+
+/// `CREATE VIEW name AS SELECT ...`. Only the source text of the query is kept;
+/// it is re-parsed and inlined wherever the view is referenced.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CreateView {
+    pub name: Name,
+    pub query_text: String,
+    pub span: Span,
+}
+
+/// `DROP VIEW [IF EXISTS] name`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DropView {
+    pub name: Name,
     pub if_exists: bool,
     pub span: Span,
 }

--- a/crates/truthdb-sql/src/parser.rs
+++ b/crates/truthdb-sql/src/parser.rs
@@ -394,11 +394,43 @@ impl Parser {
         match self.peek_keyword().as_deref() {
             Some("INDEX") => self.parse_create_index(start, unique),
             Some("TABLE") if !unique => self.parse_create_table(start),
+            Some("VIEW") if !unique => self.parse_create_view(start),
             _ => {
                 let token = self.peek().clone();
                 Err(SqlError::syntax(self.token_text(&token), token.span))
             }
         }
+    }
+
+    fn parse_create_view(&mut self, start: Span) -> SqlResult<Statement> {
+        self.expect_keyword("VIEW")?;
+        let name = self.parse_name()?;
+        // A view column list (`CREATE VIEW v (a, b) AS ...`) renames the output
+        // columns; not supported yet.
+        if self.check(&TokenKind::LParen) {
+            let token = self.peek().clone();
+            return Err(SqlError::message_only(
+                102,
+                format!(
+                    "A column list on CREATE VIEW is not supported yet, near '{}'.",
+                    self.token_text(&token)
+                ),
+            ));
+        }
+        self.expect_keyword("AS")?;
+        // Capture text from the current token so a leading `WITH` (whose CTEs
+        // precede the SELECT keyword the query span starts at) is included.
+        let query_start = self.peek().span.start;
+        let query = self.parse_select()?;
+        let query_text = self
+            .slice(Span::new(query_start, query.span.end))
+            .trim()
+            .to_string();
+        Ok(Statement::CreateView(CreateView {
+            span: start.to(query.span),
+            name,
+            query_text,
+        }))
     }
 
     fn parse_create_index(&mut self, start: Span, unique: bool) -> SqlResult<Statement> {
@@ -844,11 +876,29 @@ impl Parser {
         match self.peek_keyword().as_deref() {
             Some("INDEX") => self.parse_drop_index(start),
             Some("TABLE") => self.parse_drop_table(start),
+            Some("VIEW") => self.parse_drop_view(start),
             _ => {
                 let token = self.peek().clone();
                 Err(SqlError::syntax(self.token_text(&token), token.span))
             }
         }
+    }
+
+    fn parse_drop_view(&mut self, start: Span) -> SqlResult<Statement> {
+        self.expect_keyword("VIEW")?;
+        let if_exists = if self.peek_keyword().as_deref() == Some("IF") {
+            self.bump();
+            self.expect_keyword("EXISTS")?;
+            true
+        } else {
+            false
+        };
+        let name = self.parse_name()?;
+        Ok(Statement::DropView(DropView {
+            span: start.to(name.span),
+            name,
+            if_exists,
+        }))
     }
 
     fn parse_drop_index(&mut self, start: Span) -> SqlResult<Statement> {


### PR DESCRIPTION
Part of Stage 11 (subqueries/views/variables). Follows #56–#59, #64.

## What

Views store their `SELECT` text in the catalog and are inlined (as a derived
table) wherever referenced, reusing the derived-table / CTE machinery.

- **Catalog**: `TableDef` gains `view_query: Option<String>` (`#[serde(default)]`,
  backward-compatible); `rel_create_view` stores a view as a catalog row with no
  data pages. Views persist across restart (WAL replay / catalog reload).
- **Parser**: `CREATE VIEW name AS SELECT ...` (the query text, including a
  leading `WITH`, is captured by span slice); `DROP VIEW [IF EXISTS]`. A view
  column list is rejected for now.
- **Executor**: `build_table_source` runs a view's stored `SELECT` as a derived
  table under the view's qualifier. **Deferred name resolution** (a view over a
  not-yet-created table is created and errors at query time), matching SQL
  Server. DML against a view is rejected (read-only). `sys.views` lists views;
  `sys.tables` excludes them.
- **First cut**: a view referencing another view is rejected at query time,
  keeping expansion non-recursive (no cyclic/nested-view runtime).

Lock analysis resolves a view to its base tables so a read through a view still
Shared-locks them (no dirty read under READ COMMITTED).

## Also fixes a pre-existing CTE under-lock

`expand_ctes` now flattens **nested** CTEs (a CTE whose body itself declares a
`WITH`) at every level, so lock analysis sees every base table the executor
reads. Previously a nested CTE's base table went unlocked — a dirty-read window
— for plain queries as well as views.

## Adversarial review findings (all fixed)

- **serious — catalog corruption.** `ALTER TABLE`/`CREATE INDEX` had no view
  guard, so `ALTER TABLE view ADD CHECK (1=1)` heap-scanned the view's
  `root_page 0` — which is the catalog B-tree root — risking corruption/panic.
  Both now reject views.
- The review also confirmed no under-lock gap remains (view in EXISTS/subquery/
  join, view-over-view rejection in all forms incl. schema-qualified and
  CTE-hidden refs), the nested/cyclic-view protection caps recursion at one
  level, `query_text` capture is a standalone re-parseable SELECT, and views
  persist correctly with no object-id collision.

Two bugs I caught earlier via my own tests are also fixed: a dropped `WITH`
clause in view definitions (span started at `SELECT`), and a CTE-body lock hole.

## Tests

`crates/truthdb-core/tests/slt/views.slt` (semantics, DML/DDL rejection,
`sys.views`, deferred resolution, view-over-view reject, DROP semantics) and
`engine.rs` unit tests (persistence across restart; base-table locking including
nested-CTE and EXISTS-nested-CTE view bodies).

fmt / clippy `-D warnings` / `cargo test --workspace` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)