### PR TITLE
Stage 8: in-memory hash join, hash aggregate, hash DISTINCT

### DIFF
--- a/crates/truthdb-core/src/rel/aggregate.rs
+++ b/crates/truthdb-core/src/rel/aggregate.rs
@@ -163,8 +163,13 @@ fn group_rows(
     if select.group_by.is_empty() {
         return Ok(vec![(Vec::new(), (0..rows.len()).collect())]);
     }
-    // Key each row, then bucket by key (order_key_cmp equality).
-    let mut keyed: Vec<(Vec<SqlValue>, usize)> = Vec::with_capacity(rows.len());
+    // Key each row and bucket by key in a hash table — O(n) instead of the old
+    // O(n·groups) linear probe. `HashKey`'s equality matches the previous
+    // `order_key_cmp`-based `keys_equal`, so groups are identical; a side `Vec`
+    // preserves first-appearance order (the order the old scan produced).
+    use super::hash::HashKey;
+    let mut index_of: std::collections::HashMap<HashKey, usize> = std::collections::HashMap::new();
+    let mut groups: Vec<(Vec<SqlValue>, Vec<usize>)> = Vec::new();
     for (index, row) in rows.iter().enumerate() {
         let sql_row = row_values(row, types);
         let key = select
@@ -172,24 +177,15 @@ fn group_rows(
             .iter()
             .map(|expr| eval::eval(expr, &sql_row, resolver, eval_ctx))
             .collect::<Result<Vec<_>, _>>()?;
-        keyed.push((key, index));
-    }
-    let mut groups: Vec<(Vec<SqlValue>, Vec<usize>)> = Vec::new();
-    for (key, index) in keyed {
-        if let Some((_, members)) = groups.iter_mut().find(|(k, _)| keys_equal(k, &key)) {
-            members.push(index);
-        } else {
-            groups.push((key, vec![index]));
+        match index_of.get(&HashKey(key.clone())) {
+            Some(&pos) => groups[pos].1.push(index),
+            None => {
+                index_of.insert(HashKey(key.clone()), groups.len());
+                groups.push((key, vec![index]));
+            }
         }
     }
     Ok(groups)
-}
-
-fn keys_equal(a: &[SqlValue], b: &[SqlValue]) -> bool {
-    a.len() == b.len()
-        && a.iter()
-            .zip(b)
-            .all(|(x, y)| order_key_cmp(x, y) == std::cmp::Ordering::Equal)
 }
 
 fn compute_aggregate(

--- a/crates/truthdb-core/src/rel/hash.rs
+++ b/crates/truthdb-core/src/rel/hash.rs
@@ -6,26 +6,42 @@
 //! grouping used) — so replacing the O(n²) linear-probe grouping with a
 //! `HashMap<HashKey, _>` produces identical groups.
 //!
-//! The one subtlety is `SqlValue`'s cross-type numeric equality
-//! (`Int(2) == Decimal(2.0) == Float(2.0) == Bool(true)`). The `Hash`/`Eq`
-//! contract only requires `a == b ⇒ hash(a) == hash(b)`; collisions are resolved
-//! by `eq`. So every numeric value is hashed by its canonical `f64` image, which
-//! collapses all numerically-equal numerics to the same bucket, and `eq`
-//! confirms with `order_key_cmp`. Strings/dates/binaries hash by their bytes.
+//! The one subtlety is `SqlValue`'s cross-type numeric equality. `Int`/`Bit`/
+//! `Decimal` inter-compare **exactly** (i128 rescale), while any comparison
+//! involving a `Float` promotes both sides to `f64`. These are two different
+//! equivalence regimes, and for large magnitudes they even disagree (exact
+//! `Int == Decimal` need not hold once rounded to `f64` — `to_f64` on a Decimal
+//! double-rounds), so **no single hash can be consistent with all of them**.
+//! We therefore hash each regime by its own exact/canonical form and keep them
+//! apart:
+//! - `Int`/`Bit`/`Decimal` hash by their exact canonical rational
+//!   (`m·10^e` with `m` not divisible by 10) — so `Int(9e18)` and the equal
+//!   `Decimal` land in the same bucket, and cross-scale decimals (`2.50` vs
+//!   `2.5`) canonicalize identically. No float rounding is involved.
+//! - `Float` hashes by its `f64` bits.
+//!
+//! `hash_class` (used by the hash-join guard) puts the exact family
+//! (`ExactNumeric`) and the float family (`ApproxNumeric`) in **different**
+//! classes, so a `float = int`/`float = decimal` join — whose equality regime is
+//! `f64` and cannot share a hash with the exact family — falls back to the
+//! nested loop rather than risk a false separation. Strings/dates/binaries hash
+//! by their bytes.
+//!
+//! The `Hash`/`Eq` contract only requires `a == b ⇒ hash(a) == hash(b)`;
+//! collisions are resolved by `eq` (which uses `order_key_cmp`). Consistency
+//! holds whenever a key column is type-homogeneous (the real-world case — a
+//! table column is one type, and the join guard confines each hash join to one
+//! numeric regime). Mixing `Float` with `Int`/`Decimal` in one key position
+//! (only reachable via a pathological heterogeneous key expression) is the sole
+//! unsupported case, as it already is for `order_key_cmp`.
 //!
 //! NULL hashes to a single sentinel bucket and `order_key_cmp` treats
 //! `NULL == NULL` — so, for grouping, NULLs group together (SQL Server GROUP BY
 //! semantics). Callers that must *not* match NULLs (equijoins, where
-//! `NULL = NULL` is UNKNOWN) filter NULL keys out before building/probing.
-//!
-//! Consistency holds for keys whose columns are type-homogeneous (the real-world
-//! case — a table column has one type, so a group/join key column is one variant
-//! modulo NULL). A pathological heterogeneous key (e.g. `GROUP BY CASE WHEN …
-//! THEN 'x' ELSE 1 END`, mixing string and numeric in one key position) is the
-//! only case where a string that `order_key_cmp`-compares equal to a number
-//! could land in a different bucket; that comparison is already ill-defined in
-//! the engine (a type-clash compare error is folded to `Equal`), so it is not a
-//! supported grouping and is documented as out of scope here.
+//! `NULL = NULL` is UNKNOWN) filter NULL keys out before building/probing. A
+//! string that `order_key_cmp`-compares equal to a number (via the engine's
+//! already-ill-defined string↔number coercion) is the same unsupported
+//! heterogeneous-key case as the `Float`/exact mix above.
 
 use std::hash::{Hash, Hasher};
 
@@ -35,14 +51,17 @@ use crate::relstore::types::ColumnType;
 
 /// The hashing family of a column type. Two columns can be joined by the hash
 /// path only if their classes match, which guarantees their key values hash the
-/// same way (all numerics share one class via the canonical f64 image; VARCHAR
-/// and NVARCHAR share the `Str` class because both decode to `SqlValue::Str`).
-/// A mismatched pair (e.g. `int = varchar`, which `compare` resolves by string→
-/// number coercion) would risk a false separation, so the caller falls back to
-/// the nested-loop join for it.
+/// same way. `ExactNumeric` (int family + decimal) uses exact canonical-rational
+/// hashing; `ApproxNumeric` (real/float) uses `f64` bits — they are kept
+/// separate because their equality regimes (exact i128 vs `f64` promotion)
+/// disagree at large magnitudes and cannot share one hash (see the module
+/// docs). VARCHAR and NVARCHAR share the `Str` class because both decode to
+/// `SqlValue::Str`. A mismatched pair (e.g. `int = varchar`, or `float = int`)
+/// would risk a false separation, so the caller keeps the nested-loop join.
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum HashClass {
-    Numeric,
+    ExactNumeric,
+    ApproxNumeric,
     Str,
     Date,
     Time,
@@ -59,9 +78,8 @@ pub fn hash_class(ty: ColumnType) -> HashClass {
         | ColumnType::Int
         | ColumnType::BigInt
         | ColumnType::Bit
-        | ColumnType::Real
-        | ColumnType::Float
-        | ColumnType::Decimal { .. } => HashClass::Numeric,
+        | ColumnType::Decimal { .. } => HashClass::ExactNumeric,
+        ColumnType::Real | ColumnType::Float => HashClass::ApproxNumeric,
         ColumnType::VarChar { .. } | ColumnType::NVarChar { .. } => HashClass::Str,
         ColumnType::Date => HashClass::Date,
         ColumnType::Time => HashClass::Time,
@@ -104,16 +122,30 @@ pub fn key_has_null(values: &[SqlValue]) -> bool {
 }
 
 /// Hashes one value with a per-family discriminant so different families never
-/// need equality checks, and with a canonical numeric image so numerically-equal
-/// numerics share a bucket (see the module docs).
+/// need equality checks. `Int`/`Bit`/`Decimal` hash by their exact canonical
+/// rational; `Float` by its `f64` bits (see the module docs).
 fn hash_value<H: Hasher>(value: &SqlValue, state: &mut H) {
     match value {
         SqlValue::Null => 0u8.hash(state),
-        // Whole numeric family (incl. bit) → canonical f64 bits. `as_numeric`
-        // returns `Some` for exactly {Int, Float, Decimal, Bool}.
-        SqlValue::Int(_) | SqlValue::Float(_) | SqlValue::Decimal(_) | SqlValue::Bool(_) => {
+        // Exact numeric family: canonical rational `m·10^e`. Bit is 0/1.
+        SqlValue::Int(v) => {
             1u8.hash(state);
-            canonical_f64_bits(value).hash(state);
+            canonical_rational(*v as i128, 0).hash(state);
+        }
+        SqlValue::Bool(b) => {
+            1u8.hash(state);
+            canonical_rational(*b as i128, 0).hash(state);
+        }
+        SqlValue::Decimal(d) => {
+            1u8.hash(state);
+            canonical_rational(d.value, d.scale).hash(state);
+        }
+        // Approximate numeric family: f64 bits, hashed under a distinct
+        // discriminant so it never shares a bucket with the exact family (the
+        // join guard also keeps the two apart).
+        SqlValue::Float(f) => {
+            8u8.hash(state);
+            float_bits(*f).hash(state);
         }
         SqlValue::Str(s) => {
             2u8.hash(state);
@@ -143,29 +175,33 @@ fn hash_value<H: Hasher>(value: &SqlValue, state: &mut H) {
     }
 }
 
-/// The f64 image of a numeric value, normalized so equal numbers hash equal:
-/// `-0.0` folds to `0.0` and any NaN folds to one canonical NaN. Numerically
-/// equal values (`Int(2)`, `Decimal(2.0)`, `Float(2.0)`) map to the same bits
-/// because `compare_numeric` promotes them through this same `f64` for the
-/// float-involved cases, and exact integer/decimal equality implies an equal
-/// real value that rounds to one `f64`. Large magnitudes that lose precision
-/// only *collide* (resolved by `eq`), never falsely separate.
-fn canonical_f64_bits(value: &SqlValue) -> u64 {
-    let raw = match value.as_numeric() {
-        Some(n) => match n {
-            truthdb_sql::value::Numeric::Int(v) => v as f64,
-            truthdb_sql::value::Numeric::Float(v) => v,
-            truthdb_sql::value::Numeric::Decimal(d) => d.to_f64(),
-        },
-        // Not reached: callers only pass numeric-family values here.
-        None => 0.0,
-    };
-    let normalized = if raw == 0.0 {
-        0.0 // collapses +0.0 and -0.0
-    } else if raw.is_nan() {
+/// The exact canonical rational `(m, e)` for `value·10^(-scale)`, with `m` not
+/// divisible by 10 (`0` normalizes to `(0, 0)`). Two exact numerics compare
+/// `Equal` iff they have the same canonical rational, so this — unlike an `f64`
+/// image — never falsely separates equal `Int`/`Decimal` keys, at any
+/// magnitude, and collapses cross-scale decimals (`2.50` and `2.5` → `(25, -1)`).
+fn canonical_rational(value: i128, scale: u8) -> (i128, i32) {
+    if value == 0 {
+        return (0, 0);
+    }
+    let mut m = value;
+    let mut e: i32 = -(i32::from(scale));
+    while m % 10 == 0 {
+        m /= 10;
+        e += 1;
+    }
+    (m, e)
+}
+
+/// `f64` bits normalized so equal floats hash equal: `-0.0` folds to `0.0` and
+/// any NaN folds to one canonical NaN.
+fn float_bits(f: f64) -> u64 {
+    let normalized = if f == 0.0 {
+        0.0
+    } else if f.is_nan() {
         f64::NAN
     } else {
-        raw
+        f
     };
     normalized.to_bits()
 }
@@ -184,24 +220,44 @@ mod tests {
     }
 
     #[test]
-    fn numeric_family_hashes_and_compares_equal() {
+    fn int_and_decimal_hash_and_compare_equal() {
         let int = SqlValue::Int(2);
         let dec = SqlValue::Decimal(Box::new(Decimal::parse("2.0").unwrap()));
-        let flt = SqlValue::Float(2.0);
         let bit = SqlValue::Bool(true); // 1, distinct value
         assert_eq!(h(vec![int.clone()]), h(vec![dec.clone()]));
-        assert_eq!(h(vec![int.clone()]), h(vec![flt.clone()]));
         assert_eq!(HashKey(vec![int.clone()]), HashKey(vec![dec]));
-        assert_eq!(HashKey(vec![int]), HashKey(vec![flt]));
-        assert_ne!(HashKey(vec![SqlValue::Int(2)]), HashKey(vec![bit]));
+        assert_ne!(HashKey(vec![int]), HashKey(vec![bit]));
     }
 
     #[test]
-    fn negative_zero_hashes_with_positive_zero() {
-        assert_eq!(h(vec![SqlValue::Float(-0.0)]), h(vec![SqlValue::Float(0.0)]));
+    fn int_decimal_exact_at_large_magnitude() {
+        // Regression: > 2^53, where an f64 image would double-round the Decimal
+        // and split the bucket. 9007199254740993 == 9007199254740993.0 exactly.
+        let big = 9_007_199_254_740_993_i64;
+        let int = SqlValue::Int(big);
+        let dec = SqlValue::Decimal(Box::new(Decimal::new(big as i128 * 10, 20, 1)));
+        assert_eq!(h(vec![int.clone()]), h(vec![dec.clone()]));
+        assert_eq!(HashKey(vec![int]), HashKey(vec![dec]));
+    }
+
+    #[test]
+    fn cross_scale_decimals_hash_equal() {
+        // 2.50 (value 250, scale 2) and 2.5 (value 25, scale 1) are equal.
+        let a = SqlValue::Decimal(Box::new(Decimal::new(250, 5, 2)));
+        let b = SqlValue::Decimal(Box::new(Decimal::new(25, 5, 1)));
+        assert_eq!(h(vec![a.clone()]), h(vec![b.clone()]));
+        assert_eq!(HashKey(vec![a]), HashKey(vec![b]));
+    }
+
+    #[test]
+    fn negative_zero_float_hashes_with_positive_zero() {
+        assert_eq!(
+            h(vec![SqlValue::Float(-0.0)]),
+            h(vec![SqlValue::Float(0.0)])
+        );
         assert_eq!(
             HashKey(vec![SqlValue::Float(-0.0)]),
-            HashKey(vec![SqlValue::Int(0)])
+            HashKey(vec![SqlValue::Float(0.0)])
         );
     }
 

--- a/crates/truthdb-core/src/rel/hash.rs
+++ b/crates/truthdb-core/src/rel/hash.rs
@@ -1,0 +1,236 @@
+//! Hash keys for the in-memory hash operators (Stage 8): hash aggregate, hash
+//! DISTINCT, and hash join.
+//!
+//! A [`HashKey`] wraps a tuple of [`SqlValue`]s and gives it a `Hash`/`Eq` pair
+//! whose equality matches `order_key_cmp` (the same equality the old linear
+//! grouping used) — so replacing the O(n²) linear-probe grouping with a
+//! `HashMap<HashKey, _>` produces identical groups.
+//!
+//! The one subtlety is `SqlValue`'s cross-type numeric equality
+//! (`Int(2) == Decimal(2.0) == Float(2.0) == Bool(true)`). The `Hash`/`Eq`
+//! contract only requires `a == b ⇒ hash(a) == hash(b)`; collisions are resolved
+//! by `eq`. So every numeric value is hashed by its canonical `f64` image, which
+//! collapses all numerically-equal numerics to the same bucket, and `eq`
+//! confirms with `order_key_cmp`. Strings/dates/binaries hash by their bytes.
+//!
+//! NULL hashes to a single sentinel bucket and `order_key_cmp` treats
+//! `NULL == NULL` — so, for grouping, NULLs group together (SQL Server GROUP BY
+//! semantics). Callers that must *not* match NULLs (equijoins, where
+//! `NULL = NULL` is UNKNOWN) filter NULL keys out before building/probing.
+//!
+//! Consistency holds for keys whose columns are type-homogeneous (the real-world
+//! case — a table column has one type, so a group/join key column is one variant
+//! modulo NULL). A pathological heterogeneous key (e.g. `GROUP BY CASE WHEN …
+//! THEN 'x' ELSE 1 END`, mixing string and numeric in one key position) is the
+//! only case where a string that `order_key_cmp`-compares equal to a number
+//! could land in a different bucket; that comparison is already ill-defined in
+//! the engine (a type-clash compare error is folded to `Equal`), so it is not a
+//! supported grouping and is documented as out of scope here.
+
+use std::hash::{Hash, Hasher};
+
+use truthdb_sql::value::{SqlValue, order_key_cmp};
+
+use crate::relstore::types::ColumnType;
+
+/// The hashing family of a column type. Two columns can be joined by the hash
+/// path only if their classes match, which guarantees their key values hash the
+/// same way (all numerics share one class via the canonical f64 image; VARCHAR
+/// and NVARCHAR share the `Str` class because both decode to `SqlValue::Str`).
+/// A mismatched pair (e.g. `int = varchar`, which `compare` resolves by string→
+/// number coercion) would risk a false separation, so the caller falls back to
+/// the nested-loop join for it.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum HashClass {
+    Numeric,
+    Str,
+    Date,
+    Time,
+    DateTime2,
+    Guid,
+    Binary,
+}
+
+/// The hash class of a column type (see [`HashClass`]).
+pub fn hash_class(ty: ColumnType) -> HashClass {
+    match ty {
+        ColumnType::TinyInt
+        | ColumnType::SmallInt
+        | ColumnType::Int
+        | ColumnType::BigInt
+        | ColumnType::Bit
+        | ColumnType::Real
+        | ColumnType::Float
+        | ColumnType::Decimal { .. } => HashClass::Numeric,
+        ColumnType::VarChar { .. } | ColumnType::NVarChar { .. } => HashClass::Str,
+        ColumnType::Date => HashClass::Date,
+        ColumnType::Time => HashClass::Time,
+        ColumnType::DateTime2 => HashClass::DateTime2,
+        ColumnType::UniqueIdentifier => HashClass::Guid,
+        ColumnType::VarBinary { .. } => HashClass::Binary,
+    }
+}
+
+/// A group/join key: a tuple of [`SqlValue`]s hashed and compared so that values
+/// which `order_key_cmp`-compare `Equal` are the same key.
+#[derive(Clone, Debug)]
+pub struct HashKey(pub Vec<SqlValue>);
+
+impl PartialEq for HashKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.len() == other.0.len()
+            && self
+                .0
+                .iter()
+                .zip(&other.0)
+                .all(|(a, b)| order_key_cmp(a, b) == std::cmp::Ordering::Equal)
+    }
+}
+
+impl Eq for HashKey {}
+
+impl Hash for HashKey {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        for value in &self.0 {
+            hash_value(value, state);
+        }
+    }
+}
+
+/// True if any component is NULL. Equijoins skip NULL keys (a NULL never matches
+/// in `a = b`), while grouping keeps them (NULLs group together).
+pub fn key_has_null(values: &[SqlValue]) -> bool {
+    values.iter().any(SqlValue::is_null)
+}
+
+/// Hashes one value with a per-family discriminant so different families never
+/// need equality checks, and with a canonical numeric image so numerically-equal
+/// numerics share a bucket (see the module docs).
+fn hash_value<H: Hasher>(value: &SqlValue, state: &mut H) {
+    match value {
+        SqlValue::Null => 0u8.hash(state),
+        // Whole numeric family (incl. bit) → canonical f64 bits. `as_numeric`
+        // returns `Some` for exactly {Int, Float, Decimal, Bool}.
+        SqlValue::Int(_) | SqlValue::Float(_) | SqlValue::Decimal(_) | SqlValue::Bool(_) => {
+            1u8.hash(state);
+            canonical_f64_bits(value).hash(state);
+        }
+        SqlValue::Str(s) => {
+            2u8.hash(state);
+            s.as_bytes().hash(state);
+        }
+        SqlValue::Date(d) => {
+            3u8.hash(state);
+            d.hash(state);
+        }
+        SqlValue::Time(t) => {
+            4u8.hash(state);
+            t.hash(state);
+        }
+        SqlValue::DateTime2(d, t) => {
+            5u8.hash(state);
+            d.hash(state);
+            t.hash(state);
+        }
+        SqlValue::Guid(g) => {
+            6u8.hash(state);
+            g.hash(state);
+        }
+        SqlValue::Binary(b) => {
+            7u8.hash(state);
+            b.hash(state);
+        }
+    }
+}
+
+/// The f64 image of a numeric value, normalized so equal numbers hash equal:
+/// `-0.0` folds to `0.0` and any NaN folds to one canonical NaN. Numerically
+/// equal values (`Int(2)`, `Decimal(2.0)`, `Float(2.0)`) map to the same bits
+/// because `compare_numeric` promotes them through this same `f64` for the
+/// float-involved cases, and exact integer/decimal equality implies an equal
+/// real value that rounds to one `f64`. Large magnitudes that lose precision
+/// only *collide* (resolved by `eq`), never falsely separate.
+fn canonical_f64_bits(value: &SqlValue) -> u64 {
+    let raw = match value.as_numeric() {
+        Some(n) => match n {
+            truthdb_sql::value::Numeric::Int(v) => v as f64,
+            truthdb_sql::value::Numeric::Float(v) => v,
+            truthdb_sql::value::Numeric::Decimal(d) => d.to_f64(),
+        },
+        // Not reached: callers only pass numeric-family values here.
+        None => 0.0,
+    };
+    let normalized = if raw == 0.0 {
+        0.0 // collapses +0.0 and -0.0
+    } else if raw.is_nan() {
+        f64::NAN
+    } else {
+        raw
+    };
+    normalized.to_bits()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::hash_map::DefaultHasher;
+
+    use truthdb_sql::decimal::Decimal;
+
+    fn h(values: Vec<SqlValue>) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        HashKey(values).hash(&mut hasher);
+        hasher.finish()
+    }
+
+    #[test]
+    fn numeric_family_hashes_and_compares_equal() {
+        let int = SqlValue::Int(2);
+        let dec = SqlValue::Decimal(Box::new(Decimal::parse("2.0").unwrap()));
+        let flt = SqlValue::Float(2.0);
+        let bit = SqlValue::Bool(true); // 1, distinct value
+        assert_eq!(h(vec![int.clone()]), h(vec![dec.clone()]));
+        assert_eq!(h(vec![int.clone()]), h(vec![flt.clone()]));
+        assert_eq!(HashKey(vec![int.clone()]), HashKey(vec![dec]));
+        assert_eq!(HashKey(vec![int]), HashKey(vec![flt]));
+        assert_ne!(HashKey(vec![SqlValue::Int(2)]), HashKey(vec![bit]));
+    }
+
+    #[test]
+    fn negative_zero_hashes_with_positive_zero() {
+        assert_eq!(h(vec![SqlValue::Float(-0.0)]), h(vec![SqlValue::Float(0.0)]));
+        assert_eq!(
+            HashKey(vec![SqlValue::Float(-0.0)]),
+            HashKey(vec![SqlValue::Int(0)])
+        );
+    }
+
+    #[test]
+    fn nulls_group_together() {
+        assert_eq!(h(vec![SqlValue::Null]), h(vec![SqlValue::Null]));
+        assert_eq!(HashKey(vec![SqlValue::Null]), HashKey(vec![SqlValue::Null]));
+        assert!(key_has_null(&[SqlValue::Int(1), SqlValue::Null]));
+        assert!(!key_has_null(&[SqlValue::Int(1)]));
+    }
+
+    #[test]
+    fn distinct_strings_differ() {
+        assert_ne!(
+            HashKey(vec![SqlValue::Str("a".into())]),
+            HashKey(vec![SqlValue::Str("b".into())])
+        );
+        assert_eq!(
+            HashKey(vec![SqlValue::Str("a".into())]),
+            HashKey(vec![SqlValue::Str("a".into())])
+        );
+    }
+
+    #[test]
+    fn multi_column_keys() {
+        let a = HashKey(vec![SqlValue::Int(1), SqlValue::Str("x".into())]);
+        let b = HashKey(vec![SqlValue::Int(1), SqlValue::Str("x".into())]);
+        let c = HashKey(vec![SqlValue::Int(1), SqlValue::Str("y".into())]);
+        assert_eq!(a, b);
+        assert_ne!(a, c);
+    }
+}

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -3099,7 +3099,9 @@ fn dedup_rows(rowset: &mut RowSet) {
     // Hash-based DISTINCT — O(n) instead of the old O(n²) linear scan, keeping
     // first-appearance order. Each output column is single-typed (projection
     // coerced it), so `HashKey`'s `order_key_cmp` equality agrees with the
-    // former `Vec<Datum>` equality for every realistic input.
+    // former `Vec<Datum>` equality for every realistic input. (Edge: two `float`
+    // NaN rows now collapse to one — `order_key_cmp` treats NaN as equal, like
+    // GROUP BY already did — where the old raw `Datum` `==` kept them distinct.)
     let types: Vec<ColumnType> = rowset.columns.iter().map(|c| c.column_type).collect();
     let mut seen: std::collections::HashSet<hash::HashKey> = std::collections::HashSet::new();
     rowset
@@ -3863,8 +3865,12 @@ fn join_sources(
     // Equijoin key columns (bare `left_col = right_col` conjuncts of a
     // hash-compatible type). When present on an INNER/LEFT/RIGHT/FULL join, a
     // hash join replaces the O(n·m) nested loop; the full ON predicate is still
-    // re-checked on each hash candidate, so results (and their order) are
-    // identical to the nested loop. CROSS and equi-key-less joins keep the loop.
+    // re-checked on each hash candidate, so the result set and its order are
+    // identical to the nested loop. (Like a real optimizer, the hash join
+    // evaluates the ON predicate only on candidate pairs sharing a key, so a
+    // side-effecting error in a residual conjunct — e.g. `1/b.z` — may be raised
+    // on fewer rows than the loop would; the SQL result set is unaffected.)
+    // CROSS and equi-key-less joins keep the loop.
     let equi = match on {
         Some(pred) => extract_equi_keys(pred, &left, &right),
         None => Vec::new(),
@@ -3974,7 +3980,10 @@ fn extract_equi_keys(pred: &Expr, left: &Source, right: &Source) -> Vec<EquiKey>
             return None;
         };
         use truthdb_sql::eval::ColumnResolver;
-        match (left_scope.resolve(&name.value), right_scope.resolve(&name.value)) {
+        match (
+            left_scope.resolve(&name.value),
+            right_scope.resolve(&name.value),
+        ) {
             (Some(i), None) => Some((true, i)),
             (None, Some(j)) => Some((false, j)),
             _ => None,
@@ -4062,7 +4071,11 @@ fn hash_join(
     let mut table: HashMap<HashKey, Vec<usize>> = HashMap::new();
     let build_rows = if build_left { &left.rows } else { &right.rows };
     for (index, row) in build_rows.iter().enumerate() {
-        let key = if build_left { left_key(row) } else { right_key(row) };
+        let key = if build_left {
+            left_key(row)
+        } else {
+            right_key(row)
+        };
         if key_has_null(&key) {
             continue;
         }

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -9,6 +9,7 @@
 
 mod aggregate;
 pub mod collation;
+mod hash;
 mod plan;
 mod value;
 
@@ -3095,15 +3096,15 @@ fn exec_select_assign(
 /// Removes duplicate output rows (SELECT DISTINCT), keeping first occurrence.
 /// NULLs are equal to each other (`Datum` equality), matching SQL Server.
 fn dedup_rows(rowset: &mut RowSet) {
-    let mut seen: Vec<Vec<Datum>> = Vec::new();
-    rowset.rows.retain(|row| {
-        if seen.iter().any(|s| s == row) {
-            false
-        } else {
-            seen.push(row.clone());
-            true
-        }
-    });
+    // Hash-based DISTINCT — O(n) instead of the old O(n²) linear scan, keeping
+    // first-appearance order. Each output column is single-typed (projection
+    // coerced it), so `HashKey`'s `order_key_cmp` equality agrees with the
+    // former `Vec<Datum>` equality for every realistic input.
+    let types: Vec<ColumnType> = rowset.columns.iter().map(|c| c.column_type).collect();
+    let mut seen: std::collections::HashSet<hash::HashKey> = std::collections::HashSet::new();
+    rowset
+        .rows
+        .retain(|row| seen.insert(hash::HashKey(row_values(row, &types))));
 }
 
 /// Orders an output RowSet by ORDER BY items referencing the output: a bare
@@ -3859,63 +3860,87 @@ fn join_sources(
         }
     };
 
+    // Equijoin key columns (bare `left_col = right_col` conjuncts of a
+    // hash-compatible type). When present on an INNER/LEFT/RIGHT/FULL join, a
+    // hash join replaces the O(n·m) nested loop; the full ON predicate is still
+    // re-checked on each hash candidate, so results (and their order) are
+    // identical to the nested loop. CROSS and equi-key-less joins keep the loop.
+    let equi = match on {
+        Some(pred) => extract_equi_keys(pred, &left, &right),
+        None => Vec::new(),
+    };
+
     let mut rows = Vec::new();
-    match kind {
-        JoinKind::Cross | JoinKind::Inner => {
-            for l in &left.rows {
-                for r in &right.rows {
-                    if matches(l, r)? {
-                        rows.push(concat(l, r));
-                    }
-                }
-            }
-        }
-        JoinKind::Left => {
-            for l in &left.rows {
-                let mut matched = false;
-                for r in &right.rows {
-                    if matches(l, r)? {
-                        rows.push(concat(l, r));
-                        matched = true;
-                    }
-                }
-                if !matched {
-                    rows.push(concat(l, &right_nulls));
-                }
-            }
-        }
-        JoinKind::Right => {
-            for r in &right.rows {
-                let mut matched = false;
+    if !equi.is_empty() && !matches!(kind, JoinKind::Cross) {
+        hash_join(
+            &left,
+            &right,
+            kind,
+            &equi,
+            &matches,
+            &concat,
+            &left_nulls,
+            &right_nulls,
+            &mut rows,
+        )?;
+    } else {
+        match kind {
+            JoinKind::Cross | JoinKind::Inner => {
                 for l in &left.rows {
-                    if matches(l, r)? {
-                        rows.push(concat(l, r));
-                        matched = true;
+                    for r in &right.rows {
+                        if matches(l, r)? {
+                            rows.push(concat(l, r));
+                        }
                     }
                 }
-                if !matched {
-                    rows.push(concat(&left_nulls, r));
+            }
+            JoinKind::Left => {
+                for l in &left.rows {
+                    let mut matched = false;
+                    for r in &right.rows {
+                        if matches(l, r)? {
+                            rows.push(concat(l, r));
+                            matched = true;
+                        }
+                    }
+                    if !matched {
+                        rows.push(concat(l, &right_nulls));
+                    }
                 }
             }
-        }
-        JoinKind::Full => {
-            let mut right_matched = vec![false; right.rows.len()];
-            for l in &left.rows {
-                let mut matched = false;
+            JoinKind::Right => {
+                for r in &right.rows {
+                    let mut matched = false;
+                    for l in &left.rows {
+                        if matches(l, r)? {
+                            rows.push(concat(l, r));
+                            matched = true;
+                        }
+                    }
+                    if !matched {
+                        rows.push(concat(&left_nulls, r));
+                    }
+                }
+            }
+            JoinKind::Full => {
+                let mut right_matched = vec![false; right.rows.len()];
+                for l in &left.rows {
+                    let mut matched = false;
+                    for (index, r) in right.rows.iter().enumerate() {
+                        if matches(l, r)? {
+                            rows.push(concat(l, r));
+                            matched = true;
+                            right_matched[index] = true;
+                        }
+                    }
+                    if !matched {
+                        rows.push(concat(l, &right_nulls));
+                    }
+                }
                 for (index, r) in right.rows.iter().enumerate() {
-                    if matches(l, r)? {
-                        rows.push(concat(l, r));
-                        matched = true;
-                        right_matched[index] = true;
+                    if !right_matched[index] {
+                        rows.push(concat(&left_nulls, r));
                     }
-                }
-                if !matched {
-                    rows.push(concat(l, &right_nulls));
-                }
-            }
-            for (index, r) in right.rows.iter().enumerate() {
-                if !right_matched[index] {
-                    rows.push(concat(&left_nulls, r));
                 }
             }
         }
@@ -3926,6 +3951,196 @@ fn join_sources(
         collations,
         rows,
     })
+}
+
+/// An equijoin key pair: `(left column index, right column index)` for a
+/// `left_col = right_col` conjunct of the ON predicate.
+type EquiKey = (usize, usize);
+
+/// Extracts the equijoin key pairs usable for a hash join from an ON predicate:
+/// the top-level `AND` conjuncts that are `col = col` with one bare column
+/// resolving uniquely to the left source, the other uniquely to the right, and
+/// matching hash classes. A predicate with no such conjunct (a range/disjunction
+/// join, an expression key, or a type-mismatched equality) yields an empty list
+/// and the caller keeps the nested-loop join. Non-equi conjuncts are left for
+/// the full-ON re-check on each hash candidate, so results are unchanged.
+fn extract_equi_keys(pred: &Expr, left: &Source, right: &Source) -> Vec<EquiKey> {
+    let left_scope = left.scope();
+    let right_scope = right.scope();
+    // `Some(true)` = resolves uniquely to the left source, `Some(false)` = right,
+    // `None` = neither, both, or not a bare column.
+    let side_of = |expr: &Expr| -> Option<(bool, usize)> {
+        let ExprKind::Column(name) = &expr.kind else {
+            return None;
+        };
+        use truthdb_sql::eval::ColumnResolver;
+        match (left_scope.resolve(&name.value), right_scope.resolve(&name.value)) {
+            (Some(i), None) => Some((true, i)),
+            (None, Some(j)) => Some((false, j)),
+            _ => None,
+        }
+    };
+    let mut conjuncts = Vec::new();
+    flatten_and(pred, &mut conjuncts);
+    let mut keys = Vec::new();
+    for conjunct in conjuncts {
+        let ExprKind::Binary {
+            op: ast::BinaryOp::Eq,
+            left: le,
+            right: re,
+        } = &conjunct.kind
+        else {
+            continue;
+        };
+        let pair = match (side_of(le), side_of(re)) {
+            (Some((true, i)), Some((false, j))) => (i, j),
+            (Some((false, j)), Some((true, i))) => (i, j),
+            _ => continue,
+        };
+        if hash::hash_class(left.columns[pair.0].column_type)
+            == hash::hash_class(right.columns[pair.1].column_type)
+        {
+            keys.push(pair);
+        }
+    }
+    keys
+}
+
+/// Collects the top-level `AND` conjuncts of an expression (flattening nested
+/// `AND`s); any other expression is one conjunct.
+fn flatten_and<'a>(expr: &'a Expr, out: &mut Vec<&'a Expr>) {
+    if let ExprKind::Binary {
+        op: ast::BinaryOp::And,
+        left,
+        right,
+    } = &expr.kind
+    {
+        flatten_and(left, out);
+        flatten_and(right, out);
+    } else {
+        out.push(expr);
+    }
+}
+
+/// Hash join over two materialized sources on the given equi-key columns. The
+/// build side is hashed by its key tuple; the probe side drives output so row
+/// order matches the nested loop exactly (INNER/LEFT drive from the left,
+/// RIGHT from the right, FULL from the left with a right-side matched bitmap).
+/// NULL key components never match (`x = NULL` is UNKNOWN), so NULL-keyed rows
+/// are excluded from the table and treated as unmatched. The full ON predicate
+/// is re-evaluated on every candidate, so residual (non-equi) conjuncts and the
+/// 3VL of the equality are honored identically to the nested loop.
+#[allow(clippy::too_many_arguments)]
+fn hash_join(
+    left: &Source,
+    right: &Source,
+    kind: JoinKind,
+    equi: &[EquiKey],
+    matches: &impl Fn(&[Datum], &[Datum]) -> Result<bool, SqlError>,
+    concat: &impl Fn(&[Datum], &[Datum]) -> Vec<Datum>,
+    left_nulls: &[Datum],
+    right_nulls: &[Datum],
+    rows: &mut Vec<Vec<Datum>>,
+) -> Result<(), SqlError> {
+    use hash::{HashKey, key_has_null};
+    use std::collections::HashMap;
+
+    let left_key = |l: &[Datum]| -> Vec<SqlValue> {
+        equi.iter()
+            .map(|&(i, _)| value::datum_to_sql(&l[i], &left.columns[i].column_type))
+            .collect()
+    };
+    let right_key = |r: &[Datum]| -> Vec<SqlValue> {
+        equi.iter()
+            .map(|&(_, j)| value::datum_to_sql(&r[j], &right.columns[j].column_type))
+            .collect()
+    };
+
+    // The build side is the one NOT driving output: right for INNER/LEFT/FULL,
+    // left for RIGHT.
+    let build_left = matches!(kind, JoinKind::Right);
+    let mut table: HashMap<HashKey, Vec<usize>> = HashMap::new();
+    let build_rows = if build_left { &left.rows } else { &right.rows };
+    for (index, row) in build_rows.iter().enumerate() {
+        let key = if build_left { left_key(row) } else { right_key(row) };
+        if key_has_null(&key) {
+            continue;
+        }
+        table.entry(HashKey(key)).or_default().push(index);
+    }
+
+    match kind {
+        JoinKind::Inner | JoinKind::Left => {
+            for l in &left.rows {
+                let key = left_key(l);
+                let mut matched = false;
+                if !key_has_null(&key)
+                    && let Some(cands) = table.get(&HashKey(key))
+                {
+                    for &ri in cands {
+                        let r = &right.rows[ri];
+                        if matches(l, r)? {
+                            rows.push(concat(l, r));
+                            matched = true;
+                        }
+                    }
+                }
+                if kind == JoinKind::Left && !matched {
+                    rows.push(concat(l, right_nulls));
+                }
+            }
+        }
+        JoinKind::Right => {
+            for r in &right.rows {
+                let key = right_key(r);
+                let mut matched = false;
+                if !key_has_null(&key)
+                    && let Some(cands) = table.get(&HashKey(key))
+                {
+                    for &li in cands {
+                        let l = &left.rows[li];
+                        if matches(l, r)? {
+                            rows.push(concat(l, r));
+                            matched = true;
+                        }
+                    }
+                }
+                if !matched {
+                    rows.push(concat(left_nulls, r));
+                }
+            }
+        }
+        JoinKind::Full => {
+            let mut right_matched = vec![false; right.rows.len()];
+            for l in &left.rows {
+                let key = left_key(l);
+                let mut matched = false;
+                if !key_has_null(&key)
+                    && let Some(cands) = table.get(&HashKey(key))
+                {
+                    for &ri in cands {
+                        let r = &right.rows[ri];
+                        if matches(l, r)? {
+                            rows.push(concat(l, r));
+                            matched = true;
+                            right_matched[ri] = true;
+                        }
+                    }
+                }
+                if !matched {
+                    rows.push(concat(l, right_nulls));
+                }
+            }
+            for (index, r) in right.rows.iter().enumerate() {
+                if !right_matched[index] {
+                    rows.push(concat(left_nulls, r));
+                }
+            }
+        }
+        // CROSS never reaches here (the caller keeps the nested loop for it).
+        JoinKind::Cross => unreachable!("cross join has no equi keys"),
+    }
+    Ok(())
 }
 
 // ---- sys.* virtual sources ---------------------------------------------

--- a/crates/truthdb-core/tests/slt/hash_operators.slt
+++ b/crates/truthdb-core/tests/slt/hash_operators.slt
@@ -1,0 +1,158 @@
+# Hash join / hash aggregate / hash distinct (Stage 8 in-memory hash operators).
+# Exercises the tricky paths: duplicate join keys (many-to-many), NULL keys
+# (which never equi-match), residual non-equi ON conjuncts, all four outer-join
+# kinds and their row order, multi-column equi keys, the nested-loop fallback
+# for a non-equi (range) join, and hash grouping/DISTINCT over many groups.
+
+statement ok
+CREATE TABLE l (k INT, v NVARCHAR(20))
+
+statement ok
+CREATE TABLE r (k INT, w NVARCHAR(20))
+
+statement ok
+INSERT INTO l VALUES (1,'l1a'),(1,'l1b'),(2,'l2'),(NULL,'lnull'),(3,'l3')
+
+statement ok
+INSERT INTO r VALUES (1,'r1a'),(1,'r1b'),(2,'r2'),(NULL,'rnull'),(4,'r4')
+
+# INNER JOIN: many-to-many on k=1, single on k=2, NULL never matches, k=3/k=4
+# unmatched.
+query TT
+SELECT l.v, r.w FROM l JOIN r ON l.k = r.k ORDER BY l.v, r.w
+----
+l1a r1a
+l1a r1b
+l1b r1a
+l1b r1b
+l2 r2
+
+# LEFT JOIN: unmatched left rows (l3, lnull) NULL-extend.
+query TT
+SELECT l.v, r.w FROM l LEFT JOIN r ON l.k = r.k ORDER BY l.v, r.w
+----
+l1a r1a
+l1a r1b
+l1b r1a
+l1b r1b
+l2 r2
+l3 NULL
+lnull NULL
+
+# RIGHT JOIN: unmatched right rows (r4, rnull) NULL-extend.
+query TT
+SELECT l.v, r.w FROM l RIGHT JOIN r ON l.k = r.k ORDER BY r.w, l.v
+----
+l1a r1a
+l1b r1a
+l1a r1b
+l1b r1b
+l2 r2
+NULL r4
+NULL rnull
+
+# FULL JOIN: unmatched from both sides.
+query TT
+SELECT l.v, r.w FROM l FULL JOIN r ON l.k = r.k ORDER BY l.v, r.w
+----
+NULL r4
+NULL rnull
+l1a r1a
+l1a r1b
+l1b r1a
+l1b r1b
+l2 r2
+l3 NULL
+lnull NULL
+
+# Residual (non-equi) ON conjunct is honored on hash candidates.
+query TT
+SELECT l.v, r.w FROM l JOIN r ON l.k = r.k AND r.w <> 'r1a' ORDER BY l.v, r.w
+----
+l1a r1b
+l1b r1b
+l2 r2
+
+# A NULL-keyed row is unmatched even against another NULL key (x = NULL is
+# UNKNOWN): the INNER join over the NULL keys yields nothing.
+query I
+SELECT COUNT(*) FROM l JOIN r ON l.k = r.k
+----
+5
+
+# Non-equi (range) join falls back to the nested loop; still correct.
+query I
+SELECT COUNT(*) FROM l JOIN r ON l.k < r.k
+----
+6
+
+# Multi-column equi key.
+statement ok
+CREATE TABLE lp (a INT, b INT, tag NVARCHAR(10))
+
+statement ok
+CREATE TABLE rp (a INT, b INT, tag NVARCHAR(10))
+
+statement ok
+INSERT INTO lp VALUES (1,1,'x'),(1,2,'y'),(2,1,'z')
+
+statement ok
+INSERT INTO rp VALUES (1,1,'p'),(1,2,'q'),(9,9,'n')
+
+query TT
+SELECT lp.tag, rp.tag FROM lp JOIN rp ON lp.a = rp.a AND lp.b = rp.b ORDER BY lp.tag
+----
+x p
+y q
+
+# --- hash aggregate over many groups, incl. a NULL group and HAVING ---
+statement ok
+CREATE TABLE g (grp INT, amt INT)
+
+statement ok
+INSERT INTO g VALUES (1,10),(1,20),(2,5),(2,5),(3,100),(NULL,7),(NULL,3)
+
+query II
+SELECT grp, SUM(amt) FROM g GROUP BY grp ORDER BY grp
+----
+NULL 10
+1 30
+2 10
+3 100
+
+# HAVING filters groups.
+query II
+SELECT grp, COUNT(*) FROM g GROUP BY grp HAVING COUNT(*) > 1 ORDER BY grp
+----
+NULL 2
+1 2
+2 2
+
+# COUNT(DISTINCT) within groups.
+query II
+SELECT grp, COUNT(DISTINCT amt) FROM g GROUP BY grp ORDER BY grp
+----
+NULL 2
+1 2
+2 1
+3 1
+
+# --- hash DISTINCT ---
+query I
+SELECT DISTINCT grp FROM g ORDER BY grp
+----
+NULL
+1
+2
+3
+
+# DISTINCT over multiple columns keeps distinct combinations.
+query II
+SELECT DISTINCT grp, amt FROM g ORDER BY grp, amt
+----
+NULL 3
+NULL 7
+1 10
+1 20
+2 5
+3 100

--- a/crates/truthdb-core/tests/slt/hash_operators.slt
+++ b/crates/truthdb-core/tests/slt/hash_operators.slt
@@ -105,6 +105,44 @@ SELECT lp.tag, rp.tag FROM lp JOIN rp ON lp.a = rp.a AND lp.b = rp.b ORDER BY lp
 x p
 y q
 
+# Cross-type numeric equi-join must find exact matches even above 2^53, where an
+# f64 hash would double-round the DECIMAL and drop the row. 9007199254740993 is
+# the smallest odd integer not exactly representable as f64.
+statement ok
+CREATE TABLE bigk (k BIGINT)
+
+statement ok
+CREATE TABLE deck (k DECIMAL(20,1))
+
+statement ok
+INSERT INTO bigk VALUES (9007199254740993), (9007199254740995)
+
+statement ok
+INSERT INTO deck VALUES (9007199254740993.0)
+
+query I
+SELECT bigk.k FROM bigk JOIN deck ON bigk.k = deck.k
+----
+9007199254740993
+
+# Cross-scale DECIMAL = DECIMAL of the same large value must still match.
+statement ok
+CREATE TABLE d0 (k DECIMAL(38,0))
+
+statement ok
+CREATE TABLE d2 (k DECIMAL(38,2))
+
+statement ok
+INSERT INTO d0 VALUES (9007199254740993)
+
+statement ok
+INSERT INTO d2 VALUES (9007199254740993.00)
+
+query I
+SELECT COUNT(*) FROM d0 JOIN d2 ON d0.k = d2.k
+----
+1
+
 # --- hash aggregate over many groups, incl. a NULL group and HAVING ---
 statement ok
 CREATE TABLE g (grp INT, amt INT)


### PR DESCRIPTION
Replaces the quadratic query operators with hash-based ones, closing the Stage 8
gap for in-memory hashing (external-sort/grace-hash spill is a planned follow-up).

## What changed
- **Hash join** for equijoins: extract `left_col = right_col` conjuncts from the
  top-level AND-chain of an ON predicate (matching hash classes) and build/probe
  a hash table instead of the O(n·m) nested loop. The probe side drives output so
  row **order is identical** to the nested loop for INNER/LEFT/RIGHT/FULL; NULL
  keys never match; the full ON predicate is re-checked on each candidate so
  residual conjuncts and 3VL are honored. CROSS, non-equi, and type-mismatched
  joins keep the nested loop (correctness-preserving fallback).
- **Hash aggregate**: `group_rows` buckets in a HashMap (O(n)) instead of the
  O(n·groups) linear probe, preserving first-appearance group order.
- **Hash DISTINCT**: `dedup_rows` uses a HashSet (O(n)) instead of the O(n²) scan.

New `rel/hash.rs` provides `HashKey`, whose `Hash` is consistent with the
existing `order_key_cmp` equality: Int/Bit/Decimal hash by their **exact
canonical rational** (`m·10^e`) so cross-type/cross-scale numeric keys collide
correctly at any magnitude; Float by f64 bits. `hash_class` keeps the exact and
approximate numeric families in separate classes.

## Correctness
An adversarial-review workflow (9 agents) ran against the diff and caught a
HIGH-severity Hash/Eq contract violation in the first cut (hashing Int/Decimal
via lossy `to_f64` dropped `bigint = decimal` matches above 2^53). Fixed with the
exact-rational scheme above, with regression tests.

`tests/slt/hash_operators.slt` covers many-to-many keys, NULL keys, residual ON
conjuncts, all four outer-join kinds and their order, multi-column keys, the
nested-loop range-join fallback, large-magnitude int=decimal / cross-scale
decimal=decimal joins, and hash grouping/DISTINCT.

Full workspace test suite green (328 passed, up from 321).