### PR TITLE
Stage 12: row-level locks for point INSERT/UPDATE/DELETE

### DIFF
--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -2344,6 +2344,94 @@ mod tests {
     }
 
     #[test]
+    fn row_locks_for_point_operations() {
+        use crate::lock::{LockMode, Resource};
+        use crate::rel::Isolation;
+        let path = unique_temp_path("row-locks");
+        let engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE t (id INT NOT NULL PRIMARY KEY, v INT)")
+            .expect("t");
+        let t = table_object_id(&engine, "t");
+        let rc = Isolation::ReadCommitted;
+
+        let has_table_x = |locks: &[(Resource, LockMode)]| {
+            locks.contains(&(Resource::Table(t), LockMode::Exclusive))
+        };
+        let row_x = |locks: &[(Resource, LockMode)]| -> Option<u64> {
+            locks.iter().find_map(|(r, m)| match r {
+                Resource::Row(oid, h) if *oid == t && *m == LockMode::Exclusive => Some(*h),
+                _ => None,
+            })
+        };
+
+        // Point UPDATE: Table IX + a single Row X, no Table X.
+        let up = engine.analyze_locks("UPDATE t SET v = 9 WHERE id = 5", rc);
+        assert!(up.contains(&(Resource::Table(t), LockMode::IntentExclusive)));
+        assert!(
+            !has_table_x(&up),
+            "point UPDATE must not take Table X: {up:?}"
+        );
+        let k5 = row_x(&up).expect("point UPDATE row lock");
+
+        // Point DELETE: same row key as the UPDATE of id = 5.
+        let del = engine.analyze_locks("DELETE FROM t WHERE id = 5", rc);
+        assert_eq!(row_x(&del), Some(k5), "DELETE id=5 must lock the same row");
+
+        // A different key → a different row resource (so the two run concurrently).
+        let up6 = engine.analyze_locks("UPDATE t SET v = 1 WHERE id = 6", rc);
+        assert_ne!(row_x(&up6), Some(k5));
+
+        // Point INSERT (literal key) row-locks; INSERT ... SELECT does not.
+        let ins = engine.analyze_locks("INSERT INTO t VALUES (7, 1)", rc);
+        assert!(row_x(&ins).is_some() && !has_table_x(&ins));
+        let ins_sel = engine.analyze_locks("INSERT INTO t SELECT id, v FROM t", rc);
+        assert!(has_table_x(&ins_sel) && row_x(&ins_sel).is_none());
+
+        // Range / OR / partial predicates fall back to Table X.
+        for sql in [
+            "UPDATE t SET v = 1 WHERE id > 5",
+            "DELETE FROM t WHERE id = 5 OR id = 6",
+            "UPDATE t SET v = 1",
+            "UPDATE t SET id = 2 WHERE id = 5", // key change moves the row
+            "DELETE FROM t WHERE id = (SELECT MAX(id) FROM t)",
+        ] {
+            let locks = engine.analyze_locks(sql, rc);
+            assert!(
+                has_table_x(&locks) && row_x(&locks).is_none(),
+                "table lock for `{sql}`: {locks:?}"
+            );
+        }
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn row_locks_require_full_composite_key() {
+        use crate::lock::{LockMode, Resource};
+        use crate::rel::Isolation;
+        let path = unique_temp_path("row-locks-composite");
+        let engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE t (a INT NOT NULL, b INT NOT NULL, v INT, PRIMARY KEY (a, b))")
+            .expect("t");
+        let t = table_object_id(&engine, "t");
+        let rc = Isolation::ReadCommitted;
+        let row_x = |locks: &[(Resource, LockMode)]| {
+            locks.iter().any(|(r, m)| {
+                matches!(r, Resource::Row(oid, _) if *oid == t) && *m == LockMode::Exclusive
+            })
+        };
+        // Both key columns pinned → row lock.
+        assert!(row_x(
+            &engine.analyze_locks("UPDATE t SET v = 1 WHERE a = 1 AND b = 2", rc)
+        ));
+        // Only one pinned → table lock.
+        let partial = engine.analyze_locks("UPDATE t SET v = 1 WHERE a = 1", rc);
+        assert!(!row_x(&partial) && partial.contains(&(Resource::Table(t), LockMode::Exclusive)));
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
     fn foreign_key_insert_locks_parent_shared() {
         use crate::lock::{LockMode, Resource};
         use crate::rel::Isolation;
@@ -2359,11 +2447,20 @@ mod tests {
         let c = table_object_id(&engine, "c");
 
         // INSERT into the child reads the parent, so it must take a Shared lock
-        // on the parent (else it could read an uncommitted parent row).
+        // on the parent (else it could read an uncommitted parent row). The
+        // child is not itself an FK parent, so its point INSERT row-locks:
+        // Table IntentExclusive + a Row Exclusive on the inserted key.
         let locks = engine.analyze_locks("INSERT INTO c VALUES (1, 1)", Isolation::ReadCommitted);
         assert!(
-            locks.contains(&(Resource::Table(c), LockMode::Exclusive)),
-            "child Exclusive: {locks:?}"
+            locks.contains(&(Resource::Table(c), LockMode::IntentExclusive)),
+            "child IntentExclusive: {locks:?}"
+        );
+        assert!(
+            locks
+                .iter()
+                .any(|(r, m)| matches!(r, Resource::Row(t, _) if *t == c)
+                    && *m == LockMode::Exclusive),
+            "child Row Exclusive: {locks:?}"
         );
         assert!(
             locks.contains(&(Resource::Table(p), LockMode::Shared)),

--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -2406,6 +2406,73 @@ mod tests {
     }
 
     #[test]
+    fn row_lock_safety_guards() {
+        use crate::lock::{LockMode, Resource};
+        use crate::rel::Isolation;
+        let path = unique_temp_path("row-lock-guards");
+        let engine = new_engine(&path);
+        // Character PK, a table with a secondary UNIQUE index, and a FLOAT PK.
+        engine
+            .execute("CREATE TABLE cs (id VARCHAR(10) NOT NULL PRIMARY KEY, v INT)")
+            .expect("cs");
+        engine
+            .execute("CREATE TABLE u (id INT NOT NULL PRIMARY KEY, email VARCHAR(50))")
+            .expect("u");
+        engine
+            .execute("CREATE UNIQUE INDEX ux ON u (email)")
+            .expect("ux");
+        engine
+            .execute("CREATE TABLE f (k FLOAT NOT NULL PRIMARY KEY, v INT)")
+            .expect("f");
+        let cs = table_object_id(&engine, "cs");
+        let u = table_object_id(&engine, "u");
+        let f = table_object_id(&engine, "f");
+        let rc = Isolation::ReadCommitted;
+        let table_x = |locks: &[(Resource, LockMode)], t: u32| {
+            locks.contains(&(Resource::Table(t), LockMode::Exclusive))
+        };
+        let has_row = |locks: &[(Resource, LockMode)], t: u32| {
+            locks
+                .iter()
+                .any(|(r, _)| matches!(r, Resource::Row(o, _) if *o == t))
+        };
+
+        // Character PK vs a *string* literal row-locks; vs a *numeric* literal it
+        // does not (the executor's string->number match is many-to-one).
+        let str_lit = engine.analyze_locks("UPDATE cs SET v = 1 WHERE id = '05'", rc);
+        assert!(has_row(&str_lit, cs));
+        let num_lit = engine.analyze_locks("UPDATE cs SET v = 1 WHERE id = 5", rc);
+        assert!(table_x(&num_lit, cs) && !has_row(&num_lit, cs));
+
+        // A table with a secondary UNIQUE index: INSERT/UPDATE keep Table X;
+        // DELETE may still row-lock (a delete cannot create a duplicate).
+        let ins = engine.analyze_locks("INSERT INTO u VALUES (1, 'a@b.com')", rc);
+        assert!(table_x(&ins, u) && !has_row(&ins, u));
+        let upd = engine.analyze_locks("UPDATE u SET email = 'x' WHERE id = 1", rc);
+        assert!(table_x(&upd, u) && !has_row(&upd, u));
+        let del = engine.analyze_locks("DELETE FROM u WHERE id = 1", rc);
+        assert!(has_row(&del, u) && !table_x(&del, u));
+
+        // FLOAT PK is never row-locked (signed zero / NaN encode ambiguity).
+        let fl = engine.analyze_locks("UPDATE f SET v = 1 WHERE k = 1.0", rc);
+        assert!(table_x(&fl, f) && !has_row(&fl, f));
+
+        // A batch that point-writes AND reads the same table must end up with an
+        // exclusive table lock (the IX+S -> X combine fix), not a Shared lock.
+        let batch =
+            engine.analyze_locks("UPDATE cs SET v = 1 WHERE id = '05'; SELECT * FROM cs", rc);
+        assert!(
+            table_x(&batch, cs),
+            "point-write + same-table read must hold Table X: {batch:?}"
+        );
+        assert!(
+            !batch.contains(&(Resource::Table(cs), LockMode::Shared)),
+            "must not downgrade to Shared: {batch:?}"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
     fn row_locks_require_full_composite_key() {
         use crate::lock::{LockMode, Resource};
         use crate::rel::Isolation;

--- a/crates/truthdb-core/src/lock.rs
+++ b/crates/truthdb-core/src/lock.rs
@@ -37,9 +37,7 @@ pub enum LockMode {
 }
 
 impl LockMode {
-    /// Rank for upgrade/combine. Stage 6 only ever combines within the intent
-    /// pair `{IS,IX}` (on `Database`) or the base pair `{S,X}` (on a table),
-    /// so a plain max-by-rank is exact — no SIX lock is ever needed.
+    /// Rank in the lock lattice, for [`LockMode::combine`].
     fn rank(self) -> u8 {
         match self {
             LockMode::IntentShared => 0,
@@ -49,12 +47,19 @@ impl LockMode {
         }
     }
 
-    /// The stronger of two modes an owner needs on one resource.
+    /// The least mode an owner needs to cover both `self` and `other` on one
+    /// resource (the lattice join). `S` and `IX` are incomparable — their true
+    /// join is `SIX`, which this engine has no mode for, so it uses the stronger
+    /// `X`. This case is real since Stage 12: a batch that point-writes a row
+    /// (Table `IX`) *and* reads the same table (Table `S`) must end up with an
+    /// exclusive table lock, not `S` — otherwise max-by-rank would silently drop
+    /// the write intent and expose the uncommitted row to table-level readers.
     pub fn combine(self, other: LockMode) -> LockMode {
-        if self.rank() >= other.rank() {
-            self
-        } else {
-            other
+        use LockMode::*;
+        match (self, other) {
+            (Shared, IntentExclusive) | (IntentExclusive, Shared) => Exclusive,
+            _ if self.rank() >= other.rank() => self,
+            _ => other,
         }
     }
 
@@ -245,6 +250,20 @@ mod tests {
         lm.grant(A, T, LockMode::Exclusive);
         // Now B is excluded.
         assert_eq!(lm.conflict(B, T, LockMode::Shared), Some(A));
+    }
+
+    #[test]
+    fn combine_shared_and_intent_exclusive_escalates_to_exclusive() {
+        use LockMode::*;
+        // A batch that point-writes a row (Table IX) and reads the same table
+        // (Table S) must combine to X — not S, which would drop the write intent.
+        assert_eq!(Shared.combine(IntentExclusive), Exclusive);
+        assert_eq!(IntentExclusive.combine(Shared), Exclusive);
+        // The other pairs are plain max-by-rank.
+        assert_eq!(IntentShared.combine(IntentExclusive), IntentExclusive);
+        assert_eq!(IntentShared.combine(Shared), Shared);
+        assert_eq!(Shared.combine(Exclusive), Exclusive);
+        assert_eq!(IntentExclusive.combine(Exclusive), Exclusive);
     }
 
     #[test]

--- a/crates/truthdb-core/src/lock.rs
+++ b/crates/truthdb-core/src/lock.rs
@@ -1,21 +1,28 @@
-//! Table/database lock manager (Stage 6): coarse, table-granular two-phase
-//! locking that serializes conflicting transactions across sessions.
+//! Database/table/row lock manager (Stage 6, row locks added in Stage 12):
+//! two-phase locking that serializes conflicting transactions across sessions.
 //!
-//! The engine is a single actor thread, so it never blocks in place on a
-//! lock — the [`session`](crate::session) loop acquires a batch's locks up
-//! front and *parks* the whole request when one conflicts (see that module).
-//! This type is the pure bookkeeping underneath: which owner holds what, and
-//! whether a requested mode conflicts. Row-level keys arrive in Stage 12; for
-//! now the finest resource is a table.
+//! Worker threads never block in place on a lock — the
+//! [`session`](crate::session) scheduler acquires a batch's locks up front and
+//! *parks* the whole request when one conflicts (see that module). This type is
+//! the pure bookkeeping underneath: which owner holds what, and whether a
+//! requested mode conflicts. Point INSERT/UPDATE/DELETE take a [`Resource::Row`]
+//! lock so writers to different rows of one table need not serialize; scans and
+//! non-point predicates stay table-granular.
 
 use std::collections::HashMap;
 
-/// A lockable resource. `Database` is the hierarchy root (intent locks);
-/// `Table` is keyed by catalog object id.
+/// A lockable resource, forming a `Database` → `Table` → `Row` hierarchy.
+/// `Database` is the intent-lock root; `Table` is keyed by catalog object id;
+/// `Row` is keyed by `(table object id, key hash)` — the xxh64 of the row's
+/// clustered-key bytes (Stage 12). A row lock keeps [`Resource`] `Copy` by
+/// hashing the key rather than carrying its bytes; a hash collision only ever
+/// makes two unrelated rows share a lock queue (a rare, harmless over-serialize)
+/// — it can never let two distinct keys skip a real conflict.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Resource {
     Database,
     Table(u32),
+    Row(u32, u64),
 }
 
 /// Lock modes, weakest to strongest by [`LockMode::rank`]. Intent modes
@@ -238,6 +245,26 @@ mod tests {
         lm.grant(A, T, LockMode::Exclusive);
         // Now B is excluded.
         assert_eq!(lm.conflict(B, T, LockMode::Shared), Some(A));
+    }
+
+    #[test]
+    fn row_locks_on_distinct_keys_do_not_conflict() {
+        let mut lm = LockManager::new();
+        let r5 = Resource::Row(10, 5);
+        let r6 = Resource::Row(10, 6);
+        // Both writers take IX on the table (compatible) + X on their own row.
+        lm.grant(A, Resource::Table(10), LockMode::IntentExclusive);
+        lm.grant(A, r5, LockMode::Exclusive);
+        // B's IX on the table coexists with A's IX.
+        assert!(
+            lm.conflict(B, Resource::Table(10), LockMode::IntentExclusive)
+                .is_none()
+        );
+        lm.grant(B, Resource::Table(10), LockMode::IntentExclusive);
+        // B's X on a different row does not conflict with A's.
+        assert!(lm.conflict(B, r6, LockMode::Exclusive).is_none());
+        // But B's X on the *same* row does.
+        assert_eq!(lm.conflict(B, r5, LockMode::Exclusive), Some(A));
     }
 
     #[test]

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -24,6 +24,8 @@ use truthdb_sql::eval::EvalContext;
 use truthdb_sql::value::{SqlValue, order_key_cmp};
 use truthdb_sql::{ast, eval};
 
+use xxhash_rust::xxh64::xxh64;
+
 use crate::lock::{LockMode, Resource};
 use crate::relstore::catalog::{self, TableDef};
 use crate::relstore::row::{Column, Schema};
@@ -300,6 +302,209 @@ fn fk_child_object_ids(storage: &Storage, parent_name: &str) -> Vec<u32> {
         .collect()
 }
 
+/// True if any table has a foreign key referencing `name` — i.e. `name` is an
+/// FK parent. Such a table keeps table-granular write locks so an FK
+/// existence-read (Table IS on the parent) still serializes against a
+/// concurrent change to the referenced row.
+fn is_fk_parent(storage: &Storage, name: &str) -> bool {
+    !fk_child_object_ids(storage, name).is_empty()
+}
+
+/// Above this many row-lock keys for one statement, `analyze_locks` escalates to
+/// a single table lock (SQL Server-style lock escalation) rather than flooding
+/// the lock table.
+const ROW_LOCK_ESCALATION_THRESHOLD: usize = 1000;
+
+/// A key hash for the [`Resource::Row`] lock, from the row's clustered-key bytes.
+fn row_key_hash(schema: &Schema, key_columns: &[usize], key_values: &[Datum]) -> Option<u64> {
+    let bytes = crate::relstore::key::encode_key(schema, key_columns, key_values).ok()?;
+    Some(xxh64(&bytes, 0))
+}
+
+/// Evaluates a constant literal expression (`5`, `'x'`, `-3`, NULL, …) to a
+/// value. Returns `None` for anything that is not a self-contained literal —
+/// a column reference, variable, function call, or subquery — so the caller
+/// falls back to a coarser (table) lock rather than a wrong row key.
+fn eval_literal_const(expr: &Expr) -> Option<SqlValue> {
+    if !is_literal_const(expr) {
+        return None;
+    }
+    let empty: Vec<String> = Vec::new();
+    eval::eval(expr, &[], &empty, &EvalContext::default()).ok()
+}
+
+/// True if `expr` is a self-contained literal (no columns/vars/functions/
+/// subqueries): a literal, or a unary +/- over one.
+fn is_literal_const(expr: &Expr) -> bool {
+    match &expr.kind {
+        ExprKind::Int(_)
+        | ExprKind::Number(_)
+        | ExprKind::Str(_)
+        | ExprKind::Bool(_)
+        | ExprKind::Null
+        | ExprKind::Literal(_) => true,
+        ExprKind::Unary { expr: inner, .. } => is_literal_const(inner),
+        _ => false,
+    }
+}
+
+/// True if `expr` contains any subquery node (scalar, EXISTS, or IN (SELECT)).
+fn expr_has_subquery(expr: &Expr) -> bool {
+    match &expr.kind {
+        ExprKind::Subquery(_) | ExprKind::Exists(_) | ExprKind::InSubquery { .. } => true,
+        ExprKind::Null
+        | ExprKind::Int(_)
+        | ExprKind::Number(_)
+        | ExprKind::Str(_)
+        | ExprKind::Bool(_)
+        | ExprKind::Literal(_)
+        | ExprKind::Column(_)
+        | ExprKind::GlobalVar(_)
+        | ExprKind::LocalVar(_) => false,
+        ExprKind::Unary { expr: e, .. }
+        | ExprKind::IsNull { expr: e, .. }
+        | ExprKind::Cast { expr: e, .. } => expr_has_subquery(e),
+        ExprKind::Binary { left, right, .. } => expr_has_subquery(left) || expr_has_subquery(right),
+        ExprKind::Like {
+            expr: e, pattern, ..
+        } => expr_has_subquery(e) || expr_has_subquery(pattern),
+        ExprKind::InList { expr: e, list, .. } => {
+            expr_has_subquery(e) || list.iter().any(expr_has_subquery)
+        }
+        ExprKind::Between {
+            expr: e, low, high, ..
+        } => expr_has_subquery(e) || expr_has_subquery(low) || expr_has_subquery(high),
+        ExprKind::Function { args, .. } => args.iter().any(expr_has_subquery),
+        ExprKind::Aggregate { arg, .. } => arg.as_deref().is_some_and(expr_has_subquery),
+        ExprKind::Case {
+            operand,
+            branches,
+            else_result,
+        } => {
+            operand.as_deref().is_some_and(expr_has_subquery)
+                || branches
+                    .iter()
+                    .any(|(w, r)| expr_has_subquery(w) || expr_has_subquery(r))
+                || else_result.as_deref().is_some_and(expr_has_subquery)
+        }
+    }
+}
+
+/// The row-lock keys for an INSERT: `Some(hashes)` when the target is a
+/// clustered table and every row supplies all key columns as constant literals
+/// (so two concurrent inserters of *different* keys need not serialize).
+/// `None` — fall back to a table lock — for a heap, an IDENTITY/defaulted key
+/// (value is server-generated, unknown here), `INSERT ... SELECT`, a
+/// non-constant key expression, or more keys than the escalation threshold.
+fn insert_row_key_hashes(def: &TableDef, insert: &Insert) -> Option<Vec<u64>> {
+    if def.key_columns.is_empty() {
+        return None;
+    }
+    let InsertSource::Values(value_rows) = &insert.source else {
+        return None;
+    };
+    let schema = def.schema().ok()?;
+    let ncols = schema.columns.len();
+    let identity_col = def.identity.map(|s| s.column);
+    // Column index for each value position (explicit list, else all non-identity
+    // columns in order — matching `exec_insert`).
+    let target: Vec<usize> = match &insert.columns {
+        Some(names) => names
+            .iter()
+            .map(|n| column_index(&schema, &n.value))
+            .collect::<Option<Vec<_>>>()?,
+        None => (0..ncols).filter(|i| Some(*i) != identity_col).collect(),
+    };
+    let mut hashes = Vec::with_capacity(value_rows.len());
+    for row in value_rows {
+        if row.len() != target.len() {
+            return None; // arity mismatch — executor will error; table-lock it
+        }
+        let mut key_values = vec![Datum::Null; ncols];
+        for &kc in &def.key_columns {
+            if Some(kc) == identity_col {
+                return None; // server-generated key value
+            }
+            let pos = target.iter().position(|&t| t == kc)?; // key not supplied
+            let value = eval_literal_const(&row[pos])?;
+            let column = &schema.columns[kc];
+            key_values[kc] = value::sql_to_datum(&value, &column.column_type, &column.name).ok()?;
+        }
+        hashes.push(row_key_hash(&schema, &def.key_columns, &key_values)?);
+        if hashes.len() > ROW_LOCK_ESCALATION_THRESHOLD {
+            return None;
+        }
+    }
+    Some(hashes)
+}
+
+/// The single row-lock key for a point UPDATE/DELETE: `Some(hash)` when the
+/// WHERE clause is a subquery-free conjunction that pins *every* clustered-key
+/// column to a constant literal. `None` — fall back to a table lock — otherwise
+/// (heap, partial/absent key predicate, range/OR/subquery predicate).
+fn where_point_key_hash(def: &TableDef, where_clause: &Option<Expr>) -> Option<u64> {
+    if def.key_columns.is_empty() {
+        return None;
+    }
+    let where_clause = where_clause.as_ref()?;
+    if expr_has_subquery(where_clause) {
+        return None;
+    }
+    let schema = def.schema().ok()?;
+    let mut conjuncts = Vec::new();
+    flatten_and(where_clause, &mut conjuncts);
+    let mut key_values = vec![Datum::Null; schema.columns.len()];
+    let mut bound: std::collections::HashSet<usize> = std::collections::HashSet::new();
+    for conjunct in conjuncts {
+        let ExprKind::Binary {
+            op: ast::BinaryOp::Eq,
+            left,
+            right,
+        } = &conjunct.kind
+        else {
+            continue;
+        };
+        let (name, value_expr) = match (&left.kind, &right.kind) {
+            (ExprKind::Column(n), _) => (n, right.as_ref()),
+            (_, ExprKind::Column(n)) => (n, left.as_ref()),
+            _ => continue,
+        };
+        let Some(ci) = column_index(&schema, &name.value) else {
+            continue;
+        };
+        if !def.key_columns.contains(&ci) {
+            continue;
+        }
+        let Some(value) = eval_literal_const(value_expr) else {
+            continue;
+        };
+        let column = &schema.columns[ci];
+        if let Ok(datum) = value::sql_to_datum(&value, &column.column_type, &column.name) {
+            key_values[ci] = datum;
+            bound.insert(ci);
+        }
+    }
+    if def.key_columns.iter().any(|kc| !bound.contains(kc)) {
+        return None; // not every key column pinned
+    }
+    row_key_hash(&schema, &def.key_columns, &key_values)
+}
+
+/// The row-lock key for a point UPDATE: as [`where_point_key_hash`], but only
+/// when no assignment targets a key column (a key change moves the row, touching
+/// two keys) and no assignment value contains a subquery (which would read rows
+/// the single row lock does not cover).
+fn update_row_key_hash(def: &TableDef, update: &Update) -> Option<u64> {
+    let schema = def.schema().ok()?;
+    for assignment in &update.assignments {
+        let ci = column_index(&schema, &assignment.column.value)?;
+        if def.key_columns.contains(&ci) || expr_has_subquery(&assignment.value) {
+            return None;
+        }
+    }
+    where_point_key_hash(def, &update.where_clause)
+}
+
 pub fn analyze_locks(
     storage: &Storage,
     sql: &str,
@@ -350,8 +555,29 @@ pub fn analyze_locks(
             }
             Statement::Insert(insert) => {
                 if let Some(def) = resolve_table(storage, &insert.table.value) {
-                    add(Resource::Database, LockMode::IntentExclusive);
-                    add(Resource::Table(def.object_id), LockMode::Exclusive);
+                    // Row X locks on each inserted key (two inserters of
+                    // different keys then run concurrently under Table IX); a
+                    // heap / IDENTITY / non-literal key falls back to Table X.
+                    // A table referenced as an FK parent keeps Table X so an FK
+                    // existence-read (Table IS) still serializes against it.
+                    let hashes = if is_fk_parent(storage, &def.name) {
+                        None
+                    } else {
+                        insert_row_key_hashes(&def, insert)
+                    };
+                    match hashes {
+                        Some(hashes) => {
+                            add(Resource::Database, LockMode::IntentExclusive);
+                            add(Resource::Table(def.object_id), LockMode::IntentExclusive);
+                            for hash in hashes {
+                                add(Resource::Row(def.object_id, hash), LockMode::Exclusive);
+                            }
+                        }
+                        None => {
+                            add(Resource::Database, LockMode::IntentExclusive);
+                            add(Resource::Table(def.object_id), LockMode::Exclusive);
+                        }
+                    }
                     // A child INSERT reads its FK parents (integrity read).
                     for oid in fk_parent_object_ids(storage, &def) {
                         add(Resource::Database, LockMode::IntentShared);
@@ -374,10 +600,27 @@ pub fn analyze_locks(
                     }
                 }
             }
-            Statement::Update(Update { table, .. }) => {
-                if let Some(def) = resolve_table(storage, &table.value) {
-                    add(Resource::Database, LockMode::IntentExclusive);
-                    add(Resource::Table(def.object_id), LockMode::Exclusive);
+            Statement::Update(update) => {
+                if let Some(def) = resolve_table(storage, &update.table.value) {
+                    // A point UPDATE (WHERE pins the whole key, no key-column
+                    // write, no subquery) takes Table IX + a single Row X. A
+                    // table referenced as an FK parent keeps Table X (see INSERT).
+                    let hash = if is_fk_parent(storage, &def.name) {
+                        None
+                    } else {
+                        update_row_key_hash(&def, update)
+                    };
+                    match hash {
+                        Some(hash) => {
+                            add(Resource::Database, LockMode::IntentExclusive);
+                            add(Resource::Table(def.object_id), LockMode::IntentExclusive);
+                            add(Resource::Row(def.object_id, hash), LockMode::Exclusive);
+                        }
+                        None => {
+                            add(Resource::Database, LockMode::IntentExclusive);
+                            add(Resource::Table(def.object_id), LockMode::Exclusive);
+                        }
+                    }
                     // UPDATE reads FK parents (new values) and referencing
                     // children (a changed PK must not orphan them).
                     for oid in fk_parent_object_ids(storage, &def) {
@@ -390,10 +633,27 @@ pub fn analyze_locks(
                     }
                 }
             }
-            Statement::Delete(Delete { table, .. }) => {
-                if let Some(def) = resolve_table(storage, &table.value) {
-                    add(Resource::Database, LockMode::IntentExclusive);
-                    add(Resource::Table(def.object_id), LockMode::Exclusive);
+            Statement::Delete(delete) => {
+                if let Some(def) = resolve_table(storage, &delete.table.value) {
+                    // A point DELETE (WHERE pins the whole key, no subquery)
+                    // takes Table IX + a single Row X. A table referenced as an
+                    // FK parent keeps Table X (see INSERT).
+                    let hash = if is_fk_parent(storage, &def.name) {
+                        None
+                    } else {
+                        where_point_key_hash(&def, &delete.where_clause)
+                    };
+                    match hash {
+                        Some(hash) => {
+                            add(Resource::Database, LockMode::IntentExclusive);
+                            add(Resource::Table(def.object_id), LockMode::IntentExclusive);
+                            add(Resource::Row(def.object_id, hash), LockMode::Exclusive);
+                        }
+                        None => {
+                            add(Resource::Database, LockMode::IntentExclusive);
+                            add(Resource::Table(def.object_id), LockMode::Exclusive);
+                        }
+                    }
                     // DELETE reads referencing children (NO ACTION check).
                     for oid in fk_child_object_ids(storage, &def.name) {
                         add(Resource::Database, LockMode::IntentShared);

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -321,6 +321,43 @@ fn row_key_hash(schema: &Schema, key_columns: &[usize], key_values: &[Datum]) ->
     Some(xxh64(&bytes, 0))
 }
 
+/// True if the clustered key can be safely hashed for a row lock: no key column
+/// is a floating type. REAL/FLOAT keys are excluded because `-0.0 == 0.0` (and
+/// NaN) compare equal in evaluation but encode to distinct key bytes, so two
+/// writers to one physical row could get distinct hashes and not serialize.
+fn key_columns_row_lockable(schema: &Schema, key_columns: &[usize]) -> bool {
+    key_columns.iter().all(|&i| {
+        !matches!(
+            schema.columns[i].column_type,
+            ColumnType::Real | ColumnType::Float
+        )
+    })
+}
+
+/// True if a literal may pin a key column for a row lock: the executor's
+/// equality must be a direct same-domain match so the lock key equals the stored
+/// row's key. The hazard is a **character** key compared to a non-string literal:
+/// the executor coerces the stored string to the literal's number (many strings
+/// → one number: `'05' = 5`), while the lock key coerces the number to one
+/// canonical string — opposite directions that disagree. So a character key
+/// column requires a string literal; other domains coerce unambiguously (or
+/// `sql_to_datum` errors and the caller falls back).
+fn literal_pins_key(value: &SqlValue, column_type: &ColumnType) -> bool {
+    match column_type {
+        ColumnType::VarChar { .. } | ColumnType::NVarChar { .. } => {
+            matches!(value, SqlValue::Str(_))
+        }
+        _ => true,
+    }
+}
+
+/// True if the table has a secondary UNIQUE index. Such a table keeps
+/// table-granular locks for INSERT/UPDATE: a Row X on the clustered key alone
+/// would not serialize two writers colliding on the *unique index* key.
+fn has_secondary_unique_index(def: &TableDef) -> bool {
+    def.indexes.iter().any(|ix| ix.unique)
+}
+
 /// Evaluates a constant literal expression (`5`, `'x'`, `-3`, NULL, …) to a
 /// value. Returns `None` for anything that is not a self-contained literal —
 /// a column reference, variable, function call, or subquery — so the caller
@@ -404,6 +441,9 @@ fn insert_row_key_hashes(def: &TableDef, insert: &Insert) -> Option<Vec<u64>> {
         return None;
     };
     let schema = def.schema().ok()?;
+    if !key_columns_row_lockable(&schema, &def.key_columns) {
+        return None;
+    }
     let ncols = schema.columns.len();
     let identity_col = def.identity.map(|s| s.column);
     // Column index for each value position (explicit list, else all non-identity
@@ -428,6 +468,9 @@ fn insert_row_key_hashes(def: &TableDef, insert: &Insert) -> Option<Vec<u64>> {
             let pos = target.iter().position(|&t| t == kc)?; // key not supplied
             let value = eval_literal_const(&row[pos])?;
             let column = &schema.columns[kc];
+            if !literal_pins_key(&value, &column.column_type) {
+                return None;
+            }
             key_values[kc] = value::sql_to_datum(&value, &column.column_type, &column.name).ok()?;
         }
         hashes.push(row_key_hash(&schema, &def.key_columns, &key_values)?);
@@ -451,6 +494,9 @@ fn where_point_key_hash(def: &TableDef, where_clause: &Option<Expr>) -> Option<u
         return None;
     }
     let schema = def.schema().ok()?;
+    if !key_columns_row_lockable(&schema, &def.key_columns) {
+        return None;
+    }
     let mut conjuncts = Vec::new();
     flatten_and(where_clause, &mut conjuncts);
     let mut key_values = vec![Datum::Null; schema.columns.len()];
@@ -479,6 +525,9 @@ fn where_point_key_hash(def: &TableDef, where_clause: &Option<Expr>) -> Option<u
             continue;
         };
         let column = &schema.columns[ci];
+        if !literal_pins_key(&value, &column.column_type) {
+            continue;
+        }
         if let Ok(datum) = value::sql_to_datum(&value, &column.column_type, &column.name) {
             key_values[ci] = datum;
             bound.insert(ci);
@@ -559,12 +608,15 @@ pub fn analyze_locks(
                     // different keys then run concurrently under Table IX); a
                     // heap / IDENTITY / non-literal key falls back to Table X.
                     // A table referenced as an FK parent keeps Table X so an FK
-                    // existence-read (Table IS) still serializes against it.
-                    let hashes = if is_fk_parent(storage, &def.name) {
-                        None
-                    } else {
-                        insert_row_key_hashes(&def, insert)
-                    };
+                    // existence-read (Table IS) still serializes against it; a
+                    // secondary UNIQUE index likewise needs table-granular
+                    // serialization (the PK Row X does not cover its key).
+                    let hashes =
+                        if is_fk_parent(storage, &def.name) || has_secondary_unique_index(&def) {
+                            None
+                        } else {
+                            insert_row_key_hashes(&def, insert)
+                        };
                     match hashes {
                         Some(hashes) => {
                             add(Resource::Database, LockMode::IntentExclusive);
@@ -603,13 +655,14 @@ pub fn analyze_locks(
             Statement::Update(update) => {
                 if let Some(def) = resolve_table(storage, &update.table.value) {
                     // A point UPDATE (WHERE pins the whole key, no key-column
-                    // write, no subquery) takes Table IX + a single Row X. A
-                    // table referenced as an FK parent keeps Table X (see INSERT).
-                    let hash = if is_fk_parent(storage, &def.name) {
-                        None
-                    } else {
-                        update_row_key_hash(&def, update)
-                    };
+                    // write, no subquery) takes Table IX + a single Row X. An FK
+                    // parent or a secondary UNIQUE index keeps Table X (see INSERT).
+                    let hash =
+                        if is_fk_parent(storage, &def.name) || has_secondary_unique_index(&def) {
+                            None
+                        } else {
+                            update_row_key_hash(&def, update)
+                        };
                     match hash {
                         Some(hash) => {
                             add(Resource::Database, LockMode::IntentExclusive);
@@ -678,6 +731,36 @@ pub fn analyze_locks(
             | Statement::Rollback { .. }
             | Statement::Set(_)
             | Statement::Declare(_) => {}
+        }
+    }
+    // Batch-level lock escalation: if a table accumulated more than the
+    // threshold of row locks across the whole batch (many literal-key INSERTs,
+    // a loop, or several point statements), replace them all with one Table X.
+    // Bounds the lock set a batch can request regardless of per-statement caps.
+    let mut row_counts: std::collections::HashMap<u32, usize> = std::collections::HashMap::new();
+    for resource in needs.keys() {
+        if let Resource::Row(oid, _) = resource {
+            *row_counts.entry(*oid).or_default() += 1;
+        }
+    }
+    let escalate: std::collections::HashSet<u32> = row_counts
+        .into_iter()
+        .filter(|(_, count)| *count > ROW_LOCK_ESCALATION_THRESHOLD)
+        .map(|(oid, _)| oid)
+        .collect();
+    if !escalate.is_empty() {
+        needs.retain(
+            |resource, _| !matches!(resource, Resource::Row(oid, _) if escalate.contains(oid)),
+        );
+        for oid in escalate {
+            needs
+                .entry(Resource::Table(oid))
+                .and_modify(|m| *m = m.combine(LockMode::Exclusive))
+                .or_insert(LockMode::Exclusive);
+            needs
+                .entry(Resource::Database)
+                .and_modify(|m| *m = m.combine(LockMode::IntentExclusive))
+                .or_insert(LockMode::IntentExclusive);
         }
     }
     needs.into_iter().collect()

--- a/crates/truthdb-core/src/session.rs
+++ b/crates/truthdb-core/src/session.rs
@@ -974,6 +974,79 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn point_writers_to_different_rows_run_concurrently() {
+        // The Stage 12 row-lock win: two transactions updating *different* rows
+        // of one table no longer serialize (Table IX + distinct Row X locks).
+        let h = start(Duration::from_secs(30));
+        let a = h.handle.open_session(String::new(), String::new()).await;
+        let b = h.handle.open_session(String::new(), String::new()).await;
+        h.handle
+            .run_batch(
+                a,
+                "CREATE TABLE t (id INT NOT NULL PRIMARY KEY, v INT); INSERT INTO t VALUES (1,0),(2,0);".into(),
+            )
+            .await
+            .unwrap();
+
+        // A holds Row X on id = 1 inside an open transaction.
+        h.handle
+            .run_batch(a, "BEGIN TRAN; UPDATE t SET v = 10 WHERE id = 1;".into())
+            .await
+            .unwrap();
+
+        // B updates id = 2 — a different row — and must complete without waiting
+        // for A's commit.
+        let out = tokio::time::timeout(
+            Duration::from_secs(3),
+            h.handle
+                .run_batch(b, "UPDATE t SET v = 20 WHERE id = 2".into()),
+        )
+        .await
+        .expect("a point write to a different row must not block")
+        .unwrap();
+        assert!(error_number(&out).is_none(), "{:?}", out.outcome.error);
+
+        h.handle.run_batch(a, "COMMIT".into()).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn point_writers_to_the_same_row_serialize() {
+        let h = start(Duration::from_secs(30));
+        let a = h.handle.open_session(String::new(), String::new()).await;
+        let b = h.handle.open_session(String::new(), String::new()).await;
+        h.handle
+            .run_batch(
+                a,
+                "CREATE TABLE t (id INT NOT NULL PRIMARY KEY, v INT); INSERT INTO t VALUES (1,0);"
+                    .into(),
+            )
+            .await
+            .unwrap();
+        h.handle
+            .run_batch(a, "BEGIN TRAN; UPDATE t SET v = 10 WHERE id = 1;".into())
+            .await
+            .unwrap();
+
+        // B updates the *same* row (id = 1): it must block on A's Row X.
+        let handle_b = h.handle.clone();
+        let write = tokio::spawn(async move {
+            handle_b
+                .run_batch(b, "UPDATE t SET v = 20 WHERE id = 1".into())
+                .await
+                .unwrap()
+        });
+        tokio::time::sleep(Duration::from_millis(150)).await;
+        assert!(!write.is_finished(), "same-row writer must block");
+
+        h.handle.run_batch(a, "COMMIT".into()).await.unwrap();
+        let out = tokio::time::timeout(Duration::from_secs(5), write)
+            .await
+            .expect("writer unblocks after commit")
+            .unwrap();
+        assert!(error_number(&out).is_none(), "{:?}", out.outcome.error);
+    }
+
+    #[tokio::test]
     async fn read_uncommitted_sees_uncommitted_rows_without_blocking() {
         let h = start(Duration::from_secs(30));
         let a = h.handle.open_session(String::new(), String::new()).await;


### PR DESCRIPTION
Refines a point INSERT/UPDATE/DELETE's lock from a table X to **Table IX + a Row
X** on the row's clustered-key hash, so two transactions writing *different* rows
of one table run concurrently. Same-row writers serialize; full-table scans/
writes (Table S/X) still block point writers via the intent hierarchy. Reads are
unchanged (table-granular). Closes the Stage 12 row-lock gap; key-range locks for
phantom-free SERIALIZABLE remain table-based (documented).

## Design
`analyze_locks` computes the row keys up front (keeping the "a worker never
blocks mid-batch" model). `Resource::Row(table_oid, xxh64(keybytes))` keeps
`Resource: Copy`; the lock key and the stored row key both route through
`sql_to_datum(_, column_type)` so they always agree. Escalation to Table X above
1000 keys per batch.

## Safety guards (each preventing an isolation/lost-update hole)
- **FK parents** keep Table X (an FK existence-read via Table IS must still
  serialize against a change to the referenced row).
- **Secondary UNIQUE index** → INSERT/UPDATE keep Table X (a PK Row X does not
  serialize a collision on the unique key); DELETE may still row-lock.
- **Character key columns** require a string literal (`WHERE id=5` on a VARCHAR PK
  matches via string→number coercion, which is many-to-one).
- **FLOAT/REAL key columns** are never row-locked (`-0.0 == 0.0`, NaN).
- **`combine(S, IX) → X`**: a batch that both point-writes and reads the same
  table must hold an exclusive table lock (the {S,IX} lattice join is SIX).

## Correctness
Two adversarial-review passes: the first (8-agent workflow) found 3 HIGH + 2 LOW
isolation bugs, all fixed here; a second verification pass confirmed all five
fixed with no new hole. Tests: lock-manager unit tests, an `analyze_locks` guard
matrix, and engine integration tests (different-row point writers run
concurrently; same-row writers serialize).

Full workspace suite green (335 passed).