### PR TITLE
Ambiguous-column error 209 + SCOPE_IDENTITY()

### DIFF
--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -4359,15 +4359,18 @@ mod tests {
     #[test]
     fn sql_ambiguous_column_errors() {
         let (engine, path) = join_setup("join-ambig");
-        // `id` exists in both cust and ord → unresolvable.
+        // `id` exists in both cust and ord → ambiguous (SQL Server 209).
         let err = sql_error_number(
             &engine,
             "SELECT id FROM cust c JOIN ord o ON c.id = o.cust_id",
         );
-        assert!(
-            err == 209 || err == 207,
-            "ambiguous column error, got {err}"
+        assert_eq!(err, 209, "ambiguous column should be 209");
+        // A genuinely missing column is still 207 (invalid), not 209.
+        let missing = sql_error_number(
+            &engine,
+            "SELECT nope FROM cust c JOIN ord o ON c.id = o.cust_id",
         );
+        assert_eq!(missing, 207, "unknown column should be 207");
         let _ = std::fs::remove_file(path);
     }
 

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -55,6 +55,10 @@ pub struct TxnContext {
     database: String,
     login: String,
     spid: i32,
+    /// The last identity value inserted in this session (SQL Server scope),
+    /// surfaced as `SCOPE_IDENTITY()`. Persists across statements until the next
+    /// identity INSERT; unaffected by non-identity inserts.
+    scope_identity: Option<i64>,
 }
 
 /// Session isolation level (defaults to READ COMMITTED, like SQL Server).
@@ -83,6 +87,7 @@ impl TxnContext {
             database: self.database.clone(),
             login: self.login.clone(),
             spid: self.spid,
+            scope_identity: self.scope_identity,
         }
     }
 
@@ -853,8 +858,16 @@ fn exec_statement(
         }
         Statement::Insert(insert) => {
             let eval_ctx = txn_ctx.eval_context();
-            let mut scope = txn_ctx.scope();
-            exec_insert(storage, insert, &mut scope, &eval_ctx)
+            let (result, identity) = {
+                let mut scope = txn_ctx.scope();
+                exec_insert(storage, insert, &mut scope, &eval_ctx)?
+            };
+            // An identity INSERT updates SCOPE_IDENTITY(); a non-identity one
+            // (identity == None) leaves it unchanged.
+            if let Some(value) = identity {
+                txn_ctx.scope_identity = Some(value);
+            }
+            Ok(result)
         }
         Statement::Update(update) => {
             let eval_ctx = txn_ctx.eval_context();
@@ -2221,7 +2234,7 @@ fn exec_insert(
     insert: &Insert,
     scope: &mut TxnScope,
     eval_ctx: &EvalContext,
-) -> Result<StatementResult, SqlError> {
+) -> Result<(StatementResult, Option<i64>), SqlError> {
     let def = resolve_table(storage, &insert.table.value)
         .ok_or_else(|| SqlError::invalid_object(&insert.table.value).at(insert.table.span))?;
     reject_dml_on_view(&def)?;
@@ -2355,7 +2368,16 @@ fn exec_insert(
     storage
         .rel_insert_many(&def.name, rows, scope)
         .map_err(|err| map_storage_err(err, &def.name))?;
-    Ok(StatementResult::RowsAffected(inserted))
+    // The last identity value generated (for SCOPE_IDENTITY()): the reserved
+    // first value plus the increment for each subsequent row. `None` when the
+    // table has no identity column or no rows were inserted.
+    let last_identity = match (identity_col, identity_first) {
+        (Some(_), Some(first)) if inserted > 0 => {
+            Some(first.saturating_add((inserted as i64 - 1).saturating_mul(increment)))
+        }
+        _ => None,
+    };
+    Ok((StatementResult::RowsAffected(inserted), last_identity))
 }
 
 /// Produces the input rows an INSERT supplies, each already in target-column
@@ -2750,10 +2772,15 @@ impl JoinScope {
 
 impl truthdb_sql::eval::ColumnResolver for JoinScope {
     fn resolve(&self, name: &str) -> Option<usize> {
-        // Both branches reject an ambiguous match (more than one column) by
-        // returning None, so eval raises an invalid-column error rather than
-        // silently picking the first.
-        let mut found = None;
+        match self.resolve_detail(name) {
+            truthdb_sql::eval::Resolution::Found(index) => Some(index),
+            // Ambiguous and not-found both fail to bind a single column.
+            _ => None,
+        }
+    }
+
+    fn resolve_detail(&self, name: &str) -> truthdb_sql::eval::Resolution {
+        use truthdb_sql::eval::Resolution;
         let matches = |q: &Option<String>, c: &str| -> bool {
             if let Some((qualifier, column)) = name.rsplit_once('.') {
                 q.as_deref()
@@ -2763,15 +2790,19 @@ impl truthdb_sql::eval::ColumnResolver for JoinScope {
                 c.eq_ignore_ascii_case(name)
             }
         };
+        let mut found = None;
         for (index, (qualifier, column)) in self.columns.iter().enumerate() {
             if matches(qualifier, column) {
                 if found.is_some() {
-                    return None; // ambiguous
+                    return Resolution::Ambiguous; // more than one match
                 }
                 found = Some(index);
             }
         }
-        found
+        match found {
+            Some(index) => Resolution::Found(index),
+            None => Resolution::NotFound,
+        }
     }
 }
 

--- a/crates/truthdb-core/tests/slt/scope_identity.slt
+++ b/crates/truthdb-core/tests/slt/scope_identity.slt
@@ -1,0 +1,40 @@
+# SCOPE_IDENTITY() (Stage 5): the last identity value generated in the session.
+
+statement ok
+CREATE TABLE t (id INT NOT NULL PRIMARY KEY IDENTITY(10, 5), name NVARCHAR(10))
+
+statement ok
+CREATE TABLE plain (id INT NOT NULL PRIMARY KEY, name NVARCHAR(10))
+
+# Before any identity insert, SCOPE_IDENTITY() is NULL.
+query I
+SELECT CAST(SCOPE_IDENTITY() AS BIGINT)
+----
+NULL
+
+# A single identity insert: seed 10.
+statement ok
+INSERT INTO t (name) VALUES ('a')
+
+query I
+SELECT CAST(SCOPE_IDENTITY() AS BIGINT)
+----
+10
+
+# A multi-row insert: the LAST value (10, 15, 20 -> 20).
+statement ok
+INSERT INTO t (name) VALUES ('b'), ('c')
+
+query I
+SELECT CAST(SCOPE_IDENTITY() AS BIGINT)
+----
+20
+
+# An insert into a table WITHOUT an identity column does not change it.
+statement ok
+INSERT INTO plain VALUES (99, 'x')
+
+query I
+SELECT CAST(SCOPE_IDENTITY() AS BIGINT)
+----
+20

--- a/crates/truthdb-sql/src/error.rs
+++ b/crates/truthdb-sql/src/error.rs
@@ -63,6 +63,11 @@ impl SqlError {
         SqlError::new(207, 16, 1, format!("Invalid column name '{name}'."))
     }
 
+    /// 209: ambiguous column name (matches more than one source column).
+    pub fn ambiguous_column(name: &str) -> Self {
+        SqlError::new(209, 16, 1, format!("Ambiguous column name '{name}'."))
+    }
+
     /// 2627: primary key / unique constraint violation.
     pub fn pk_violation(table: &str) -> Self {
         SqlError::new(

--- a/crates/truthdb-sql/src/eval.rs
+++ b/crates/truthdb-sql/src/eval.rs
@@ -13,9 +13,28 @@ use crate::error::{SqlError, SqlResult};
 use crate::functions;
 use crate::value::{self, Numeric, SqlValue};
 
+/// The outcome of resolving a column name, distinguishing a missing column from
+/// one that is ambiguous (matches more than one source column) so each maps to
+/// the correct SQL Server error (208-family 207 vs 209).
+pub enum Resolution {
+    Found(usize),
+    NotFound,
+    Ambiguous,
+}
+
 /// Resolves a column name to its position in the row, case-insensitively.
 pub trait ColumnResolver {
     fn resolve(&self, name: &str) -> Option<usize>;
+
+    /// Like [`ColumnResolver::resolve`] but distinguishes not-found from
+    /// ambiguous. The default cannot detect ambiguity (a `None` from `resolve`
+    /// is reported as not-found); a multi-source resolver overrides it.
+    fn resolve_detail(&self, name: &str) -> Resolution {
+        match self.resolve(name) {
+            Some(index) => Resolution::Found(index),
+            None => Resolution::NotFound,
+        }
+    }
 }
 
 impl ColumnResolver for [String] {
@@ -54,6 +73,9 @@ pub struct EvalContext {
     pub login: String,
     /// The session process id — `@@SPID`.
     pub spid: i32,
+    /// The last identity value inserted in this scope — `SCOPE_IDENTITY()`.
+    /// `None` until an identity INSERT runs.
+    pub scope_identity: Option<i64>,
 }
 
 /// Evaluates `expr` against `row`, resolving columns via `resolver`.
@@ -168,10 +190,11 @@ fn eval_column(
     row: &[SqlValue],
     resolver: &impl ColumnResolver,
 ) -> SqlResult<SqlValue> {
-    let index = resolver
-        .resolve(&name.value)
-        .ok_or_else(|| SqlError::invalid_column(&name.value).at(name.span))?;
-    Ok(row[index].clone())
+    match resolver.resolve_detail(&name.value) {
+        Resolution::Found(index) => Ok(row[index].clone()),
+        Resolution::Ambiguous => Err(SqlError::ambiguous_column(&name.value).at(name.span)),
+        Resolution::NotFound => Err(SqlError::invalid_column(&name.value).at(name.span)),
+    }
 }
 
 #[inline(never)]
@@ -375,6 +398,12 @@ fn eval_session_function(name: &str, args: &[Expr]) -> Option<fn(&EvalContext) -
         "SUSER_SNAME" | "SUSER_NAME" if args.is_empty() => {
             Some(|ctx| SqlValue::Str(ctx.login.clone()))
         }
+        // SQL Server returns NUMERIC(38,0); NULL when no identity has been
+        // generated in the scope yet.
+        "SCOPE_IDENTITY" if args.is_empty() => Some(|ctx| match ctx.scope_identity {
+            Some(value) => SqlValue::Decimal(Box::new(Decimal::new(value as i128, 38, 0))),
+            None => SqlValue::Null,
+        }),
         _ => None,
     }
 }


### PR DESCRIPTION
Two small SQL-completeness fixes closing Stage 8 and Stage 5 gaps.

## Ambiguous column → 209
`ColumnResolver::resolve` conflated not-found and ambiguous (both `None`). Adds
`resolve_detail` → `Found/NotFound/Ambiguous`; `eval_column` maps not-found to
207 and ambiguous to 209 ("Ambiguous column name"). `JoinScope` reports
`Ambiguous` when a name matches more than one source column.

## SCOPE_IDENTITY()
Returns the last identity value generated in the session (NUMERIC(38,0)), NULL
before any identity insert. `exec_insert` returns the last reserved+incremented
identity; the session records it (`TxnContext.scope_identity`, surfaced through
`EvalContext`) on an identity INSERT and leaves it unchanged on a non-identity
one. Persists across batches within a session so a driver that splits `INSERT`
and `SELECT SCOPE_IDENTITY()` into separate round-trips still works.

Tests: 209-vs-207 assertions; `tests/slt/scope_identity.slt`. Full suite green.