### PR TITLE
Stage 10: FK parent-side probe uses a child index

### DIFF
--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -1722,10 +1722,40 @@ fn enforce_child_fks(
     Ok(())
 }
 
+/// A child index whose leading key columns are exactly the FK's child columns,
+/// usable to probe for referencing rows by seeking the removed parent key
+/// instead of scanning the whole child.
+fn fk_probe_index<'a>(
+    child: &'a TableDef,
+    fk: &catalog::ForeignKeyDef,
+) -> Option<&'a catalog::IndexDef> {
+    child.indexes.iter().find(|index| {
+        index.columns.len() >= fk.columns.len()
+            && index
+                .columns
+                .iter()
+                .zip(&fk.columns)
+                .all(|((col, _asc), &fk_col)| *col == fk_col)
+    })
+}
+
+/// The error raised when a surviving child row references a removed parent key.
+fn reference_conflict(verb: &str, fk_name: &str, child_name: &str) -> SqlError {
+    SqlError::new(
+        547,
+        16,
+        0,
+        format!(
+            "The {verb} statement conflicted with the REFERENCE constraint \"{fk_name}\". The conflict occurred in database \"truthdb\", table \"dbo.{child_name}\"."
+        ),
+    )
+}
+
 /// Enforces NO ACTION on the parent side: no surviving child row may reference
 /// any of `removed_keys` (parent primary-key values being deleted or vacated by
-/// an UPDATE). A referencing child is error 547. Referencing children are found
-/// by scanning every table's foreign keys (FK-index optimization deferred).
+/// an UPDATE). A referencing child is error 547. When the child has an index on
+/// the FK columns, each removed key is probed by an index seek; otherwise the
+/// child is scanned.
 fn enforce_parent_fks(
     storage: &Storage,
     parent: &TableDef,
@@ -1752,13 +1782,42 @@ fn enforce_parent_fks(
         if self_ref && !check_self_ref {
             continue;
         }
-        let child_rows = storage
-            .rel_scan(&child.name)
-            .map_err(|e| map_storage_err(e, &child.name))?;
         for fk in &child.foreign_keys {
             if !fk.parent.eq_ignore_ascii_case(&parent.name) {
                 continue;
             }
+            // Fast path: an index on the FK columns lets us seek each removed
+            // parent key instead of scanning the child. Not used for a
+            // self-reference (whose own being-removed rows must be excluded). If
+            // a key fails to encode (unexpected type mismatch), fall back to the
+            // scan rather than risk missing a reference.
+            if !self_ref && let Some(index) = fk_probe_index(child, fk) {
+                let mut handled = true;
+                for key in removed_keys {
+                    match crate::relstore::index::encode_index_prefix(key, &index.columns) {
+                        Ok(lower) => {
+                            let upper = crate::relstore::index::prefix_upper_bound(&lower);
+                            let matches = storage
+                                .rel_index_scan(&child.name, index.object_id, Some(lower), upper)
+                                .map_err(|e| map_storage_err(e, &child.name))?;
+                            if !matches.is_empty() {
+                                return Err(reference_conflict(verb, &fk.name, &child.name));
+                            }
+                        }
+                        Err(_) => {
+                            handled = false;
+                            break;
+                        }
+                    }
+                }
+                if handled {
+                    continue;
+                }
+            }
+            // Fallback: scan the child and compare each row's FK key.
+            let child_rows = storage
+                .rel_scan(&child.name)
+                .map_err(|e| map_storage_err(e, &child.name))?;
             for row in &child_rows {
                 // A self-referencing row that is itself being removed does not
                 // count as a surviving reference.
@@ -1773,15 +1832,7 @@ fn enforce_parent_fks(
                     continue;
                 };
                 if removed_keys.contains(&key) {
-                    return Err(SqlError::new(
-                        547,
-                        16,
-                        0,
-                        format!(
-                            "The {verb} statement conflicted with the REFERENCE constraint \"{}\". The conflict occurred in database \"truthdb\", table \"dbo.{}\".",
-                            fk.name, child.name
-                        ),
-                    ));
+                    return Err(reference_conflict(verb, &fk.name, &child.name));
                 }
             }
         }

--- a/crates/truthdb-core/tests/slt/foreign_keys.slt
+++ b/crates/truthdb-core/tests/slt/foreign_keys.slt
@@ -59,3 +59,51 @@ SELECT name FROM sys.foreign_keys ORDER BY name
 ----
 FK__child__parent__1
 fk_region
+
+# --- FK parent-side probe uses a child index when present (Stage 10) ---
+# The child has an index on its FK column, so a parent DELETE/UPDATE seeks it
+# rather than scanning the whole child. Results are identical to the scan path.
+statement ok
+CREATE TABLE par (id INT NOT NULL PRIMARY KEY, label NVARCHAR(10))
+
+statement ok
+CREATE TABLE chld (id INT NOT NULL PRIMARY KEY, par_id INT REFERENCES par (id))
+
+statement ok
+CREATE INDEX ix_chld_par ON chld (par_id)
+
+statement ok
+INSERT INTO par VALUES (1, 'a'), (2, 'b'), (3, 'c')
+
+statement ok
+INSERT INTO chld VALUES (100, 1), (101, 1), (102, 2)
+
+# Deleting a referenced parent is blocked (found via the index).
+statement error
+DELETE FROM par WHERE id = 1
+
+# Deleting an unreferenced parent succeeds.
+statement ok
+DELETE FROM par WHERE id = 3
+
+# Changing a referenced parent's key is also blocked.
+statement error
+UPDATE par SET id = 9 WHERE id = 2
+
+# After the referencing children are gone, the parent can be deleted.
+statement ok
+DELETE FROM chld WHERE par_id = 1
+
+statement ok
+DELETE FROM par WHERE id = 1
+
+# A child row with a NULL FK does not reference any parent (index seek skips it):
+# once the real reference to par 2 is gone, only a NULL-FK child remains.
+statement ok
+DELETE FROM chld WHERE par_id = 2
+
+statement ok
+INSERT INTO chld VALUES (200, NULL)
+
+statement ok
+DELETE FROM par WHERE id = 2


### PR DESCRIPTION
Enforcing NO ACTION on a parent DELETE/UPDATE previously always full-scanned
every referencing child. When a child has an index whose leading key columns are
the FK columns, each removed parent key is now probed with an **index seek**
(`encode_index_prefix` + `prefix_upper_bound`, the planner's point-seek) instead
of scanning the whole child — O(log n + matches) vs O(child rows). Results are
identical to the scan (the existing FK suite passes unchanged = A/B validation).

The scan stays the fallback for: no matching index, a self-referencing FK, or a
key that fails to encode. NULL FK values never match a non-null parent key.

Adds an indexed-FK slt case. Full suite green (335).