### PR TITLE
Stage 8: spill infrastructure + external merge sort

### DIFF
--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -2401,6 +2401,55 @@ mod tests {
     }
 
     #[test]
+    fn order_by_spills_wide_join_rows() {
+        // A join's source row is the concatenation of both tables' columns. Each
+        // per-table row fits (< the ~2020 B clustered cell cap), but the joined
+        // source row (two ~1950 B strings) exceeds the 3900 B in-row table cap —
+        // sorting it (pre-projection) must still spill: the spill codec is
+        // cap-free, whereas reusing the table codec would error 1701.
+        let path = unique_temp_path("sort-spill-wide");
+        let engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE a (k INT NOT NULL PRIMARY KEY, s VARCHAR(2000))")
+            .expect("a");
+        engine
+            .execute("CREATE TABLE b (k INT NOT NULL PRIMARY KEY, s VARCHAR(2000))")
+            .expect("b");
+        for i in 0..40 {
+            engine
+                .execute(&format!(
+                    "INSERT INTO a VALUES ({i}, '{}')",
+                    "x".repeat(1950)
+                ))
+                .expect("a ins");
+            engine
+                .execute(&format!(
+                    "INSERT INTO b VALUES ({i}, '{}')",
+                    "y".repeat(1950)
+                ))
+                .expect("b ins");
+        }
+        let query = "SELECT a.k FROM a JOIN b ON a.k = b.k ORDER BY a.k DESC";
+        let (_, reference) = sql_rows(&engine, query);
+        assert_eq!(
+            reference.len(),
+            40,
+            "join+sort should return 40 rows in memory"
+        );
+        // Each joined source row is ~3.9 KB (> 3900) — forced to spill.
+        crate::rel::set_test_sort_budget(Some(300));
+        let (_, rows) = sql_rows(&engine, query);
+        crate::rel::set_test_sort_budget(None);
+        assert_eq!(
+            rows, reference,
+            "spilled wide-join sort must match in-memory"
+        );
+        assert_eq!(rows[0][0].as_deref(), Some("39"));
+        assert_eq!(rows[39][0].as_deref(), Some("0"));
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
     fn row_locks_for_point_operations() {
         use crate::lock::{LockMode, Resource};
         use crate::rel::Isolation;

--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -2354,6 +2354,53 @@ mod tests {
     }
 
     #[test]
+    fn order_by_spills_and_matches_in_memory_sort() {
+        // A tiny sort budget forces the external merge sort (spill sorted runs
+        // to temp extents + k-way merge); its output must be byte-identical to
+        // the in-memory sort, ties included.
+        let path = unique_temp_path("sort-spill");
+        let engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE t (id INT NOT NULL PRIMARY KEY, grp INT, tag NVARCHAR(20))")
+            .expect("t");
+        // 600 rows with many tied `grp` values (exercises stable cross-run ties).
+        for i in 0..600 {
+            engine
+                .execute(&format!(
+                    "INSERT INTO t VALUES ({i}, {}, 'tag-{}')",
+                    (i * 7) % 50,
+                    i % 13
+                ))
+                .expect("insert");
+        }
+        let query = "SELECT id, grp, tag FROM t ORDER BY grp, tag, id";
+
+        // Reference: default (in-memory) budget.
+        let (_, reference) = sql_rows(&engine, query);
+
+        // Forced spill: a 300-byte budget makes almost every row its own run.
+        crate::rel::set_test_sort_budget(Some(300));
+        let (_, spilled) = sql_rows(&engine, query);
+        crate::rel::set_test_sort_budget(None);
+
+        assert_eq!(reference.len(), 600);
+        assert_eq!(
+            spilled, reference,
+            "spilled sort must match the in-memory sort"
+        );
+        // Sanity: the result really is ordered by (grp, tag, id).
+        let key = |r: &Vec<Option<String>>| {
+            (
+                r[1].clone().unwrap().parse::<i64>().unwrap(),
+                r[2].clone().unwrap(),
+                r[0].clone().unwrap().parse::<i64>().unwrap(),
+            )
+        };
+        assert!(spilled.windows(2).all(|w| key(&w[0]) <= key(&w[1])));
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
     fn row_locks_for_point_operations() {
         use crate::lock::{LockMode, Resource};
         use crate::rel::Isolation;

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -3953,10 +3953,11 @@ fn exec_select(
     }
 
     // ORDER BY (evaluated against the source row; stable so equal keys keep
-    // input order).
+    // input order). Spills to temp extents when the input exceeds the budget.
     if !select.order_by.is_empty() {
-        order_rows(
-            &mut rows,
+        rows = order_rows(
+            storage,
+            rows,
             &select.order_by,
             &types,
             &source.collations,
@@ -4134,18 +4135,70 @@ fn order_output(
     Ok(())
 }
 
-fn order_rows(
-    rows: &mut [Vec<Datum>],
+/// Per-query sort memory budget: a sort whose rows exceed this spills to temp
+/// extents (external merge sort) rather than growing without bound.
+const SORT_MEMORY_BUDGET: usize = 64 * 1024 * 1024;
+
+/// A row paired with its evaluated ORDER BY key, as carried through the sort.
+type KeyedRow = (Vec<SqlValue>, Vec<Datum>);
+
+#[cfg(test)]
+thread_local! {
+    /// Test-only override that forces the external-sort spill path on small
+    /// inputs (execution runs on the calling thread in tests).
+    static TEST_SORT_BUDGET: std::cell::Cell<Option<usize>> = const { std::cell::Cell::new(None) };
+}
+
+/// The active sort memory budget (overridable in tests).
+fn sort_budget() -> usize {
+    #[cfg(test)]
+    if let Some(budget) = TEST_SORT_BUDGET.with(std::cell::Cell::get) {
+        return budget;
+    }
+    SORT_MEMORY_BUDGET
+}
+
+/// Forces (or clears) the sort spill budget for the current test thread.
+#[cfg(test)]
+pub(crate) fn set_test_sort_budget(budget: Option<usize>) {
+    TEST_SORT_BUDGET.with(|cell| cell.set(budget));
+}
+
+/// The ORDER BY comparator for one pair of pre-evaluated key tuples: per item,
+/// collation-aware for a character column, else value order (NULLs first);
+/// `descending` reverses. No tie-break here — the caller adds stability.
+fn compare_sort_keys(
+    a: &[SqlValue],
+    b: &[SqlValue],
+    order_by: &[OrderItem],
+    collators: &[Option<collation::Collation>],
+) -> std::cmp::Ordering {
+    use std::cmp::Ordering;
+    for (col, item) in order_by.iter().enumerate() {
+        let ord = match (&collators[col], &a[col], &b[col]) {
+            (Some(coll), SqlValue::Str(x), SqlValue::Str(y)) => coll.compare(x, y),
+            (Some(_), SqlValue::Null, SqlValue::Null) => Ordering::Equal,
+            (Some(_), SqlValue::Null, _) => Ordering::Less,
+            (Some(_), _, SqlValue::Null) => Ordering::Greater,
+            _ => order_key_cmp(&a[col], &b[col]),
+        };
+        let ord = if item.descending { ord.reverse() } else { ord };
+        if ord != Ordering::Equal {
+            return ord;
+        }
+    }
+    Ordering::Equal
+}
+
+/// Builds the per-item collators (only a bare character column is collation-
+/// ordered; everything else uses value order).
+fn sort_collators(
     order_by: &[OrderItem],
     types: &[ColumnType],
     collations: &[Option<String>],
     resolver: &JoinScope,
-    eval_ctx: &EvalContext,
-) -> Result<(), SqlError> {
-    use std::cmp::Ordering;
-    // A bare character column is ordered by its collation (its COLLATE clause,
-    // else the database default); anything else uses value ordering.
-    let collators: Vec<Option<collation::Collation>> = order_by
+) -> Vec<Option<collation::Collation>> {
+    order_by
         .iter()
         .map(|item| {
             let index = bare_column_index(&item.expr, resolver)?;
@@ -4163,40 +4216,216 @@ fn order_rows(
                 .unwrap_or_else(|| collation::DEFAULT_COLLATION.to_string());
             Some(collation::Collation::from_name(&name))
         })
-        .collect();
+        .collect()
+}
 
-    // Precompute sort keys to keep comparisons cheap and to surface eval
-    // errors before sorting.
-    let mut keyed: Vec<(Vec<SqlValue>, usize)> = Vec::with_capacity(rows.len());
-    for (index, row) in rows.iter().enumerate() {
-        let values = row_values(row, types);
-        let mut key = Vec::with_capacity(order_by.len());
-        for item in order_by {
-            key.push(eval::eval(&item.expr, &values, resolver, eval_ctx)?);
+/// The ORDER BY key of one row.
+fn sort_key(
+    row: &[Datum],
+    order_by: &[OrderItem],
+    types: &[ColumnType],
+    resolver: &JoinScope,
+    eval_ctx: &EvalContext,
+) -> Result<Vec<SqlValue>, SqlError> {
+    let values = row_values(row, types);
+    order_by
+        .iter()
+        .map(|item| eval::eval(&item.expr, &values, resolver, eval_ctx))
+        .collect()
+}
+
+/// A rough in-memory byte estimate for a row, for the sort budget.
+fn approx_row_bytes(row: &[Datum]) -> usize {
+    let payload: usize = row
+        .iter()
+        .map(|d| match d {
+            Datum::VarChar(s) | Datum::NVarChar(s) => s.len() + 16,
+            Datum::VarBinary(b) => b.len() + 16,
+            _ => 16,
+        })
+        .sum();
+    payload + 24
+}
+
+/// Sorts the (already WHERE-filtered) source rows by ORDER BY. Fits-in-budget
+/// inputs sort in memory (Rust's stable `sort_by`); a larger input spills
+/// sorted runs to temp extents and k-way merges them (external merge sort),
+/// bounding the sort's working memory instead of erroring or doubling memory.
+fn order_rows(
+    storage: &Storage,
+    rows: Vec<Vec<Datum>>,
+    order_by: &[OrderItem],
+    types: &[ColumnType],
+    collations: &[Option<String>],
+    resolver: &JoinScope,
+    eval_ctx: &EvalContext,
+) -> Result<Vec<Vec<Datum>>, SqlError> {
+    order_rows_budgeted(
+        storage,
+        rows,
+        order_by,
+        types,
+        collations,
+        resolver,
+        eval_ctx,
+        sort_budget(),
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn order_rows_budgeted<'a>(
+    storage: &'a Storage,
+    rows: Vec<Vec<Datum>>,
+    order_by: &[OrderItem],
+    types: &[ColumnType],
+    collations: &[Option<String>],
+    resolver: &JoinScope,
+    eval_ctx: &EvalContext,
+    budget: usize,
+) -> Result<Vec<Vec<Datum>>, SqlError> {
+    let collators = sort_collators(order_by, types, collations, resolver);
+    let cmp = |a: &Vec<SqlValue>, b: &Vec<SqlValue>| compare_sort_keys(a, b, order_by, &collators);
+
+    // Generate sorted runs, spilling a run to a `RowSpool` each time the
+    // accumulated rows reach the budget. The final (in-memory) run is kept.
+    let schema = sort_spill_schema(types);
+    let mut runs: Vec<crate::relstore::spill::RowSpool<'a>> = Vec::new();
+    let mut current: Vec<KeyedRow> = Vec::new();
+    let mut current_bytes = 0usize;
+    for row in rows {
+        let key = sort_key(&row, order_by, types, resolver, eval_ctx)?;
+        current_bytes += approx_row_bytes(&row);
+        current.push((key, row));
+        if current_bytes >= budget {
+            runs.push(sort_and_spill(storage, &schema, &mut current, &cmp)?);
+            current_bytes = 0;
         }
-        keyed.push((key, index));
     }
-    keyed.sort_by(|(a, ai), (b, bi)| {
-        for (col, item) in order_by.iter().enumerate() {
-            let ord = match (&collators[col], &a[col], &b[col]) {
-                (Some(coll), SqlValue::Str(x), SqlValue::Str(y)) => coll.compare(x, y),
-                // NULL still sorts first even under a collation.
-                (Some(_), SqlValue::Null, SqlValue::Null) => Ordering::Equal,
-                (Some(_), SqlValue::Null, _) => Ordering::Less,
-                (Some(_), _, SqlValue::Null) => Ordering::Greater,
-                _ => order_key_cmp(&a[col], &b[col]),
-            };
-            let ord = if item.descending { ord.reverse() } else { ord };
-            if ord != Ordering::Equal {
-                return ord;
+    // No spill: a plain stable in-memory sort.
+    if runs.is_empty() {
+        current.sort_by(|(a, _), (b, _)| cmp(a, b));
+        return Ok(current.into_iter().map(|(_, row)| row).collect());
+    }
+    // Sort the final partial run and merge every run.
+    current.sort_by(|(a, _), (b, _)| cmp(a, b));
+    merge_runs(
+        &runs, current, order_by, types, resolver, eval_ctx, &collators,
+    )
+}
+
+/// A minimal schema (types only) for the sort spill codec.
+fn sort_spill_schema(types: &[ColumnType]) -> crate::relstore::row::Schema {
+    crate::relstore::row::Schema {
+        columns: types
+            .iter()
+            .enumerate()
+            .map(|(i, ty)| crate::relstore::row::Column {
+                name: format!("c{i}"),
+                column_type: *ty,
+                nullable: true,
+                collation: None,
+            })
+            .collect(),
+    }
+}
+
+/// Stably sorts `run` in place and writes its rows (in sorted order) to a fresh
+/// `RowSpool`, clearing `run`.
+fn sort_and_spill<'a>(
+    storage: &'a Storage,
+    schema: &crate::relstore::row::Schema,
+    run: &mut Vec<KeyedRow>,
+    cmp: &impl Fn(&Vec<SqlValue>, &Vec<SqlValue>) -> std::cmp::Ordering,
+) -> Result<crate::relstore::spill::RowSpool<'a>, SqlError> {
+    run.sort_by(|(a, _), (b, _)| cmp(a, b));
+    let mut spool = crate::relstore::spill::RowSpool::new(storage, schema.clone());
+    for (_, row) in run.drain(..) {
+        spool
+            .write_row(&row)
+            .map_err(|e| map_storage_err(e, "<sort spill>"))?;
+    }
+    spool
+        .finish_writing()
+        .map_err(|e| map_storage_err(e, "<sort spill>"))?;
+    Ok(spool)
+}
+
+/// K-way merges the sorted spilled `runs` and the sorted in-memory `tail` run
+/// into one sorted row vector. Keys are recomputed per row on read (cheap for
+/// column refs); ties prefer the earlier run so the merge is globally stable
+/// (spilled runs hold earlier input rows than the in-memory tail).
+#[allow(clippy::too_many_arguments)]
+fn merge_runs(
+    runs: &[crate::relstore::spill::RowSpool<'_>],
+    tail: Vec<KeyedRow>,
+    order_by: &[OrderItem],
+    types: &[ColumnType],
+    resolver: &JoinScope,
+    eval_ctx: &EvalContext,
+    collators: &[Option<collation::Collation>],
+) -> Result<Vec<Vec<Datum>>, SqlError> {
+    // One cursor per source: spilled-run readers first, then the in-memory tail.
+    let mut readers: Vec<_> = runs.iter().map(|r| r.reader()).collect();
+    let mut tail_iter = tail.into_iter();
+
+    // Current head (key + row) of each source, in the same order.
+    let source_count = readers.len() + 1;
+    let mut heads: Vec<Option<(Vec<SqlValue>, Vec<Datum>)>> = Vec::with_capacity(source_count);
+    for reader in &mut readers {
+        heads.push(read_head(reader, order_by, types, resolver, eval_ctx)?);
+    }
+    heads.push(tail_iter.next());
+
+    let total: usize = runs.iter().map(|r| r.row_count() as usize).sum::<usize>() + heads.len();
+    let mut out: Vec<Vec<Datum>> = Vec::with_capacity(total);
+    loop {
+        // Pick the smallest head; on a key tie, the earliest source (lowest
+        // index) wins, which preserves input order across runs.
+        let mut best: Option<usize> = None;
+        for (i, head) in heads.iter().enumerate() {
+            let Some((key, _)) = head else { continue };
+            match best {
+                None => best = Some(i),
+                Some(b) => {
+                    let (bkey, _) = heads[b].as_ref().unwrap();
+                    if compare_sort_keys(key, bkey, order_by, collators) == std::cmp::Ordering::Less
+                    {
+                        best = Some(i);
+                    }
+                }
             }
         }
-        ai.cmp(bi) // stable tie-break
-    });
-    let order: Vec<usize> = keyed.into_iter().map(|(_, i)| i).collect();
-    let reordered: Vec<Vec<Datum>> = order.iter().map(|&i| rows[i].clone()).collect();
-    rows.clone_from_slice(&reordered);
-    Ok(())
+        let Some(i) = best else { break };
+        let (_, row) = heads[i].take().unwrap();
+        out.push(row);
+        // Advance the chosen source.
+        heads[i] = if i < readers.len() {
+            read_head(&mut readers[i], order_by, types, resolver, eval_ctx)?
+        } else {
+            tail_iter.next()
+        };
+    }
+    Ok(out)
+}
+
+/// Reads the next row from a spool reader and pairs it with its ORDER BY key.
+fn read_head(
+    reader: &mut crate::relstore::spill::RowSpoolReader,
+    order_by: &[OrderItem],
+    types: &[ColumnType],
+    resolver: &JoinScope,
+    eval_ctx: &EvalContext,
+) -> Result<Option<KeyedRow>, SqlError> {
+    match reader
+        .next_row()
+        .map_err(|e| map_storage_err(e, "<sort spill>"))?
+    {
+        Some(row) => {
+            let key = sort_key(&row, order_by, types, resolver, eval_ctx)?;
+            Ok(Some((key, row)))
+        }
+        None => Ok(None),
+    }
 }
 
 fn project(

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -4288,7 +4288,6 @@ fn order_rows_budgeted<'a>(
 
     // Generate sorted runs, spilling a run to a `RowSpool` each time the
     // accumulated rows reach the budget. The final (in-memory) run is kept.
-    let schema = sort_spill_schema(types);
     let mut runs: Vec<crate::relstore::spill::RowSpool<'a>> = Vec::new();
     let mut current: Vec<KeyedRow> = Vec::new();
     let mut current_bytes = 0usize;
@@ -4297,7 +4296,7 @@ fn order_rows_budgeted<'a>(
         current_bytes += approx_row_bytes(&row);
         current.push((key, row));
         if current_bytes >= budget {
-            runs.push(sort_and_spill(storage, &schema, &mut current, &cmp)?);
+            runs.push(sort_and_spill(storage, &mut current, &cmp)?);
             current_bytes = 0;
         }
     }
@@ -4313,32 +4312,15 @@ fn order_rows_budgeted<'a>(
     )
 }
 
-/// A minimal schema (types only) for the sort spill codec.
-fn sort_spill_schema(types: &[ColumnType]) -> crate::relstore::row::Schema {
-    crate::relstore::row::Schema {
-        columns: types
-            .iter()
-            .enumerate()
-            .map(|(i, ty)| crate::relstore::row::Column {
-                name: format!("c{i}"),
-                column_type: *ty,
-                nullable: true,
-                collation: None,
-            })
-            .collect(),
-    }
-}
-
 /// Stably sorts `run` in place and writes its rows (in sorted order) to a fresh
 /// `RowSpool`, clearing `run`.
 fn sort_and_spill<'a>(
     storage: &'a Storage,
-    schema: &crate::relstore::row::Schema,
     run: &mut Vec<KeyedRow>,
     cmp: &impl Fn(&Vec<SqlValue>, &Vec<SqlValue>) -> std::cmp::Ordering,
 ) -> Result<crate::relstore::spill::RowSpool<'a>, SqlError> {
     run.sort_by(|(a, _), (b, _)| cmp(a, b));
-    let mut spool = crate::relstore::spill::RowSpool::new(storage, schema.clone());
+    let mut spool = crate::relstore::spill::RowSpool::new(storage);
     for (_, row) in run.drain(..) {
         spool
             .write_row(&row)

--- a/crates/truthdb-core/src/relstore/mod.rs
+++ b/crates/truthdb-core/src/relstore/mod.rs
@@ -15,6 +15,7 @@ pub mod page;
 pub mod recovery;
 pub mod row;
 pub mod slotted;
+pub mod spill;
 #[cfg(test)]
 mod tests;
 pub mod types;

--- a/crates/truthdb-core/src/relstore/spill.rs
+++ b/crates/truthdb-core/src/relstore/spill.rs
@@ -1,9 +1,11 @@
 //! Temp-extent-backed row spool for spill-capable operators (external merge
 //! sort, grace-hash) — Stage 8.
 //!
-//! Rows are serialized with the ordinary [`row`](crate::relstore::row) codec and
-//! laid out as a length-prefixed byte stream across one or more 64-page
-//! *temporary* extents ([`Storage::allocate_extent`] with `temp = true`). Temp
+//! Rows are serialized with a self-describing, cap-free spill codec
+//! ([`encode_spill_row`]) and laid out as a length-prefixed byte stream across
+//! one or more 64-page *temporary* extents ([`Storage::allocate_extent`] with
+//! `temp = true`). Unlike the on-disk table codec the spill codec has no
+//! 3900-byte in-row cap, so arbitrarily wide scratch rows round-trip. Temp
 //! extents are excluded from the checkpoint bitmap and reclaimed wholesale on
 //! restart, and spill page writes bypass the WAL, so a spool is pure
 //! query-scratch: never durable, never recovered. The extents are freed when the
@@ -14,7 +16,6 @@
 //! storage ops; a dedicated spill file handle is a later optimization.
 
 use crate::allocator::EXTENT_PAGES;
-use crate::relstore::row::{Schema, decode_row, encode_row};
 use crate::relstore::types::Datum;
 use crate::storage::{Storage, StorageError};
 use crate::storage_layout::PAGE_SIZE;
@@ -22,9 +23,12 @@ use crate::storage_layout::PAGE_SIZE;
 /// An append-then-scan spool of rows on temp extents. Write every row, call
 /// [`RowSpool::finish_writing`], then read them back in order with
 /// [`RowSpool::reader`]. Dropping the spool frees its temp extents.
+///
+/// Rows use a self-describing spill encoding ([`encode_spill_row`]) with no size
+/// cap — spill scratch rows can be arbitrarily wide (e.g. a join's concatenated
+/// source row), unlike the 3900-byte in-row table codec.
 pub struct RowSpool<'a> {
     storage: &'a Storage,
-    schema: Schema,
     /// Start page of each allocated 64-page temp extent, in write order.
     extents: Vec<u64>,
     /// Bytes accumulated but not yet flushed to a full page.
@@ -39,12 +43,10 @@ pub struct RowSpool<'a> {
 }
 
 impl<'a> RowSpool<'a> {
-    /// Creates an empty spool. `schema` must match the rows written (its column
-    /// types drive the row codec; names/nullability only need to round-trip).
-    pub fn new(storage: &'a Storage, schema: Schema) -> Self {
+    /// Creates an empty spool.
+    pub fn new(storage: &'a Storage) -> Self {
         RowSpool {
             storage,
-            schema,
             extents: Vec::new(),
             pending: Vec::new(),
             pages_written: 0,
@@ -72,7 +74,7 @@ impl<'a> RowSpool<'a> {
     /// Appends one row.
     pub fn write_row(&mut self, row: &[Datum]) -> Result<(), StorageError> {
         debug_assert!(!self.finished);
-        let encoded = encode_row(&self.schema, row).map_err(spill_codec_err)?;
+        let encoded = encode_spill_row(row);
         let len = encoded.len() as u32;
         self.pending.extend_from_slice(&len.to_le_bytes());
         self.pending.extend_from_slice(&encoded);
@@ -126,10 +128,153 @@ impl Drop for RowSpool<'_> {
     }
 }
 
-/// Maps a row-codec failure to a storage error (spill payloads are engine-
-/// generated, so this indicates a bug rather than user input).
-fn spill_codec_err(err: crate::relstore::types::TypeError) -> StorageError {
-    StorageError::InvalidConfig(format!("spill row codec: {err}"))
+/// Serializes one row for spill: a self-describing, cap-free tag+payload stream
+/// (`u16` column count, then per datum a 1-byte tag and its value; variable-
+/// length values carry a `u32` length). Unlike the on-disk table codec it has no
+/// 3900-byte in-row cap and no `u16` var-section limit, so an arbitrarily wide
+/// scratch row (a join's concatenated source row) round-trips.
+pub fn encode_spill_row(row: &[Datum]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(2 + row.len() * 8);
+    out.extend_from_slice(&(row.len() as u16).to_le_bytes());
+    for datum in row {
+        match datum {
+            Datum::Null => out.push(0),
+            Datum::TinyInt(v) => {
+                out.push(1);
+                out.push(*v);
+            }
+            Datum::SmallInt(v) => {
+                out.push(2);
+                out.extend_from_slice(&v.to_le_bytes());
+            }
+            Datum::Int(v) => {
+                out.push(3);
+                out.extend_from_slice(&v.to_le_bytes());
+            }
+            Datum::BigInt(v) => {
+                out.push(4);
+                out.extend_from_slice(&v.to_le_bytes());
+            }
+            Datum::Bit(b) => {
+                out.push(5);
+                out.push(*b as u8);
+            }
+            Datum::Real(v) => {
+                out.push(6);
+                out.extend_from_slice(&v.to_le_bytes());
+            }
+            Datum::Float(v) => {
+                out.push(7);
+                out.extend_from_slice(&v.to_le_bytes());
+            }
+            Datum::Decimal(v) => {
+                out.push(8);
+                out.extend_from_slice(&v.to_le_bytes());
+            }
+            Datum::Date(v) => {
+                out.push(9);
+                out.extend_from_slice(&v.to_le_bytes());
+            }
+            Datum::Time(v) => {
+                out.push(10);
+                out.extend_from_slice(&v.to_le_bytes());
+            }
+            Datum::DateTime2(d, t) => {
+                out.push(11);
+                out.extend_from_slice(&d.to_le_bytes());
+                out.extend_from_slice(&t.to_le_bytes());
+            }
+            Datum::UniqueIdentifier(g) => {
+                out.push(12);
+                out.extend_from_slice(g);
+            }
+            Datum::VarChar(s) => encode_bytes(&mut out, 13, s.as_bytes()),
+            Datum::NVarChar(s) => encode_bytes(&mut out, 14, s.as_bytes()),
+            Datum::VarBinary(b) => encode_bytes(&mut out, 15, b),
+        }
+    }
+    out
+}
+
+fn encode_bytes(out: &mut Vec<u8>, tag: u8, bytes: &[u8]) {
+    out.push(tag);
+    out.extend_from_slice(&(bytes.len() as u32).to_le_bytes());
+    out.extend_from_slice(bytes);
+}
+
+/// Decodes a row written by [`encode_spill_row`]. A malformed buffer (never
+/// produced by the encoder) is a storage error.
+pub fn decode_spill_row(bytes: &[u8]) -> Result<Vec<Datum>, StorageError> {
+    let mut cur = Cursor { bytes, pos: 0 };
+    let ncols = cur.u16()? as usize;
+    let mut row = Vec::with_capacity(ncols);
+    for _ in 0..ncols {
+        let tag = cur.u8()?;
+        let datum = match tag {
+            0 => Datum::Null,
+            1 => Datum::TinyInt(cur.u8()?),
+            2 => Datum::SmallInt(i16::from_le_bytes(cur.fixed()?)),
+            3 => Datum::Int(i32::from_le_bytes(cur.fixed()?)),
+            4 => Datum::BigInt(i64::from_le_bytes(cur.fixed()?)),
+            5 => Datum::Bit(cur.u8()? != 0),
+            6 => Datum::Real(f32::from_le_bytes(cur.fixed()?)),
+            7 => Datum::Float(f64::from_le_bytes(cur.fixed()?)),
+            8 => Datum::Decimal(i128::from_le_bytes(cur.fixed()?)),
+            9 => Datum::Date(u32::from_le_bytes(cur.fixed()?)),
+            10 => Datum::Time(u64::from_le_bytes(cur.fixed()?)),
+            11 => Datum::DateTime2(
+                u32::from_le_bytes(cur.fixed()?),
+                u64::from_le_bytes(cur.fixed()?),
+            ),
+            12 => Datum::UniqueIdentifier(cur.fixed()?),
+            13 => Datum::VarChar(cur.string()?),
+            14 => Datum::NVarChar(cur.string()?),
+            15 => Datum::VarBinary(cur.bytes()?.to_vec()),
+            other => {
+                return Err(StorageError::InvalidFile(format!(
+                    "spill row: unknown datum tag {other}"
+                )));
+            }
+        };
+        row.push(datum);
+    }
+    Ok(row)
+}
+
+/// A little-endian reader over a spill row buffer.
+struct Cursor<'b> {
+    bytes: &'b [u8],
+    pos: usize,
+}
+
+impl<'b> Cursor<'b> {
+    fn take(&mut self, n: usize) -> Result<&'b [u8], StorageError> {
+        let end = self.pos.checked_add(n).filter(|&e| e <= self.bytes.len());
+        let Some(end) = end else {
+            return Err(StorageError::InvalidFile("spill row: truncated".into()));
+        };
+        let slice = &self.bytes[self.pos..end];
+        self.pos = end;
+        Ok(slice)
+    }
+    fn u8(&mut self) -> Result<u8, StorageError> {
+        Ok(self.take(1)?[0])
+    }
+    fn u16(&mut self) -> Result<u16, StorageError> {
+        Ok(u16::from_le_bytes(self.take(2)?.try_into().unwrap()))
+    }
+    fn fixed<const N: usize>(&mut self) -> Result<[u8; N], StorageError> {
+        Ok(self.take(N)?.try_into().unwrap())
+    }
+    fn bytes(&mut self) -> Result<&'b [u8], StorageError> {
+        let len = u32::from_le_bytes(self.take(4)?.try_into().unwrap()) as usize;
+        self.take(len)
+    }
+    fn string(&mut self) -> Result<String, StorageError> {
+        let raw = self.bytes()?;
+        String::from_utf8(raw.to_vec())
+            .map_err(|_| StorageError::InvalidFile("spill row: invalid utf8".into()))
+    }
 }
 
 /// Sequential reader returned by [`RowSpool::reader`].
@@ -190,8 +335,7 @@ impl RowSpoolReader<'_, '_> {
                 continue;
             }
             let start = self.buf_pos + 4;
-            let row = decode_row(&self.spool.schema, &self.buf[start..start + len])
-                .map_err(spill_codec_err)?;
+            let row = decode_spill_row(&self.buf[start..start + len])?;
             self.buf_pos += 4 + len;
             return Ok(Some(row));
         }
@@ -201,8 +345,6 @@ impl RowSpoolReader<'_, '_> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::relstore::row::Column;
-    use crate::relstore::types::ColumnType;
     use crate::storage::StorageOptions;
 
     fn temp_storage(label: &str) -> Storage {
@@ -228,25 +370,6 @@ mod tests {
         .expect("create storage")
     }
 
-    fn schema() -> Schema {
-        Schema {
-            columns: vec![
-                Column {
-                    name: "id".into(),
-                    column_type: ColumnType::Int,
-                    nullable: false,
-                    collation: None,
-                },
-                Column {
-                    name: "s".into(),
-                    column_type: ColumnType::NVarChar { max_len: 4000 },
-                    nullable: true,
-                    collation: None,
-                },
-            ],
-        }
-    }
-
     fn read_all(spool: &RowSpool) -> Vec<Vec<Datum>> {
         let mut reader = spool.reader();
         let mut out = Vec::new();
@@ -270,7 +393,7 @@ mod tests {
             })
             .collect();
 
-        let mut spool = RowSpool::new(&storage, schema());
+        let mut spool = RowSpool::new(&storage);
         for row in &expected {
             spool.write_row(row).expect("write");
         }
@@ -284,17 +407,19 @@ mod tests {
     }
 
     #[test]
-    fn null_and_empty_and_boundary_rows() {
+    fn null_empty_and_wide_rows() {
         let storage = temp_storage("nulls");
         let expected = vec![
             vec![Datum::Int(1), Datum::Null],
             vec![Datum::Int(2), Datum::NVarChar(String::new())],
-            // A near-cap row (rows straddle page boundaries; the codec caps a
-            // single row below a page, so a row never exceeds one page itself).
-            vec![Datum::Int(3), Datum::NVarChar("y".repeat(1800))],
-            vec![Datum::Int(4), Datum::NVarChar("z".into())],
+            // A row far WIDER than the 3900-byte in-row table cap and than one
+            // page — the spill codec has no cap, so it must round-trip (this is
+            // the wide join/derived source row the table codec would reject).
+            vec![Datum::Int(3), Datum::NVarChar("y".repeat(20_000))],
+            vec![Datum::Int(4), Datum::VarBinary(vec![0xAB; 9000])],
+            vec![Datum::Int(5), Datum::NVarChar("z".into())],
         ];
-        let mut spool = RowSpool::new(&storage, schema());
+        let mut spool = RowSpool::new(&storage);
         for row in &expected {
             spool.write_row(row).expect("write");
         }
@@ -303,9 +428,36 @@ mod tests {
     }
 
     #[test]
+    fn every_datum_variant_round_trips() {
+        let storage = temp_storage("variants");
+        let row = vec![
+            Datum::Null,
+            Datum::TinyInt(255),
+            Datum::SmallInt(-12345),
+            Datum::Int(-1),
+            Datum::BigInt(i64::MIN),
+            Datum::Bit(true),
+            Datum::Real(-2.5),
+            Datum::Float(std::f64::consts::PI),
+            Datum::Decimal(-170141183460469231731687303715884105728),
+            Datum::Date(738000),
+            Datum::Time(863990000000),
+            Datum::DateTime2(738000, 12345),
+            Datum::UniqueIdentifier([7u8; 16]),
+            Datum::VarChar("héllo".into()),
+            Datum::NVarChar("naïve 😀".into()),
+            Datum::VarBinary(vec![0, 1, 2, 255]),
+        ];
+        let mut spool = RowSpool::new(&storage);
+        spool.write_row(&row).expect("write");
+        spool.finish_writing().expect("finish");
+        assert_eq!(read_all(&spool), vec![row]);
+    }
+
+    #[test]
     fn empty_spool_reads_nothing() {
         let storage = temp_storage("empty");
-        let mut spool = RowSpool::new(&storage, schema());
+        let mut spool = RowSpool::new(&storage);
         spool.finish_writing().expect("finish");
         assert_eq!(spool.row_count(), 0);
         assert!(read_all(&spool).is_empty());
@@ -315,7 +467,7 @@ mod tests {
     fn dropping_a_spool_frees_its_temp_extents_for_reuse() {
         let storage = temp_storage("reclaim");
         let first_extent = {
-            let mut spool = RowSpool::new(&storage, schema());
+            let mut spool = RowSpool::new(&storage);
             for i in 0..500 {
                 spool
                     .write_row(&[Datum::Int(i), Datum::NVarChar("data".repeat(50))])

--- a/crates/truthdb-core/src/relstore/spill.rs
+++ b/crates/truthdb-core/src/relstore/spill.rs
@@ -1,0 +1,334 @@
+//! Temp-extent-backed row spool for spill-capable operators (external merge
+//! sort, grace-hash) — Stage 8.
+//!
+//! Rows are serialized with the ordinary [`row`](crate::relstore::row) codec and
+//! laid out as a length-prefixed byte stream across one or more 64-page
+//! *temporary* extents ([`Storage::allocate_extent`] with `temp = true`). Temp
+//! extents are excluded from the checkpoint bitmap and reclaimed wholesale on
+//! restart, and spill page writes bypass the WAL, so a spool is pure
+//! query-scratch: never durable, never recovered. The extents are freed when the
+//! [`RowSpool`] is dropped.
+//!
+//! Concurrency: page I/O currently goes through the single storage lock (one
+//! locked call per 4 KiB page). That is correct but serializes with other
+//! storage ops; a dedicated spill file handle is a later optimization.
+
+use crate::allocator::EXTENT_PAGES;
+use crate::relstore::row::{Schema, decode_row, encode_row};
+use crate::relstore::types::Datum;
+use crate::storage::{Storage, StorageError};
+use crate::storage_layout::PAGE_SIZE;
+
+/// An append-then-scan spool of rows on temp extents. Write every row, call
+/// [`RowSpool::finish_writing`], then read them back in order with
+/// [`RowSpool::reader`]. Dropping the spool frees its temp extents.
+pub struct RowSpool<'a> {
+    storage: &'a Storage,
+    schema: Schema,
+    /// Start page of each allocated 64-page temp extent, in write order.
+    extents: Vec<u64>,
+    /// Bytes accumulated but not yet flushed to a full page.
+    pending: Vec<u8>,
+    /// Number of whole pages already written (the spool's logical page count
+    /// minus the not-yet-flushed tail).
+    pages_written: u64,
+    /// Total payload bytes (length prefixes + encoded rows).
+    byte_len: u64,
+    rows: u64,
+    finished: bool,
+}
+
+impl<'a> RowSpool<'a> {
+    /// Creates an empty spool. `schema` must match the rows written (its column
+    /// types drive the row codec; names/nullability only need to round-trip).
+    pub fn new(storage: &'a Storage, schema: Schema) -> Self {
+        RowSpool {
+            storage,
+            schema,
+            extents: Vec::new(),
+            pending: Vec::new(),
+            pages_written: 0,
+            byte_len: 0,
+            rows: 0,
+            finished: false,
+        }
+    }
+
+    pub fn row_count(&self) -> u64 {
+        self.rows
+    }
+
+    /// The absolute data-region page number for logical spool page `index`,
+    /// allocating a new temp extent when the current ones are exhausted.
+    fn page_for(&mut self, index: u64) -> Result<u64, StorageError> {
+        let extent_ix = (index / EXTENT_PAGES) as usize;
+        while extent_ix >= self.extents.len() {
+            let start = self.storage.allocate_extent(true)?;
+            self.extents.push(start);
+        }
+        Ok(self.extents[extent_ix] + index % EXTENT_PAGES)
+    }
+
+    /// Appends one row.
+    pub fn write_row(&mut self, row: &[Datum]) -> Result<(), StorageError> {
+        debug_assert!(!self.finished);
+        let encoded = encode_row(&self.schema, row).map_err(spill_codec_err)?;
+        let len = encoded.len() as u32;
+        self.pending.extend_from_slice(&len.to_le_bytes());
+        self.pending.extend_from_slice(&encoded);
+        self.byte_len += 4 + encoded.len() as u64;
+        while self.pending.len() >= PAGE_SIZE {
+            let page = self.page_for(self.pages_written)?;
+            self.storage
+                .spill_write_page(page, &self.pending[..PAGE_SIZE])?;
+            self.pending.drain(..PAGE_SIZE);
+            self.pages_written += 1;
+        }
+        self.rows += 1;
+        Ok(())
+    }
+
+    /// Flushes the final partial page. Must be called before reading.
+    pub fn finish_writing(&mut self) -> Result<(), StorageError> {
+        if self.finished {
+            return Ok(());
+        }
+        if !self.pending.is_empty() {
+            let page = self.page_for(self.pages_written)?;
+            let mut padded = vec![0u8; PAGE_SIZE];
+            padded[..self.pending.len()].copy_from_slice(&self.pending);
+            self.storage.spill_write_page(page, &padded)?;
+            self.pending.clear();
+            self.pages_written += 1;
+        }
+        self.finished = true;
+        Ok(())
+    }
+
+    /// A sequential reader over the spooled rows (in write order).
+    pub fn reader(&self) -> RowSpoolReader<'_, 'a> {
+        debug_assert!(self.finished);
+        RowSpoolReader {
+            spool: self,
+            buf: Vec::new(),
+            buf_pos: 0,
+            next_page: 0,
+            bytes_read: 0,
+        }
+    }
+}
+
+impl Drop for RowSpool<'_> {
+    fn drop(&mut self) {
+        for start in &self.extents {
+            let _ = self.storage.free_extent(*start);
+        }
+    }
+}
+
+/// Maps a row-codec failure to a storage error (spill payloads are engine-
+/// generated, so this indicates a bug rather than user input).
+fn spill_codec_err(err: crate::relstore::types::TypeError) -> StorageError {
+    StorageError::InvalidConfig(format!("spill row codec: {err}"))
+}
+
+/// Sequential reader returned by [`RowSpool::reader`].
+pub struct RowSpoolReader<'s, 'a> {
+    spool: &'s RowSpool<'a>,
+    /// Bytes read from pages but not yet consumed into rows.
+    buf: Vec<u8>,
+    buf_pos: usize,
+    next_page: u64,
+    bytes_read: u64,
+}
+
+impl RowSpoolReader<'_, '_> {
+    /// Reads the next spool page into `buf`, bounded by the spool's payload
+    /// length so the padding of the final page is never parsed. Returns whether
+    /// a page was read.
+    fn fill(&mut self) -> Result<bool, StorageError> {
+        if self.bytes_read >= self.spool.byte_len {
+            return Ok(false);
+        }
+        let index = self.next_page;
+        let extent_ix = (index / EXTENT_PAGES) as usize;
+        let page = self.spool.extents[extent_ix] + index % EXTENT_PAGES;
+        let mut frame = vec![0u8; PAGE_SIZE];
+        self.spool.storage.spill_read_page(page, &mut frame)?;
+        let remaining = self.spool.byte_len - self.bytes_read;
+        let take = (PAGE_SIZE as u64).min(remaining) as usize;
+        // Drop already-consumed bytes to keep `buf` bounded, then append.
+        self.buf.drain(..self.buf_pos);
+        self.buf_pos = 0;
+        self.buf.extend_from_slice(&frame[..take]);
+        self.bytes_read += take as u64;
+        self.next_page += 1;
+        Ok(true)
+    }
+
+    /// The next row, or `None` at end of spool.
+    pub fn next_row(&mut self) -> Result<Option<Vec<Datum>>, StorageError> {
+        loop {
+            // Need the 4-byte length prefix.
+            if self.buf.len() - self.buf_pos < 4 {
+                if !self.fill()? {
+                    return Ok(None);
+                }
+                continue;
+            }
+            let len_bytes = [
+                self.buf[self.buf_pos],
+                self.buf[self.buf_pos + 1],
+                self.buf[self.buf_pos + 2],
+                self.buf[self.buf_pos + 3],
+            ];
+            let len = u32::from_le_bytes(len_bytes) as usize;
+            if self.buf.len() - self.buf_pos < 4 + len {
+                if !self.fill()? {
+                    return Ok(None); // truncated tail — treat as end
+                }
+                continue;
+            }
+            let start = self.buf_pos + 4;
+            let row = decode_row(&self.spool.schema, &self.buf[start..start + len])
+                .map_err(spill_codec_err)?;
+            self.buf_pos += 4 + len;
+            return Ok(Some(row));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::relstore::row::Column;
+    use crate::relstore::types::ColumnType;
+    use crate::storage::StorageOptions;
+
+    fn temp_storage(label: &str) -> Storage {
+        let mut path = std::env::temp_dir();
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        path.push(format!("truthdb-spill-{label}-{nanos}.db"));
+        Storage::create_with_wal_bounds(
+            path,
+            StorageOptions {
+                size_gib: 1,
+                wal_ratio: 0.05,
+                metadata_ratio: 0.08,
+                snapshot_ratio: 0.02,
+                allocator_ratio: 0.02,
+                reserved_ratio: 0.17,
+            },
+            8 * 1024 * 1024,
+            8 * 1024 * 1024,
+        )
+        .expect("create storage")
+    }
+
+    fn schema() -> Schema {
+        Schema {
+            columns: vec![
+                Column {
+                    name: "id".into(),
+                    column_type: ColumnType::Int,
+                    nullable: false,
+                    collation: None,
+                },
+                Column {
+                    name: "s".into(),
+                    column_type: ColumnType::NVarChar { max_len: 4000 },
+                    nullable: true,
+                    collation: None,
+                },
+            ],
+        }
+    }
+
+    fn read_all(spool: &RowSpool) -> Vec<Vec<Datum>> {
+        let mut reader = spool.reader();
+        let mut out = Vec::new();
+        while let Some(row) = reader.next_row().expect("read") {
+            out.push(row);
+        }
+        out
+    }
+
+    #[test]
+    fn round_trips_many_rows_across_extents() {
+        let storage = temp_storage("roundtrip");
+        // Enough rows (each with a chunky string) to fill well past one 64-page
+        // (256 KiB) extent, so the multi-extent path is exercised.
+        let expected: Vec<Vec<Datum>> = (0..3000)
+            .map(|i| {
+                vec![
+                    Datum::Int(i),
+                    Datum::NVarChar(format!("row-{i}-{}", "x".repeat((i % 200) as usize))),
+                ]
+            })
+            .collect();
+
+        let mut spool = RowSpool::new(&storage, schema());
+        for row in &expected {
+            spool.write_row(row).expect("write");
+        }
+        spool.finish_writing().expect("finish");
+        assert_eq!(spool.row_count(), expected.len() as u64);
+        assert!(spool.extents.len() > 1, "should span multiple temp extents");
+
+        assert_eq!(read_all(&spool), expected);
+        // A second read yields the same rows (the spool is not consumed).
+        assert_eq!(read_all(&spool), expected);
+    }
+
+    #[test]
+    fn null_and_empty_and_boundary_rows() {
+        let storage = temp_storage("nulls");
+        let expected = vec![
+            vec![Datum::Int(1), Datum::Null],
+            vec![Datum::Int(2), Datum::NVarChar(String::new())],
+            // A near-cap row (rows straddle page boundaries; the codec caps a
+            // single row below a page, so a row never exceeds one page itself).
+            vec![Datum::Int(3), Datum::NVarChar("y".repeat(1800))],
+            vec![Datum::Int(4), Datum::NVarChar("z".into())],
+        ];
+        let mut spool = RowSpool::new(&storage, schema());
+        for row in &expected {
+            spool.write_row(row).expect("write");
+        }
+        spool.finish_writing().expect("finish");
+        assert_eq!(read_all(&spool), expected);
+    }
+
+    #[test]
+    fn empty_spool_reads_nothing() {
+        let storage = temp_storage("empty");
+        let mut spool = RowSpool::new(&storage, schema());
+        spool.finish_writing().expect("finish");
+        assert_eq!(spool.row_count(), 0);
+        assert!(read_all(&spool).is_empty());
+    }
+
+    #[test]
+    fn dropping_a_spool_frees_its_temp_extents_for_reuse() {
+        let storage = temp_storage("reclaim");
+        let first_extent = {
+            let mut spool = RowSpool::new(&storage, schema());
+            for i in 0..500 {
+                spool
+                    .write_row(&[Datum::Int(i), Datum::NVarChar("data".repeat(50))])
+                    .expect("write");
+            }
+            spool.finish_writing().expect("finish");
+            let start = spool.extents[0];
+            assert!(storage.is_page_allocated(start));
+            start
+        }; // spool dropped here -> extents freed
+        assert!(
+            !storage.is_page_allocated(first_extent),
+            "temp extent must be freed on drop"
+        );
+    }
+}

--- a/crates/truthdb-core/src/storage.rs
+++ b/crates/truthdb-core/src/storage.rs
@@ -282,6 +282,18 @@ impl Storage {
         self.lock().free_extent(start_page)
     }
 
+    /// Writes one raw page (`PAGE_SIZE` bytes) to a data-region page — used by
+    /// the spill spool over temp extents. Bypasses the buffer pool and the WAL
+    /// (spill pages are query-scratch, never recovered).
+    pub(crate) fn spill_write_page(&self, page: u64, data: &[u8]) -> Result<(), StorageError> {
+        self.lock().spill_write_page(page, data)
+    }
+
+    /// Reads one raw data-region page (`PAGE_SIZE` bytes) into `out`.
+    pub(crate) fn spill_read_page(&self, page: u64, out: &mut [u8]) -> Result<(), StorageError> {
+        self.lock().spill_read_page(page, out)
+    }
+
     pub fn is_page_allocated(&self, page: u64) -> bool {
         self.lock().is_page_allocated(page)
     }
@@ -2193,6 +2205,24 @@ impl StorageFile {
             &record.encode(),
         )?;
         self.allocator.free(start_page, EXTENT_PAGES);
+        Ok(())
+    }
+
+    fn spill_write_page(&mut self, page: u64, data: &[u8]) -> Result<(), StorageError> {
+        debug_assert_eq!(data.len(), PAGE_SIZE);
+        let mut frame = crate::direct_io::AlignedPageBuf::new();
+        frame.as_mut_slice().copy_from_slice(data);
+        let offset = self.layout.data_offset + page * PAGE_SIZE as u64;
+        self.file.write_page_from(offset, &frame)?;
+        Ok(())
+    }
+
+    fn spill_read_page(&mut self, page: u64, out: &mut [u8]) -> Result<(), StorageError> {
+        debug_assert_eq!(out.len(), PAGE_SIZE);
+        let mut frame = crate::direct_io::AlignedPageBuf::new();
+        let offset = self.layout.data_offset + page * PAGE_SIZE as u64;
+        self.file.read_page_into(offset, &mut frame)?;
+        out.copy_from_slice(frame.as_slice());
         Ok(())
     }
 


### PR DESCRIPTION
The greenfield spill layer the plan flagged, plus the first spilling operator.

## Spill foundation
Storage gains raw spill-page I/O (`spill_write_page`/`spill_read_page`) that
writes/reads data-region pages directly, bypassing the buffer pool and WAL.
`relstore/spill.rs` adds `RowSpool`: an append-then-scan row spool laid across
64-page **temporary** extents (never WAL-logged, reclaimed on restart, freed on
drop), using a self-describing **cap-free** row codec (no 3900-byte in-row limit,
so a join's wide concatenated source row round-trips).

## External merge sort
`ORDER BY` is now spill-capable. `order_rows` sorts in memory below a per-query
budget (default 64 MiB); above it, it spills sorted runs to `RowSpool`s and
k-way merges them — so a sort larger than the budget completes with bounded
working memory instead of the old ~2× in-memory clone / eventual OOM. Ties break
toward the earlier run, making the external sort globally stable = byte-identical
to the in-memory sort.

## Correctness
An adversarial-review workflow found a HIGH bug in the first cut: the spill
reused the capped table codec, so a wide-row join `ORDER BY` errored 1701 when it
spilled. Fixed with the cap-free codec above.

Tests: RowSpool round-trip across extents / wide (20 KB) rows / all Datum
variants / reclamation-on-drop; a forced-spill sort matching the in-memory sort
(600 rows, heavy ties); a forced-spill wide-**join** sort. Full suite green (342).

Remaining Stage 8 spill: grace-hash for aggregate/join, and streaming scans to
reduce the input materialization too (documented).