### PR TITLE
Stage 8: grace-hash spill for GROUP BY aggregation

### DIFF
--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -2401,6 +2401,42 @@ mod tests {
     }
 
     #[test]
+    fn group_by_grace_hash_spills_and_matches_in_memory() {
+        // A tiny budget forces grace-hash aggregation (partition rows by
+        // group-key hash to temp extents, aggregate each partition). Results
+        // must match the in-memory hash aggregate — group keys, SUM, COUNT, and
+        // COUNT(DISTINCT), including a NULL group and HAVING.
+        let path = unique_temp_path("agg-spill");
+        let engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE t (id INT NOT NULL PRIMARY KEY, grp INT, amt INT)")
+            .expect("t");
+        for i in 0..800 {
+            let grp = if i % 37 == 0 {
+                "NULL".to_string()
+            } else {
+                (i % 60).to_string()
+            };
+            engine
+                .execute(&format!("INSERT INTO t VALUES ({i}, {grp}, {})", i % 10))
+                .expect("insert");
+        }
+        let query = "SELECT grp, SUM(amt), COUNT(*), COUNT(DISTINCT amt) FROM t GROUP BY grp HAVING COUNT(*) > 2 ORDER BY grp";
+
+        let (_, reference) = sql_rows(&engine, query);
+        crate::rel::set_test_sort_budget(Some(400));
+        let (_, spilled) = sql_rows(&engine, query);
+        crate::rel::set_test_sort_budget(None);
+
+        assert!(!reference.is_empty());
+        assert_eq!(
+            spilled, reference,
+            "grace-hash aggregate must match in-memory"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
     fn order_by_spills_wide_join_rows() {
         // A join's source row is the concatenation of both tables' columns. Each
         // per-table row fits (< the ~2020 B clustered cell cap), but the joined

--- a/crates/truthdb-core/src/rel/aggregate.rs
+++ b/crates/truthdb-core/src/rel/aggregate.rs
@@ -74,6 +74,7 @@ struct AggSpec {
 /// Runs the grouped query over the (already WHERE-filtered) source rows and
 /// returns the projected output rows (before DISTINCT/ORDER BY/TOP).
 pub fn execute(
+    storage: &crate::storage::Storage,
     select: &Select,
     rows: &[Vec<Datum>],
     types: &[ColumnType],
@@ -115,18 +116,62 @@ pub fn execute(
         .chain((0..aggs.len()).map(|j| format!("$agg{j}")))
         .collect();
 
-    let groups = group_rows(select, rows, types, resolver, eval_ctx)?;
+    // A GROUP BY over an input larger than the operator memory budget spills:
+    // partition the rows by group-key hash (so every member of a group lands in
+    // one partition) to temp extents, then aggregate each partition in bounded
+    // memory. Without GROUP BY (one group) or within budget, aggregate directly.
+    let budget = super::sort_budget();
+    let input_bytes: usize = rows.iter().map(|r| super::approx_row_bytes(r)).sum();
+    let out_rows = if select.group_by.is_empty() || input_bytes <= budget {
+        aggregate_partition(
+            select, rows, types, resolver, eval_ctx, &aggs, &having, &out_exprs, &synth,
+        )?
+    } else {
+        grace_hash_aggregate(
+            storage,
+            select,
+            rows,
+            types,
+            resolver,
+            eval_ctx,
+            &aggs,
+            &having,
+            &out_exprs,
+            &synth,
+            input_bytes,
+            budget,
+        )?
+    };
 
+    build_rowset(out_names, out_rows)
+}
+
+/// Groups `rows`, computes each aggregate and HAVING, and projects the output
+/// SQL-value rows. This is the in-memory aggregation used both directly and per
+/// grace-hash partition.
+#[allow(clippy::too_many_arguments, clippy::ptr_arg)]
+fn aggregate_partition(
+    select: &Select,
+    rows: &[Vec<Datum>],
+    types: &[ColumnType],
+    resolver: &JoinScope,
+    eval_ctx: &EvalContext,
+    aggs: &[AggSpec],
+    having: &Option<Expr>,
+    out_exprs: &[Expr],
+    synth: &Vec<String>,
+) -> Result<Vec<Vec<SqlValue>>, SqlError> {
+    let groups = group_rows(select, rows, types, resolver, eval_ctx)?;
     let mut out_rows: Vec<Vec<SqlValue>> = Vec::new();
     for (keys, members) in &groups {
         let mut group_row = keys.clone();
-        for spec in &aggs {
+        for spec in aggs {
             group_row.push(compute_aggregate(
                 spec, rows, types, resolver, members, eval_ctx,
             )?);
         }
-        if let Some(having) = &having {
-            match eval::eval(having, &group_row, &synth, eval_ctx)? {
+        if let Some(having) = having {
+            match eval::eval(having, &group_row, synth, eval_ctx)? {
                 SqlValue::Bool(true) => {}
                 SqlValue::Bool(false) | SqlValue::Null => continue,
                 _ => {
@@ -140,13 +185,89 @@ pub fn execute(
             }
         }
         let mut row = Vec::with_capacity(out_exprs.len());
-        for expr in &out_exprs {
-            row.push(eval::eval(expr, &group_row, &synth, eval_ctx)?);
+        for expr in out_exprs {
+            row.push(eval::eval(expr, &group_row, synth, eval_ctx)?);
         }
         out_rows.push(row);
     }
+    Ok(out_rows)
+}
 
-    build_rowset(out_names, out_rows)
+/// Grace-hash aggregation: partition rows by group-key hash into temp-extent
+/// spools, then aggregate each partition independently and concatenate.
+/// (Extreme group skew — one partition far larger than the budget — is not
+/// re-partitioned; a first cut, documented.)
+#[allow(clippy::too_many_arguments, clippy::ptr_arg)]
+fn grace_hash_aggregate(
+    storage: &crate::storage::Storage,
+    select: &Select,
+    rows: &[Vec<Datum>],
+    types: &[ColumnType],
+    resolver: &JoinScope,
+    eval_ctx: &EvalContext,
+    aggs: &[AggSpec],
+    having: &Option<Expr>,
+    out_exprs: &[Expr],
+    synth: &Vec<String>,
+    input_bytes: usize,
+    budget: usize,
+) -> Result<Vec<Vec<SqlValue>>, SqlError> {
+    let partitions = (input_bytes / budget + 1).max(2);
+    let mut spools: Vec<crate::relstore::spill::RowSpool> = (0..partitions)
+        .map(|_| crate::relstore::spill::RowSpool::new(storage))
+        .collect();
+    for row in rows {
+        let key = group_key(select, row, types, resolver, eval_ctx)?;
+        let index = partition_index(&key, partitions);
+        spools[index]
+            .write_row(row)
+            .map_err(|e| super::map_storage_err(e, "<agg spill>"))?;
+    }
+    let mut out_rows: Vec<Vec<SqlValue>> = Vec::new();
+    for spool in &mut spools {
+        spool
+            .finish_writing()
+            .map_err(|e| super::map_storage_err(e, "<agg spill>"))?;
+    }
+    for spool in &spools {
+        let mut part_rows: Vec<Vec<Datum>> = Vec::with_capacity(spool.row_count() as usize);
+        let mut reader = spool.reader();
+        while let Some(row) = reader
+            .next_row()
+            .map_err(|e| super::map_storage_err(e, "<agg spill>"))?
+        {
+            part_rows.push(row);
+        }
+        out_rows.extend(aggregate_partition(
+            select, &part_rows, types, resolver, eval_ctx, aggs, having, out_exprs, synth,
+        )?);
+    }
+    Ok(out_rows)
+}
+
+/// The GROUP BY key of one row (used to route it to a grace-hash partition).
+fn group_key(
+    select: &Select,
+    row: &[Datum],
+    types: &[ColumnType],
+    resolver: &JoinScope,
+    eval_ctx: &EvalContext,
+) -> Result<Vec<SqlValue>, SqlError> {
+    let sql_row = row_values(row, types);
+    select
+        .group_by
+        .iter()
+        .map(|expr| eval::eval(expr, &sql_row, resolver, eval_ctx))
+        .collect()
+}
+
+/// The partition a group key routes to. Uses the same `HashKey` hashing as the
+/// in-memory grouping, so equal group keys always share a partition.
+fn partition_index(key: &[SqlValue], partitions: usize) -> usize {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    super::hash::HashKey(key.to_vec()).hash(&mut hasher);
+    (hasher.finish() % partitions as u64) as usize
 }
 
 /// Groups the rows by the GROUP BY key expressions. With no GROUP BY the whole

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -3931,7 +3931,7 @@ fn exec_select(
     // can order by columns that are not in the SELECT list.
     if aggregate::is_aggregated(select) || select.distinct {
         let mut out = if aggregate::is_aggregated(select) {
-            aggregate::execute(select, &rows, &types, &resolver, eval_ctx)?
+            aggregate::execute(storage, select, &rows, &types, &resolver, eval_ctx)?
         } else {
             project(
                 &select.items,


### PR DESCRIPTION
A GROUP BY whose input exceeds the operator memory budget now **partitions its
rows by group-key hash** into temp-extent `RowSpool`s (every member of a group
lands in one partition), then aggregates each partition independently in bounded
memory — so the group hash table (which for high-cardinality GROUP BY could grow
as large as the input) is never built whole. Below budget, or with no GROUP BY,
it aggregates in memory as before.

Per-partition aggregation reuses the existing in-memory path, so HAVING,
`COUNT(DISTINCT)`, and NULL groups behave identically. Partitioning uses the same
`HashKey` hashing as in-memory grouping, so equal keys always share a partition.
Extreme single-group skew is not re-partitioned (documented). Shares the sort's
memory budget.

Test: 800 rows with a NULL group + HAVING + `COUNT(DISTINCT)`, forced to
grace-hash via a 400-byte budget, matches the in-memory aggregate. Full suite
green (343).