### PR TITLE
Stage 5: case-insensitive collation-aware equality

### DIFF
--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -4193,7 +4193,7 @@ mod tests {
     }
 
     #[test]
-    fn sql_nvarchar_equality_seeks_but_range_scans() {
+    fn sql_nvarchar_equality_seeks_case_insensitively() {
         let path = unique_temp_path("sql-index-nvarchar");
         let engine = new_engine(&path);
         engine
@@ -4206,22 +4206,34 @@ mod tests {
             .execute("CREATE INDEX ix_name ON t (name)")
             .expect("index");
 
-        // Equality is an exact byte match, so it seeks; the filter compares by
-        // code point, so it is case-sensitive.
+        // Under the default (case-insensitive) collation, equality folds case.
+        // The index key is folded the same way, so it still SEEKS (not scans) and
+        // the seek finds every case-variant: 'abc' and 'ABC' share one folded key.
         let plan = plan_lines(&engine, "SELECT id FROM t WHERE name = 'abc'");
         assert!(plan.iter().any(|l| l.contains("Index Seek")), "{plan:?}");
-        let (_, rows) = sql_rows(&engine, "SELECT id FROM t WHERE name = 'abc'");
-        assert_eq!(rows, vec![vec![Some("1".into())]], "'ABC' is not 'abc'");
+        let (_, mut rows) = sql_rows(&engine, "SELECT id FROM t WHERE name = 'abc'");
+        rows.sort();
+        assert_eq!(
+            rows,
+            vec![vec![Some("1".into())], vec![Some("2".into())]],
+            "case-insensitive equality matches both 'abc' and 'ABC'"
+        );
 
-        // A range on NVARCHAR must NOT seek (UTF-16BE key order can diverge
-        // from code-point order at astral characters); it scans and stays
-        // correct.
+        // A range on NVARCHAR must NOT seek (UTF-16BE key order can diverge from
+        // the filter's order at astral characters); it scans and stays correct.
+        // Case-insensitive: 'ABC' folds to 'abc' > 'a', so all three match.
         let plan = plan_lines(&engine, "SELECT id FROM t WHERE name > 'a'");
         assert_eq!(plan, vec!["Table Scan(t)".to_string()]);
         let (_, mut rows) = sql_rows(&engine, "SELECT id FROM t WHERE name > 'a'");
         rows.sort();
-        // 'ABC' (0x41..) < 'a' (0x61) by code point; 'abc','xyz' > 'a'.
-        assert_eq!(rows, vec![vec![Some("1".into())], vec![Some("3".into())]]);
+        assert_eq!(
+            rows,
+            vec![
+                vec![Some("1".into())],
+                vec![Some("2".into())],
+                vec![Some("3".into())]
+            ]
+        );
         let _ = std::fs::remove_file(path);
     }
 
@@ -4764,5 +4776,392 @@ mod tests {
             .as_nanos();
         path.push(format!("truthdb-{label}-{nanos}.db"));
         path
+    }
+
+    // ---- Stage 5: collation-aware equality (case-insensitive default) --------
+    //
+    // The database default collation is `..._CI_AS` (case-insensitive), so string
+    // equality, grouping, DISTINCT, joins, key seeks, and uniqueness all fold
+    // case unless a column is declared `_CS`/`_BIN`. These tests exercise every
+    // folded-key path — a missed fold site would surface as a wrong result here.
+
+    #[test]
+    fn collation_ci_where_and_predicates_fold_case() {
+        let path = unique_temp_path("coll-ci-where");
+        let engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE t (id INT NOT NULL PRIMARY KEY, name VARCHAR(20))")
+            .expect("create");
+        engine
+            .execute("INSERT INTO t VALUES (1, 'abc'), (2, 'ABC'), (3, 'Xyz')")
+            .expect("insert");
+        // Equality (scan path, no index): matches every case-variant.
+        let (_, mut rows) = sql_rows(&engine, "SELECT id FROM t WHERE name = 'aBc' ORDER BY id");
+        rows.sort();
+        assert_eq!(
+            rows,
+            vec![vec![Some("1".into())], vec![Some("2".into())]],
+            "CI equality matches both cases"
+        );
+        // IN, LIKE, BETWEEN all fold case too.
+        let (_, r) = sql_rows(&engine, "SELECT COUNT(*) FROM t WHERE name IN ('ABC')");
+        assert_eq!(r, vec![vec![Some("2".into())]], "CI IN");
+        let (_, r) = sql_rows(&engine, "SELECT COUNT(*) FROM t WHERE name LIKE 'X%'");
+        assert_eq!(r, vec![vec![Some("1".into())]], "CI LIKE matches 'Xyz'");
+        let (_, r) = sql_rows(
+            &engine,
+            "SELECT COUNT(*) FROM t WHERE name BETWEEN 'A' AND 'D'",
+        );
+        assert_eq!(r, vec![vec![Some("2".into())]], "CI BETWEEN folds bounds");
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn collation_ci_char_pk_uniqueness_and_lookup() {
+        let path = unique_temp_path("coll-ci-pk");
+        let engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE t (code VARCHAR(10) NOT NULL PRIMARY KEY, v INT)")
+            .expect("create");
+        engine
+            .execute("INSERT INTO t VALUES ('ABC', 1)")
+            .expect("ins1");
+        // A case-variant is a duplicate PK under the case-insensitive collation.
+        assert_eq!(
+            sql_error_number(&engine, "INSERT INTO t VALUES ('abc', 2)"),
+            2627,
+            "CI clustered PK rejects a case-variant duplicate"
+        );
+        // A clustered PK lookup by a case-variant finds the stored row.
+        let (_, rows) = sql_rows(&engine, "SELECT v FROM t WHERE code = 'aBc'");
+        assert_eq!(rows, vec![vec![Some("1".into())]]);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn collation_ci_unique_index_folds_case() {
+        let path = unique_temp_path("coll-ci-uix");
+        let engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE t (id INT NOT NULL PRIMARY KEY, email VARCHAR(50))")
+            .expect("create");
+        engine
+            .execute("CREATE UNIQUE INDEX ux ON t (email)")
+            .expect("uix");
+        engine
+            .execute("INSERT INTO t VALUES (1, 'A@B.com')")
+            .expect("ins1");
+        assert_eq!(
+            sql_error_number(&engine, "INSERT INTO t VALUES (2, 'a@b.COM')"),
+            2601,
+            "CI unique index rejects a case-variant duplicate"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn collation_ci_join_and_grouping_fold_case() {
+        let path = unique_temp_path("coll-ci-join");
+        let engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE l (id INT NOT NULL PRIMARY KEY, k VARCHAR(10))")
+            .expect("l");
+        engine
+            .execute("CREATE TABLE r (id INT NOT NULL PRIMARY KEY, k VARCHAR(10))")
+            .expect("r");
+        engine
+            .execute("INSERT INTO l VALUES (1, 'abc'), (2, 'ABC'), (3, 'zzz')")
+            .expect("l ins");
+        engine
+            .execute("INSERT INTO r VALUES (10, 'ABC'), (20, 'aBc')")
+            .expect("r ins");
+        // Hash join equi-key folds: every l/r case-variant pair matches (2*2 = 4).
+        let (_, rows) = sql_rows(&engine, "SELECT COUNT(*) FROM l JOIN r ON l.k = r.k");
+        assert_eq!(
+            rows,
+            vec![vec![Some("4".into())]],
+            "CI join matches all case pairs"
+        );
+        // GROUP BY folds case: 'abc'/'ABC' form one group of 2, 'zzz' one of 1.
+        let (_, mut rows) = sql_rows(&engine, "SELECT COUNT(*) FROM l GROUP BY k");
+        rows.sort();
+        assert_eq!(
+            rows,
+            vec![vec![Some("1".into())], vec![Some("2".into())]],
+            "CI GROUP BY collapses case-variants into 2 groups (sizes 1 and 2)"
+        );
+        // DISTINCT collapses case-variants to {abc, zzz}; COUNT(DISTINCT) counts once.
+        let (_, rows) = sql_rows(&engine, "SELECT DISTINCT k FROM l");
+        assert_eq!(rows.len(), 2, "CI DISTINCT collapses 'abc'/'ABC': {rows:?}");
+        let (_, rows) = sql_rows(&engine, "SELECT COUNT(DISTINCT k) FROM l");
+        assert_eq!(rows, vec![vec![Some("2".into())]], "CI COUNT(DISTINCT)");
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn collation_ci_foreign_key_folds_case() {
+        let path = unique_temp_path("coll-ci-fk");
+        let engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE parent (code VARCHAR(10) NOT NULL PRIMARY KEY)")
+            .expect("parent");
+        engine
+            .execute(
+                "CREATE TABLE child (id INT NOT NULL PRIMARY KEY, pcode VARCHAR(10) \
+                 REFERENCES parent(code))",
+            )
+            .expect("child");
+        engine
+            .execute("INSERT INTO parent VALUES ('ABC')")
+            .expect("parent ins");
+        // A child FK value matches the parent case-insensitively (folded probe).
+        engine
+            .execute("INSERT INTO child VALUES (1, 'aBc')")
+            .expect("child ins with case-variant FK");
+        // Deleting the parent is blocked by the case-variant child reference.
+        assert_eq!(
+            sql_error_number(&engine, "DELETE FROM parent WHERE code = 'ABC'"),
+            547,
+            "CI FK: child 'aBc' still references parent 'ABC'"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn collation_cs_override_is_case_sensitive() {
+        let path = unique_temp_path("coll-cs");
+        let engine = new_engine(&path);
+        engine
+            .execute(
+                "CREATE TABLE t (code VARCHAR(10) COLLATE Latin1_General_CS_AS NOT NULL PRIMARY KEY)",
+            )
+            .expect("create cs pk");
+        // Under a case-sensitive collation, case-variants are distinct keys.
+        engine
+            .execute("INSERT INTO t VALUES ('ABC')")
+            .expect("ins ABC");
+        engine
+            .execute("INSERT INTO t VALUES ('abc')")
+            .expect("case-sensitive PK admits 'abc' alongside 'ABC'");
+        // Equality is exact: only the matching case.
+        let (_, rows) = sql_rows(&engine, "SELECT code FROM t WHERE code = 'abc'");
+        assert_eq!(rows, vec![vec![Some("abc".into())]], "CS equality is exact");
+        let (_, rows) = sql_rows(&engine, "SELECT COUNT(*) FROM t");
+        assert_eq!(rows, vec![vec![Some("2".into())]]);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn collation_ci_folded_keys_survive_restart() {
+        let path = unique_temp_path("coll-ci-restart");
+        {
+            let engine = new_engine(&path);
+            engine
+                .execute("CREATE TABLE t (id INT NOT NULL PRIMARY KEY, name VARCHAR(20))")
+                .expect("create");
+            engine
+                .execute("INSERT INTO t VALUES (1, 'Hello'), (2, 'WORLD')")
+                .expect("insert");
+            engine
+                .execute("CREATE INDEX ix ON t (name)")
+                .expect("index");
+        }
+        // Reopen: the folded index keys on disk must still seek case-insensitively.
+        let storage = Storage::open(path.clone()).expect("reopen");
+        let engine = Engine::new(storage).expect("engine");
+        let plan = plan_lines(&engine, "SELECT id FROM t WHERE name = 'hello'");
+        assert!(plan.iter().any(|l| l.contains("Index Seek")), "{plan:?}");
+        let (_, rows) = sql_rows(&engine, "SELECT id FROM t WHERE name = 'hello'");
+        assert_eq!(
+            rows,
+            vec![vec![Some("1".into())]],
+            "folded seek survives restart"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    // ---- Regression tests for adversarial-review findings on #82 -------------
+
+    #[test]
+    fn collation_ci_group_by_spill_folds_case() {
+        // The grace-hash GROUP BY spill path must partition by the FOLDED key, or
+        // case-variant groups split across partitions on large input. 'World'/
+        // 'world' hash to *different* partitions unfolded (unlike 'ABC'/'abc',
+        // which collide by luck), so this pair reliably catches the bug.
+        let path = unique_temp_path("coll-ci-agg-spill");
+        let engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE t (id INT NOT NULL PRIMARY KEY, k VARCHAR(10))")
+            .expect("create");
+        for i in 0..200 {
+            let k = if i % 2 == 0 { "World" } else { "world" };
+            engine
+                .execute(&format!("INSERT INTO t VALUES ({i}, '{k}')"))
+                .expect("ins");
+        }
+        let query = "SELECT COUNT(*) FROM t GROUP BY k";
+        let (_, reference) = sql_rows(&engine, query);
+        assert_eq!(
+            reference,
+            vec![vec![Some("200".into())]],
+            "in-memory: one case-insensitive group of 200"
+        );
+        crate::rel::set_test_sort_budget(Some(400));
+        let (_, spilled) = sql_rows(&engine, query);
+        crate::rel::set_test_sort_budget(None);
+        assert_eq!(
+            spilled, reference,
+            "spilled GROUP BY must fold case like the in-memory path (one group)"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn collation_cs_column_delete_is_exact() {
+        // UPDATE/DELETE WHERE on a _CS column must compare exactly — a plain
+        // Vec<String> resolver would report the CI default for every column and
+        // delete case-variant rows it must keep (data loss).
+        let path = unique_temp_path("coll-cs-dml");
+        let engine = new_engine(&path);
+        engine
+            .execute(
+                "CREATE TABLE t (id INT NOT NULL PRIMARY KEY, code VARCHAR(10) COLLATE Latin1_General_CS_AS)",
+            )
+            .expect("create");
+        engine
+            .execute("INSERT INTO t VALUES (1, 'abc'), (2, 'ABC')")
+            .expect("ins");
+        engine
+            .execute("DELETE FROM t WHERE code = 'abc'")
+            .expect("delete");
+        let (_, rows) = sql_rows(&engine, "SELECT id FROM t ORDER BY id");
+        assert_eq!(
+            rows,
+            vec![vec![Some("2".into())]],
+            "CS DELETE removes only the exact 'abc' (id=1), keeps 'ABC' (id=2)"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn collation_ci_self_ref_fk_same_statement() {
+        // A self-referencing FK to a case-variant sibling in the SAME statement
+        // must resolve case-insensitively (the sibling isn't committed yet, so the
+        // batch match — not the folded rel_get — is the only satisfying path).
+        let path = unique_temp_path("coll-ci-selfref");
+        let engine = new_engine(&path);
+        engine
+            .execute(
+                "CREATE TABLE t (id VARCHAR(10) NOT NULL PRIMARY KEY, pid VARCHAR(10) REFERENCES t(id))",
+            )
+            .expect("create");
+        engine
+            .execute("INSERT INTO t VALUES ('ABC', NULL), ('X', 'abc')")
+            .expect("case-variant self-reference to a same-statement sibling");
+        let (_, rows) = sql_rows(&engine, "SELECT COUNT(*) FROM t");
+        assert_eq!(rows, vec![vec![Some("2".into())]]);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn collation_cs_distinct_is_exact() {
+        // DISTINCT on a _CS column must keep case-variants distinct, consistent
+        // with GROUP BY and COUNT(DISTINCT) on the same column.
+        let path = unique_temp_path("coll-cs-distinct");
+        let engine = new_engine(&path);
+        engine
+            .execute(
+                "CREATE TABLE t (id INT NOT NULL PRIMARY KEY, code VARCHAR(10) COLLATE Latin1_General_CS_AS)",
+            )
+            .expect("create");
+        engine
+            .execute("INSERT INTO t VALUES (1, 'abc'), (2, 'ABC')")
+            .expect("ins");
+        let (_, rows) = sql_rows(&engine, "SELECT DISTINCT code FROM t");
+        assert_eq!(rows.len(), 2, "CS DISTINCT keeps both cases: {rows:?}");
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn collation_mixed_fk_still_enforced_on_delete() {
+        // A mixed-collation FK (child _CS, parent CI) must not take the index fast
+        // path — that folds by the child collation and would miss a case-variant
+        // reference (child 'abc' → parent 'ABC'), wrongly allowing the parent
+        // delete. The collation-match gate routes it to the parent-collation scan.
+        let path = unique_temp_path("coll-mixed-fk");
+        let engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE parent (code VARCHAR(10) NOT NULL PRIMARY KEY)")
+            .expect("parent");
+        engine
+            .execute(
+                "CREATE TABLE child (id INT NOT NULL PRIMARY KEY, pcode VARCHAR(10) \
+                 COLLATE Latin1_General_CS_AS REFERENCES parent(code))",
+            )
+            .expect("child");
+        engine
+            .execute("CREATE INDEX ix ON child (pcode)")
+            .expect("index"); // would otherwise enable the fast path
+        engine
+            .execute("INSERT INTO parent VALUES ('ABC')")
+            .expect("parent ins");
+        engine
+            .execute("INSERT INTO child VALUES (1, 'abc')")
+            .expect("child references parent case-insensitively");
+        assert_eq!(
+            sql_error_number(&engine, "DELETE FROM parent WHERE code = 'ABC'"),
+            547,
+            "mixed-collation FK is still enforced (child 'abc' references parent 'ABC')"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn collation_cs_having_is_exact() {
+        // HAVING (and the SELECT projection) evaluate against a synthetic group
+        // row; on a _CS grouping column they must compare exactly, or a HAVING
+        // re-merges groups that grouping kept apart.
+        let path = unique_temp_path("coll-cs-having");
+        let engine = new_engine(&path);
+        engine
+            .execute(
+                "CREATE TABLE t (id INT NOT NULL PRIMARY KEY, code VARCHAR(10) COLLATE Latin1_General_CS_AS)",
+            )
+            .expect("create");
+        engine
+            .execute("INSERT INTO t VALUES (1, 'abc'), (2, 'ABC')")
+            .expect("ins");
+        let (_, rows) = sql_rows(
+            &engine,
+            "SELECT code FROM t GROUP BY code HAVING code = 'ABC'",
+        );
+        assert_eq!(
+            rows,
+            vec![vec![Some("ABC".into())]],
+            "CS HAVING matches only the exact 'ABC' group"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn collation_ci_self_ref_fk_update() {
+        // UPDATE setting a self-referencing FK to a case-variant of an existing
+        // PK must succeed under the case-insensitive collation.
+        let path = unique_temp_path("coll-ci-selfref-upd");
+        let engine = new_engine(&path);
+        engine
+            .execute(
+                "CREATE TABLE t (id VARCHAR(10) NOT NULL PRIMARY KEY, pid VARCHAR(10) REFERENCES t(id))",
+            )
+            .expect("create");
+        engine
+            .execute("INSERT INTO t VALUES ('ABC', NULL), ('X', NULL)")
+            .expect("ins");
+        engine
+            .execute("UPDATE t SET pid = 'abc' WHERE id = 'X'")
+            .expect("case-variant self-reference resolves on UPDATE");
+        let (_, rows) = sql_rows(&engine, "SELECT pid FROM t WHERE id = 'X'");
+        assert_eq!(rows, vec![vec![Some("abc".into())]], "UPDATE applied");
+        let _ = std::fs::remove_file(path);
     }
 }

--- a/crates/truthdb-core/src/rel/aggregate.rs
+++ b/crates/truthdb-core/src/rel/aggregate.rs
@@ -8,6 +8,7 @@
 //! inside an aggregate is rejected with error 8120.
 
 use truthdb_sql::ast::{AggFunc, BinaryOp, Expr, ExprKind, Name, Select, SelectItem};
+use truthdb_sql::collation::CollationSensitivity;
 use truthdb_sql::error::SqlError;
 use truthdb_sql::eval::{self, EvalContext};
 use truthdb_sql::value::{SqlValue, order_key_cmp};
@@ -63,6 +64,28 @@ fn contains_aggregate(expr: &Expr) -> bool {
     }
 }
 
+/// Resolver over the synthetic group row `[group keys..., aggregate results...]`.
+/// Carries each grouping column's collation (aggregate-result slots default to
+/// the case-insensitive database default) so HAVING / projection comparisons on
+/// a `_CS`/`_BIN` grouping column stay case-sensitive.
+struct SynthScope {
+    names: Vec<String>,
+    collations: Vec<CollationSensitivity>,
+}
+
+impl truthdb_sql::eval::ColumnResolver for SynthScope {
+    fn resolve(&self, name: &str) -> Option<usize> {
+        self.names.iter().position(|n| n.eq_ignore_ascii_case(name))
+    }
+
+    fn collation(&self, index: usize) -> CollationSensitivity {
+        self.collations
+            .get(index)
+            .copied()
+            .unwrap_or(CollationSensitivity::DEFAULT)
+    }
+}
+
 /// One aggregate to compute over each group.
 struct AggSpec {
     func: AggFunc,
@@ -110,11 +133,22 @@ pub fn execute(
         None => None,
     };
 
-    // The synthetic resolver over [group keys..., aggregate results...].
-    let synth: Vec<String> = (0..select.group_by.len())
+    // The synthetic resolver over [group keys..., aggregate results...], carrying
+    // each grouping column's collation so HAVING / projection comparisons on a
+    // `_CS`/`_BIN` grouping column stay case-sensitive (a bare name list would
+    // report the case-insensitive default and re-merge groups `group_rows` kept
+    // apart). Aggregate-result slots take the database default.
+    let names: Vec<String> = (0..select.group_by.len())
         .map(|i| format!("$gk{i}"))
         .chain((0..aggs.len()).map(|j| format!("$agg{j}")))
         .collect();
+    let collations: Vec<CollationSensitivity> = select
+        .group_by
+        .iter()
+        .map(|expr| eval::key_collation(expr, resolver))
+        .chain((0..aggs.len()).map(|_| CollationSensitivity::DEFAULT))
+        .collect();
+    let synth = SynthScope { names, collations };
 
     // A GROUP BY over an input larger than the operator memory budget spills:
     // partition the rows by group-key hash (so every member of a group lands in
@@ -149,7 +183,7 @@ pub fn execute(
 /// Groups `rows`, computes each aggregate and HAVING, and projects the output
 /// SQL-value rows. This is the in-memory aggregation used both directly and per
 /// grace-hash partition.
-#[allow(clippy::too_many_arguments, clippy::ptr_arg)]
+#[allow(clippy::too_many_arguments)]
 fn aggregate_partition(
     select: &Select,
     rows: &[Vec<Datum>],
@@ -159,7 +193,7 @@ fn aggregate_partition(
     aggs: &[AggSpec],
     having: &Option<Expr>,
     out_exprs: &[Expr],
-    synth: &Vec<String>,
+    synth: &SynthScope,
 ) -> Result<Vec<Vec<SqlValue>>, SqlError> {
     let groups = group_rows(select, rows, types, resolver, eval_ctx)?;
     let mut out_rows: Vec<Vec<SqlValue>> = Vec::new();
@@ -197,7 +231,7 @@ fn aggregate_partition(
 /// spools, then aggregate each partition independently and concatenate.
 /// (Extreme group skew — one partition far larger than the budget — is not
 /// re-partitioned; a first cut, documented.)
-#[allow(clippy::too_many_arguments, clippy::ptr_arg)]
+#[allow(clippy::too_many_arguments)]
 fn grace_hash_aggregate(
     storage: &crate::storage::Storage,
     select: &Select,
@@ -208,7 +242,7 @@ fn grace_hash_aggregate(
     aggs: &[AggSpec],
     having: &Option<Expr>,
     out_exprs: &[Expr],
-    synth: &Vec<String>,
+    synth: &SynthScope,
     input_bytes: usize,
     budget: usize,
 ) -> Result<Vec<Vec<SqlValue>>, SqlError> {
@@ -246,6 +280,9 @@ fn grace_hash_aggregate(
 }
 
 /// The GROUP BY key of one row (used to route it to a grace-hash partition).
+/// The key is *folded* by each grouping column's collation — identically to the
+/// in-memory `group_rows` — so case-insensitive-equal keys route to the same
+/// partition and are not split across partitions on a spilling GROUP BY.
 fn group_key(
     select: &Select,
     row: &[Datum],
@@ -254,11 +291,17 @@ fn group_key(
     eval_ctx: &EvalContext,
 ) -> Result<Vec<SqlValue>, SqlError> {
     let sql_row = row_values(row, types);
-    select
+    let key_sens: Vec<CollationSensitivity> = select
+        .group_by
+        .iter()
+        .map(|expr| eval::key_collation(expr, resolver))
+        .collect();
+    let raw = select
         .group_by
         .iter()
         .map(|expr| eval::eval(expr, &sql_row, resolver, eval_ctx))
-        .collect()
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(super::hash::fold_hash_key(&raw, &key_sens))
 }
 
 /// The partition a group key routes to. Uses the same `HashKey` hashing as the
@@ -288,7 +331,17 @@ fn group_rows(
     // O(n·groups) linear probe. `HashKey`'s equality matches the previous
     // `order_key_cmp`-based `keys_equal`, so groups are identical; a side `Vec`
     // preserves first-appearance order (the order the old scan produced).
-    use super::hash::HashKey;
+    use super::hash::{HashKey, fold_hash_key};
+    // The collation of each grouping column (a bare column keeps its collation;
+    // any other expression takes the database default). Groups are bucketed by
+    // the *folded* key so case-insensitive-equal keys collapse into one group,
+    // while the stored key keeps the first row's original value for output —
+    // `GROUP BY name` over `'ABC'`,`'abc'` returns one group labelled `'ABC'`.
+    let key_sens: Vec<truthdb_sql::collation::CollationSensitivity> = select
+        .group_by
+        .iter()
+        .map(|expr| eval::key_collation(expr, resolver))
+        .collect();
     let mut index_of: std::collections::HashMap<HashKey, usize> = std::collections::HashMap::new();
     let mut groups: Vec<(Vec<SqlValue>, Vec<usize>)> = Vec::new();
     for (index, row) in rows.iter().enumerate() {
@@ -298,10 +351,11 @@ fn group_rows(
             .iter()
             .map(|expr| eval::eval(expr, &sql_row, resolver, eval_ctx))
             .collect::<Result<Vec<_>, _>>()?;
-        match index_of.get(&HashKey(key.clone())) {
+        let folded = fold_hash_key(&key, &key_sens);
+        match index_of.get(&HashKey(folded.clone())) {
             Some(&pos) => groups[pos].1.push(index),
             None => {
-                index_of.insert(HashKey(key.clone()), groups.len());
+                index_of.insert(HashKey(folded), groups.len());
                 groups.push((key, vec![index]));
             }
         }
@@ -321,6 +375,10 @@ fn compute_aggregate(
     let Some(arg) = &spec.arg else {
         return Ok(SqlValue::Int(members.len() as i64));
     };
+    // The argument column's collation governs DISTINCT deduplication and MIN/MAX
+    // for character values (case-insensitive by default), consistent with GROUP
+    // BY and WHERE.
+    let sensitivity = eval::key_collation(arg, resolver);
     let mut values: Vec<SqlValue> = Vec::new();
     for &index in members {
         let sql_row = row_values(&rows[index], types);
@@ -330,13 +388,34 @@ fn compute_aggregate(
         }
     }
     if spec.distinct {
-        values.sort_by(order_key_cmp);
-        values.dedup_by(|a, b| order_key_cmp(a, b) == std::cmp::Ordering::Equal);
+        // Dedup case-insensitively under a `_CI` collation: `COUNT(DISTINCT name)`
+        // counts `'ABC'` and `'abc'` once. Strings compare by the collation;
+        // everything else keeps `order_key_cmp`.
+        let cmp = |a: &SqlValue, b: &SqlValue| collated_cmp(a, b, sensitivity);
+        values.sort_by(&cmp);
+        values.dedup_by(|a, b| cmp(a, b) == std::cmp::Ordering::Equal);
     }
-    fold(spec.func, values)
+    fold(spec.func, values, sensitivity)
 }
 
-fn fold(func: AggFunc, values: Vec<SqlValue>) -> Result<SqlValue, SqlError> {
+/// Compares two aggregate values under a collation: character operands fold by
+/// case sensitivity, all others fall back to `order_key_cmp`.
+fn collated_cmp(
+    a: &SqlValue,
+    b: &SqlValue,
+    sensitivity: CollationSensitivity,
+) -> std::cmp::Ordering {
+    match (a, b) {
+        (SqlValue::Str(x), SqlValue::Str(y)) => sensitivity.compare_str(x, y),
+        _ => order_key_cmp(a, b),
+    }
+}
+
+fn fold(
+    func: AggFunc,
+    values: Vec<SqlValue>,
+    sensitivity: CollationSensitivity,
+) -> Result<SqlValue, SqlError> {
     match func {
         AggFunc::Count => Ok(SqlValue::Int(values.len() as i64)),
         AggFunc::Min | AggFunc::Max => {
@@ -346,9 +425,7 @@ fn fold(func: AggFunc, values: Vec<SqlValue>) -> Result<SqlValue, SqlError> {
                 best = Some(match best {
                     None => value,
                     Some(current) => {
-                        let ord = current
-                            .compare(&value)?
-                            .unwrap_or(std::cmp::Ordering::Equal);
+                        let ord = collated_cmp(&current, &value, sensitivity);
                         let take_new = if want_max {
                             ord == std::cmp::Ordering::Less
                         } else {

--- a/crates/truthdb-core/src/rel/hash.rs
+++ b/crates/truthdb-core/src/rel/hash.rs
@@ -45,9 +45,29 @@
 
 use std::hash::{Hash, Hasher};
 
+use truthdb_sql::collation::CollationSensitivity;
 use truthdb_sql::value::{SqlValue, order_key_cmp};
 
 use crate::relstore::types::ColumnType;
+
+/// Folds the string components of a group/DISTINCT key to their collation-
+/// canonical form (`sensitivities[i]` governs `key[i]`; a missing entry defaults
+/// to the case-insensitive database default), so case-insensitive-equal keys
+/// share a bucket and compare `Eq`. The caller keeps the original key for output
+/// — this produces only the bucketing/equality key. (Non-string values and
+/// case-sensitive columns pass through unchanged.)
+pub fn fold_hash_key(key: &[SqlValue], sensitivities: &[CollationSensitivity]) -> Vec<SqlValue> {
+    key.iter()
+        .enumerate()
+        .map(|(index, value)| {
+            let sens = sensitivities
+                .get(index)
+                .copied()
+                .unwrap_or(CollationSensitivity::DEFAULT);
+            sens.fold_value(value.clone())
+        })
+        .collect()
+}
 
 /// The hashing family of a column type. Two columns can be joined by the hash
 /// path only if their classes match, which guarantees their key values hash the

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -19,6 +19,7 @@ use truthdb_sql::ast::{
     Insert, InsertSource, IsolationLevel, JoinKind, Name, OrderItem, Select, SelectItem,
     SetStatement, Statement, TableRef, Update,
 };
+use truthdb_sql::collation::CollationSensitivity;
 use truthdb_sql::error::SqlError;
 use truthdb_sql::eval::{ColumnResolver, EvalContext};
 use truthdb_sql::value::{SqlValue, order_key_cmp};
@@ -330,6 +331,11 @@ fn row_key_hash(schema: &Schema, key_columns: &[usize], key_values: &[Datum]) ->
 /// is a floating type. REAL/FLOAT keys are excluded because `-0.0 == 0.0` (and
 /// NaN) compare equal in evaluation but encode to distinct key bytes, so two
 /// writers to one physical row could get distinct hashes and not serialize.
+///
+/// Character keys are safe even under a case-insensitive collation: the row-lock
+/// hash is taken over the *folded* key (`encode_key` folds character keys by
+/// collation, Stage 5), so `WHERE key = 'ABC'` and a concurrent write of `'abc'`
+/// hash to the same row resource and serialize.
 fn key_columns_row_lockable(schema: &Schema, key_columns: &[usize]) -> bool {
     key_columns.iter().all(|&i| {
         !matches!(
@@ -1638,7 +1644,7 @@ fn parse_checks(def: &TableDef) -> Result<Vec<(String, Expr)>, SqlError> {
 fn enforce_checks(
     checks: &[(String, Expr)],
     row: &[SqlValue],
-    resolver: &Vec<String>,
+    resolver: &impl ColumnResolver,
     eval_ctx: &EvalContext,
     verb: &str,
     table: &str,
@@ -1701,9 +1707,20 @@ fn fk_parent_exists(
         return Ok(true);
     }
     if fk.parent.eq_ignore_ascii_case(&child.name) && child.key_columns.len() == key.len() {
-        return Ok(batch
+        // Fold both the referencing key and each sibling's PK by the parent PK
+        // collation, so a case-insensitive self-reference matches a case-variant
+        // sibling in the same statement — consistent with the folded `rel_get`
+        // above (which handles the committed-row case).
+        let key_coll: Vec<Option<String>> = child
+            .key_columns
             .iter()
-            .any(|r| child.key_columns.iter().zip(key).all(|(&i, k)| &r[i] == k)));
+            .map(|&i| child.collations.get(i).cloned().flatten())
+            .collect();
+        let folded_key = fold_datum_key(key, &key_coll);
+        return Ok(batch.iter().any(|r| {
+            let sibling: Vec<Datum> = child.key_columns.iter().map(|&i| r[i].clone()).collect();
+            fold_datum_key(&sibling, &key_coll) == folded_key
+        }));
     }
     Ok(false)
 }
@@ -1764,6 +1781,23 @@ fn fk_probe_index<'a>(
     })
 }
 
+/// Whether the child FK columns and the referenced parent PK columns have the
+/// same case sensitivity. The FK index fast path folds the probe key by the
+/// *child* column collation (to match the child index's folded keys), while the
+/// insert-time check (`rel_get`) and the scan fallback fold by the *parent* PK
+/// collation; when they disagree (a mixed-collation FK) the fast path can miss a
+/// reference, so it is only used when the collations match — otherwise the scan
+/// fallback (parent collation, consistent with insert) handles it.
+fn fk_collations_match(child: &TableDef, fk: &catalog::ForeignKeyDef, parent: &TableDef) -> bool {
+    fk.columns.len() == parent.key_columns.len()
+        && fk.columns.iter().zip(&parent.key_columns).all(|(&c, &p)| {
+            CollationSensitivity::from_optional(child.collations.get(c).and_then(|x| x.as_deref()))
+                == CollationSensitivity::from_optional(
+                    parent.collations.get(p).and_then(|x| x.as_deref()),
+                )
+        })
+}
+
 /// The error raised when a surviving child row references a removed parent key.
 fn reference_conflict(verb: &str, fk_name: &str, child_name: &str) -> SqlError {
     SqlError::new(
@@ -1791,6 +1825,18 @@ fn enforce_parent_fks(
     if removed_keys.is_empty() {
         return Ok(());
     }
+    // Fold the removed parent keys by the parent PK collation so the scan
+    // fallback matches child references case-insensitively — the same folding the
+    // index fast path gets from the child index's key encoding.
+    let parent_key_coll: Vec<Option<String>> = parent
+        .key_columns
+        .iter()
+        .map(|&i| parent.collations.get(i).cloned().flatten())
+        .collect();
+    let removed_folded: Vec<Vec<Datum>> = removed_keys
+        .iter()
+        .map(|k| fold_datum_key(k, &parent_key_coll))
+        .collect();
     let children: Vec<TableDef> = storage
         .rel_tables()
         .into_iter()
@@ -1816,10 +1862,17 @@ fn enforce_parent_fks(
             // self-reference (whose own being-removed rows must be excluded). If
             // a key fails to encode (unexpected type mismatch), fall back to the
             // scan rather than risk missing a reference.
-            if !self_ref && let Some(index) = fk_probe_index(child, fk) {
+            if !self_ref
+                && fk_collations_match(child, fk, parent)
+                && let Some(index) = fk_probe_index(child, fk)
+            {
                 let mut handled = true;
                 for key in removed_keys {
-                    match crate::relstore::index::encode_index_prefix(key, &index.columns) {
+                    match crate::relstore::index::encode_index_prefix(
+                        key,
+                        &index.columns,
+                        &child.collations,
+                    ) {
                         Ok(lower) => {
                             let upper = crate::relstore::index::prefix_upper_bound(&lower);
                             let matches = storage
@@ -1849,14 +1902,14 @@ fn enforce_parent_fks(
                 if self_ref {
                     let pk: Vec<Datum> =
                         parent.key_columns.iter().map(|&i| row[i].clone()).collect();
-                    if removed_keys.contains(&pk) {
+                    if removed_folded.contains(&fold_datum_key(&pk, &parent_key_coll)) {
                         continue;
                     }
                 }
                 let Some(key) = fk_key(fk, row) else {
                     continue;
                 };
-                if removed_keys.contains(&key) {
+                if removed_folded.contains(&fold_datum_key(&key, &parent_key_coll)) {
                     return Err(reference_conflict(verb, &fk.name, &child.name));
                 }
             }
@@ -1868,6 +1921,23 @@ fn enforce_parent_fks(
 /// The primary-key values of a row (in key-column order).
 fn pk_of(def: &TableDef, row: &[Datum]) -> Vec<Datum> {
     def.key_columns.iter().map(|&i| row[i].clone()).collect()
+}
+
+/// Folds a key's character values to their collation-canonical form (`collations`
+/// parallel to `values`), so value-level key comparisons (e.g. the FK scan
+/// fallback) match case-insensitively, consistent with the folded key bytes.
+fn fold_datum_key(values: &[Datum], collations: &[Option<String>]) -> Vec<Datum> {
+    values
+        .iter()
+        .enumerate()
+        .map(|(i, value)| {
+            crate::relstore::key::fold_key_datum(
+                value,
+                collations.get(i).and_then(|c| c.as_deref()),
+            )
+            .into_owned()
+        })
+        .collect()
 }
 
 /// Maps a parsed [`DataType`] to a storage [`ColumnType`], validating length
@@ -2230,7 +2300,7 @@ fn alter_add_check(
         new_def.name.clone(),
         truthdb_sql::parse_expr(&new_def.predicate)?,
     )];
-    let resolver = schema_names(&schema);
+    let resolver = SchemaScope { schema: &schema };
     let types = schema_types(&schema);
     let rows = storage
         .rel_scan(&def.name)
@@ -2321,7 +2391,7 @@ fn exec_insert(
 
     // CHECK constraints are parsed once and evaluated against each built row.
     let checks = parse_checks(&def)?;
-    let check_resolver = schema_names(&schema);
+    let check_resolver = SchemaScope { schema: &schema };
     let check_types = schema_types(&schema);
 
     // Target column indices. An explicit list may not name the identity column
@@ -2557,7 +2627,7 @@ fn exec_update(
         .ok_or_else(|| SqlError::invalid_object(&update.table.value).at(update.table.span))?;
     reject_dml_on_view(&def)?;
     let schema = def.schema().map_err(|e| map_storage_err(e, &def.name))?;
-    let resolver = schema_names(&schema);
+    let resolver = SchemaScope { schema: &schema };
     let identity_col = def.identity.map(|s| s.column);
     let checks = parse_checks(&def)?;
 
@@ -2666,7 +2736,19 @@ fn exec_update(
             .filter(|r| !old_pks.contains(&pk_of(&def, r)))
             .collect();
         post_rows.extend(updates.iter().map(|(_, _, new)| new.clone()));
-        let post_pks: Vec<Vec<Datum>> = post_rows.iter().map(|r| pk_of(&def, r)).collect();
+        // Fold the surviving PKs and each FK reference by the (self-referenced)
+        // PK collation, so a case-insensitive self-reference matches a case-
+        // variant sibling — consistent with the INSERT batch path
+        // (`fk_parent_exists`) and the DELETE path (`enforce_parent_fks`).
+        let key_coll: Vec<Option<String>> = def
+            .key_columns
+            .iter()
+            .map(|&i| def.collations.get(i).cloned().flatten())
+            .collect();
+        let post_pks: Vec<Vec<Datum>> = post_rows
+            .iter()
+            .map(|r| fold_datum_key(&pk_of(&def, r), &key_coll))
+            .collect();
         for r in &post_rows {
             for fk in def
                 .foreign_keys
@@ -2674,7 +2756,7 @@ fn exec_update(
                 .filter(|fk| fk.parent.eq_ignore_ascii_case(&def.name))
             {
                 if let Some(key) = fk_key(fk, r)
-                    && !post_pks.contains(&key)
+                    && !post_pks.contains(&fold_datum_key(&key, &key_coll))
                 {
                     return Err(fk_child_violation(&fk.name, "UPDATE", &fk.parent));
                 }
@@ -2698,7 +2780,7 @@ fn exec_delete(
         .ok_or_else(|| SqlError::invalid_object(&delete.table.value).at(delete.table.span))?;
     reject_dml_on_view(&def)?;
     let schema = def.schema().map_err(|e| map_storage_err(e, &def.name))?;
-    let resolver = schema_names(&schema);
+    let resolver = SchemaScope { schema: &schema };
 
     let types = schema_types(&schema);
     let located = storage
@@ -2725,8 +2807,32 @@ fn exec_delete(
     Ok(StatementResult::RowsAffected(count as u64))
 }
 
-fn schema_names(schema: &Schema) -> Vec<String> {
-    schema.columns.iter().map(|c| c.name.clone()).collect()
+/// Resolver over a single table's schema columns, carrying per-column collation.
+/// UPDATE/DELETE/CHECK predicate evaluation must go through this (not a bare
+/// `Vec<String>`, whose `ColumnResolver::collation` reports the case-insensitive
+/// default for *every* column) so an explicit `_CS`/`_BIN` column compares
+/// case-sensitively — otherwise a `DELETE ... WHERE cs_col = 'abc'` would fold
+/// case and remove case-variant rows it must keep.
+struct SchemaScope<'a> {
+    schema: &'a Schema,
+}
+
+impl truthdb_sql::eval::ColumnResolver for SchemaScope<'_> {
+    fn resolve(&self, name: &str) -> Option<usize> {
+        self.schema
+            .columns
+            .iter()
+            .position(|c| c.name.eq_ignore_ascii_case(name))
+    }
+
+    fn collation(&self, index: usize) -> CollationSensitivity {
+        CollationSensitivity::from_optional(
+            self.schema
+                .columns
+                .get(index)
+                .and_then(|c| c.collation.as_deref()),
+        )
+    }
 }
 
 fn schema_types(schema: &Schema) -> Vec<ColumnType> {
@@ -2740,7 +2846,7 @@ fn predicate_true(
     where_clause: &Option<Expr>,
     row: &[Datum],
     types: &[ColumnType],
-    resolver: &Vec<String>,
+    resolver: &impl ColumnResolver,
     eval_ctx: &EvalContext,
 ) -> Result<bool, SqlError> {
     let Some(predicate) = where_clause else {
@@ -2786,6 +2892,7 @@ impl Source {
                 .zip(&self.columns)
                 .map(|(qualifier, column)| (qualifier.clone(), column.name.clone()))
                 .collect(),
+            collations: self.collations.clone(),
         }
     }
 }
@@ -2797,11 +2904,23 @@ impl Source {
 pub(super) struct JoinScope {
     /// (qualifier, bare column name) per source column.
     columns: Vec<(Option<String>, String)>,
+    /// Per-column collation names, parallel to `columns` (`None` = database
+    /// default). Empty for correlation-only scopes that never drive comparison.
+    collations: Vec<Option<String>>,
 }
 
 /// Resolver over an output RowSet's columns. Output columns are unqualified,
 /// so a qualified `t.col` reference (e.g. in a grouped query's ORDER BY)
 /// resolves by its bare name.
+///
+/// It does not carry per-column collation, so an *embedded equality* in an
+/// ORDER BY expression over a `_CS`/`_BIN` output column (e.g.
+/// `ORDER BY CASE WHEN code = 'ABC' THEN 0 ELSE 1 END`) folds case
+/// (case-insensitive default). The sort key itself is collation-correct — the
+/// non-aggregated path orders via `sort_collators` (real per-column collation)
+/// and the aggregated/DISTINCT path via `order_key_cmp` — so this only affects a
+/// nested `=` inside an ORDER BY expression on a case-sensitive column: a narrow,
+/// documented limitation.
 struct OutputScope {
     names: Vec<String>,
 }
@@ -2879,6 +2998,12 @@ impl truthdb_sql::eval::ColumnResolver for JoinScope {
             Some(index) => Resolution::Found(index),
             None => Resolution::NotFound,
         }
+    }
+
+    fn collation(&self, index: usize) -> truthdb_sql::collation::CollationSensitivity {
+        truthdb_sql::collation::CollationSensitivity::from_optional(
+            self.collations.get(index).and_then(|c| c.as_deref()),
+        )
     }
 }
 
@@ -3127,7 +3252,10 @@ fn rewrite_select_subqueries(
         .from
         .as_ref()
         .and_then(|from| from_column_names(storage, from))
-        .map(|columns| JoinScope { columns });
+        .map(|columns| JoinScope {
+            collations: Vec::new(),
+            columns,
+        });
     let items = select
         .items
         .iter()
@@ -3431,7 +3559,10 @@ fn subquery_inner_scope(storage: &Storage, subquery: &Select) -> Option<JoinScop
         Some(from) => from_column_names(storage, from)?,
         None => Vec::new(),
     };
-    Some(JoinScope { columns })
+    Some(JoinScope {
+        collations: Vec::new(),
+        columns,
+    })
 }
 
 /// True if `subquery` references a column that resolves in the enclosing `outer`
@@ -3943,7 +4074,21 @@ fn exec_select(
             )?
         };
         if select.distinct {
-            dedup_rows(storage, &mut out)?;
+            // Each output column's collation (resolved back to its source column;
+            // a computed/aliased column has no source column → the case-
+            // insensitive default), so DISTINCT honours an explicit `_CS`/`_BIN`
+            // column exactly like GROUP BY / COUNT(DISTINCT) do.
+            let out_sens: Vec<CollationSensitivity> = out
+                .columns
+                .iter()
+                .map(|c| {
+                    resolver
+                        .resolve(&c.name)
+                        .map(|i| resolver.collation(i))
+                        .unwrap_or(CollationSensitivity::DEFAULT)
+                })
+                .collect();
+            dedup_rows(storage, &mut out, &out_sens)?;
         }
         order_output(&mut out, &select.order_by, eval_ctx)?;
         if let Some(top) = select.top {
@@ -4064,7 +4209,11 @@ fn exec_select_assign(
 
 /// Removes duplicate output rows (SELECT DISTINCT), keeping first occurrence.
 /// NULLs are equal to each other (`Datum` equality), matching SQL Server.
-fn dedup_rows(storage: &Storage, rowset: &mut RowSet) -> Result<(), SqlError> {
+fn dedup_rows(
+    storage: &Storage,
+    rowset: &mut RowSet,
+    sensitivities: &[CollationSensitivity],
+) -> Result<(), SqlError> {
     // Hash-based DISTINCT — O(n) instead of the old O(n²) linear scan. Each
     // output column is single-typed (projection coerced it), so `HashKey`'s
     // `order_key_cmp` equality agrees with the former `Vec<Datum>` equality for
@@ -4072,6 +4221,11 @@ fn dedup_rows(storage: &Storage, rowset: &mut RowSet) -> Result<(), SqlError> {
     // `order_key_cmp` treats NaN as equal, like GROUP BY already did — where the
     // old raw `Datum` `==` kept them distinct.)
     let types: Vec<ColumnType> = rowset.columns.iter().map(|c| c.column_type).collect();
+    // DISTINCT folds string columns by each output column's collation
+    // (`sensitivities`, parallel to the columns), so a `_CI` column folds case
+    // and a `_CS`/`_BIN` column stays exact — consistent with GROUP BY and
+    // COUNT(DISTINCT). `dedup_key` keeps the original row for output.
+    let dedup_key = |row: &[Datum]| hash::fold_hash_key(&row_values(row, &types), sensitivities);
     let approx: usize = rowset.rows.iter().map(|r| approx_row_bytes(r)).sum();
     if approx <= sort_budget() {
         // In-memory: keep first-appearance order (DISTINCT without ORDER BY has
@@ -4079,7 +4233,7 @@ fn dedup_rows(storage: &Storage, rowset: &mut RowSet) -> Result<(), SqlError> {
         let mut seen: std::collections::HashSet<hash::HashKey> = std::collections::HashSet::new();
         rowset
             .rows
-            .retain(|row| seen.insert(hash::HashKey(row_values(row, &types))));
+            .retain(|row| seen.insert(hash::HashKey(dedup_key(row))));
         return Ok(());
     }
 
@@ -4100,7 +4254,10 @@ fn dedup_rows(storage: &Storage, rowset: &mut RowSet) -> Result<(), SqlError> {
         .map(|_| crate::relstore::spill::RowSpool::new(storage))
         .collect();
     for row in &rowset.rows {
-        let key = row_values(row, &types);
+        // Partition by the *folded* key so case-insensitive-equal rows land in
+        // the same partition (else a cross-partition duplicate is missed); the
+        // stored row stays original for output.
+        let key = dedup_key(row);
         parts[partition_of(&key)]
             .write_row(row)
             .map_err(spill_err)?;
@@ -4113,7 +4270,7 @@ fn dedup_rows(storage: &Storage, rowset: &mut RowSet) -> Result<(), SqlError> {
         let mut seen: std::collections::HashSet<hash::HashKey> = std::collections::HashSet::new();
         let mut reader = part.reader();
         while let Some(row) = reader.next_row().map_err(spill_err)? {
-            if seen.insert(hash::HashKey(row_values(&row, &types))) {
+            if seen.insert(hash::HashKey(dedup_key(&row))) {
                 out.push(row);
             }
         }
@@ -5084,6 +5241,7 @@ fn join_sources(
             .zip(&columns)
             .map(|(q, c)| (q.clone(), c.name.clone()))
             .collect(),
+        collations: collations.clone(),
     };
     let left_nulls = vec![Datum::Null; left.columns.len()];
     let right_nulls = vec![Datum::Null; right.columns.len()];
@@ -5474,14 +5632,36 @@ fn hash_join(
     use hash::{HashKey, key_has_null};
     use std::collections::HashMap;
 
+    // The case sensitivity governing each equi-key pair — the combined collation
+    // of its two columns. The hash key is only a *pre-filter*: the full ON
+    // predicate (collation-aware `matches`) re-checks each candidate, so the
+    // buckets must be a superset of true matches. Folding both sides' key strings
+    // by this sensitivity ensures case-insensitive-equal keys share a bucket (an
+    // unfolded, case-sensitive hash would put `'abc'` and `'ABC'` in different
+    // buckets, and the CI `matches` would never be consulted → a lost match).
+    let key_sens: Vec<CollationSensitivity> = equi
+        .iter()
+        .map(|&(i, j)| {
+            CollationSensitivity::from_optional(left.collations.get(i).and_then(|c| c.as_deref()))
+                .combine(CollationSensitivity::from_optional(
+                    right.collations.get(j).and_then(|c| c.as_deref()),
+                ))
+        })
+        .collect();
     let left_key = |l: &[Datum]| -> Vec<SqlValue> {
         equi.iter()
-            .map(|&(i, _)| value::datum_to_sql(&l[i], &left.columns[i].column_type))
+            .zip(&key_sens)
+            .map(|(&(i, _), &sens)| {
+                sens.fold_value(value::datum_to_sql(&l[i], &left.columns[i].column_type))
+            })
             .collect()
     };
     let right_key = |r: &[Datum]| -> Vec<SqlValue> {
         equi.iter()
-            .map(|&(_, j)| value::datum_to_sql(&r[j], &right.columns[j].column_type))
+            .zip(&key_sens)
+            .map(|(&(_, j), &sens)| {
+                sens.fold_value(value::datum_to_sql(&r[j], &right.columns[j].column_type))
+            })
             .collect()
     };
 

--- a/crates/truthdb-core/src/rel/plan.rs
+++ b/crates/truthdb-core/src/rel/plan.rs
@@ -170,18 +170,20 @@ fn as_sarg(
     None
 }
 
-/// Whether a column may back an index *range* seek. An index seek is correct
-/// only when the index's key byte order matches the WHERE filter's compare
-/// order for that column. The filter compares strings by Rust `str` order
-/// (Unicode code point; collation-insensitive for now). Numbers/dates/GUIDs
-/// and VARCHAR (UTF-8 bytes) already match. NVARCHAR index keys are UTF-16BE,
-/// whose byte order diverges from code-point order at supplementary-plane
-/// characters (surrogate pairs) — so an NVARCHAR *range* bound could exclude a
-/// matching row the filter keeps. Equality seeks are exact byte matches and
-/// stay correct for every type, so only NVARCHAR ranges are excluded here.
+/// Whether a column may back an index *range* seek. A seek is correct only when
+/// the index's key byte order matches the WHERE filter's compare order for that
+/// column. The filter now compares strings by the column's collation (Stage 5)
+/// and the index key is folded the same way (`fold_key_datum`), so VARCHAR keys
+/// (UTF-8 bytes of the folded string) match the filter order — equality seeks
+/// (folded literal vs folded key) and VARCHAR ranges stay correct, including
+/// case-insensitively. NVARCHAR index keys are UTF-16BE, whose byte order
+/// diverges from the filter's order at supplementary-plane characters (surrogate
+/// pairs) regardless of folding — so an NVARCHAR *range* bound could exclude a
+/// matching row the filter keeps, and only NVARCHAR ranges are excluded here.
+/// (Equality seeks stay correct for NVARCHAR: they are exact folded-key matches.)
 ///
-/// (When a later stage makes WHERE collation-aware, index keys must switch to
-/// collation sort keys or this gate must widen to non-binary collations too.)
+/// Locale-specific ordering (Swedish å-after-z) would still need collation sort
+/// keys; case-folding alone gives correct *equality*, not linguistic order.
 fn range_seekable_column(column: &Column) -> bool {
     !matches!(column.column_type, ColumnType::NVarChar { .. })
 }
@@ -269,7 +271,7 @@ fn try_index(index: &IndexDef, schema: &Schema, sargs: &[Sarg]) -> Option<(u32, 
     if eq_values.is_empty() && lower_extra.is_none() && upper_extra.is_none() {
         return None;
     }
-    let (lower, upper) = build_bounds(index, &eq_values, &lower_extra, &upper_extra)?;
+    let (lower, upper) = build_bounds(index, schema, &eq_values, &lower_extra, &upper_extra)?;
     let unique_full = index.unique && eq_values.len() == index.columns.len();
     let score = (eq_values.len() as u32) * 10
         + if unique_full { 1000 } else { 0 }
@@ -289,11 +291,16 @@ fn try_index(index: &IndexDef, schema: &Schema, sargs: &[Sarg]) -> Option<(u32, 
 
 fn build_bounds(
     index: &IndexDef,
+    schema: &Schema,
     eq_values: &[Datum],
     lower_extra: &Option<Datum>,
     upper_extra: &Option<Datum>,
 ) -> Option<Bounds> {
     let cols = &index.columns;
+    // Per-column collations (by schema index) so a seek literal folds exactly as
+    // the stored index key did — a case-insensitive character seek matches.
+    let collations: Vec<Option<String>> =
+        schema.columns.iter().map(|c| c.collation.clone()).collect();
     let mut lower_vals = eq_values.to_vec();
     if let Some(value) = lower_extra {
         lower_vals.push(value.clone());
@@ -301,15 +308,15 @@ fn build_bounds(
     let lower = if lower_vals.is_empty() {
         None
     } else {
-        Some(index::encode_index_prefix(&lower_vals, cols).ok()?)
+        Some(index::encode_index_prefix(&lower_vals, cols, &collations).ok()?)
     };
     let upper = if let Some(value) = upper_extra {
         let mut upper_vals = eq_values.to_vec();
         upper_vals.push(value.clone());
-        let encoded = index::encode_index_prefix(&upper_vals, cols).ok()?;
+        let encoded = index::encode_index_prefix(&upper_vals, cols, &collations).ok()?;
         index::prefix_upper_bound(&encoded)
     } else if !eq_values.is_empty() {
-        let encoded = index::encode_index_prefix(eq_values, cols).ok()?;
+        let encoded = index::encode_index_prefix(eq_values, cols, &collations).ok()?;
         index::prefix_upper_bound(&encoded)
     } else {
         None

--- a/crates/truthdb-core/src/relstore/index.rs
+++ b/crates/truthdb-core/src/relstore/index.rs
@@ -15,8 +15,14 @@
 //! is likewise unique (NULL encodes to one byte), as in SQL Server.
 
 use crate::relstore::heap::Rid;
-use crate::relstore::key::encode_datum;
+use crate::relstore::key::{encode_datum, fold_key_datum};
 use crate::relstore::types::{Datum, TypeError};
+
+/// The collation of the schema column at `index` (empty/short slice → the
+/// case-insensitive database default), for folding character index keys.
+fn column_collation(collations: &[Option<String>], index: usize) -> Option<&str> {
+    collations.get(index).and_then(|c| c.as_deref())
+}
 
 /// How to fetch a base-table row from an index entry: by clustered PK key
 /// bytes, or by heap home RID.
@@ -30,21 +36,25 @@ const LOCATOR_KEY: u8 = 0;
 const LOCATOR_RID: u8 = 1;
 
 /// Encodes an index's key columns from a row's values, applying per-column
-/// ASC/DESC direction. `columns` is `(schema index, ascending)` in key order.
+/// ASC/DESC direction. `columns` is `(schema index, ascending)` in key order;
+/// `collations` is the table's per-column collation (by schema index), so a
+/// case-insensitive character index key folds the same way as the clustered key.
 pub fn encode_index_columns(
     values: &[Datum],
     columns: &[(usize, bool)],
+    collations: &[Option<String>],
 ) -> Result<Vec<u8>, TypeError> {
     let mut out = Vec::new();
     for &(index, ascending) in columns {
         let value = values
             .get(index)
             .ok_or_else(|| TypeError(format!("index column {index} out of range")))?;
+        let folded = fold_key_datum(value, column_collation(collations, index));
         if ascending {
-            encode_datum(value, &mut out)?;
+            encode_datum(&folded, &mut out)?;
         } else {
             let start = out.len();
-            encode_datum(value, &mut out)?;
+            encode_datum(&folded, &mut out)?;
             // DESC: invert this column's bytes so ordering reverses.
             for b in &mut out[start..] {
                 *b = !*b;
@@ -56,19 +66,23 @@ pub fn encode_index_columns(
 
 /// Encodes a leading prefix of an index's columns directly from seek values
 /// (`values[i]` is the value for `columns[i]`), applying ASC/DESC. Used to
-/// build index-seek bounds.
+/// build index-seek bounds. Folds the same way as [`encode_index_columns`], so a
+/// seek literal matches the stored (folded) key under a case-insensitive
+/// collation.
 pub fn encode_index_prefix(
     values: &[Datum],
     columns: &[(usize, bool)],
+    collations: &[Option<String>],
 ) -> Result<Vec<u8>, TypeError> {
     let mut out = Vec::new();
     for (i, value) in values.iter().enumerate() {
-        let (_, ascending) = columns[i];
+        let (index, ascending) = columns[i];
+        let folded = fold_key_datum(value, column_collation(collations, index));
         if ascending {
-            encode_datum(value, &mut out)?;
+            encode_datum(&folded, &mut out)?;
         } else {
             let start = out.len();
-            encode_datum(value, &mut out)?;
+            encode_datum(&folded, &mut out)?;
             for b in &mut out[start..] {
                 *b = !*b;
             }
@@ -143,7 +157,10 @@ mod tests {
     use std::cmp::Ordering;
 
     fn key(values: &[Datum], columns: &[(usize, bool)]) -> Vec<u8> {
-        encode_index_columns(values, columns).expect("encode")
+        // Case-sensitive collation everywhere, so these order/DESC tests exercise
+        // the raw byte layout directly (no case-folding of string keys).
+        let cs = vec![Some("Latin1_General_CS_AS".to_string()); 8];
+        encode_index_columns(values, columns, &cs).expect("encode")
     }
 
     #[test]

--- a/crates/truthdb-core/src/relstore/key.rs
+++ b/crates/truthdb-core/src/relstore/key.rs
@@ -15,11 +15,41 @@
 //! Keys are compared, never decoded: B+ tree leaves carry the full row, so
 //! values are always recoverable without reversing this encoding.
 
+use std::borrow::Cow;
+
+use truthdb_sql::collation::CollationSensitivity;
+
 use crate::relstore::row::Schema;
 use crate::relstore::types::{Datum, TypeError};
 
 const NULL_MARKER: u8 = 0x00;
 const VALUE_MARKER: u8 = 0x01;
+
+/// Folds a character key value to its collation-canonical form so keys under a
+/// case-insensitive collation compare, seek, and enforce uniqueness case-
+/// insensitively (`'ABC'` and `'abc'` map to one key). Non-character values and
+/// case-sensitive / binary collations pass through unchanged. Only the *key*
+/// folds — the stored row keeps the original value, so output is unaffected. Both
+/// the stored key and a seek/probe literal fold identically (same column
+/// collation), so `seek(fold('abc'))` finds the row stored as `'ABC'`.
+///
+/// (Case folding, not a full linguistic sort key: `_CI` case-insensitivity is
+/// exact, but locale ordering and accent-insensitivity in *index order* still
+/// need icu sort keys — see [`CollationSensitivity`]'s note.)
+pub fn fold_key_datum<'a>(value: &'a Datum, collation: Option<&str>) -> Cow<'a, Datum> {
+    if CollationSensitivity::from_optional(collation) != CollationSensitivity::CaseInsensitive {
+        return Cow::Borrowed(value);
+    }
+    match value {
+        Datum::VarChar(s) => Cow::Owned(Datum::VarChar(fold_ci(s))),
+        Datum::NVarChar(s) => Cow::Owned(Datum::NVarChar(fold_ci(s))),
+        _ => Cow::Borrowed(value),
+    }
+}
+
+fn fold_ci(s: &str) -> String {
+    CollationSensitivity::CaseInsensitive.fold(s).into_owned()
+}
 
 /// SQL Server's uniqueidentifier comparison evaluates bytes in this
 /// significance order (most significant first).
@@ -40,8 +70,12 @@ pub fn encode_key(
         let value = values
             .get(index)
             .ok_or_else(|| TypeError(format!("row has no value for key column {index}")))?;
-        let _ = column;
-        encode_datum(value, &mut out)?;
+        // Fold character keys by the column's collation so a case-insensitive
+        // clustered/PK key seeks and enforces uniqueness case-insensitively.
+        encode_datum(
+            &fold_key_datum(value, column.collation.as_deref()),
+            &mut out,
+        )?;
     }
     Ok(out)
 }

--- a/crates/truthdb-core/src/storage.rs
+++ b/crates/truthdb-core/src/storage.rs
@@ -503,11 +503,12 @@ fn index_insert_row(
     ctx: &mut RelCtx<'_>,
     txn: &mut TxnLink,
     indexes: &[IndexDef],
+    collations: &[Option<String>],
     values: &[Datum],
     locator: &Locator,
 ) -> Result<(), StorageError> {
     for index in indexes {
-        let index_key = index::encode_index_columns(values, &index.columns)
+        let index_key = index::encode_index_columns(values, &index.columns, collations)
             .map_err(|err| StorageError::InvalidConfig(err.0))?;
         let (key, value) = index::leaf_entry(&index_key, locator, index.unique);
         let tree = BTree {
@@ -534,16 +535,17 @@ fn apply_index_updates(
     ctx: &mut RelCtx<'_>,
     txn: &mut TxnLink,
     indexes: &[IndexDef],
+    collations: &[Option<String>],
     ops: &[(Vec<Datum>, Locator, Vec<Datum>, Locator)],
 ) -> Result<(), StorageError> {
     if indexes.is_empty() {
         return Ok(());
     }
     for (old_values, old_locator, _, _) in ops {
-        index_delete_row(ctx, txn, indexes, old_values, old_locator)?;
+        index_delete_row(ctx, txn, indexes, collations, old_values, old_locator)?;
     }
     for (_, _, new_values, new_locator) in ops {
-        index_insert_row(ctx, txn, indexes, new_values, new_locator)?;
+        index_insert_row(ctx, txn, indexes, collations, new_values, new_locator)?;
     }
     Ok(())
 }
@@ -553,11 +555,12 @@ fn index_delete_row(
     ctx: &mut RelCtx<'_>,
     txn: &mut TxnLink,
     indexes: &[IndexDef],
+    collations: &[Option<String>],
     values: &[Datum],
     locator: &Locator,
 ) -> Result<(), StorageError> {
     for index in indexes {
-        let index_key = index::encode_index_columns(values, &index.columns)
+        let index_key = index::encode_index_columns(values, &index.columns, collations)
             .map_err(|err| StorageError::InvalidConfig(err.0))?;
         let (key, _) = index::leaf_entry(&index_key, locator, index.unique);
         let tree = BTree {
@@ -899,7 +902,7 @@ impl StorageFile {
                     RowLocator::Key(key) => Locator::Key(key.clone()),
                     RowLocator::Rid(rid) => Locator::Rid(*rid),
                 };
-                let index_key = index::encode_index_columns(values, &columns)
+                let index_key = index::encode_index_columns(values, &columns, &def.collations)
                     .map_err(|err| StorageError::InvalidConfig(err.0))?;
                 let (key, value) = index::leaf_entry(&index_key, &locator, unique);
                 // Backfill is system-logged: the fresh tree is not in the
@@ -1052,6 +1055,7 @@ impl StorageFile {
         }
 
         let indexes = def.indexes.clone();
+        let collations = def.collations.clone();
         if def.is_tree() {
             let tree = BTree {
                 object_id: def.object_id,
@@ -1069,7 +1073,14 @@ impl StorageFile {
                         }
                     }
                     // Clustered rows locate by PK key.
-                    index_insert_row(ctx, txn, &indexes, values, &Locator::Key(key.clone()))?;
+                    index_insert_row(
+                        ctx,
+                        txn,
+                        &indexes,
+                        &collations,
+                        values,
+                        &Locator::Key(key.clone()),
+                    )?;
                 }
                 Ok(())
             })
@@ -1082,7 +1093,7 @@ impl StorageFile {
                 for ((_, row), values) in encoded.iter().zip(rows.iter()) {
                     // Heap rows locate by their home RID.
                     let rid = heap.insert(ctx, txn, row)?;
-                    index_insert_row(ctx, txn, &indexes, values, &Locator::Rid(rid))?;
+                    index_insert_row(ctx, txn, &indexes, &collations, values, &Locator::Rid(rid))?;
                 }
                 Ok(())
             })
@@ -1107,9 +1118,16 @@ impl StorageFile {
                 "wrong number of key values".to_string(),
             ));
         }
+        // Fold each key column so a case-insensitive character PK lookup matches
+        // the stored (folded) key — the seek literal must fold exactly as the
+        // stored key did.
         let mut key = Vec::new();
-        for value in key_values {
-            crate::relstore::key::encode_datum(value, &mut key)?;
+        for (value, &col) in key_values.iter().zip(&def.key_columns) {
+            let folded = crate::relstore::key::fold_key_datum(
+                value,
+                schema.columns[col].collation.as_deref(),
+            );
+            crate::relstore::key::encode_datum(&folded, &mut key)?;
         }
         let tree = BTree {
             object_id: def.object_id,
@@ -1361,6 +1379,7 @@ impl StorageFile {
             return Ok(0);
         }
         let indexes = def.indexes.clone();
+        let collations = def.collations.clone();
         if def.is_tree() {
             let tree = BTree {
                 object_id: def.object_id,
@@ -1370,7 +1389,14 @@ impl StorageFile {
                 for (loc, values) in &targets {
                     if let RowLocator::Key(key) = loc {
                         tree.delete(ctx, &mut OpMode::Txn(txn), key)?;
-                        index_delete_row(ctx, txn, &indexes, values, &Locator::Key(key.clone()))?;
+                        index_delete_row(
+                            ctx,
+                            txn,
+                            &indexes,
+                            &collations,
+                            values,
+                            &Locator::Key(key.clone()),
+                        )?;
                     }
                 }
                 Ok(())
@@ -1384,7 +1410,14 @@ impl StorageFile {
                 for (loc, values) in &targets {
                     if let RowLocator::Rid(rid) = loc {
                         heap.delete(ctx, txn, *rid)?;
-                        index_delete_row(ctx, txn, &indexes, values, &Locator::Rid(*rid))?;
+                        index_delete_row(
+                            ctx,
+                            txn,
+                            &indexes,
+                            &collations,
+                            values,
+                            &Locator::Rid(*rid),
+                        )?;
                     }
                 }
                 Ok(())
@@ -1413,6 +1446,7 @@ impl StorageFile {
             return Ok(0);
         }
         let indexes = def.indexes.clone();
+        let collations = def.collations.clone();
         // (old values, old locator, new values, new locator) for index upkeep.
         let mut idx_ops: Vec<(Vec<Datum>, Locator, Vec<Datum>, Locator)> = Vec::new();
         if def.is_tree() {
@@ -1464,7 +1498,7 @@ impl StorageFile {
                 for (key, row) in &in_place {
                     tree.update(ctx, &mut OpMode::Txn(txn), key, row)?;
                 }
-                apply_index_updates(ctx, txn, &indexes, &idx_ops)?;
+                apply_index_updates(ctx, txn, &indexes, &collations, &idx_ops)?;
                 Ok(())
             })?;
         } else {
@@ -1490,7 +1524,7 @@ impl StorageFile {
                 for (rid, row) in &encoded {
                     heap.update(ctx, txn, *rid, row)?;
                 }
-                apply_index_updates(ctx, txn, &indexes, &idx_ops)?;
+                apply_index_updates(ctx, txn, &indexes, &collations, &idx_ops)?;
                 Ok(())
             })?;
         }

--- a/crates/truthdb-sql/src/collation.rs
+++ b/crates/truthdb-sql/src/collation.rs
@@ -1,0 +1,179 @@
+//! Case/accent sensitivity of a collation, for *equality* comparisons.
+//!
+//! Full linguistic ordering (locale-specific sort, accent-insensitivity) lives
+//! behind icu4x in the storage crate and drives `ORDER BY` and index keys. This
+//! module carries only the piece that equality operators (`WHERE =`, joins,
+//! `GROUP BY`, `DISTINCT`, `MIN`/`MAX`) need: whether two strings that differ
+//! only in *case* are equal. The database default collation is case-insensitive
+//! (`..._CI_AS`), so string equality is case-insensitive unless a column is
+//! explicitly declared `_CS`/`_BIN`.
+//!
+//! Accent-insensitivity (`_AI`) is **not** modelled here — the default is
+//! accent-sensitive, and icu4x 1.5 exposes no public sort-key/fold API to derive
+//! a canonical accent-stripped form consistently with the `ORDER BY` collator.
+//! An `_AI` collation therefore behaves accent-sensitively for equality (a
+//! documented limitation, mirroring `collation.rs`'s note that icu cannot express
+//! case-sensitive + accent-insensitive either).
+
+use std::borrow::Cow;
+use std::cmp::Ordering;
+
+use crate::value::SqlValue;
+
+/// Whether string equality folds case. Derived from a SQL Server collation name.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CollationSensitivity {
+    /// Case-insensitive (`_CI`) — the database default. `'abc' == 'ABC'`.
+    CaseInsensitive,
+    /// Case-sensitive (`_CS`) or binary (`_BIN`/`_BIN2`). Compares exactly.
+    CaseSensitive,
+}
+
+impl CollationSensitivity {
+    /// The database default: case-insensitive (matches `DEFAULT_COLLATION`,
+    /// `SQL_Latin1_General_CP1_CI_AS`).
+    pub const DEFAULT: CollationSensitivity = CollationSensitivity::CaseInsensitive;
+
+    /// Parses the case sensitivity out of a SQL Server collation name. A `_BIN`
+    /// or explicit `_CS` name is case-sensitive; everything else (incl. the
+    /// default `_CI`) is case-insensitive.
+    pub fn from_name(name: &str) -> CollationSensitivity {
+        let lower = name.to_ascii_lowercase();
+        if lower.contains("_bin") || lower.contains("_cs") {
+            CollationSensitivity::CaseSensitive
+        } else {
+            CollationSensitivity::CaseInsensitive
+        }
+    }
+
+    /// Parses an optional collation name, defaulting to the database default
+    /// (case-insensitive) when absent — a column with no explicit `COLLATE`
+    /// inherits the case-insensitive database default.
+    pub fn from_optional(name: Option<&str>) -> CollationSensitivity {
+        name.map_or(
+            CollationSensitivity::DEFAULT,
+            CollationSensitivity::from_name,
+        )
+    }
+
+    /// Combines the sensitivities of the operands of one comparison. A single
+    /// explicitly case-sensitive operand forces an exact comparison (this
+    /// resolves a mixed `CI`/`CS` comparison conservatively — toward *not*
+    /// over-matching — rather than raising SQL Server's collation-conflict
+    /// error, which this engine does not model).
+    pub fn combine(self, other: CollationSensitivity) -> CollationSensitivity {
+        match (self, other) {
+            (CollationSensitivity::CaseSensitive, _) | (_, CollationSensitivity::CaseSensitive) => {
+                CollationSensitivity::CaseSensitive
+            }
+            _ => CollationSensitivity::CaseInsensitive,
+        }
+    }
+
+    /// The canonical form of `s` for this sensitivity: lower-cased under a
+    /// case-insensitive collation (so case-variants share a bucket and compare
+    /// equal), unchanged under a case-sensitive one. Case-insensitive folding
+    /// uses Unicode simple lowercasing, which matches the icu secondary-strength
+    /// collator's case equality for realistic (case-only-differing) text; exotic
+    /// Unicode case equivalences the collator recognises but lowercasing does not
+    /// are a documented edge (they only ever *split* a group, never merge
+    /// unequal values).
+    pub fn fold<'a>(self, s: &'a str) -> Cow<'a, str> {
+        match self {
+            CollationSensitivity::CaseSensitive => Cow::Borrowed(s),
+            CollationSensitivity::CaseInsensitive => {
+                if s.is_ascii() {
+                    Cow::Owned(s.to_ascii_lowercase())
+                } else {
+                    Cow::Owned(s.to_lowercase())
+                }
+            }
+        }
+    }
+
+    /// Compares two strings under this sensitivity (case-folded for `_CI`).
+    pub fn compare_str(self, a: &str, b: &str) -> Ordering {
+        match self {
+            CollationSensitivity::CaseSensitive => a.cmp(b),
+            CollationSensitivity::CaseInsensitive => self.fold(a).cmp(&self.fold(b)),
+        }
+    }
+
+    /// Folds a value used as a hash/comparison key: a string is canonicalised for
+    /// this sensitivity (so case-insensitive-equal strings share a bucket and
+    /// compare equal); every other value is returned unchanged. Only the key is
+    /// folded — callers keep the original value for output.
+    pub fn fold_value(self, value: SqlValue) -> SqlValue {
+        match value {
+            SqlValue::Str(s) => SqlValue::Str(self.fold(&s).into_owned()),
+            other => other,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_is_case_insensitive() {
+        assert_eq!(
+            CollationSensitivity::DEFAULT,
+            CollationSensitivity::CaseInsensitive
+        );
+        assert_eq!(
+            CollationSensitivity::from_name("SQL_Latin1_General_CP1_CI_AS"),
+            CollationSensitivity::CaseInsensitive
+        );
+        assert_eq!(
+            CollationSensitivity::from_optional(None),
+            CollationSensitivity::CaseInsensitive
+        );
+    }
+
+    #[test]
+    fn cs_and_bin_are_case_sensitive() {
+        assert_eq!(
+            CollationSensitivity::from_name("Latin1_General_CS_AS"),
+            CollationSensitivity::CaseSensitive
+        );
+        assert_eq!(
+            CollationSensitivity::from_name("Latin1_General_BIN2"),
+            CollationSensitivity::CaseSensitive
+        );
+    }
+
+    #[test]
+    fn ci_folds_case_cs_does_not() {
+        assert_eq!(
+            CollationSensitivity::CaseInsensitive.compare_str("abc", "ABC"),
+            Ordering::Equal
+        );
+        assert_ne!(
+            CollationSensitivity::CaseSensitive.compare_str("abc", "ABC"),
+            Ordering::Equal
+        );
+    }
+
+    #[test]
+    fn ci_folds_non_ascii() {
+        // 'É' (U+00C9) lowercases to 'é' (U+00E9).
+        assert_eq!(
+            CollationSensitivity::CaseInsensitive.compare_str("café É", "café é"),
+            Ordering::Equal
+        );
+        // Accent-sensitive: 'é' != 'e' even under CI.
+        assert_ne!(
+            CollationSensitivity::CaseInsensitive.compare_str("é", "e"),
+            Ordering::Equal
+        );
+    }
+
+    #[test]
+    fn combine_prefers_case_sensitive() {
+        use CollationSensitivity::*;
+        assert_eq!(CaseInsensitive.combine(CaseInsensitive), CaseInsensitive);
+        assert_eq!(CaseInsensitive.combine(CaseSensitive), CaseSensitive);
+        assert_eq!(CaseSensitive.combine(CaseInsensitive), CaseSensitive);
+    }
+}

--- a/crates/truthdb-sql/src/eval.rs
+++ b/crates/truthdb-sql/src/eval.rs
@@ -8,6 +8,7 @@
 use std::cmp::Ordering;
 
 use crate::ast::{BinaryOp, DataType, Expr, ExprKind, Name, UnaryOp};
+use crate::collation::CollationSensitivity;
 use crate::decimal::Decimal;
 use crate::error::{SqlError, SqlResult};
 use crate::functions;
@@ -34,6 +35,15 @@ pub trait ColumnResolver {
             Some(index) => Resolution::Found(index),
             None => Resolution::NotFound,
         }
+    }
+
+    /// The case sensitivity of the column at `index` — its collation. Drives
+    /// case-insensitive string equality. The default (case-insensitive, the
+    /// database default) is used by resolvers with no per-column collation; a
+    /// resolver over base-table columns overrides it to honour explicit
+    /// `_CS`/`_BIN` columns.
+    fn collation(&self, _index: usize) -> CollationSensitivity {
+        CollationSensitivity::DEFAULT
     }
 }
 
@@ -137,7 +147,8 @@ fn eval_at(
         ExprKind::Binary { op, left, right } => {
             let l = eval_at(left, row, resolver, ctx, depth + 1)?;
             let r = eval_at(right, row, resolver, ctx, depth + 1)?;
-            eval_binary(*op, l, r)
+            let sensitivity = comparison_sensitivity(left, right, resolver);
+            eval_binary(*op, l, r, sensitivity)
         }
         ExprKind::Like {
             expr,
@@ -262,7 +273,12 @@ fn eval_like_expr<R: ColumnResolver>(
             "LIKE requires character-string operands".to_string(),
         ));
     };
-    let matched = crate::like::like_match(text, pattern, escape);
+    // Under a case-insensitive collation, fold both sides before matching (LIKE
+    // wildcards are ASCII and survive lowercasing); the LHS column's collation
+    // governs. `_CS`/`_BIN` columns match exactly.
+    let sensitivity = operand_sensitivity(expr, resolver).unwrap_or(CollationSensitivity::DEFAULT);
+    let matched =
+        crate::like::like_match(&sensitivity.fold(text), &sensitivity.fold(pattern), escape);
     Ok(SqlValue::Bool(matched != negated))
 }
 
@@ -287,11 +303,14 @@ fn eval_in_expr<R: ColumnResolver>(
     if value.is_null() {
         return Ok(SqlValue::Null);
     }
+    // The operand's column collation governs the string equality; a list of
+    // literals contributes nothing.
+    let sensitivity = operand_sensitivity(expr, resolver).unwrap_or(CollationSensitivity::DEFAULT);
     // `x IN (list)` is `x=a OR x=b OR ...` under three-valued logic.
     let mut any_unknown = false;
     for item in list {
         let candidate = eval_at(item, row, resolver, ctx, depth + 1)?;
-        match value.compare(&candidate)? {
+        match value.compare_collated(&candidate, sensitivity)? {
             Some(std::cmp::Ordering::Equal) => return Ok(SqlValue::Bool(!negated)),
             None => any_unknown = true,
             _ => {}
@@ -319,9 +338,15 @@ fn eval_between_expr<R: ColumnResolver>(
     let value = eval_at(expr, row, resolver, ctx, depth + 1)?;
     let lo = eval_at(low, row, resolver, ctx, depth + 1)?;
     let hi = eval_at(high, row, resolver, ctx, depth + 1)?;
-    // `x BETWEEN a AND b` is `x>=a AND x<=b` (three-valued).
-    let ge = value.compare(&lo)?.map(|o| o != Ordering::Less);
-    let le = value.compare(&hi)?.map(|o| o != Ordering::Greater);
+    // `x BETWEEN a AND b` is `x>=a AND x<=b` (three-valued); the operand's column
+    // collation governs the string comparison.
+    let sensitivity = operand_sensitivity(expr, resolver).unwrap_or(CollationSensitivity::DEFAULT);
+    let ge = value
+        .compare_collated(&lo, sensitivity)?
+        .map(|o| o != Ordering::Less);
+    let le = value
+        .compare_collated(&hi, sensitivity)?
+        .map(|o| o != Ordering::Greater);
     let within = value::and(ge, le);
     Ok(three_valued(if negated {
         value::not(within)
@@ -614,17 +639,64 @@ fn eval_number_literal(text: &str) -> SqlResult<SqlValue> {
 }
 
 #[inline(never)]
-fn eval_binary(op: BinaryOp, l: SqlValue, r: SqlValue) -> SqlResult<SqlValue> {
+fn eval_binary(
+    op: BinaryOp,
+    l: SqlValue,
+    r: SqlValue,
+    sensitivity: CollationSensitivity,
+) -> SqlResult<SqlValue> {
     use BinaryOp::*;
     match op {
         And => Ok(three_valued(value::and(l.as_predicate(), r.as_predicate()))),
         Or => Ok(three_valued(value::or(l.as_predicate(), r.as_predicate()))),
         Eq | Ne | Lt | Le | Gt | Ge => {
-            let ordering = l.compare(&r)?;
+            let ordering = l.compare_collated(&r, sensitivity)?;
             Ok(three_valued(ordering.map(|ord| compare_matches(op, ord))))
         }
         Add | Sub | Mul | Div | Mod => arithmetic(op, l, r),
     }
+}
+
+/// The case sensitivity governing a comparison of `left` and `right`. A column
+/// operand contributes its column collation (implicit precedence); a literal or
+/// computed expression contributes nothing (coercible-default, which yields). If
+/// any participating column is case-sensitive the comparison is case-sensitive;
+/// otherwise it is case-insensitive (the database default). Ignored for
+/// non-string operands.
+fn comparison_sensitivity(
+    left: &Expr,
+    right: &Expr,
+    resolver: &impl ColumnResolver,
+) -> CollationSensitivity {
+    match (
+        operand_sensitivity(left, resolver),
+        operand_sensitivity(right, resolver),
+    ) {
+        (Some(a), Some(b)) => a.combine(b),
+        (Some(a), None) | (None, Some(a)) => a,
+        (None, None) => CollationSensitivity::DEFAULT,
+    }
+}
+
+/// The implicit collation of `expr` if it is a resolvable column reference, else
+/// `None` (a literal or computed expression is coercible-default and yields to a
+/// column's collation).
+fn operand_sensitivity(
+    expr: &Expr,
+    resolver: &impl ColumnResolver,
+) -> Option<CollationSensitivity> {
+    if let ExprKind::Column(name) = &expr.kind {
+        return resolver.resolve(&name.value).map(|i| resolver.collation(i));
+    }
+    None
+}
+
+/// The collation governing `expr` when it is used as a grouping / join / DISTINCT
+/// key column: its column collation if it is a column reference, else the
+/// database default (case-insensitive). Used by the hash operators to fold key
+/// strings so case-insensitive-equal keys share a bucket.
+pub fn key_collation(expr: &Expr, resolver: &impl ColumnResolver) -> CollationSensitivity {
+    operand_sensitivity(expr, resolver).unwrap_or(CollationSensitivity::DEFAULT)
 }
 
 fn compare_matches(op: BinaryOp, ord: std::cmp::Ordering) -> bool {

--- a/crates/truthdb-sql/src/lib.rs
+++ b/crates/truthdb-sql/src/lib.rs
@@ -7,6 +7,7 @@
 //! Server-compatible numbers (see [`error`]).
 
 pub mod ast;
+pub mod collation;
 pub mod decimal;
 pub mod error;
 pub mod eval;

--- a/crates/truthdb-sql/src/value.rs
+++ b/crates/truthdb-sql/src/value.rs
@@ -9,6 +9,7 @@
 
 use std::cmp::Ordering;
 
+use crate::collation::CollationSensitivity;
 use crate::decimal::Decimal;
 use crate::error::{SqlError, SqlResult};
 use crate::temporal;
@@ -85,6 +86,26 @@ impl SqlValue {
     pub fn compare(&self, other: &SqlValue) -> SqlResult<Option<Ordering>> {
         if self.is_null() || other.is_null() {
             return Ok(None);
+        }
+        self.compare_non_null(other).map(Some)
+    }
+
+    /// Three-valued comparison under a collation's case sensitivity: like
+    /// [`SqlValue::compare`], but two `Str` operands are compared case-folded
+    /// when `sensitivity` is case-insensitive (the database default). Every
+    /// non-string comparison is identical to `compare`. This is the entry point
+    /// for SQL-visible string equality (`WHERE =`, joins, `IN`, `BETWEEN`);
+    /// binary/internal comparisons keep using `compare`.
+    pub fn compare_collated(
+        &self,
+        other: &SqlValue,
+        sensitivity: CollationSensitivity,
+    ) -> SqlResult<Option<Ordering>> {
+        if self.is_null() || other.is_null() {
+            return Ok(None);
+        }
+        if let (SqlValue::Str(a), SqlValue::Str(b)) = (self, other) {
+            return Ok(Some(sensitivity.compare_str(a, b)));
         }
         self.compare_non_null(other).map(Some)
     }


### PR DESCRIPTION
The default collation is `SQL_Latin1_General_CP1_CI_AS` (case-**insensitive**),
but the engine was self-contradictory: `ORDER BY name` already folded case while
`WHERE name = 'ABC'`, `GROUP BY`, joins, and uniqueness did **not**. This makes
case-insensitive string equality consistent everywhere — query layer *and*
storage key layer — honouring explicit `_CS`/`_BIN` columns.

## Query layer
- `eval` compares via `SqlValue::compare_collated`, picking sensitivity from the
  operand column collations (WHERE / JOIN-ON / IN / BETWEEN / LIKE). A `_CS`
  operand forces exact (simplified precedence — no collation-conflict error).
- Hash operators fold key strings by collation — GROUP BY, DISTINCT, hash-join
  (build + probe), and the **grace-hash spill partition routers** — keeping the
  original value for output. MIN/MAX and COUNT(DISTINCT) fold too.
- UPDATE / DELETE / CHECK and the aggregate HAVING/projection resolvers now carry
  per-column collation (`SchemaScope`, `SynthScope`) — a `Vec<String>` resolver
  had reported the CI default for *every* column (a `DELETE ... WHERE cs_col='abc'`
  data-loss bug).

## Storage key layer
`key.rs::fold_key_datum` folds character key **bytes** by collation across the
clustered PK (`encode_key`), secondary indexes (`encode_index_columns/_prefix`,
threaded a per-column `collations` slice), clustered lookup (`rel_get`), index
seeks (`build_bounds`), FK probes (index fast path **gated on collation match** +
the Datum-value scan fallback + self-ref INSERT/UPDATE paths), and the row-lock
hash. So seeks, PK/UNIQUE, and FK all match case-insensitively, and CI-equal
point-writers re-serialise on one row lock — **resolving** the row-lock coupling
flagged last session (no exclusion needed).

## Not done (documented)
icu4x **collation sort keys** for locale-specific ORDER-BY *ordering* (Swedish
å-after-z) and `_AI` accent-insensitivity — blocked by `icu_collator` 1.5 exposing
no public sort-key API. Case-folding gives correct *equality*, not linguistic
order. Two narrow edges documented in-code (ambiguous cross-source
`SELECT DISTINCT a.col`; a `_CS` equality *embedded in* an ORDER BY expression).

## Testing
A CI/CS matrix — folded-key uniqueness, clustered/secondary/FK case-insensitive
seeks, join/GROUP BY/DISTINCT folding, `_CS` exactness, folded-key persistence
across restart — plus a regression test for **every** review finding. SLT corpus
unchanged (no case-sensitivity regressions).

A 3-lens adversarial review + a verification sweep caught **ten** fold-consistency
bugs pre-merge (a `_CS` UPDATE/DELETE data-loss bug and a spilling-GROUP-BY
wrong-grouping bug among them), all fixed and regression-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)