### PR TITLE
Stage 6: statement-level atomicity + SET XACT_ABORT

### DIFF
--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -3787,21 +3787,86 @@ mod tests {
     }
 
     #[test]
-    fn txn_error_dooms_transaction_until_rollback() {
-        let path = unique_temp_path("txn-doomed");
+    fn txn_statement_error_rolls_back_statement_not_transaction() {
+        // SQL Server default (XACT_ABORT OFF): a non-fatal statement error rolls
+        // back only that statement; the transaction stays open and the batch
+        // continues past it.
+        let path = unique_temp_path("txn-stmt-atomic");
         let engine = new_engine(&path);
         let mut ctx = TxnContext::default();
-
         batch(
             &engine,
             &mut ctx,
             "CREATE TABLE t (id INT NOT NULL PRIMARY KEY)",
         );
-        // A duplicate-PK failure inside the transaction dooms it.
+        // The middle INSERT is a duplicate PK (2627, severity 14): it rolls back
+        // only itself; the surrounding inserts still apply and COMMIT persists them.
         let out = batch(
             &engine,
             &mut ctx,
-            "BEGIN TRAN; INSERT INTO t VALUES (1); INSERT INTO t VALUES (1);",
+            "BEGIN TRAN; INSERT INTO t VALUES (1); INSERT INTO t VALUES (1); INSERT INTO t VALUES (2); COMMIT",
+        );
+        assert_eq!(
+            out.error.as_ref().map(|e| e.number),
+            Some(2627),
+            "the duplicate is reported"
+        );
+        assert!(
+            !ctx.has_open_transaction(),
+            "COMMIT ran — the transaction was not doomed"
+        );
+        let out = batch(&engine, &mut ctx, "SELECT id FROM t");
+        assert_eq!(
+            ids(&out),
+            vec![1, 2],
+            "the dup rolled back; 1 and 2 committed"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn txn_partial_multirow_insert_is_atomic() {
+        // A multi-row INSERT that fails partway undoes ALL its rows (statement
+        // atomicity), leaving no partial write in the surviving transaction.
+        let path = unique_temp_path("txn-multirow-atomic");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        batch(
+            &engine,
+            &mut ctx,
+            "CREATE TABLE t (id INT NOT NULL PRIMARY KEY)",
+        );
+        batch(&engine, &mut ctx, "INSERT INTO t VALUES (5)");
+        batch(&engine, &mut ctx, "BEGIN TRAN");
+        // (6) inserts, then (5) is a duplicate — the whole statement rolls back.
+        let out = batch(&engine, &mut ctx, "INSERT INTO t VALUES (6), (5)");
+        assert_eq!(out.error.as_ref().map(|e| e.number), Some(2627));
+        batch(&engine, &mut ctx, "COMMIT");
+        let out = batch(&engine, &mut ctx, "SELECT id FROM t");
+        assert_eq!(
+            ids(&out),
+            vec![5],
+            "the partial (6) was undone with the statement"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn txn_error_dooms_transaction_when_xact_abort_on() {
+        // SET XACT_ABORT ON: a statement error dooms the whole transaction — only
+        // ROLLBACK is then accepted (error 3930).
+        let path = unique_temp_path("txn-doomed");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        batch(
+            &engine,
+            &mut ctx,
+            "CREATE TABLE t (id INT NOT NULL PRIMARY KEY)",
+        );
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "SET XACT_ABORT ON; BEGIN TRAN; INSERT INTO t VALUES (1); INSERT INTO t VALUES (1);",
         );
         assert_eq!(out.error.as_ref().map(|e| e.number), Some(2627));
 
@@ -3919,6 +3984,74 @@ mod tests {
             "SELECT id FROM t ORDER BY id",
         );
         assert_eq!(ids(&out), vec![1]);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn txn_statement_rollback_then_crash_recovers_cleanly() {
+        // A statement rolled back to a savepoint writes CLRs; if the transaction
+        // then crashes uncommitted, recovery must undo the surviving ops and SKIP
+        // the already-compensated statement (follow the CLR chain — never
+        // double-undo). This exercises the ARIES correctness of `rollback_to`.
+        let path = unique_temp_path("txn-stmt-rollback-crash");
+        let engine = new_engine(&path);
+        batch(
+            &engine,
+            &mut TxnContext::default(),
+            "CREATE TABLE t (id INT NOT NULL PRIMARY KEY)",
+        );
+
+        // Session A: open a transaction, insert 10, hit a duplicate-PK (rolled back
+        // to a savepoint under XACT_ABORT OFF), then insert 11 — all uncommitted.
+        let mut ctx_a = TxnContext::default();
+        batch(
+            &engine,
+            &mut ctx_a,
+            "BEGIN TRAN; INSERT INTO t VALUES (10); INSERT INTO t VALUES (10); INSERT INTO t VALUES (11)",
+        );
+        assert!(
+            ctx_a.has_open_transaction(),
+            "the transaction survived the statement error (XACT_ABORT OFF)"
+        );
+
+        // An autocommit insert forces A's WAL records — including the compensation
+        // CLRs from the rolled-back statement — to disk.
+        batch(
+            &engine,
+            &mut TxnContext::default(),
+            "INSERT INTO t VALUES (1)",
+        );
+
+        // Crash before A commits.
+        drop(ctx_a);
+        drop(engine);
+
+        // Recovery undoes A entirely (10 and 11 gone); the compensated duplicate is
+        // skipped via its CLR chain (no double-undo / corruption); row 1 survives.
+        let storage = Storage::open(path.clone()).expect("reopen");
+        let engine = Engine::new(storage).expect("replay");
+        let out = batch(
+            &engine,
+            &mut TxnContext::default(),
+            "SELECT id FROM t ORDER BY id",
+        );
+        assert_eq!(
+            ids(&out),
+            vec![1],
+            "A fully undone; only the committed row survives"
+        );
+        // The table is writable and 10/11 are free again (fully rolled back).
+        batch(
+            &engine,
+            &mut TxnContext::default(),
+            "INSERT INTO t VALUES (10), (11)",
+        );
+        let out = batch(
+            &engine,
+            &mut TxnContext::default(),
+            "SELECT id FROM t ORDER BY id",
+        );
+        assert_eq!(ids(&out), vec![1, 10, 11]);
         let _ = std::fs::remove_file(path);
     }
 

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -150,6 +150,13 @@ pub struct RowSet {
     pub rows: Vec<Vec<Datum>>,
 }
 
+/// Error severity at or above which a statement failure dooms the whole
+/// transaction even under `SET XACT_ABORT OFF` (SQL Server treats severity ≥ 17
+/// as resource/batch-level, versus 11–16 statement-level). Constraint violations
+/// (2627/2601/515/547, severity 14–16) stay below it, so they roll back only the
+/// failing statement and the transaction survives.
+const XACT_ABORT_SEVERITY: u8 = 17;
+
 /// A batch's outcome: the results of the statements that ran, plus the error
 /// that stopped the batch (if any). Statements before an error have already
 /// committed (each statement is autocommit in Stage 3), so their results are
@@ -209,6 +216,10 @@ pub fn execute_batch_with_params(
     // the WAL fsync to one call at the end of the batch (see
     // [`finalize_durability`]).
     let mut committed = false;
+    // The last non-dooming statement error under `SET XACT_ABORT OFF` — the batch
+    // continues past it (SQL Server default), so it is reported alongside the
+    // results rather than terminating the batch.
+    let mut last_error: Option<SqlError> = None;
     for statement in &statements {
         // Flag durability by statement kind, before matching the result: a
         // write/DDL/COMMIT can commit even when it then errors — an autocommit
@@ -219,8 +230,18 @@ pub fn execute_batch_with_params(
         match exec_statement(storage, statement, txn_ctx) {
             Ok(result) => results.push(result),
             Err(error) => {
-                // A statement failure inside an explicit transaction dooms it
-                // (XACT_ABORT-style): only ROLLBACK is then permitted.
+                // Inside an explicit transaction the statement's partial writes
+                // were already undone to a savepoint (`rel_statement_scoped`), so
+                // the transaction is consistent either way. `SET XACT_ABORT` (and
+                // error severity) then decides its fate: OFF (the default) with a
+                // non-fatal error rolls back only the statement and the batch
+                // continues; ON — or a high-severity error — dooms the whole
+                // transaction (only ROLLBACK is then accepted, error 3930).
+                let dooms = txn_ctx.xact_abort || error.level >= XACT_ABORT_SEVERITY;
+                if txn_ctx.in_txn() && !dooms {
+                    last_error = Some(error);
+                    continue;
+                }
                 if txn_ctx.in_txn() {
                     txn_ctx.doomed = true;
                 }
@@ -229,7 +250,7 @@ pub fn execute_batch_with_params(
             }
         }
     }
-    let error = finalize_durability(storage, committed, None);
+    let error = finalize_durability(storage, committed, last_error);
     BatchOutcome { results, error }
 }
 
@@ -257,10 +278,13 @@ fn statement_may_commit(statement: &Statement) -> bool {
 
 /// Blocks until the batch's commit records are fsync-durable (group commit),
 /// when the batch may have committed anything. A durability (fsync) failure
-/// wedges the store — the in-memory state is now ahead of the log, so no
-/// further op may serve it — and is reported unless the batch already carries a
-/// statement error (which the client asked about and takes precedence; the
-/// wedge then surfaces on the next operation).
+/// wedges the store — the in-memory state is now ahead of the log, so no further
+/// op may serve it — and *takes precedence over any `prior` statement error*: a
+/// lost commit is more severe than a statement error the client asked about, and
+/// a benign, continued error (e.g. a duplicate-key under `XACT_ABORT OFF` that
+/// the batch ran past before a real `COMMIT`) must not mask it — otherwise the
+/// client would be told the transaction committed while its data is silently
+/// undone as a loser on restart.
 fn finalize_durability(
     storage: &Storage,
     committed: bool,
@@ -273,7 +297,7 @@ fn finalize_durability(
         Ok(()) => prior,
         Err(err) => {
             storage.wedge();
-            Some(prior.unwrap_or_else(|| map_storage_err(err, "")))
+            Some(map_storage_err(err, ""))
         }
     }
 }

--- a/crates/truthdb-core/src/relstore/ctx.rs
+++ b/crates/truthdb-core/src/relstore/ctx.rs
@@ -74,6 +74,25 @@ pub(crate) struct TxnLink {
     pub undo_log: Vec<(u64, PageOpUndo)>,
 }
 
+/// A marker in a live transaction's log to which a later partial rollback can
+/// return, undoing only the work done since (statement-level atomicity). Captures
+/// the undo-log length and the WAL chain tail at capture time.
+#[derive(Clone, Copy)]
+pub(crate) struct Savepoint {
+    pub undo_len: usize,
+    pub last_lsn: u64,
+}
+
+impl TxnLink {
+    /// Captures a savepoint at the current point in this transaction.
+    pub fn savepoint(&self) -> Savepoint {
+        Savepoint {
+            undo_len: self.undo_log.len(),
+            last_lsn: self.last_lsn,
+        }
+    }
+}
+
 /// How an access-method operation logs its user-visible page op: as a
 /// forward transaction record (with undo) or as a compensation record
 /// during rollback/recovery-undo. Structural changes (splits, new pages)

--- a/crates/truthdb-core/src/relstore/recovery.rs
+++ b/crates/truthdb-core/src/relstore/recovery.rs
@@ -296,6 +296,35 @@ pub(crate) fn undo_one(
     Ok(())
 }
 
+/// Rolls a live transaction back to a [`Savepoint`], undoing only the work done
+/// since it was taken (statement-level atomicity) while the transaction stays
+/// open. Undoes the undo-log suffix in reverse with the same CLR discipline as a
+/// full rollback, so a crash before the eventual commit/rollback recovers
+/// correctly: each compensation CLR's `undo_next` points before the undone op, so
+/// recovery's undo skips it (never double-undoing). The undo-log suffix is
+/// dropped, so a later full rollback unwinds only the surviving prefix.
+pub(crate) fn rollback_to(
+    ctx: &mut RelCtx<'_>,
+    txn: &mut TxnLink,
+    savepoint: crate::relstore::ctx::Savepoint,
+    tree_roots: &HashMap<u32, u64>,
+) -> Result<(), StorageError> {
+    ctx.use_reserve = true;
+    // Detach the suffix (work done after the savepoint) and undo it tail-first.
+    let suffix: Vec<(u64, PageOpUndo)> = txn.undo_log.split_off(savepoint.undo_len);
+    for (index, (lsn, undo)) in suffix.iter().enumerate().rev() {
+        // The predecessor of the first undone op is the savepoint's chain tail,
+        // so its sealing CLR moves the undo cursor back to the savepoint.
+        let prev = if index == 0 {
+            savepoint.last_lsn
+        } else {
+            suffix[index - 1].0
+        };
+        undo_one(ctx, txn, undo, *lsn, prev, tree_roots)?;
+    }
+    Ok(())
+}
+
 /// Rolls back a live transaction (statement failure) using its in-memory
 /// undo log; same CLR discipline as recovery undo.
 pub(crate) fn rollback(

--- a/crates/truthdb-core/src/storage.rs
+++ b/crates/truthdb-core/src/storage.rs
@@ -2027,7 +2027,12 @@ impl StorageFile {
     }
 
     /// Runs one statement under `scope`: autocommit (begin+commit) or appended
-    /// to a caller-held transaction (no commit; partial ops survive an error).
+    /// to a caller-held transaction. In both cases the statement is *atomic* — an
+    /// error undoes its own partial writes. For the explicit transaction, the
+    /// undo is a partial rollback to a savepoint taken before the statement; the
+    /// transaction stays open (the SQL layer decides, per `SET XACT_ABORT`,
+    /// whether to continue or doom it), so a failed statement never leaves partial
+    /// rows behind.
     fn rel_statement_scoped<T>(
         &mut self,
         scope: &mut TxnScope,
@@ -2036,8 +2041,26 @@ impl StorageFile {
         match scope {
             TxnScope::Auto => self.rel_statement(f),
             TxnScope::Explicit(stx) => {
+                let roots = self.rel.tree_roots();
                 let mut ctx = self.rel_ctx();
-                f(&mut ctx, &mut stx.txn)
+                let savepoint = stx.txn.savepoint();
+                let (result, wedged) = match f(&mut ctx, &mut stx.txn) {
+                    Ok(value) => (Ok(value), false),
+                    Err(err) => {
+                        match rel_recovery::rollback_to(&mut ctx, &mut stx.txn, savepoint, &roots) {
+                            Ok(()) => (Err(err), false),
+                            // A half-undone statement the WAL cannot explain:
+                            // wedge the engine (a checkpoint would make it
+                            // permanent), mirroring the autocommit path.
+                            Err(rollback_err) => (Err(rollback_err), true),
+                        }
+                    }
+                };
+                let _ = ctx;
+                if wedged {
+                    self.rel.wedged = true;
+                }
+                result
             }
         }
     }


### PR DESCRIPTION
The engine behaved as if `SET XACT_ABORT` were permanently **ON** — any statement
error inside an explicit transaction doomed the whole transaction. SQL Server's
default is `XACT_ABORT OFF`, where a non-fatal statement error rolls back only
that statement and the transaction continues.

## New ARIES savepoint
- `TxnLink::savepoint()` captures the undo-log length + WAL chain tail.
- `rollback_to(savepoint)` (relstore/recovery.rs) undoes the undo-log **suffix**
  in reverse via the existing `undo_one`/CLR discipline (each sealing CLR's
  `undo_next` = the undone op's predecessor) — **crash-safe by construction**: a
  crash after a partial rollback recovers without double-undoing the compensated
  statement (recovery follows the CLR chain). The suffix is dropped from the
  in-memory undo log, so a later full rollback unwinds only the surviving prefix.

## Wiring
- `rel_statement_scoped`'s explicit-txn arm savepoints before each statement and
  rolls back to it on error — a failed statement undoes only its own writes (a
  partial multi-row `INSERT` undoes **all** its rows). The transaction stays open.
- `execute_batch_with_params` honours `SET XACT_ABORT`: **OFF** (default) with a
  non-fatal error (severity < 17 — constraint violations are 14–16) rolls back
  just the statement and the batch continues, reporting the error alongside the
  surviving results; **ON**, or severity ≥ 17, dooms the transaction (3930).

## Durability fix (found by review)
A benign continued statement error must not mask a `COMMIT`'s fsync failure —
`finalize_durability` now always surfaces a durability failure over a prior
statement error (a lost commit is more severe than a warning the client asked
about; otherwise the client is told the transaction committed while its data is
undone as a loser on restart).

## Testing
Statement + multi-row atomicity, `XACT_ABORT` ON vs OFF, and a
**crash-mid-transaction recovery** test proving a post-savepoint crash undoes
cleanly without double-undo. A 3-lens adversarial review (crash safety, atomicity
scope, XACT_ABORT semantics) found the durability-masking bug — fixed.

Remaining Stage 6/14 error work (all can reuse `rollback_to`): TRY/CATCH,
`XACT_STATE()`, explicit `SAVE TRANSACTION`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)