### PR TITLE
Stage 6: SAVE TRANSACTION / ROLLBACK TRANSACTION <name>

### DIFF
--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -4055,6 +4055,101 @@ mod tests {
         let _ = std::fs::remove_file(path);
     }
 
+    #[test]
+    fn save_transaction_partial_rollback_keeps_earlier_work() {
+        // SAVE TRANSACTION + ROLLBACK TRANSACTION <name> undoes only the work done
+        // since the savepoint; the transaction stays open and commits the rest.
+        let path = unique_temp_path("save-tran");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        batch(
+            &engine,
+            &mut ctx,
+            "CREATE TABLE t (id INT NOT NULL PRIMARY KEY)",
+        );
+        batch(
+            &engine,
+            &mut ctx,
+            "BEGIN TRAN; INSERT INTO t VALUES (1); SAVE TRANSACTION sp; INSERT INTO t VALUES (2); INSERT INTO t VALUES (3)",
+        );
+        // Roll back to the savepoint: 2 and 3 are undone, 1 remains, txn open.
+        let out = batch(&engine, &mut ctx, "ROLLBACK TRANSACTION sp");
+        assert!(out.error.is_none(), "{:?}", out.error);
+        assert!(ctx.has_open_transaction(), "the transaction stays open");
+        let out = batch(&engine, &mut ctx, "SELECT id FROM t ORDER BY id");
+        assert_eq!(ids(&out), vec![1], "2 and 3 rolled back; 1 remains");
+        // The transaction is still usable and commits the survivors.
+        batch(&engine, &mut ctx, "INSERT INTO t VALUES (4); COMMIT");
+        let out = batch(&engine, &mut ctx, "SELECT id FROM t ORDER BY id");
+        assert_eq!(ids(&out), vec![1, 4]);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn rollback_to_unknown_savepoint_errors_3908() {
+        let path = unique_temp_path("save-tran-missing");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        batch(
+            &engine,
+            &mut ctx,
+            "CREATE TABLE t (id INT NOT NULL PRIMARY KEY)",
+        );
+        batch(&engine, &mut ctx, "BEGIN TRAN; INSERT INTO t VALUES (1)");
+        let out = batch(&engine, &mut ctx, "ROLLBACK TRANSACTION nope");
+        assert_eq!(
+            out.error.as_ref().map(|e| e.number),
+            Some(3908),
+            "rolling back to an unknown savepoint errors 3908"
+        );
+        // The transaction is untouched — a full ROLLBACK still works.
+        batch(&engine, &mut ctx, "ROLLBACK");
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn save_transaction_rollback_then_crash_recovers_cleanly() {
+        // A ROLLBACK TO savepoint writes CLRs; if the transaction then crashes
+        // uncommitted, recovery must undo it all without double-undoing the
+        // savepoint-compensated work.
+        let path = unique_temp_path("save-tran-crash");
+        let engine = new_engine(&path);
+        batch(
+            &engine,
+            &mut TxnContext::default(),
+            "CREATE TABLE t (id INT NOT NULL PRIMARY KEY)",
+        );
+        let mut ctx_a = TxnContext::default();
+        batch(
+            &engine,
+            &mut ctx_a,
+            "BEGIN TRAN; INSERT INTO t VALUES (10); SAVE TRANSACTION sp; INSERT INTO t VALUES (11); ROLLBACK TRANSACTION sp; INSERT INTO t VALUES (12)",
+        );
+        assert!(ctx_a.has_open_transaction());
+        // Force A's WAL (incl. the savepoint-rollback CLRs) to disk.
+        batch(
+            &engine,
+            &mut TxnContext::default(),
+            "INSERT INTO t VALUES (1)",
+        );
+        drop(ctx_a);
+        drop(engine);
+
+        let storage = Storage::open(path.clone()).expect("reopen");
+        let engine = Engine::new(storage).expect("replay");
+        let out = batch(
+            &engine,
+            &mut TxnContext::default(),
+            "SELECT id FROM t ORDER BY id",
+        );
+        assert_eq!(
+            ids(&out),
+            vec![1],
+            "A (10/12) fully undone; committed row 1 survives"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
     // ---- secondary indexes + planner (Stage 7) -------------------------
 
     /// Plan text lines for a SELECT under SHOWPLAN_TEXT (one batch so the SET

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -60,6 +60,10 @@ pub struct TxnContext {
     /// surfaced as `SCOPE_IDENTITY()`. Persists across statements until the next
     /// identity INSERT; unaffected by non-identity inserts.
     scope_identity: Option<i64>,
+    /// Named savepoints in the current transaction (`SAVE TRANSACTION <name>`,
+    /// lowercased) → the point to which `ROLLBACK TRANSACTION <name>` returns.
+    /// Cleared when the transaction ends.
+    savepoints: std::collections::HashMap<String, crate::relstore::ctx::Savepoint>,
 }
 
 /// Session isolation level (defaults to READ COMMITTED, like SQL Server).
@@ -764,6 +768,7 @@ pub fn analyze_locks(
             Statement::BeginTransaction { .. }
             | Statement::Commit { .. }
             | Statement::Rollback { .. }
+            | Statement::SaveTransaction { .. }
             | Statement::Set(_)
             | Statement::Declare(_) => {}
         }
@@ -829,7 +834,9 @@ fn exec_statement(
     txn_ctx: &mut TxnContext,
 ) -> Result<StatementResult, SqlError> {
     // A doomed transaction rejects everything but ROLLBACK.
-    if txn_ctx.doomed && !matches!(statement, Statement::Rollback { .. }) {
+    // A doomed transaction accepts only a full ROLLBACK (no savepoint name); a
+    // partial rollback or a new savepoint on a doomed transaction is rejected.
+    if txn_ctx.doomed && !matches!(statement, Statement::Rollback { name: None, .. }) {
         return Err(SqlError::new(
             3930,
             16,
@@ -840,7 +847,8 @@ fn exec_statement(
     match statement {
         Statement::BeginTransaction { .. } => exec_begin(storage, txn_ctx),
         Statement::Commit { .. } => exec_commit(storage, txn_ctx),
-        Statement::Rollback { .. } => exec_rollback(storage, txn_ctx),
+        Statement::Rollback { name, .. } => exec_rollback(storage, txn_ctx, name.as_ref()),
+        Statement::SaveTransaction { name, .. } => exec_save(storage, txn_ctx, name),
         Statement::Set(set) => exec_set(txn_ctx, set),
         Statement::Declare(decls) => exec_declare(txn_ctx, decls),
         Statement::CreateTable(create) => {
@@ -1010,6 +1018,7 @@ fn exec_commit(storage: &Storage, ctx: &mut TxnContext) -> Result<StatementResul
     if ctx.trancount == 0
         && let Some(txn) = ctx.txn.take()
     {
+        ctx.savepoints.clear();
         storage
             .rel_commit(txn)
             .map_err(|e| map_storage_err(e, ""))?;
@@ -1017,7 +1026,11 @@ fn exec_commit(storage: &Storage, ctx: &mut TxnContext) -> Result<StatementResul
     Ok(StatementResult::Done)
 }
 
-fn exec_rollback(storage: &Storage, ctx: &mut TxnContext) -> Result<StatementResult, SqlError> {
+fn exec_rollback(
+    storage: &Storage,
+    ctx: &mut TxnContext,
+    name: Option<&Name>,
+) -> Result<StatementResult, SqlError> {
     if ctx.trancount == 0 {
         return Err(SqlError::new(
             3903,
@@ -1026,10 +1039,39 @@ fn exec_rollback(storage: &Storage, ctx: &mut TxnContext) -> Result<StatementRes
             "The ROLLBACK TRANSACTION request has no corresponding BEGIN TRANSACTION.",
         ));
     }
-    // ROLLBACK always unwinds the whole transaction, regardless of nesting.
-    // Reset the session's transaction counters even if the storage rollback
-    // fails (which wedges the store): the transaction is over either way, so
-    // leaving @@TRANCOUNT / doomed set would desync the session.
+    // ROLLBACK <savepoint>: partial rollback — the transaction stays open and
+    // @@TRANCOUNT is unchanged; only the work done since the savepoint is undone.
+    if let Some(name) = name {
+        let Some(savepoint) = ctx
+            .savepoints
+            .get(&name.value.to_ascii_lowercase())
+            .copied()
+        else {
+            return Err(SqlError::new(
+                3908,
+                16,
+                1,
+                format!(
+                    "Cannot roll back {}. No transaction or savepoint of that name was found.",
+                    name.value
+                ),
+            ));
+        };
+        if let Some(txn) = ctx.txn.as_mut() {
+            storage
+                .rel_rollback_to(txn, savepoint)
+                .map_err(|e| map_storage_err(e, ""))?;
+        }
+        // Savepoints taken after this one are invalidated — their undo-log suffix
+        // was just discarded (the target savepoint itself remains re-usable).
+        ctx.savepoints
+            .retain(|_, sp| sp.undo_len <= savepoint.undo_len);
+        return Ok(StatementResult::Done);
+    }
+    // ROLLBACK (whole transaction), regardless of nesting. Reset the session's
+    // transaction counters even if the storage rollback fails (which wedges the
+    // store): the transaction is over either way, so leaving @@TRANCOUNT /
+    // doomed set would desync the session.
     let result = match ctx.txn.take() {
         Some(txn) => storage
             .rel_rollback(txn)
@@ -1038,7 +1080,25 @@ fn exec_rollback(storage: &Storage, ctx: &mut TxnContext) -> Result<StatementRes
     };
     ctx.trancount = 0;
     ctx.doomed = false;
+    ctx.savepoints.clear();
     result.map(|()| StatementResult::Done)
+}
+
+/// `SAVE TRANSACTION <name>`: record a savepoint the transaction can later roll
+/// back to. Requires an active transaction (in autocommit there is nothing to
+/// save, so it is a no-op). Re-saving an existing name overwrites it, as in
+/// SQL Server.
+fn exec_save(
+    storage: &Storage,
+    ctx: &mut TxnContext,
+    name: &Name,
+) -> Result<StatementResult, SqlError> {
+    if let Some(txn) = ctx.txn.as_ref() {
+        let savepoint = storage.rel_savepoint(txn);
+        ctx.savepoints
+            .insert(name.value.to_ascii_lowercase(), savepoint);
+    }
+    Ok(StatementResult::Done)
 }
 
 fn exec_set(ctx: &mut TxnContext, set: &SetStatement) -> Result<StatementResult, SqlError> {

--- a/crates/truthdb-core/src/storage.rs
+++ b/crates/truthdb-core/src/storage.rs
@@ -448,6 +448,22 @@ impl Storage {
         self.lock().rel_rollback(txn)
     }
 
+    /// Captures a savepoint in a caller-held transaction (`SAVE TRANSACTION`).
+    pub(crate) fn rel_savepoint(&self, txn: &StorageTxn) -> crate::relstore::ctx::Savepoint {
+        txn.txn.savepoint()
+    }
+
+    /// Rolls a caller-held transaction back to a savepoint (`ROLLBACK
+    /// TRANSACTION <name>`), undoing only the work done since; the transaction
+    /// stays open.
+    pub(crate) fn rel_rollback_to(
+        &self,
+        txn: &mut StorageTxn,
+        savepoint: crate::relstore::ctx::Savepoint,
+    ) -> Result<(), StorageError> {
+        self.lock().rollback_txn_to(txn, savepoint)
+    }
+
     pub(crate) fn has_active_transactions(&self) -> bool {
         self.lock().has_active_transactions()
     }
@@ -2100,6 +2116,29 @@ impl StorageFile {
         let roots = stx.roots;
         let mut ctx = self.rel_ctx();
         match rel_recovery::rollback(&mut ctx, stx.txn, &roots) {
+            Ok(()) => {
+                let _ = ctx.io.wal.sync_all();
+                Ok(())
+            }
+            Err(err) => {
+                self.rel.wedged = true;
+                Err(err)
+            }
+        }
+    }
+
+    /// Rolls a still-open transaction back to a savepoint (partial rollback,
+    /// `ROLLBACK TRANSACTION <name>`). The transaction remains active — its count
+    /// is untouched — so only the work done since the savepoint is undone.
+    fn rollback_txn_to(
+        &mut self,
+        stx: &mut StorageTxn,
+        savepoint: crate::relstore::ctx::Savepoint,
+    ) -> Result<(), StorageError> {
+        self.ensure_rel_usable()?;
+        let roots = stx.roots.clone();
+        let mut ctx = self.rel_ctx();
+        match rel_recovery::rollback_to(&mut ctx, &mut stx.txn, savepoint, &roots) {
             Ok(()) => {
                 let _ = ctx.io.wal.sync_all();
                 Ok(())

--- a/crates/truthdb-sql/src/ast.rs
+++ b/crates/truthdb-sql/src/ast.rs
@@ -24,8 +24,15 @@ pub enum Statement {
     Commit {
         span: Span,
     },
-    /// `ROLLBACK [TRAN[SACTION]] [name]`.
+    /// `ROLLBACK [TRAN[SACTION]] [name]`. A `name` rolls back to that savepoint
+    /// (the transaction stays open); no name rolls back the whole transaction.
     Rollback {
+        name: Option<Name>,
+        span: Span,
+    },
+    /// `SAVE TRAN[SACTION] name` — a named savepoint within a transaction.
+    SaveTransaction {
+        name: Name,
         span: Span,
     },
     /// `SET` session option (XACT_ABORT / TRANSACTION ISOLATION LEVEL) or a

--- a/crates/truthdb-sql/src/parser.rs
+++ b/crates/truthdb-sql/src/parser.rs
@@ -115,6 +115,7 @@ impl Parser {
             Some("BEGIN") => self.parse_begin(),
             Some("COMMIT") => self.parse_commit(),
             Some("ROLLBACK") => self.parse_rollback(),
+            Some("SAVE") => self.parse_save(),
             Some("SET") => self.parse_set(),
             Some("DECLARE") => self.parse_declare(),
             _ => {
@@ -156,10 +157,39 @@ impl Parser {
 
     fn parse_rollback(&mut self) -> SqlResult<Statement> {
         let start = self.expect_keyword("ROLLBACK")?;
-        let end = self.eat_optional_tran_and_name(start);
+        let mut end = start;
+        if matches!(
+            self.peek_keyword().as_deref(),
+            Some("TRAN") | Some("TRANSACTION") | Some("WORK")
+        ) {
+            end = self.bump().span;
+        }
+        // A name after ROLLBACK [TRAN] targets a savepoint (partial rollback).
+        let name = self.parse_optional_txn_name();
+        if let Some(n) = &name {
+            end = n.span;
+        }
         Ok(Statement::Rollback {
+            name,
             span: start.to(end),
         })
+    }
+
+    fn parse_save(&mut self) -> SqlResult<Statement> {
+        let start = self.expect_keyword("SAVE")?;
+        // SAVE TRAN[SACTION] <name> — both the keyword and the name are required.
+        match self.peek_keyword().as_deref() {
+            Some("TRAN") | Some("TRANSACTION") => {
+                self.bump();
+            }
+            _ => {
+                let token = self.peek().clone();
+                return Err(SqlError::syntax(self.token_text(&token), token.span));
+            }
+        }
+        let name = self.parse_name()?;
+        let span = start.to(name.span);
+        Ok(Statement::SaveTransaction { name, span })
     }
 
     /// Consumes an optional `TRAN`/`TRANSACTION`/`WORK` keyword and transaction


### PR DESCRIPTION
Named savepoints, built on the `rollback_to` primitive from statement-level
atomicity (#83). `SAVE TRANSACTION <name>` records a savepoint in the open
transaction; `ROLLBACK TRANSACTION <name>` partially rolls back to it — the
transaction stays open and `@@TRANCOUNT` is unchanged, only work since the
savepoint is undone.

## Changes
- **Storage**: `rel_savepoint(txn)` captures a `Savepoint`; `rel_rollback_to(txn,
  sp)` runs a partial rollback (the transaction stays active).
- **Parser**: `SAVE TRAN[SACTION] <name>` (name required); `ROLLBACK [TRAN]` now
  captures an optional savepoint name (AST `Rollback` gains `name`; new
  `SaveTransaction`).
- **Executor**: `TxnContext` holds a `name → Savepoint` map. `ROLLBACK TO`
  invalidates later savepoints and errors **3908** for an unknown name;
  savepoints clear on the outermost `COMMIT` / full `ROLLBACK`; a doomed
  transaction rejects `SAVE` and partial `ROLLBACK` (only a full `ROLLBACK`).

## Testing
Partial rollback keeps earlier work and commits the rest, unknown-name 3908, and
a **crash-mid-transaction recovery** through a `ROLLBACK TO` savepoint (reusing
the crash-safe CLR discipline). A focused adversarial verification of the
savepoint semantics (invalidation, nesting/`@@TRANCOUNT`, lifetime, doomed
interaction, no-txn error ordering, staleness across full-rollback, parser edges)
found no issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)