### PR TITLE
Stage 2: fuzzy checkpoints (checkpoint with open transactions)

### DIFF
--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -228,23 +228,18 @@ impl Engine {
     }
 
     fn maybe_checkpoint(&self, meta: &EngineMeta) -> Result<(), EngineError> {
-        // A checkpoint flushes dirty pages and truncates the WAL head. While a
-        // transaction is open its uncommitted pages would be made durable and
-        // its undo records discarded, so a crash could not roll it back. The
-        // check-and-write must be atomic: with a concurrent worker pool a
-        // transaction can begin between a bare check and the truncation, so the
-        // decision is re-made under the storage lock in `checkpoint_if_quiescent`
-        // (which no transaction can `begin` across). The bare pre-check here
-        // just avoids serializing state on every batch in the common case.
-        if self.storage.has_active_transactions()
-            || self.wal_usage_ratio() < WAL_CHECKPOINT_THRESHOLD
-        {
+        // A (fuzzy) checkpoint flushes dirty pages and truncates the WAL head to
+        // the oldest open transaction's begin LSN, so it may run with open
+        // transactions (their undo survives). The decision is (re-)made under the
+        // storage lock in `checkpoint_if_wal_full`; this bare pre-check just
+        // avoids serializing state on every batch below the WAL threshold.
+        if self.wal_usage_ratio() < WAL_CHECKPOINT_THRESHOLD {
             return Ok(());
         }
         let data = serde_json::to_vec(&meta.state)
             .map_err(|err| EngineError::Replay(format!("failed to serialize state: {err}")))?;
         let checkpoint_seq = meta.next_seq_no.saturating_sub(1);
-        self.storage.checkpoint_if_quiescent(
+        self.storage.checkpoint_if_wal_full(
             &data,
             checkpoint_seq,
             meta.next_seq_no,

--- a/crates/truthdb-core/src/relstore/mod.rs
+++ b/crates/truthdb-core/src/relstore/mod.rs
@@ -40,11 +40,12 @@ pub(crate) struct RelState {
     pub tables: HashMap<String, TableDef>,
     pub next_txn_id: u64,
     pub next_object_id: u32,
-    /// Open explicit (multi-statement) transactions. A checkpoint must not run
-    /// while any is open: it would flush their uncommitted pages and truncate
-    /// the WAL past their undo records, making uncommitted writes permanent on
-    /// crash. Autocommit statements never leave one open across calls.
-    pub active_txns: u32,
+    /// Open explicit (multi-statement) transactions: txn id → its `BEGIN` LSN.
+    /// A (fuzzy) checkpoint may run while these are open — it flushes their
+    /// (uncommitted) pages under the steal policy — but must clamp the WAL head
+    /// to the *oldest* begin LSN here so their undo records survive for crash
+    /// rollback. Autocommit statements never leave one open across calls.
+    pub active_txn_begins: std::collections::BTreeMap<u64, u64>,
 }
 
 impl RelState {
@@ -57,7 +58,7 @@ impl RelState {
             tables: HashMap::new(),
             next_txn_id: 1,
             next_object_id: FIRST_USER_OBJECT_ID,
-            active_txns: 0,
+            active_txn_begins: std::collections::BTreeMap::new(),
         }
     }
 

--- a/crates/truthdb-core/src/relstore/tests.rs
+++ b/crates/truthdb-core/src/relstore/tests.rs
@@ -157,11 +157,10 @@ fn committed_statements_survive_crash_without_checkpoint() {
 }
 
 #[test]
-fn active_transaction_count_gates_checkpoints() {
-    // The checkpoint gate (Engine::maybe_checkpoint) reads
-    // `has_active_transactions`; verify it tracks explicit transactions across
-    // both the commit and rollback paths so a checkpoint can never run while
-    // an explicit transaction is open (which would truncate its undo records).
+fn active_transaction_count_tracks_open_transactions() {
+    // The active-transaction set (which a fuzzy checkpoint clamps the WAL head
+    // to) must track explicit transactions across both the commit and rollback
+    // paths, so `has_active_transactions` flips on begin and off on end.
     let path = unique_temp_path("active-txn-gate");
     let mut storage = create_storage(&path);
     assert!(!storage.has_active_transactions());
@@ -185,6 +184,90 @@ fn active_transaction_count_gates_checkpoints() {
         "rollback clears the active transaction"
     );
 
+    drop(storage);
+    let _ = std::fs::remove_file(path);
+}
+
+#[test]
+fn fuzzy_checkpoint_with_open_txn_then_crash_undoes_it() {
+    // A checkpoint may now run WHILE an explicit transaction is open. It flushes
+    // the txn's uncommitted page but clamps the WAL head to the txn's begin LSN,
+    // so its undo survives. On crash the open txn is rolled back; a row committed
+    // before the checkpoint survives.
+    use crate::storage::TxnScope;
+    let path = unique_temp_path("fuzzy-ckpt-crash");
+    let mut storage = create_storage(&path);
+    create_tree_table(&mut storage, "t");
+    storage
+        .rel_insert("t", row(1, "committed"))
+        .expect("insert 1");
+
+    let mut txn = storage.rel_begin().expect("begin");
+    storage
+        .rel_insert_many(
+            "t",
+            vec![row(99, "uncommitted")],
+            &mut TxnScope::Explicit(&mut txn),
+        )
+        .expect("insert 99 under txn");
+    assert!(storage.has_active_transactions());
+
+    // Fuzzy checkpoint with the transaction still open (previously refused).
+    storage
+        .write_checkpoint(b"fuzzy", 1, 2, 1)
+        .expect("checkpoint runs with an open transaction");
+
+    drop(txn); // crash before commit
+    drop(storage);
+
+    let mut storage = Storage::open(path.clone()).expect("reopen");
+    assert_eq!(
+        scan_ids(&mut storage, "t"),
+        vec![1],
+        "open txn rolled back after the fuzzy checkpoint; committed row survives"
+    );
+    drop(storage);
+    let _ = std::fs::remove_file(path);
+}
+
+#[test]
+fn fuzzy_checkpoint_then_commit_survives_crash() {
+    // Work done both before AND after a fuzzy checkpoint, then committed, must
+    // survive a crash — the checkpoint clamped the WAL head to the txn's begin,
+    // so redo replays everything the commit made durable.
+    use crate::storage::TxnScope;
+    let path = unique_temp_path("fuzzy-ckpt-commit");
+    let mut storage = create_storage(&path);
+    create_tree_table(&mut storage, "t");
+
+    let mut txn = storage.rel_begin().expect("begin");
+    storage
+        .rel_insert_many(
+            "t",
+            vec![row(50, "before-ckpt")],
+            &mut TxnScope::Explicit(&mut txn),
+        )
+        .expect("insert 50");
+    storage
+        .write_checkpoint(b"fuzzy", 1, 2, 1)
+        .expect("checkpoint with open txn");
+    storage
+        .rel_insert_many(
+            "t",
+            vec![row(51, "after-ckpt")],
+            &mut TxnScope::Explicit(&mut txn),
+        )
+        .expect("insert 51");
+    storage.rel_commit(txn).expect("commit forces the log");
+
+    drop(storage); // crash after commit
+
+    let mut storage = Storage::open(path.clone()).expect("reopen");
+    assert_eq!(
+        scan_ids(&mut storage, "t"),
+        vec![50, 51],
+        "both pre- and post-checkpoint rows of the committed txn survive"
+    );
     drop(storage);
     let _ = std::fs::remove_file(path);
 }

--- a/crates/truthdb-core/src/storage.rs
+++ b/crates/truthdb-core/src/storage.rs
@@ -240,14 +240,14 @@ impl Storage {
             .write_checkpoint(data, checkpoint_seq, next_seq_no, next_doc_id)
     }
 
-    /// Writes a checkpoint only if no transaction is active and the WAL is at
-    /// least `threshold` full — decided and written under a single lock hold, so
-    /// a transaction cannot `begin` (which also takes this lock) in the window
-    /// between the check and the WAL truncation. Without that atomicity a
-    /// concurrent worker could open a transaction just after the check, and the
-    /// checkpoint would flush its uncommitted pages and discard its undo,
-    /// resurrecting uncommitted data after a crash. Returns whether it wrote.
-    pub fn checkpoint_if_quiescent(
+    /// Writes a checkpoint if the WAL is at least `threshold` full. This is a
+    /// *fuzzy* checkpoint: it may run with open explicit transactions — it
+    /// flushes their (uncommitted) pages under the steal policy and clamps the
+    /// WAL head to the oldest open transaction's begin LSN, so their undo records
+    /// survive a crash. Decided and written under one lock hold (a transaction
+    /// cannot `begin`, changing the oldest begin LSN, in the window between the
+    /// clamp computation and the truncation). Returns whether it wrote.
+    pub fn checkpoint_if_wal_full(
         &self,
         data: &[u8],
         checkpoint_seq: u64,
@@ -259,7 +259,7 @@ impl Storage {
         // A wedged store's in-memory state is ahead of the durable log after a
         // failed fsync; checkpointing would flush and re-fsync exactly the data
         // whose durability failed (and was reported to the client as failed).
-        if file.rel.wedged || file.has_active_transactions() || file.wal_usage_ratio() < threshold {
+        if file.rel.wedged || file.wal_usage_ratio() < threshold {
             return Ok(false);
         }
         file.write_checkpoint(data, checkpoint_seq, next_seq_no, next_doc_id)?;
@@ -464,6 +464,7 @@ impl Storage {
         self.lock().rollback_txn_to(txn, savepoint)
     }
 
+    #[cfg(test)]
     pub(crate) fn has_active_transactions(&self) -> bool {
         self.lock().has_active_transactions()
     }
@@ -2089,9 +2090,10 @@ impl StorageFile {
         let roots = self.rel.tree_roots();
         let mut ctx = self.rel_ctx();
         let txn = ctx.begin(txn_id)?;
-        // The transaction is now open (its undo records must survive until it
-        // commits or rolls back, which gates checkpoints — see `active_txns`).
-        self.rel.active_txns += 1;
+        // Track the transaction's BEGIN LSN so a checkpoint clamps the WAL head
+        // to the oldest open transaction, preserving its undo records for crash
+        // rollback (its uncommitted pages may still be flushed under steal).
+        self.rel.active_txn_begins.insert(txn.txn_id, txn.last_lsn);
         Ok(StorageTxn { txn, roots })
     }
 
@@ -2099,7 +2101,7 @@ impl StorageFile {
     /// store, as for autocommit commits.
     fn commit_txn(&mut self, stx: StorageTxn) -> Result<(), StorageError> {
         // The transaction is ending (the `StorageTxn` is consumed either way).
-        self.rel.active_txns = self.rel.active_txns.saturating_sub(1);
+        self.rel.active_txn_begins.remove(&stx.txn.txn_id);
         let mut ctx = self.rel_ctx();
         match ctx.commit(stx.txn) {
             Ok(()) => Ok(()),
@@ -2112,7 +2114,7 @@ impl StorageFile {
 
     /// Rolls back a caller-held transaction via its in-memory undo log (CLRs).
     fn rollback_txn(&mut self, stx: StorageTxn) -> Result<(), StorageError> {
-        self.rel.active_txns = self.rel.active_txns.saturating_sub(1);
+        self.rel.active_txn_begins.remove(&stx.txn.txn_id);
         let roots = stx.roots;
         let mut ctx = self.rel_ctx();
         match rel_recovery::rollback(&mut ctx, stx.txn, &roots) {
@@ -2150,11 +2152,21 @@ impl StorageFile {
         }
     }
 
-    /// Whether any explicit transaction is open. A checkpoint must be skipped
-    /// while this is true (its WAL truncation would discard undo records still
-    /// needed to roll the open transaction back after a crash).
+    /// Whether any explicit transaction is open.
+    #[cfg(test)]
     fn has_active_transactions(&self) -> bool {
-        self.rel.active_txns > 0
+        !self.rel.active_txn_begins.is_empty()
+    }
+
+    /// The WAL LSN a checkpoint may truncate up to: the oldest open transaction's
+    /// BEGIN LSN (so its undo records survive), or the WAL tail if none is open.
+    fn checkpoint_wal_head(&self) -> u64 {
+        self.rel
+            .active_txn_begins
+            .values()
+            .min()
+            .copied()
+            .map_or(self.wal.tail(), |oldest| oldest.min(self.wal.tail()))
     }
 
     fn ensure_rel_usable(&self) -> Result<(), StorageError> {
@@ -2484,12 +2496,11 @@ impl StorageFile {
         desc_offset: u64,
         data_write_offset: u64,
     ) -> Result<(), StorageError> {
-        // Flush every dirty relational page (WAL-before-data enforced per
-        // page by the pool) and reset the dirty-page table: the next change
-        // to any page starts a fresh FPI epoch. With the engine single-
-        // threaded, no relational transaction can span a checkpoint, so the
-        // WAL head may advance to the tail below (a future concurrent engine
-        // must clamp it to the oldest active transaction's begin LSN).
+        // Flush every dirty relational page (WAL-before-data enforced per page
+        // by the pool) and reset the dirty-page table: the next change to any
+        // page starts a fresh FPI epoch. Flushing an *uncommitted* page is safe
+        // (ARIES steal) because the WAL head is clamped below to the oldest open
+        // transaction's begin LSN, so its undo records survive to roll it back.
         self.wal.sync_all()?;
         {
             let RelState { pool, dpt, .. } = &mut self.rel;
@@ -2522,9 +2533,10 @@ impl StorageFile {
             .write_all_at(self.layout.allocator_offset, &bitmap)?;
         self.file.sync_data()?;
 
-        // 4. Advance the WAL head and publish both superblocks (new active
-        //    first).
-        self.wal.set_head(self.wal.tail());
+        // 4. Advance the WAL head — to the tail, or clamped to the oldest open
+        //    transaction's begin LSN so its undo survives (fuzzy checkpoint) —
+        //    and publish both superblocks (new active first).
+        self.wal.set_head(self.checkpoint_wal_head());
         let new_active = match self.active_superblock {
             ActiveSuperblock::A => ActiveSuperblock::B,
             ActiveSuperblock::B => ActiveSuperblock::A,


### PR DESCRIPTION
Closes the Stage 2 🟡 gap: checkpoints were **quiescent** — refused while any
explicit transaction was open — because truncating the WAL head to the tail
would discard undo records an open txn needs for crash rollback. Under continuous
load the WAL could never truncate.

Now the checkpoint is **fuzzy**: it may run with open transactions. It still
flushes all dirty pages (ARIES steal — flushing an uncommitted page is safe), but
**clamps the WAL head to the oldest open transaction's begin LSN** instead of the
tail, so every open txn's redo + undo records survive.

- `RelState` tracks active txns' begin LSNs (`BTreeMap<txn_id, begin_lsn>`)
  instead of a bare count.
- `finish_checkpoint` advances the head to `min(oldest begin LSN, tail)`.
- `checkpoint_if_quiescent` → `checkpoint_if_wal_full`: active-txn gate dropped.

The ES/search subsystem shares the WAL ring but filters replay by snapshot
sequence, not `wal_head`, so retaining its sub-checkpoint entries doesn't
double-apply them.

**Tested** (crash-recovery): a fuzzy checkpoint + open txn + crash rolls the txn
back while a pre-checkpoint committed row survives; and a txn with work before and
after a fuzzy checkpoint, then committed, survives a crash. A 3-lens adversarial
review (undo/redo survival, allocator replay from a clamped head, shared-WAL /
ring capacity) found no issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)