### PR TITLE
Stage 4: TDS Attention (cancel) aborts a running statement

### DIFF
--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -4051,6 +4051,37 @@ mod tests {
     }
 
     #[test]
+    fn attention_cancel_aborts_a_batch() {
+        // A TDS Attention sets the batch's cancel flag; the executor polls it and
+        // aborts, returning the internal cancel marker (3617) instead of results.
+        // The transaction is not doomed.
+        let path = unique_temp_path("attn-cancel");
+        let engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE t (id INT NOT NULL PRIMARY KEY)")
+            .expect("create");
+        for i in 0..10 {
+            engine
+                .execute(&format!("INSERT INTO t VALUES ({i})"))
+                .expect("ins");
+        }
+        // Simulate an Attention arriving: raise the cancel flag for this thread.
+        let flag = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true));
+        crate::rel::set_test_cancel(flag);
+        let env = sql(&engine, "SELECT id FROM t");
+        // Clear before asserting so a panic can't leak the flag to another test.
+        crate::rel::clear_test_cancel();
+        assert_eq!(
+            env["error"]["number"], 3617,
+            "a cancelled batch aborts instead of returning rows: {env}"
+        );
+        // The engine is still usable afterwards.
+        let (_, rows) = sql_rows(&engine, "SELECT COUNT(*) FROM t");
+        assert_eq!(rows, vec![vec![Some("10".into())]]);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
     fn save_transaction_partial_rollback_keeps_earlier_work() {
         // SAVE TRANSACTION + ROLLBACK TRANSACTION <name> undoes only the work done
         // since the savepoint; the transaction stays open and commits the rest.

--- a/crates/truthdb-core/src/rel/aggregate.rs
+++ b/crates/truthdb-core/src/rel/aggregate.rs
@@ -345,6 +345,7 @@ fn group_rows(
     let mut index_of: std::collections::HashMap<HashKey, usize> = std::collections::HashMap::new();
     let mut groups: Vec<(Vec<SqlValue>, Vec<usize>)> = Vec::new();
     for (index, row) in rows.iter().enumerate() {
+        super::check_cancelled()?;
         let sql_row = row_values(row, types);
         let key = select
             .group_by

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -225,6 +225,11 @@ pub fn execute_batch_with_params(
     // results rather than terminating the batch.
     let mut last_error: Option<SqlError> = None;
     for statement in &statements {
+        // A TDS Attention (cancel) aborts the batch before the next statement.
+        if let Err(cancel) = check_cancelled() {
+            let error = finalize_durability(storage, committed, Some(cancel));
+            return BatchOutcome { results, error };
+        }
         // Flag durability by statement kind, before matching the result: a
         // write/DDL/COMMIT can commit even when it then errors — an autocommit
         // statement, an identity reservation (its own mini-commit, made even
@@ -234,6 +239,16 @@ pub fn execute_batch_with_params(
         match exec_statement(storage, statement, txn_ctx) {
             Ok(result) => results.push(result),
             Err(error) => {
+                // A cancelled statement (whose `check_cancelled` fired inside an
+                // operator) aborts the batch immediately — the transaction stays
+                // open (its partial write was already undone to a savepoint), not
+                // doomed. Key on the cancel marker, not the flag: an Attention
+                // landing concurrently with an *unrelated* failure must not
+                // suppress that failure's XACT_ABORT/severity dooming.
+                if error.number == CANCEL_ERROR {
+                    let error = finalize_durability(storage, committed, Some(error));
+                    return BatchOutcome { results, error };
+                }
                 // Inside an explicit transaction the statement's partial writes
                 // were already undone to a savepoint (`rel_statement_scoped`), so
                 // the transaction is consistent either way. `SET XACT_ABORT` (and
@@ -2536,6 +2551,7 @@ fn exec_insert(
     // Build every row up front; insert them as one atomic statement.
     let mut rows = Vec::with_capacity(input_rows.len());
     for (row_no, input) in input_rows.iter().enumerate() {
+        check_cancelled()?;
         // Full row in schema order: unspecified columns start NULL.
         let mut values = vec![Datum::Null; ncols];
         for (position, sql_value) in target.iter().zip(input) {
@@ -2756,6 +2772,7 @@ fn exec_update(
     let types = schema_types(&schema);
     let mut updates = Vec::new();
     for (locator, row) in located {
+        check_cancelled()?;
         if !predicate_true(&update.where_clause, &row, &types, &resolver, eval_ctx)? {
             continue;
         }
@@ -2872,6 +2889,7 @@ fn exec_delete(
         .map_err(|e| map_storage_err(e, &def.name))?;
     let mut targets = Vec::new();
     for (locator, row) in located {
+        check_cancelled()?;
         if predicate_true(&delete.where_clause, &row, &types, &resolver, eval_ctx)? {
             // Keep the row values for secondary-index maintenance.
             targets.push((locator, row));
@@ -4107,6 +4125,7 @@ fn exec_select(
     let where_correlated = select.where_clause.as_ref().is_some_and(expr_has_subquery);
     let mut rows: Vec<Vec<Datum>> = Vec::new();
     for row in source.rows {
+        check_cancelled()?;
         let sql_row = row_values(&row, &types);
         let keep = match &select.where_clause {
             None => true,
@@ -4449,6 +4468,74 @@ pub(crate) fn set_test_sort_budget(budget: Option<usize>) {
     TEST_SORT_BUDGET.with(|cell| cell.set(budget));
 }
 
+thread_local! {
+    /// The cancellation flag for the batch running on this worker thread — set by
+    /// the connection task when a TDS Attention (cancel) arrives. Executor loops
+    /// poll it via [`check_cancelled`] so a running statement can be aborted.
+    static CANCEL_FLAG: std::cell::RefCell<Option<std::sync::Arc<std::sync::atomic::AtomicBool>>> =
+        const { std::cell::RefCell::new(None) };
+}
+
+/// Binds a cancellation flag to the current thread for one batch, clearing it on
+/// drop so a later batch on the same pooled worker never sees a stale flag.
+pub struct CancelScope;
+
+impl CancelScope {
+    pub fn enter(flag: std::sync::Arc<std::sync::atomic::AtomicBool>) -> CancelScope {
+        CANCEL_FLAG.with(|c| *c.borrow_mut() = Some(flag));
+        CancelScope
+    }
+}
+
+impl Drop for CancelScope {
+    fn drop(&mut self) {
+        CANCEL_FLAG.with(|c| *c.borrow_mut() = None);
+    }
+}
+
+/// True if the batch on this thread has been asked to cancel (Attention).
+fn is_cancelled() -> bool {
+    CANCEL_FLAG.with(|c| {
+        c.borrow()
+            .as_ref()
+            .is_some_and(|f| f.load(std::sync::atomic::Ordering::Relaxed))
+    })
+}
+
+/// Errors if the current batch has been cancelled (TDS Attention). Executor
+/// loops call this periodically so a long statement aborts mid-flight. The
+/// client is answered with a `DONE(attention)`, not this error — it is an
+/// internal marker the batch driver recognises to stop without dooming the txn.
+pub fn check_cancelled() -> Result<(), SqlError> {
+    if is_cancelled() {
+        Err(SqlError::message_only(
+            CANCEL_ERROR,
+            "The query was canceled.",
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+/// The error number [`check_cancelled`] raises. The batch driver keys on this
+/// (not the raw cancel flag) so a concurrent Attention can't suppress the
+/// `XACT_ABORT`/severity dooming of an *unrelated* statement failure.
+const CANCEL_ERROR: i32 = 3617;
+
+/// Sets the current thread's cancel flag (test helper — execution runs on the
+/// calling thread in tests, so this simulates an Attention).
+#[cfg(test)]
+pub(crate) fn set_test_cancel(flag: std::sync::Arc<std::sync::atomic::AtomicBool>) {
+    CANCEL_FLAG.with(|c| *c.borrow_mut() = Some(flag));
+}
+
+/// Clears the current thread's cancel flag (test helper — reset before other
+/// tests reuse the thread).
+#[cfg(test)]
+pub(crate) fn clear_test_cancel() {
+    CANCEL_FLAG.with(|c| *c.borrow_mut() = None);
+}
+
 /// The ORDER BY comparator for one pair of pre-evaluated key tuples: per item,
 /// collation-aware for a character column, else value order (NULLs first);
 /// `descending` reverses. No tie-break here — the caller adds stability.
@@ -4577,6 +4664,7 @@ fn order_rows_budgeted<'a>(
     let mut current: Vec<KeyedRow> = Vec::new();
     let mut current_bytes = 0usize;
     for row in rows {
+        check_cancelled()?;
         let key = sort_key(&row, order_by, types, resolver, eval_ctx)?;
         current_bytes += approx_row_bytes(&row);
         current.push((key, row));
@@ -5383,6 +5471,7 @@ fn join_sources(
         match kind {
             JoinKind::Cross | JoinKind::Inner => {
                 for l in &left.rows {
+                    check_cancelled()?;
                     for r in &right.rows {
                         if matches(l, r)? {
                             rows.push(concat(l, r));
@@ -5392,6 +5481,7 @@ fn join_sources(
             }
             JoinKind::Left => {
                 for l in &left.rows {
+                    check_cancelled()?;
                     let mut matched = false;
                     for r in &right.rows {
                         if matches(l, r)? {
@@ -5406,6 +5496,7 @@ fn join_sources(
             }
             JoinKind::Right => {
                 for r in &right.rows {
+                    check_cancelled()?;
                     let mut matched = false;
                     for l in &left.rows {
                         if matches(l, r)? {
@@ -5421,6 +5512,7 @@ fn join_sources(
             JoinKind::Full => {
                 let mut right_matched = vec![false; right.rows.len()];
                 for l in &left.rows {
+                    check_cancelled()?;
                     let mut matched = false;
                     for (index, r) in right.rows.iter().enumerate() {
                         if matches(l, r)? {
@@ -5609,6 +5701,7 @@ fn grace_hash_join(
     // Partition non-null-key rows; null-key rows can't match, so emit the outer
     // side's now and drop the rest.
     for p in probe_rows {
+        check_cancelled()?;
         let key = probe_key(p);
         if key_has_null(&key) {
             if preserve_probe {
@@ -5621,6 +5714,7 @@ fn grace_hash_join(
             .map_err(spill_err)?;
     }
     for b in build_rows_all {
+        check_cancelled()?;
         let key = build_key(b);
         if key_has_null(&key) {
             if preserve_build {
@@ -5781,6 +5875,7 @@ fn hash_join(
     let mut table: HashMap<HashKey, Vec<usize>> = HashMap::new();
     let build_rows = if build_left { &left.rows } else { &right.rows };
     for (index, row) in build_rows.iter().enumerate() {
+        check_cancelled()?;
         let key = if build_left {
             left_key(row)
         } else {
@@ -5795,6 +5890,7 @@ fn hash_join(
     match kind {
         JoinKind::Inner | JoinKind::Left => {
             for l in &left.rows {
+                check_cancelled()?;
                 let key = left_key(l);
                 let mut matched = false;
                 if !key_has_null(&key)
@@ -5815,6 +5911,7 @@ fn hash_join(
         }
         JoinKind::Right => {
             for r in &right.rows {
+                check_cancelled()?;
                 let key = right_key(r);
                 let mut matched = false;
                 if !key_has_null(&key)
@@ -5836,6 +5933,7 @@ fn hash_join(
         JoinKind::Full => {
             let mut right_matched = vec![false; right.rows.len()];
             for l in &left.rows {
+                check_cancelled()?;
                 let key = left_key(l);
                 let mut matched = false;
                 if !key_has_null(&key)

--- a/crates/truthdb-core/src/session.rs
+++ b/crates/truthdb-core/src/session.rs
@@ -135,6 +135,8 @@ enum EngineCall {
         session: SessionId,
         sql: String,
         params: Vec<crate::rel::RpcParam>,
+        /// Set by the connection on a TDS Attention to abort the batch mid-flight.
+        cancel: Arc<AtomicBool>,
         reply: oneshot::Sender<Result<BatchReply, EngineError>>,
     },
     /// A native-protocol command (ES or SQL): rendered text.
@@ -196,12 +198,39 @@ impl EngineHandle {
         sql: String,
         params: Vec<crate::rel::RpcParam>,
     ) -> Result<BatchReply, EngineError> {
+        self.run_rpc_cancellable(session, sql, params, Arc::new(AtomicBool::new(false)))
+            .await
+    }
+
+    /// Like [`Self::run_batch`] but the caller holds `cancel`: setting it (on a
+    /// TDS Attention) aborts the running statement mid-flight (the executor polls
+    /// it). Pass a shared clone to the connection's Attention handler.
+    pub async fn run_batch_cancellable(
+        &self,
+        session: SessionId,
+        sql: String,
+        cancel: Arc<AtomicBool>,
+    ) -> Result<BatchReply, EngineError> {
+        self.run_rpc_cancellable(session, sql, Vec::new(), cancel)
+            .await
+    }
+
+    /// Like [`Self::run_rpc`] but cancellable via `cancel` (see
+    /// [`Self::run_batch_cancellable`]).
+    pub async fn run_rpc_cancellable(
+        &self,
+        session: SessionId,
+        sql: String,
+        params: Vec<crate::rel::RpcParam>,
+        cancel: Arc<AtomicBool>,
+    ) -> Result<BatchReply, EngineError> {
         let (reply, rx) = oneshot::channel();
         self.tx
             .send(EngineCall::RunBatch {
                 session,
                 sql,
                 params,
+                cancel,
                 reply,
             })
             .map_err(|_| EngineError::Unavailable)?;
@@ -322,6 +351,7 @@ struct Runnable {
     session: SessionId,
     sql: String,
     params: Vec<crate::rel::RpcParam>,
+    cancel: Arc<AtomicBool>,
     reply: oneshot::Sender<Result<BatchReply, EngineError>>,
     txn_ctx: TxnContext,
 }
@@ -385,8 +415,9 @@ fn worker_loop(shared: &Arc<Shared>) {
                 session,
                 sql,
                 params,
+                cancel,
                 reply,
-            }) => dispatch_batch(shared, session, sql, params, reply),
+            }) => dispatch_batch(shared, session, sql, params, cancel, reply),
             Some(EngineCall::RunNative { command, reply }) => {
                 let _ = reply.send(shared.engine.execute(&command));
             }
@@ -413,6 +444,7 @@ fn dispatch_batch(
     session: SessionId,
     sql: String,
     params: Vec<crate::rel::RpcParam>,
+    cancel: Arc<AtomicBool>,
     reply: oneshot::Sender<Result<BatchReply, EngineError>>,
 ) {
     let runnable = {
@@ -427,6 +459,7 @@ fn dispatch_batch(
                 session,
                 sql,
                 params,
+                cancel,
                 reply,
                 txn_ctx,
             })
@@ -436,6 +469,7 @@ fn dispatch_batch(
                 session,
                 sql,
                 params,
+                cancel,
                 reply,
                 needs,
                 deadline,
@@ -461,9 +495,13 @@ fn run_and_finish(shared: &Arc<Shared>, work: Runnable) {
         session,
         sql,
         params,
+        cancel,
         reply,
         mut txn_ctx,
     } = work;
+    // Bind the cancel flag to this worker thread for the batch, so the executor's
+    // `check_cancelled` polls see a TDS Attention; the guard clears it on return.
+    let _cancel_guard = crate::rel::CancelScope::enter(cancel);
     let outcome = shared
         .engine
         .sql_batch_with_params(&sql, &mut txn_ctx, &params);
@@ -499,6 +537,7 @@ struct Parked {
     session: SessionId,
     sql: String,
     params: Vec<crate::rel::RpcParam>,
+    cancel: Arc<AtomicBool>,
     reply: oneshot::Sender<Result<BatchReply, EngineError>>,
     needs: Vec<(Resource, LockMode)>,
     deadline: Instant,
@@ -651,6 +690,7 @@ impl Scheduler {
                     session: parked.session,
                     sql: parked.sql,
                     params: parked.params,
+                    cancel: parked.cancel,
                     reply: parked.reply,
                     txn_ctx,
                 });

--- a/crates/truthdb-tds/src/packet.rs
+++ b/crates/truthdb-tds/src/packet.rs
@@ -21,7 +21,7 @@ pub const PKT_TRANSACTION_MANAGER: u8 = 0x0e;
 pub const PKT_LOGIN7: u8 = 0x10;
 pub const PKT_PRELOGIN: u8 = 0x12;
 
-const HEADER_LEN: usize = 8;
+pub const HEADER_LEN: usize = 8;
 const STATUS_EOM: u8 = 0x01;
 
 /// Upper bound on a fully reassembled message. A peer controls the EOM bit, so

--- a/crates/truthdb-tds/src/server.rs
+++ b/crates/truthdb-tds/src/server.rs
@@ -2,15 +2,17 @@
 
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
-use tokio::io::{self, AsyncRead, AsyncWrite};
+use tokio::io::{self, AsyncRead, AsyncReadExt, AsyncWrite};
 use truthdb_core::rel::{BatchOutcome, StatementResult};
 use truthdb_core::session::{EngineHandle, SessionId};
 
 use crate::login::{self, parse_login7};
 use crate::packet::{
-    self, DEFAULT_PACKET_SIZE, Message, PKT_ATTENTION, PKT_LOGIN7, PKT_PRELOGIN, PKT_RPC,
-    PKT_SQL_BATCH, PKT_TABULAR_RESULT, PKT_TRANSACTION_MANAGER, read_message, write_message,
+    self, DEFAULT_PACKET_SIZE, HEADER_LEN, Message, PKT_ATTENTION, PKT_LOGIN7, PKT_PRELOGIN,
+    PKT_RPC, PKT_SQL_BATCH, PKT_TABULAR_RESULT, PKT_TRANSACTION_MANAGER, read_message,
+    write_message,
 };
 use crate::rpc::{self, RpcProc};
 use crate::token;
@@ -156,12 +158,24 @@ where
         match message.kind {
             PKT_SQL_BATCH => {
                 let sql = batch_sql(&message.payload)?;
-                let response = run_batch(engine, session, &sql).await;
-                write_message(stream, PKT_TABULAR_RESULT, &response, packet_size).await?;
+                let cancel = Arc::new(AtomicBool::new(false));
+                let work = run_batch(engine, session, &sql, cancel.clone());
+                match run_watching_attention(stream, cancel, work).await? {
+                    Some(response) => {
+                        write_message(stream, PKT_TABULAR_RESULT, &response, packet_size).await?
+                    }
+                    None => return Ok(()),
+                }
             }
             PKT_RPC => {
-                let response = run_rpc(engine, session, &message.payload).await;
-                write_message(stream, PKT_TABULAR_RESULT, &response, packet_size).await?;
+                let cancel = Arc::new(AtomicBool::new(false));
+                let work = run_rpc(engine, session, &message.payload, cancel.clone());
+                match run_watching_attention(stream, cancel, work).await? {
+                    Some(response) => {
+                        write_message(stream, PKT_TABULAR_RESULT, &response, packet_size).await?
+                    }
+                    None => return Ok(()),
+                }
             }
             PKT_TRANSACTION_MANAGER => {
                 let response = handle_tm_request(
@@ -175,9 +189,9 @@ where
                 write_message(stream, PKT_TABULAR_RESULT, &response, packet_size).await?;
             }
             PKT_ATTENTION => {
-                // Acknowledge cancel with a DONE(attention). True mid-batch
-                // interruption arrives in a later stage; batches here run to
-                // completion.
+                // An Attention arriving with no batch in flight (the batch it
+                // targeted already finished): just acknowledge it. Mid-batch
+                // Attentions are handled by `run_watching_attention` above.
                 let mut out = Vec::new();
                 token::done_attention(&mut out);
                 write_message(stream, PKT_TABULAR_RESULT, &out, packet_size).await?;
@@ -297,9 +311,93 @@ fn authenticate(config: &TdsConfig, username: &str, password: &str) -> bool {
         .is_some_and(|expected| expected == password)
 }
 
-/// Runs a SQL batch through the engine actor and builds its token stream.
-async fn run_batch(engine: &EngineHandle, session: SessionId, sql: &str) -> Vec<u8> {
-    match engine.run_batch(session, sql.to_string()).await {
+/// Runs `work` (a batch/RPC that respects `cancel`) while concurrently watching
+/// the connection for a TDS Attention. If one arrives, `cancel` is set so the
+/// executor aborts the statement, and the client is answered with a
+/// `DONE(attention)` instead of the (partial) result. Returns `Ok(None)` if the
+/// client disconnected mid-batch.
+///
+/// `AsyncReadExt::read` is cancellation-safe, so bytes read into `hdr` survive a
+/// `select!` iteration that resolves to the batch instead; any partial header
+/// left when the batch wins is completed afterwards so packet framing is intact.
+async fn run_watching_attention<S, F>(
+    stream: &mut S,
+    cancel: Arc<AtomicBool>,
+    work: F,
+) -> io::Result<Option<Vec<u8>>>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+    F: std::future::Future<Output = Vec<u8>>,
+{
+    let mut work = std::pin::pin!(work);
+    let mut hdr = [0u8; HEADER_LEN];
+    let mut got = 0usize;
+    let mut attention = false;
+    let result = loop {
+        tokio::select! {
+            resp = &mut work => break resp,
+            read = stream.read(&mut hdr[got..]) => match read? {
+                0 => {
+                    // Client disconnected mid-batch: abort and drain, then drop.
+                    cancel.store(true, Ordering::Relaxed);
+                    let _ = (&mut work).await;
+                    return Ok(None);
+                }
+                n => {
+                    got += n;
+                    if got == HEADER_LEN {
+                        // Only an Attention (a header-only packet) is legal during
+                        // a running batch — TDS is request/response with no MARS.
+                        if hdr[0] == PKT_ATTENTION {
+                            attention = true;
+                            cancel.store(true, Ordering::Relaxed);
+                            got = 0;
+                        } else {
+                            // A pipelined non-Attention packet: fail loud rather
+                            // than silently ignore its (undrained) body and misframe
+                            // the next read. Abort the batch, then error out.
+                            cancel.store(true, Ordering::Relaxed);
+                            let _ = (&mut work).await;
+                            return Err(protocol_err(
+                                "unexpected TDS packet during a running batch",
+                            ));
+                        }
+                    }
+                }
+            },
+        }
+    };
+    // The batch finished before a header fully arrived: complete it so the next
+    // read stays framed (and still honour a late Attention).
+    if got > 0 {
+        stream.read_exact(&mut hdr[got..]).await?;
+        if hdr[0] == PKT_ATTENTION {
+            attention = true;
+        } else {
+            return Err(protocol_err("unexpected TDS packet during a running batch"));
+        }
+    }
+    if attention {
+        let mut out = Vec::new();
+        token::done_attention(&mut out);
+        Ok(Some(out))
+    } else {
+        Ok(Some(result))
+    }
+}
+
+/// Runs a SQL batch through the engine actor and builds its token stream. The
+/// batch is cancellable: setting `cancel` (on a TDS Attention) aborts it.
+async fn run_batch(
+    engine: &EngineHandle,
+    session: SessionId,
+    sql: &str,
+    cancel: Arc<AtomicBool>,
+) -> Vec<u8> {
+    match engine
+        .run_batch_cancellable(session, sql.to_string(), cancel)
+        .await
+    {
         Ok(reply) => build_batch_tokens(&reply.outcome, reply.in_transaction),
         Err(err) => {
             // A genuine engine/storage failure (not a SQL-level error).
@@ -315,7 +413,12 @@ async fn run_batch(engine: &EngineHandle, session: SessionId, sql: &str) -> Vec<
 /// typed parameters, run them, and return the same token stream a batch would.
 /// Any other procedure, or a malformed request, is answered with an error token
 /// plus a final DONE so the connection stays usable.
-async fn run_rpc(engine: &EngineHandle, session: SessionId, payload: &[u8]) -> Vec<u8> {
+async fn run_rpc(
+    engine: &EngineHandle,
+    session: SessionId,
+    payload: &[u8],
+    cancel: Arc<AtomicBool>,
+) -> Vec<u8> {
     let request = match rpc::parse_rpc_request(skip_all_headers(payload)) {
         Ok(request) => request,
         Err(err) => return rpc_error(&format!("malformed RPC request: {err}")),
@@ -326,7 +429,10 @@ async fn run_rpc(engine: &EngineHandle, session: SessionId, payload: &[u8]) -> V
                 Ok(split) => split,
                 Err(err) => return rpc_error(&err.to_string()),
             };
-            match engine.run_rpc(session, sql, params).await {
+            match engine
+                .run_rpc_cancellable(session, sql, params, cancel)
+                .await
+            {
                 Ok(reply) => build_batch_tokens(&reply.outcome, reply.in_transaction),
                 Err(err) => rpc_error(&err.to_string()),
             }
@@ -438,4 +544,55 @@ fn protocol_err(message: &str) -> io::Error {
 #[doc(hidden)]
 pub async fn read_raw_message<R: AsyncRead + Unpin>(reader: &mut R) -> io::Result<Message> {
     read_message(reader).await
+}
+
+#[cfg(test)]
+mod attention_tests {
+    use super::*;
+    use tokio::io::AsyncWriteExt;
+
+    #[tokio::test]
+    async fn attention_during_batch_cancels_and_acks() {
+        let (mut client, mut server) = tokio::io::duplex(64);
+        let cancel = Arc::new(AtomicBool::new(false));
+        let cwork = cancel.clone();
+        // A "batch" that runs until its cancel flag is set (like the executor
+        // polling `check_cancelled`), then would return a normal result.
+        let work = async move {
+            loop {
+                if cwork.load(Ordering::Relaxed) {
+                    return b"RESULT".to_vec();
+                }
+                tokio::task::yield_now().await;
+            }
+        };
+        // The client sends an Attention (header-only packet) during the batch.
+        let attn = [PKT_ATTENTION, 0x01, 0x00, 0x08, 0, 0, 0, 0];
+        client.write_all(&attn).await.expect("send attention");
+        let out = run_watching_attention(&mut server, cancel.clone(), work)
+            .await
+            .expect("io ok")
+            .expect("not disconnected");
+        assert!(
+            cancel.load(Ordering::Relaxed),
+            "the Attention set the cancel flag"
+        );
+        let mut expected = Vec::new();
+        token::done_attention(&mut expected);
+        assert_eq!(out, expected, "response is DONE(attention), not the result");
+    }
+
+    #[tokio::test]
+    async fn no_attention_returns_the_batch_result() {
+        let (_client, mut server) = tokio::io::duplex(64);
+        let cancel = Arc::new(AtomicBool::new(false));
+        // The batch completes on its own; no Attention is ever sent.
+        let work = async move { b"RESULT".to_vec() };
+        let out = run_watching_attention(&mut server, cancel.clone(), work)
+            .await
+            .expect("io ok")
+            .expect("not disconnected");
+        assert!(!cancel.load(Ordering::Relaxed));
+        assert_eq!(out, b"RESULT".to_vec(), "no attention -> the real result");
+    }
 }


### PR DESCRIPTION
Closes the Stage 4 🟡 gap: an Attention was only acknowledged; a batch ran to
completion. Now a mid-statement Attention actually cancels it, across three layers.

- **Engine**: a thread-local cancel flag (`CancelScope`, cleared on drop) polled by
  `check_cancelled()` in the executor's per-row loops — `exec_select` filter,
  **hash-join build+probe**, grace-hash join, nested-loop join, **ORDER BY sort**,
  **GROUP BY grouping**, and the **UPDATE/DELETE/INSERT** row loops. A cancelled
  statement aborts the batch (internal error 3617) but leaves the transaction
  OPEN (not doomed).
- **Actor**: the `Arc<AtomicBool>` cancel flag is threaded connection → engine actor
  → worker, bound to the worker thread via `CancelScope`.
- **TDS server**: `run_watching_attention` runs the batch while concurrently
  watching the socket. `AsyncReadExt::read` is cancellation-safe; a partial header
  is completed afterward so framing stays intact. An Attention → `DONE(attention)`;
  a pipelined non-Attention packet mid-batch → protocol error (fail loud).

## Review findings fixed
- The abort guard now keys on the cancel error number (3617), **not** the raw
  flag — so a concurrent Attention can't suppress an unrelated failure's
  `XACT_ABORT` dooming.
- The poll set was widened from `exec_select`/nested-loop-join to the **hash-join,
  sort, aggregate, and DML** loops that dominate real long-running queries (the
  hash-join omission was an oversight vs. its polled nested-loop sibling).

## Testing
An engine-level cancel aborts a batch and leaves the engine usable; a
duplex-stream test drives an Attention arriving during a batch and asserts the
flag is set and the response is `DONE(attention)`. Two adversarial reviews
(async/framing + engine lifecycle/coverage) — framing clean; the two coverage/
guard findings fixed.

Known limitation (documented): a batch blocked on a lock (parked) or inside a
single monolithic `rel_scan` cancels with latency, not instantly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)