### PR TITLE
Stage 6: TRY/CATCH, XACT_STATE() and the ERROR_*() intrinsics

### DIFF
--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -3865,11 +3865,15 @@ mod tests {
         );
         assert_eq!(out.error.as_ref().map(|e| e.number), Some(2627));
 
-        // A doomed transaction rejects further work with 3930...
-        let out = batch(&engine, &mut ctx, "SELECT 1 AS n");
+        // A doomed transaction rejects further writes with 3930...
+        let out = batch(&engine, &mut ctx, "INSERT INTO t VALUES (2)");
         assert_eq!(out.error.as_ref().map(|e| e.number), Some(3930));
 
-        // ...but ROLLBACK is allowed and clears the doom.
+        // ...but a read is still allowed (so a CATCH can inspect state)...
+        let out = batch(&engine, &mut ctx, "SELECT 1 AS n");
+        assert_eq!(ids(&out), vec![1]);
+
+        // ...and ROLLBACK is allowed and clears the doom.
         let out = batch(&engine, &mut ctx, "ROLLBACK");
         assert!(out.error.is_none(), "{:?}", out.error);
         assert!(!ctx.has_open_transaction());
@@ -3877,6 +3881,238 @@ mod tests {
         // The table is usable again and holds nothing (the txn rolled back).
         let out = batch(&engine, &mut ctx, "SELECT id FROM t");
         assert_eq!(ids(&out), Vec::<i32>::new());
+        let _ = std::fs::remove_file(path);
+    }
+
+    // ---- TRY/CATCH + XACT_STATE() / ERROR_*() (Stage 6) ------------------
+
+    /// Every rowset's integer column 0, in statement order (a batch with
+    /// TRY/CATCH can emit several rowsets).
+    fn all_int_rows(outcome: &BatchOutcome) -> Vec<Vec<i32>> {
+        outcome
+            .results
+            .iter()
+            .filter_map(|r| match r {
+                StatementResult::Rows(rowset) => Some(
+                    rowset
+                        .rows
+                        .iter()
+                        .map(|row| match row[0] {
+                            Datum::TinyInt(v) => v as i32,
+                            Datum::SmallInt(v) => v as i32,
+                            Datum::Int(v) => v,
+                            Datum::BigInt(v) => v as i32,
+                            ref other => panic!("expected integer, got {other:?}"),
+                        })
+                        .collect(),
+                ),
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn try_catch_error_transfers_to_catch() {
+        let path = unique_temp_path("try-catch-basic");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        batch(
+            &engine,
+            &mut ctx,
+            "CREATE TABLE t (id INT NOT NULL PRIMARY KEY)",
+        );
+        batch(&engine, &mut ctx, "INSERT INTO t VALUES (1)");
+        // The first TRY statement is a duplicate PK (2627); control jumps to the
+        // CATCH, so the second INSERT never runs and the batch reports no error.
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "BEGIN TRY \
+               INSERT INTO t VALUES (1); \
+               INSERT INTO t VALUES (99); \
+             END TRY \
+             BEGIN CATCH \
+               SELECT ERROR_NUMBER() AS n; \
+             END CATCH",
+        );
+        assert!(
+            out.error.is_none(),
+            "a caught error is not reported: {:?}",
+            out.error
+        );
+        assert_eq!(ids(&out), vec![2627], "CATCH sees the error number");
+        // The post-error TRY statement was skipped; only the seed row exists.
+        let out = batch(&engine, &mut ctx, "SELECT id FROM t ORDER BY id");
+        assert_eq!(ids(&out), vec![1]);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn try_catch_error_message_and_null_outside() {
+        let path = unique_temp_path("try-catch-msg");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        batch(
+            &engine,
+            &mut ctx,
+            "CREATE TABLE t (id INT NOT NULL PRIMARY KEY)",
+        );
+        batch(&engine, &mut ctx, "INSERT INTO t VALUES (1)");
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "BEGIN TRY INSERT INTO t VALUES (1); END TRY \
+             BEGIN CATCH SELECT ERROR_MESSAGE() AS m; END CATCH",
+        );
+        let StatementResult::Rows(rowset) = &out.results[0] else {
+            panic!("expected a rowset");
+        };
+        let Datum::NVarChar(msg) = &rowset.rows[0][0] else {
+            panic!("expected a string, got {:?}", rowset.rows[0][0]);
+        };
+        assert!(
+            msg.contains("PRIMARY KEY") || msg.to_lowercase().contains("duplicate"),
+            "ERROR_MESSAGE() text: {msg}"
+        );
+        // Outside any CATCH block, ERROR_*() are NULL.
+        let out = batch(&engine, &mut ctx, "SELECT ERROR_NUMBER() AS n");
+        let StatementResult::Rows(rowset) = &out.results[0] else {
+            panic!("expected a rowset");
+        };
+        assert_eq!(rowset.rows[0][0], Datum::Null);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn try_catch_canonical_form_without_terminators_runs() {
+        // The way TRY/CATCH is actually written: no `;` before END TRY/END CATCH.
+        let path = unique_temp_path("try-catch-canonical");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        batch(
+            &engine,
+            &mut ctx,
+            "CREATE TABLE t (id INT NOT NULL PRIMARY KEY)",
+        );
+        batch(&engine, &mut ctx, "INSERT INTO t VALUES (1)");
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "BEGIN TRY\n    INSERT INTO t VALUES (1)\nEND TRY\nBEGIN CATCH\n    SELECT ERROR_NUMBER() AS n\nEND CATCH",
+        );
+        assert!(out.error.is_none(), "{:?}", out.error);
+        assert_eq!(ids(&out), vec![2627]);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn try_catch_success_skips_catch() {
+        let path = unique_temp_path("try-catch-ok");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "BEGIN TRY SELECT 1 AS n; END TRY BEGIN CATCH SELECT 2 AS n; END CATCH",
+        );
+        assert!(out.error.is_none());
+        assert_eq!(all_int_rows(&out), vec![vec![1]], "the CATCH did not run");
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn try_catch_xact_state_committable() {
+        // A caught non-fatal error inside a transaction leaves it committable
+        // (XACT_STATE = 1); the transaction survives and COMMIT persists its work.
+        let path = unique_temp_path("try-catch-xs1");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        batch(
+            &engine,
+            &mut ctx,
+            "CREATE TABLE t (id INT NOT NULL PRIMARY KEY)",
+        );
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "BEGIN TRAN; \
+             INSERT INTO t VALUES (1); \
+             BEGIN TRY INSERT INTO t VALUES (1); END TRY \
+             BEGIN CATCH SELECT XACT_STATE() AS n; END CATCH; \
+             COMMIT;",
+        );
+        assert!(out.error.is_none(), "{:?}", out.error);
+        assert_eq!(ids(&out), vec![1], "committable (1) inside the CATCH");
+        assert!(!ctx.has_open_transaction(), "COMMIT closed the transaction");
+        let out = batch(&engine, &mut ctx, "SELECT id FROM t");
+        assert_eq!(ids(&out), vec![1], "the surviving insert committed");
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn try_catch_xact_state_doomed_under_xact_abort() {
+        // Under SET XACT_ABORT ON, an error inside TRY still transfers to CATCH,
+        // but the transaction is doomed (XACT_STATE = -1) and only ROLLBACK works.
+        let path = unique_temp_path("try-catch-xs-doomed");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        batch(
+            &engine,
+            &mut ctx,
+            "CREATE TABLE t (id INT NOT NULL PRIMARY KEY)",
+        );
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "SET XACT_ABORT ON; \
+             BEGIN TRAN; \
+             INSERT INTO t VALUES (1); \
+             BEGIN TRY INSERT INTO t VALUES (1); END TRY \
+             BEGIN CATCH SELECT XACT_STATE() AS n; END CATCH",
+        );
+        assert!(out.error.is_none(), "the error was caught: {:?}", out.error);
+        assert_eq!(ids(&out), vec![-1], "doomed (-1) inside the CATCH");
+        assert!(ctx.has_open_transaction(), "still open, awaiting ROLLBACK");
+        // A doomed transaction rejects further writes with 3930.
+        let out = batch(&engine, &mut ctx, "INSERT INTO t VALUES (2)");
+        assert_eq!(out.error.as_ref().map(|e| e.number), Some(3930));
+        // ROLLBACK clears it; nothing persisted.
+        batch(&engine, &mut ctx, "ROLLBACK");
+        assert!(!ctx.has_open_transaction());
+        let out = batch(&engine, &mut ctx, "SELECT id FROM t");
+        assert_eq!(ids(&out), Vec::<i32>::new());
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn try_catch_nested_inner_handles_outer_continues() {
+        // The inner CATCH handles the inner error; because it does not re-raise,
+        // the outer TRY continues and the outer CATCH never runs.
+        let path = unique_temp_path("try-catch-nested");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        batch(
+            &engine,
+            &mut ctx,
+            "CREATE TABLE t (id INT NOT NULL PRIMARY KEY)",
+        );
+        batch(&engine, &mut ctx, "INSERT INTO t VALUES (1)");
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "BEGIN TRY \
+               BEGIN TRY INSERT INTO t VALUES (1); END TRY \
+               BEGIN CATCH SELECT ERROR_NUMBER() AS n; END CATCH; \
+               SELECT 777 AS n; \
+             END TRY \
+             BEGIN CATCH SELECT 999 AS n; END CATCH",
+        );
+        assert!(out.error.is_none());
+        assert_eq!(
+            all_int_rows(&out),
+            vec![vec![2627], vec![777]],
+            "inner CATCH ran (2627), outer TRY continued (777), outer CATCH skipped"
+        );
         let _ = std::fs::remove_file(path);
     }
 

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -64,6 +64,10 @@ pub struct TxnContext {
     /// lowercased) → the point to which `ROLLBACK TRANSACTION <name>` returns.
     /// Cleared when the transaction ends.
     savepoints: std::collections::HashMap<String, crate::relstore::ctx::Savepoint>,
+    /// Errors caught by the currently-executing `CATCH` blocks (a stack, so
+    /// nested `TRY`/`CATCH` restore the outer error on exit). `ERROR_*()` read
+    /// the top; empty outside any `CATCH` block.
+    error_stack: Vec<truthdb_sql::eval::ErrorInfo>,
 }
 
 /// Session isolation level (defaults to READ COMMITTED, like SQL Server).
@@ -93,7 +97,37 @@ impl TxnContext {
             login: self.login.clone(),
             spid: self.spid,
             scope_identity: self.scope_identity,
+            error: self.error_stack.last().cloned(),
+            xact_state: self.xact_state(),
         }
+    }
+
+    /// `XACT_STATE()`: 0 with no open transaction, -1 when the open transaction
+    /// is doomed (uncommittable), else 1.
+    fn xact_state(&self) -> i8 {
+        if !self.in_txn() {
+            0
+        } else if self.doomed {
+            -1
+        } else {
+            1
+        }
+    }
+
+    /// Enters a `CATCH` block: records the caught error so `ERROR_*()` resolve
+    /// to it (pushed, so nested `TRY`/`CATCH` restore the outer error on exit).
+    fn push_error(&mut self, error: &SqlError) {
+        self.error_stack.push(truthdb_sql::eval::ErrorInfo {
+            number: error.number,
+            message: error.message.clone(),
+            severity: error.level,
+            state: error.state,
+        });
+    }
+
+    /// Leaves a `CATCH` block, restoring the enclosing error context (if any).
+    fn pop_error(&mut self) {
+        self.error_stack.pop();
     }
 
     /// Records the connection identity used by session intrinsics. Called once
@@ -215,62 +249,123 @@ pub fn execute_batch_with_params(
             };
         }
     };
-    let mut results = Vec::with_capacity(statements.len());
-    // Whether any statement may have made a durable commit: group commit defers
-    // the WAL fsync to one call at the end of the batch (see
-    // [`finalize_durability`]).
-    let mut committed = false;
-    // The last non-dooming statement error under `SET XACT_ABORT OFF` — the batch
-    // continues past it (SQL Server default), so it is reported alongside the
-    // results rather than terminating the batch.
-    let mut last_error: Option<SqlError> = None;
-    for statement in &statements {
+    let mut run = BatchRun {
+        results: Vec::with_capacity(statements.len()),
+        committed: false,
+        last_error: None,
+    };
+    // `run_block` returns Err only when the batch must terminate (a cancel, or a
+    // dooming/uncaught error outside any TRY); a non-dooming error under
+    // `XACT_ABORT OFF` is recorded in `run.last_error` and the batch continues.
+    let terminating = run_block(storage, &statements, txn_ctx, &mut run, false).err();
+    let prior = terminating.or(run.last_error);
+    let error = finalize_durability(storage, run.committed, prior);
+    BatchOutcome {
+        results: run.results,
+        error,
+    }
+}
+
+/// The mutable accumulator threaded through [`run_block`] across a batch and its
+/// nested `TRY`/`CATCH` blocks.
+struct BatchRun {
+    results: Vec<StatementResult>,
+    /// Whether any executed statement may have made a durable commit: group
+    /// commit defers the WAL fsync to one call at the end of the batch.
+    committed: bool,
+    /// The last non-dooming statement error under `SET XACT_ABORT OFF` (outside
+    /// any TRY) — the batch continues past it (SQL Server default) and it is
+    /// reported alongside the results rather than terminating the batch.
+    last_error: Option<SqlError>,
+}
+
+/// Runs a statement list, recursing into `TRY`/`CATCH`. `in_try` is true while
+/// executing inside a `TRY` block, where a statement error transfers control to
+/// the matching `CATCH` (returned as `Err`) instead of applying the normal
+/// batch policy. Returns `Err` when the enclosing context must stop: a cancel,
+/// an error that propagates to a `CATCH`, or a dooming/terminating error at the
+/// top level.
+fn run_block(
+    storage: &Storage,
+    statements: &[Statement],
+    txn_ctx: &mut TxnContext,
+    run: &mut BatchRun,
+    in_try: bool,
+) -> Result<(), SqlError> {
+    for statement in statements {
         // A TDS Attention (cancel) aborts the batch before the next statement.
-        if let Err(cancel) = check_cancelled() {
-            let error = finalize_durability(storage, committed, Some(cancel));
-            return BatchOutcome { results, error };
+        // It is never catchable — it propagates straight out, past any TRY.
+        check_cancelled()?;
+        if let Statement::TryCatch {
+            try_block,
+            catch_block,
+            ..
+        } = statement
+        {
+            match run_block(storage, try_block, txn_ctx, run, true) {
+                Ok(()) => {}
+                // An Attention that landed inside the TRY block is not caught.
+                Err(cancel) if cancel.number == CANCEL_ERROR => return Err(cancel),
+                Err(error) => {
+                    // The failed statement's own writes were already undone to
+                    // its savepoint (`rel_statement_scoped`). `SET XACT_ABORT`
+                    // (or a high-severity error) still dooms the transaction —
+                    // but control transfers to CATCH either way (unlike outside
+                    // a TRY, where a dooming error ends the batch). Inside CATCH,
+                    // XACT_STATE() then reports -1 for a doomed transaction.
+                    let dooms = txn_ctx.xact_abort || error.level >= XACT_ABORT_SEVERITY;
+                    if txn_ctx.in_txn() && dooms {
+                        txn_ctx.doomed = true;
+                    }
+                    txn_ctx.push_error(&error);
+                    // The CATCH block runs in the *enclosing* try-context: its
+                    // own errors are not caught here, so they propagate to an
+                    // outer CATCH (or end the batch) per `in_try`.
+                    let caught = run_block(storage, catch_block, txn_ctx, run, in_try);
+                    txn_ctx.pop_error();
+                    caught?;
+                }
+            }
+            continue;
         }
         // Flag durability by statement kind, before matching the result: a
         // write/DDL/COMMIT can commit even when it then errors — an autocommit
         // statement, an identity reservation (its own mini-commit, made even
         // inside an open transaction and even if the row insert later fails),
         // or the outermost COMMIT.
-        committed |= statement_may_commit(statement);
+        run.committed |= statement_may_commit(statement);
         match exec_statement(storage, statement, txn_ctx) {
-            Ok(result) => results.push(result),
+            Ok(result) => run.results.push(result),
             Err(error) => {
-                // A cancelled statement (whose `check_cancelled` fired inside an
-                // operator) aborts the batch immediately — the transaction stays
-                // open (its partial write was already undone to a savepoint), not
-                // doomed. Key on the cancel marker, not the flag: an Attention
-                // landing concurrently with an *unrelated* failure must not
-                // suppress that failure's XACT_ABORT/severity dooming.
+                // A cancelled statement aborts the batch immediately (see above):
+                // key on the cancel marker, not any flag, so an Attention landing
+                // concurrently with an unrelated failure cannot suppress that
+                // failure's dooming.
                 if error.number == CANCEL_ERROR {
-                    let error = finalize_durability(storage, committed, Some(error));
-                    return BatchOutcome { results, error };
+                    return Err(error);
                 }
-                // Inside an explicit transaction the statement's partial writes
-                // were already undone to a savepoint (`rel_statement_scoped`), so
-                // the transaction is consistent either way. `SET XACT_ABORT` (and
-                // error severity) then decides its fate: OFF (the default) with a
-                // non-fatal error rolls back only the statement and the batch
-                // continues; ON — or a high-severity error — dooms the whole
-                // transaction (only ROLLBACK is then accepted, error 3930).
+                // Inside a TRY, any error transfers to the matching CATCH.
+                if in_try {
+                    return Err(error);
+                }
+                // Outside a TRY: `SET XACT_ABORT` (and error severity) decides
+                // the transaction's fate. OFF (the default) with a non-fatal
+                // error rolls back only the statement and the batch continues;
+                // ON — or a high-severity error — dooms the whole transaction
+                // (only ROLLBACK is then accepted, error 3930).
                 let dooms = txn_ctx.xact_abort || error.level >= XACT_ABORT_SEVERITY;
                 if txn_ctx.in_txn() && !dooms {
-                    last_error = Some(error);
+                    run.last_error = Some(error);
                     continue;
                 }
                 if txn_ctx.in_txn() {
                     txn_ctx.doomed = true;
                 }
-                let error = finalize_durability(storage, committed, Some(error));
-                return BatchOutcome { results, error };
+                return Err(error);
             }
         }
     }
-    let error = finalize_durability(storage, committed, last_error);
-    BatchOutcome { results, error }
+    Ok(())
 }
 
 /// Whether a statement can make a durable commit that the batch must fsync: any
@@ -613,9 +708,13 @@ pub fn analyze_locks(
     sql: &str,
     isolation: Isolation,
 ) -> Vec<(Resource, LockMode)> {
-    let Ok(statements) = truthdb_sql::parse(sql) else {
+    let Ok(parsed) = truthdb_sql::parse(sql) else {
         return Vec::new();
     };
+    // Flatten TRY/CATCH so the locks a batch needs are pre-acquired for the
+    // statements inside its try/catch blocks too, not just the top level.
+    let mut statements: Vec<&Statement> = Vec::new();
+    flatten_statements(&parsed, &mut statements);
     // Reads take shared locks except under READ UNCOMMITTED, which takes none.
     // A batch that raises the isolation level (e.g. `SET ISOLATION LEVEL
     // SERIALIZABLE; SELECT ...`) must lock its reads even if the session was
@@ -637,7 +736,7 @@ pub fn analyze_locks(
             .and_modify(|m| *m = m.combine(mode))
             .or_insert(mode);
     };
-    for statement in &statements {
+    for statement in statements.iter().copied() {
         match statement {
             Statement::Select(select) => {
                 if !reads_lock {
@@ -780,12 +879,15 @@ pub fn analyze_locks(
                 add(Resource::Database, LockMode::Exclusive);
             }
             // Transaction control, SET, and DECLARE take no data locks.
+            // TRY/CATCH was flattened away by `flatten_statements`, so its
+            // contained statements appear here directly.
             Statement::BeginTransaction { .. }
             | Statement::Commit { .. }
             | Statement::Rollback { .. }
             | Statement::SaveTransaction { .. }
             | Statement::Set(_)
-            | Statement::Declare(_) => {}
+            | Statement::Declare(_)
+            | Statement::TryCatch { .. } => {}
         }
     }
     // Batch-level lock escalation: if a table accumulated more than the
@@ -848,10 +950,12 @@ fn exec_statement(
     statement: &Statement,
     txn_ctx: &mut TxnContext,
 ) -> Result<StatementResult, SqlError> {
-    // A doomed transaction rejects everything but ROLLBACK.
-    // A doomed transaction accepts only a full ROLLBACK (no savepoint name); a
-    // partial rollback or a new savepoint on a doomed transaction is rejected.
-    if txn_ctx.doomed && !matches!(statement, Statement::Rollback { name: None, .. }) {
+    // A doomed (uncommittable) transaction rejects log writes with 3930, but —
+    // like SQL Server — still allows reads (`SELECT`), `SET`, `DECLARE`, and a
+    // full `ROLLBACK`, so a CATCH block can inspect `XACT_STATE()`/`ERROR_*()`
+    // and then roll back. A partial rollback to a savepoint and `SAVE` stay
+    // rejected (an uncommittable transaction can only be fully rolled back).
+    if txn_ctx.doomed && !doomed_allows(statement) {
         return Err(SqlError::new(
             3930,
             16,
@@ -950,6 +1054,46 @@ fn exec_statement(
                     storage, select, &eval_ctx,
                 )?))
             }
+        }
+        // TRY/CATCH is control flow, handled by `run_block`, which never routes
+        // it here.
+        Statement::TryCatch { .. } => Err(SqlError::message_only(
+            0,
+            "internal error: TRY/CATCH must be executed by run_block",
+        )),
+    }
+}
+
+/// Statements a doomed (uncommittable) transaction still permits: reads
+/// (`SELECT`, including `SELECT @v = ...`), session-state changes (`SET`,
+/// `DECLARE`), and a full `ROLLBACK`. Everything else (DML/DDL, `COMMIT`,
+/// `SAVE`, a partial `ROLLBACK` to a savepoint) writes to the log and is
+/// rejected with 3930.
+fn doomed_allows(statement: &Statement) -> bool {
+    matches!(
+        statement,
+        Statement::Select(_)
+            | Statement::Set(_)
+            | Statement::Declare(_)
+            | Statement::Rollback { name: None, .. }
+    )
+}
+
+/// Flattens `TRY`/`CATCH` blocks into the leaf statements they contain, so lock
+/// analysis (which pre-acquires every table lock a batch needs) sees the
+/// statements nested inside try/catch blocks too.
+fn flatten_statements<'a>(statements: &'a [Statement], out: &mut Vec<&'a Statement>) {
+    for statement in statements {
+        match statement {
+            Statement::TryCatch {
+                try_block,
+                catch_block,
+                ..
+            } => {
+                flatten_statements(try_block, out);
+                flatten_statements(catch_block, out);
+            }
+            other => out.push(other),
         }
     }
 }

--- a/crates/truthdb-sql/src/ast.rs
+++ b/crates/truthdb-sql/src/ast.rs
@@ -42,6 +42,13 @@ pub enum Statement {
     AlterTable(AlterTable),
     /// `DECLARE @a TYPE [= expr], ...` — batch variable declarations.
     Declare(Vec<Declaration>),
+    /// `BEGIN TRY <try_block> END TRY BEGIN CATCH <catch_block> END CATCH`. An
+    /// error in the try block transfers control to the catch block.
+    TryCatch {
+        try_block: Vec<Statement>,
+        catch_block: Vec<Statement>,
+        span: Span,
+    },
 }
 
 /// One `@name TYPE [= initializer]` in a `DECLARE`.

--- a/crates/truthdb-sql/src/eval.rs
+++ b/crates/truthdb-sql/src/eval.rs
@@ -86,6 +86,24 @@ pub struct EvalContext {
     /// The last identity value inserted in this scope — `SCOPE_IDENTITY()`.
     /// `None` until an identity INSERT runs.
     pub scope_identity: Option<i64>,
+    /// The error that transferred control to the innermost active `CATCH`
+    /// block, read by `ERROR_NUMBER()`/`ERROR_MESSAGE()`/etc. `None` outside any
+    /// `CATCH` block (where those functions return NULL).
+    pub error: Option<ErrorInfo>,
+    /// `XACT_STATE()`: 1 = an active, committable transaction; -1 = an active
+    /// but uncommittable (doomed) transaction; 0 = no transaction.
+    pub xact_state: i8,
+}
+
+/// The error captured by a `CATCH` block, surfaced by the `ERROR_*()`
+/// functions. Line and procedure are not tracked (no statement-line map, no
+/// stored procedures), so `ERROR_LINE()` reports 0 and `ERROR_PROCEDURE()` NULL.
+#[derive(Debug, Clone, Default)]
+pub struct ErrorInfo {
+    pub number: i32,
+    pub message: String,
+    pub severity: u8,
+    pub state: u8,
 }
 
 /// Evaluates `expr` against `row`, resolving columns via `resolver`.
@@ -429,6 +447,31 @@ fn eval_session_function(name: &str, args: &[Expr]) -> Option<fn(&EvalContext) -
             Some(value) => SqlValue::Decimal(Box::new(Decimal::new(value as i128, 38, 0))),
             None => SqlValue::Null,
         }),
+        // Error intrinsics — NULL outside a CATCH block, the caught error's
+        // fields within one. (Line/procedure untracked: 0 / NULL.)
+        "ERROR_NUMBER" if args.is_empty() => Some(|ctx| match &ctx.error {
+            Some(e) => SqlValue::Int(e.number as i64),
+            None => SqlValue::Null,
+        }),
+        "ERROR_MESSAGE" if args.is_empty() => Some(|ctx| match &ctx.error {
+            Some(e) => SqlValue::Str(e.message.clone()),
+            None => SqlValue::Null,
+        }),
+        "ERROR_SEVERITY" if args.is_empty() => Some(|ctx| match &ctx.error {
+            Some(e) => SqlValue::Int(e.severity as i64),
+            None => SqlValue::Null,
+        }),
+        "ERROR_STATE" if args.is_empty() => Some(|ctx| match &ctx.error {
+            Some(e) => SqlValue::Int(e.state as i64),
+            None => SqlValue::Null,
+        }),
+        "ERROR_LINE" if args.is_empty() => Some(|ctx| match &ctx.error {
+            Some(_) => SqlValue::Int(0),
+            None => SqlValue::Null,
+        }),
+        "ERROR_PROCEDURE" if args.is_empty() => Some(|_| SqlValue::Null),
+        // Committability of the current transaction (independent of any CATCH).
+        "XACT_STATE" if args.is_empty() => Some(|ctx| SqlValue::Int(ctx.xact_state as i64)),
         _ => None,
     }
 }

--- a/crates/truthdb-sql/src/parser.rs
+++ b/crates/truthdb-sql/src/parser.rs
@@ -129,7 +129,12 @@ impl Parser {
 
     fn parse_begin(&mut self) -> SqlResult<Statement> {
         let start = self.expect_keyword("BEGIN")?;
-        // Stage 6 has no BEGIN...END blocks; BEGIN must open a transaction.
+        // `BEGIN` opens either a transaction or a `TRY` block; there are no
+        // general `BEGIN...END` blocks. (A bare `BEGIN CATCH` is invalid — it
+        // is only reachable inside `parse_try_catch`, after `END TRY`.)
+        if matches!(self.peek_keyword().as_deref(), Some("TRY")) {
+            return self.parse_try_catch(start);
+        }
         let mut end = match self.peek_keyword().as_deref() {
             Some("TRAN") | Some("TRANSACTION") => self.bump().span,
             _ => {
@@ -145,6 +150,47 @@ impl Parser {
             name,
             span: start.to(end),
         })
+    }
+
+    /// `BEGIN TRY <block> END TRY BEGIN CATCH <block> END CATCH` (the opening
+    /// `BEGIN` is already consumed).
+    fn parse_try_catch(&mut self, start: Span) -> SqlResult<Statement> {
+        self.expect_keyword("TRY")?;
+        let try_block = self.parse_block()?;
+        self.expect_keyword("END")?;
+        self.expect_keyword("TRY")?;
+        self.expect_keyword("BEGIN")?;
+        self.expect_keyword("CATCH")?;
+        let catch_block = self.parse_block()?;
+        self.expect_keyword("END")?;
+        let end = self.expect_keyword("CATCH")?;
+        Ok(Statement::TryCatch {
+            try_block,
+            catch_block,
+            span: start.to(end),
+        })
+    }
+
+    /// Parses statements up to (but not consuming) the closing `END` of a
+    /// `TRY`/`CATCH` block. A nested `BEGIN TRY` is consumed whole by
+    /// `parse_statement`, so a top-level `END` here always closes this block.
+    fn parse_block(&mut self) -> SqlResult<Vec<Statement>> {
+        let mut statements = Vec::new();
+        loop {
+            while self.eat(&TokenKind::Semicolon) {}
+            if matches!(self.peek_keyword().as_deref(), Some("END")) || self.at_eof() {
+                break;
+            }
+            statements.push(self.parse_statement()?);
+            if !self.at_eof()
+                && !matches!(self.peek_keyword().as_deref(), Some("END"))
+                && !self.check(&TokenKind::Semicolon)
+            {
+                let token = self.peek().clone();
+                return Err(SqlError::syntax(self.token_text(&token), token.span));
+            }
+        }
+        Ok(statements)
     }
 
     fn parse_commit(&mut self) -> SqlResult<Statement> {
@@ -2161,9 +2207,13 @@ fn binary(op: BinaryOp, left: Expr, right: Expr) -> Expr {
 
 /// Keywords that end the SELECT-list / cannot be an implicit alias.
 fn is_clause_keyword(keyword: &str) -> bool {
+    // `END` closes a TRY/CATCH block and is reserved in T-SQL, so a bare `END`
+    // is never an implicit alias — without this, `SELECT 1 END TRY` would read
+    // `END` as the alias for `1` and then fail on `TRY`. (An explicit `AS end`
+    // or a delimited `[end]` still aliases, as before.)
     matches!(
         keyword,
-        "FROM" | "WHERE" | "ORDER" | "GROUP" | "HAVING" | "AS"
+        "FROM" | "WHERE" | "ORDER" | "GROUP" | "HAVING" | "AS" | "END"
     )
 }
 
@@ -2262,6 +2312,85 @@ mod tests {
         assert!(Parser::parse_str(&sql).is_ok());
         let chain = format!("SELECT 1{}", " + 1".repeat(100));
         assert!(Parser::parse_str(&chain).is_ok());
+    }
+
+    #[test]
+    fn try_catch_parses_into_blocks() {
+        let stmts = Parser::parse_str(
+            "BEGIN TRY \
+               INSERT INTO t VALUES (1); \
+               SELECT 2; \
+             END TRY \
+             BEGIN CATCH \
+               SELECT ERROR_NUMBER(); \
+             END CATCH",
+        )
+        .expect("parse");
+        let Statement::TryCatch {
+            try_block,
+            catch_block,
+            ..
+        } = &stmts[0]
+        else {
+            panic!("expected a TRY/CATCH, got {:?}", stmts[0]);
+        };
+        assert_eq!(try_block.len(), 2, "two statements in the TRY block");
+        assert_eq!(catch_block.len(), 1, "one statement in the CATCH block");
+        assert!(matches!(try_block[0], Statement::Insert(_)));
+
+        // A nested TRY inside the TRY block is consumed whole (its END TRY / END
+        // CATCH do not close the outer block).
+        let stmts = Parser::parse_str(
+            "BEGIN TRY \
+               BEGIN TRY SELECT 1; END TRY BEGIN CATCH SELECT 2; END CATCH; \
+               SELECT 3; \
+             END TRY \
+             BEGIN CATCH SELECT 4; END CATCH",
+        )
+        .expect("parse");
+        let Statement::TryCatch { try_block, .. } = &stmts[0] else {
+            panic!("expected a TRY/CATCH");
+        };
+        assert_eq!(try_block.len(), 2, "nested TRY + the following SELECT");
+        assert!(matches!(try_block[0], Statement::TryCatch { .. }));
+
+        // An unterminated TRY block is a syntax error, not a hang.
+        assert_eq!(
+            Parser::parse_str("BEGIN TRY SELECT 1;").unwrap_err().number,
+            102,
+        );
+    }
+
+    #[test]
+    fn try_catch_parses_without_statement_terminators() {
+        // The canonical T-SQL form omits the `;` before END TRY / END CATCH.
+        // `END` must not be read as an implicit alias for the preceding select
+        // item (or table), which would leave the cursor on `TRY`.
+        for sql in [
+            "BEGIN TRY SELECT 1 END TRY BEGIN CATCH SELECT 2 END CATCH",
+            "BEGIN TRY SELECT * FROM t END TRY BEGIN CATCH SELECT 2 END CATCH",
+            "BEGIN TRY SELECT a FROM t WHERE a = 1 END TRY \
+             BEGIN CATCH SELECT ERROR_MESSAGE() END CATCH",
+        ] {
+            let stmts = Parser::parse_str(sql).unwrap_or_else(|e| panic!("{sql}: {e:?}"));
+            let Statement::TryCatch {
+                try_block,
+                catch_block,
+                ..
+            } = &stmts[0]
+            else {
+                panic!("expected a TRY/CATCH for {sql}");
+            };
+            assert_eq!(try_block.len(), 1, "{sql}");
+            assert_eq!(catch_block.len(), 1, "{sql}");
+        }
+
+        // An explicit `AS end` still aliases (only the *bare* END is declined),
+        // and a delimited [end] is an identifier, not the block terminator.
+        let stmts = Parser::parse_str("SELECT 1 AS end").expect("AS end still aliases");
+        assert!(matches!(stmts[0], Statement::Select(_)));
+        let stmts = Parser::parse_str("SELECT 1 [end]").expect("[end] still aliases");
+        assert!(matches!(stmts[0], Statement::Select(_)));
     }
 
     #[test]


### PR DESCRIPTION
Builds T-SQL structured error handling on the ARIES `rollback_to` savepoint primitive from #83 — the last functional gap in the Stage 6 SQL bullet.

## What
- **Parser**: `BEGIN TRY … END TRY BEGIN CATCH … END CATCH` → `Statement::TryCatch`; nesting supported.
- **Execution**: batch loop becomes a recursive `run_block(.., in_try)`. Inside a TRY any error transfers to the matching CATCH; outside one the existing XACT_ABORT policy is unchanged. The failed statement's writes are already undone to its per-statement savepoint, so the CATCH sees a consistent transaction. `XACT_ABORT ON` (or severity ≥ 17) still dooms the txn, but control still reaches the CATCH, where `XACT_STATE()` reports -1. A TDS Attention is never catchable.
- **Intrinsics**: `XACT_STATE()` (1 / -1 / 0) and `ERROR_NUMBER/MESSAGE/SEVERITY/STATE` off a stack (nested TRY/CATCH restore the outer error). `ERROR_LINE()`=0, `ERROR_PROCEDURE()`=NULL — documented gaps (no statement-line map, no stored procs).
- **Doomed gate corrected to SQL Server semantics**: an uncommittable txn rejects *log writes* (3930) but allows reads/SET/DECLARE. Previously it rejected everything but ROLLBACK — which would make `SELECT XACT_STATE()` in a doomed CATCH impossible. Partial ROLLBACK/SAVE stay rejected; one existing test updated to probe with a write.
- **Lock analysis** flattens TRY/CATCH so nested statements still pre-acquire table locks.

## Review
Two adversarial reviews. Control-flow: **no bugs** (verified cancel-not-caught, doomed-CATCH reads, nested error-stack scoping, commit-in-CATCH durability, savepoint isolation empirically). Integration found a **real parser bug**: the lexer has no reserved-word set, so the alias parsers read a bare `END` as an implicit alias — the *canonical* semicolon-less form (`SELECT 1 END TRY`) failed with 102, and every test passed only because they used semicolons. `END` is reserved in T-SQL and is now declined as a bare alias (`AS end` / `[end]` still alias), with parser + end-to-end regression tests.

## Verification
All 16 suites green (272 core, 60 sql, TDS); `cargo fmt --check` clean; no clippy warnings in implementation code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)