### PR TITLE
Stage 6: validate ALL_HEADERS and the transaction descriptor

### DIFF
--- a/crates/truthdb-tds/src/server.rs
+++ b/crates/truthdb-tds/src/server.rs
@@ -158,7 +158,7 @@ where
         match message.kind {
             PKT_SQL_BATCH => {
                 let headers = parse_all_headers(&message.payload)?;
-                check_transaction_descriptor(&headers, tran_descriptor)?;
+                check_transaction_descriptor(headers.transaction_descriptor, tran_descriptor)?;
                 let sql = batch_sql(headers.body)?;
                 let cancel = Arc::new(AtomicBool::new(false));
                 let work = run_batch(engine, session, &sql, cancel.clone());
@@ -171,7 +171,7 @@ where
             }
             PKT_RPC => {
                 let headers = parse_all_headers(&message.payload)?;
-                check_transaction_descriptor(&headers, tran_descriptor)?;
+                check_transaction_descriptor(headers.transaction_descriptor, tran_descriptor)?;
                 let cancel = Arc::new(AtomicBool::new(false));
                 let work = run_rpc(engine, session, headers.body, cancel.clone());
                 match run_watching_attention(stream, cancel, work).await? {
@@ -183,11 +183,11 @@ where
             }
             PKT_TRANSACTION_MANAGER => {
                 let headers = parse_all_headers(&message.payload)?;
-                check_transaction_descriptor(&headers, tran_descriptor)?;
                 let response = handle_tm_request(
                     engine,
                     session,
                     headers.body,
+                    headers.transaction_descriptor,
                     &mut tran_descriptor,
                     &mut next_descriptor,
                 )
@@ -215,10 +215,20 @@ async fn handle_tm_request(
     engine: &EngineHandle,
     session: SessionId,
     body: &[u8],
+    claimed_descriptor: Option<u64>,
     tran_descriptor: &mut u64,
     next_descriptor: &mut u64,
 ) -> io::Result<Vec<u8>> {
     let (request_type, isolation) = parse_tm_request(body)?;
+    // Only COMMIT/ROLLBACK are validated: they name the transaction they end,
+    // so a mismatch means the client is ending a transaction it is not in. A
+    // BEGIN's descriptor references no transaction yet — it is a placeholder,
+    // and real drivers treat it as one: go-mssqldb hardcodes 0 on BEGIN while
+    // using the live descriptor everywhere else. Validating it would kill the
+    // connection of a perfectly correct client.
+    if request_type != TM_BEGIN_XACT {
+        check_transaction_descriptor(claimed_descriptor, *tran_descriptor)?;
+    }
     let sql = match request_type {
         TM_BEGIN_XACT => match isolation_set_clause(isolation) {
             Some(set) => format!("{set}; BEGIN TRANSACTION"),
@@ -265,13 +275,22 @@ async fn handle_tm_request(
             *tran_descriptor = descriptor;
             token::envchange_begin_tran(&mut out, descriptor);
         }
+        // A nested COMMIT (@@TRANCOUNT 2 -> 1) does not end the transaction, so
+        // it emits no terminating ENVCHANGE and keeps the descriptor: the
+        // transaction the client is in has not changed. Announcing the end of a
+        // still-open transaction would contradict this reply's own DONE(INXACT)
+        // and, now that the descriptor is validated, desynchronise the client.
         TM_COMMIT_XACT => {
-            token::envchange_commit_tran(&mut out, *tran_descriptor);
-            *tran_descriptor = 0;
+            if !reply.in_transaction {
+                token::envchange_commit_tran(&mut out, *tran_descriptor);
+                *tran_descriptor = 0;
+            }
         }
         TM_ROLLBACK_XACT => {
-            token::envchange_rollback_tran(&mut out, *tran_descriptor);
-            *tran_descriptor = 0;
+            if !reply.in_transaction {
+                token::envchange_rollback_tran(&mut out, *tran_descriptor);
+                *tran_descriptor = 0;
+            }
         }
         _ => unreachable!("request type validated above"),
     }
@@ -577,8 +596,10 @@ fn parse_all_headers(payload: &[u8]) -> io::Result<AllHeaders<'_>> {
 /// meaningful when present, and refusing requests without one would break
 /// clients that omit it (MS-TDS mandates it, but tolerating absence costs
 /// nothing here — a client that never sends one never desynchronises).
-fn check_transaction_descriptor(headers: &AllHeaders<'_>, current: u64) -> io::Result<()> {
-    match headers.transaction_descriptor {
+///
+/// Nor is a `TM_BEGIN_XACT` checked — see [`handle_tm_request`].
+fn check_transaction_descriptor(claimed: Option<u64>, current: u64) -> io::Result<()> {
+    match claimed {
         Some(descriptor) if descriptor != current => Err(protocol_err(&format!(
             "transaction descriptor {descriptor} does not match this connection's transaction {current}"
         ))),

--- a/crates/truthdb-tds/src/server.rs
+++ b/crates/truthdb-tds/src/server.rs
@@ -157,7 +157,9 @@ where
         };
         match message.kind {
             PKT_SQL_BATCH => {
-                let sql = batch_sql(&message.payload)?;
+                let headers = parse_all_headers(&message.payload)?;
+                check_transaction_descriptor(&headers, tran_descriptor)?;
+                let sql = batch_sql(headers.body)?;
                 let cancel = Arc::new(AtomicBool::new(false));
                 let work = run_batch(engine, session, &sql, cancel.clone());
                 match run_watching_attention(stream, cancel, work).await? {
@@ -168,8 +170,10 @@ where
                 }
             }
             PKT_RPC => {
+                let headers = parse_all_headers(&message.payload)?;
+                check_transaction_descriptor(&headers, tran_descriptor)?;
                 let cancel = Arc::new(AtomicBool::new(false));
-                let work = run_rpc(engine, session, &message.payload, cancel.clone());
+                let work = run_rpc(engine, session, headers.body, cancel.clone());
                 match run_watching_attention(stream, cancel, work).await? {
                     Some(response) => {
                         write_message(stream, PKT_TABULAR_RESULT, &response, packet_size).await?
@@ -178,10 +182,12 @@ where
                 }
             }
             PKT_TRANSACTION_MANAGER => {
+                let headers = parse_all_headers(&message.payload)?;
+                check_transaction_descriptor(&headers, tran_descriptor)?;
                 let response = handle_tm_request(
                     engine,
                     session,
-                    &message.payload,
+                    headers.body,
                     &mut tran_descriptor,
                     &mut next_descriptor,
                 )
@@ -208,11 +214,11 @@ where
 async fn handle_tm_request(
     engine: &EngineHandle,
     session: SessionId,
-    payload: &[u8],
+    body: &[u8],
     tran_descriptor: &mut u64,
     next_descriptor: &mut u64,
 ) -> io::Result<Vec<u8>> {
-    let (request_type, isolation) = parse_tm_request(payload)?;
+    let (request_type, isolation) = parse_tm_request(body)?;
     let sql = match request_type {
         TM_BEGIN_XACT => match isolation_set_clause(isolation) {
             Some(set) => format!("{set}; BEGIN TRANSACTION"),
@@ -273,11 +279,10 @@ async fn handle_tm_request(
     Ok(out)
 }
 
-/// Parses a Transaction Manager request payload: an ALL_HEADERS block, then a
+/// Parses a Transaction Manager request body (the bytes *after* ALL_HEADERS): a
 /// `RequestType` (u16 LE), then for `TM_BEGIN_XACT` an isolation-level byte.
 /// Returns the request type and (for BEGIN) the isolation byte.
-fn parse_tm_request(payload: &[u8]) -> io::Result<(u16, u8)> {
-    let body = skip_all_headers(payload);
+fn parse_tm_request(body: &[u8]) -> io::Result<(u16, u8)> {
     if body.len() < 2 {
         return Err(protocol_err("transaction manager request too short"));
     }
@@ -416,10 +421,10 @@ async fn run_batch(
 async fn run_rpc(
     engine: &EngineHandle,
     session: SessionId,
-    payload: &[u8],
+    body: &[u8],
     cancel: Arc<AtomicBool>,
 ) -> Vec<u8> {
-    let request = match rpc::parse_rpc_request(skip_all_headers(payload)) {
+    let request = match rpc::parse_rpc_request(body) {
         Ok(request) => request,
         Err(err) => return rpc_error(&format!("malformed RPC request: {err}")),
     };
@@ -504,27 +509,85 @@ fn build_batch_tokens(outcome: &BatchOutcome, in_transaction: bool) -> Vec<u8> {
     out
 }
 
-/// Skips a request payload's ALL_HEADERS block, returning the bytes after it.
-/// ALL_HEADERS starts with a `TotalLength u32` covering the whole block (incl.
-/// itself); a missing or malformed block means the payload has no headers.
-fn skip_all_headers(payload: &[u8]) -> &[u8] {
-    let start = if payload.len() >= 4 {
-        let total = u32::from_le_bytes(payload[0..4].try_into().unwrap()) as usize;
-        if (4..=payload.len()).contains(&total) {
-            total
-        } else {
-            0
-        }
-    } else {
-        0
-    };
-    &payload[start..]
+/// The Transaction Descriptor header (MS-TDS 2.2.5.3.1): the descriptor the
+/// server handed out via ENVCHANGE 8, plus an outstanding-request count.
+const HEADER_TRANSACTION_DESCRIPTOR: u16 = 0x0002;
+
+/// A request's parsed ALL_HEADERS block.
+struct AllHeaders<'a> {
+    /// The descriptor from the Transaction Descriptor header, if the client
+    /// sent one (the header is mandatory in MS-TDS, but absence is tolerated —
+    /// see [`check_transaction_descriptor`]).
+    transaction_descriptor: Option<u64>,
+    /// The request body following the header block.
+    body: &'a [u8],
 }
 
-/// Extracts the SQL text from a SQLBatch payload: an ALL_HEADERS block
-/// (`TotalLength u32` covering the headers) followed by the UCS-2LE query.
-fn batch_sql(payload: &[u8]) -> io::Result<String> {
-    let text = skip_all_headers(payload);
+/// Parses a request payload's ALL_HEADERS block (MS-TDS 2.2.5.2): a
+/// `TotalLength u32` covering the whole block (including itself), then headers
+/// of `HeaderLength u32 | HeaderType u16 | data`. Unknown header types are
+/// skipped (forward compatibility).
+///
+/// A malformed block is a protocol error rather than being silently taken as
+/// request data: treating a bad `TotalLength` as "no headers" would hand the
+/// header bytes to the SQL/RPC decoder as if they were the request.
+fn parse_all_headers(payload: &[u8]) -> io::Result<AllHeaders<'_>> {
+    if payload.len() < 4 {
+        return Err(protocol_err("request is missing its ALL_HEADERS block"));
+    }
+    let total = u32::from_le_bytes(payload[0..4].try_into().unwrap()) as usize;
+    if !(4..=payload.len()).contains(&total) {
+        return Err(protocol_err("ALL_HEADERS TotalLength is out of range"));
+    }
+    let mut rest = &payload[4..total];
+    let mut transaction_descriptor = None;
+    while !rest.is_empty() {
+        // Each entry is at least its own length field plus a type.
+        if rest.len() < 6 {
+            return Err(protocol_err("ALL_HEADERS entry is truncated"));
+        }
+        let len = u32::from_le_bytes(rest[0..4].try_into().unwrap()) as usize;
+        // `len` must cover the header itself and stay inside the block — a zero
+        // or oversized length would otherwise stall or overrun the walk.
+        if !(6..=rest.len()).contains(&len) {
+            return Err(protocol_err("ALL_HEADERS HeaderLength is out of range"));
+        }
+        if u16::from_le_bytes([rest[4], rest[5]]) == HEADER_TRANSACTION_DESCRIPTOR {
+            // TransactionDescriptor u64, then OutstandingRequestCount u32.
+            let data = &rest[6..len];
+            if data.len() < 12 {
+                return Err(protocol_err("transaction descriptor header is truncated"));
+            }
+            transaction_descriptor = Some(u64::from_le_bytes(data[0..8].try_into().unwrap()));
+        }
+        rest = &rest[len..];
+    }
+    Ok(AllHeaders {
+        transaction_descriptor,
+        body: &payload[total..],
+    })
+}
+
+/// Rejects a request whose transaction descriptor disagrees with the
+/// transaction this connection is actually in — the client's view has
+/// desynchronised from the server's, so running the request would apply it to
+/// the wrong transaction.
+///
+/// A client that sends no descriptor header is not checked: the header is only
+/// meaningful when present, and refusing requests without one would break
+/// clients that omit it (MS-TDS mandates it, but tolerating absence costs
+/// nothing here — a client that never sends one never desynchronises).
+fn check_transaction_descriptor(headers: &AllHeaders<'_>, current: u64) -> io::Result<()> {
+    match headers.transaction_descriptor {
+        Some(descriptor) if descriptor != current => Err(protocol_err(&format!(
+            "transaction descriptor {descriptor} does not match this connection's transaction {current}"
+        ))),
+        _ => Ok(()),
+    }
+}
+
+/// Decodes a SQLBatch body (the UCS-2LE query text after ALL_HEADERS).
+fn batch_sql(text: &[u8]) -> io::Result<String> {
     if !text.len().is_multiple_of(2) {
         return Err(protocol_err("SQLBatch text is not UCS-2 aligned"));
     }

--- a/crates/truthdb-tds/tests/tds_client.rs
+++ b/crates/truthdb-tds/tests/tds_client.rs
@@ -61,6 +61,10 @@ fn ucs2le(s: &str) -> Vec<u8> {
 /// A minimal client that speaks just enough TDS to test the server.
 struct Client {
     stream: DuplexStream,
+    /// The connection's current transaction descriptor, learned from ENVCHANGE
+    /// 8 (begin) and cleared by 9/10 (commit/rollback). Real drivers echo this
+    /// in every request's ALL_HEADERS, and the server validates it.
+    tran_descriptor: u64,
 }
 
 impl Client {
@@ -79,6 +83,31 @@ impl Client {
         self.stream.write_all(&header).await.unwrap();
         self.stream.write_all(payload).await.unwrap();
         self.stream.flush().await.unwrap();
+    }
+
+    /// Reads a message, or None if the server closed the connection (which is
+    /// how a protocol error surfaces to the client).
+    async fn try_read_message(&mut self) -> Option<(u8, Vec<u8>)> {
+        let mut header = [0u8; 8];
+        self.stream.read_exact(&mut header).await.ok()?;
+        let kind = header[0];
+        let mut payload = self.read_body(&header).await;
+        let mut status = header[1];
+        while status & 0x01 == 0 {
+            self.stream.read_exact(&mut header).await.ok()?;
+            status = header[1];
+            payload.extend(self.read_body(&header).await);
+        }
+        Some((kind, payload))
+    }
+
+    /// Sends a SQLBatch with a caller-supplied ALL_HEADERS block (to exercise
+    /// malformed / mismatched headers the normal `batch` path cannot produce).
+    async fn raw_batch(&mut self, headers_block: &[u8], sql: &str) {
+        let mut payload = Vec::new();
+        payload.extend_from_slice(headers_block);
+        payload.extend(ucs2le(sql));
+        self.write_packet(PKT_SQL_BATCH, &payload).await;
     }
 
     /// Reads a full message (packets until EOM) -> (kind, payload).
@@ -121,21 +150,37 @@ impl Client {
         let mut payload = Vec::new();
         // ALL_HEADERS: TotalLength includes itself (the 4-byte field) plus
         // the header block; the SQL text starts right after.
-        let headers = all_headers();
+        let headers = all_headers(self.tran_descriptor);
         let total = 4 + headers.len();
         payload.extend_from_slice(&(total as u32).to_le_bytes());
         payload.extend_from_slice(&headers);
         payload.extend(ucs2le(sql));
         self.write_packet(PKT_SQL_BATCH, &payload).await;
         let (_, response) = self.read_message().await;
-        parse_tokens(&response)
+        let tokens = parse_tokens(&response);
+        self.track_descriptor(&tokens);
+        tokens
+    }
+
+    /// Applies any transaction ENVCHANGE in a response to the tracked
+    /// descriptor, exactly as a real driver would.
+    fn track_descriptor(&mut self, tokens: &[Token]) {
+        for token in tokens {
+            if let Token::EnvChange { kind, descriptor } = token {
+                match kind {
+                    8 => self.tran_descriptor = *descriptor,
+                    9 | 10 => self.tran_descriptor = 0,
+                    _ => {}
+                }
+            }
+        }
     }
 
     /// Sends a Transaction Manager request (request type + optional isolation
     /// byte for BEGIN) and returns the decoded response tokens.
     async fn tm_request(&mut self, request_type: u16, isolation: u8) -> Vec<Token> {
         let mut payload = Vec::new();
-        let headers = all_headers();
+        let headers = all_headers(self.tran_descriptor);
         let total = 4 + headers.len();
         payload.extend_from_slice(&(total as u32).to_le_bytes());
         payload.extend_from_slice(&headers);
@@ -146,18 +191,43 @@ impl Client {
         }
         self.write_packet(PKT_TRANSACTION_MANAGER, &payload).await;
         let (_, response) = self.read_message().await;
-        parse_tokens(&response)
+        let tokens = parse_tokens(&response);
+        self.track_descriptor(&tokens);
+        tokens
     }
 }
 
-/// A minimal ALL_HEADERS with a transaction-descriptor header (type 2).
-fn all_headers() -> Vec<u8> {
+/// The transaction descriptor carried by an ENVCHANGE body, or 0 if there is
+/// none. Body = `type u8 | NewValue B_VARBYTE | OldValue B_VARBYTE`; type 8
+/// (begin) puts the new descriptor in NewValue, types 9/10 (commit/rollback)
+/// leave NewValue empty and put the ending descriptor in OldValue.
+fn envchange_descriptor(body: &[u8]) -> u64 {
+    let read_varbyte = |at: usize| -> Option<(u64, usize)> {
+        let len = *body.get(at)? as usize;
+        if len == 8 && body.len() >= at + 1 + 8 {
+            let bytes: [u8; 8] = body[at + 1..at + 9].try_into().ok()?;
+            Some((u64::from_le_bytes(bytes), at + 1 + len))
+        } else {
+            Some((0, at + 1 + len))
+        }
+    };
+    // NewValue first; if it was empty, fall through to OldValue.
+    match read_varbyte(1) {
+        Some((value, _)) if value != 0 => value,
+        Some((_, next)) => read_varbyte(next).map(|(v, _)| v).unwrap_or(0),
+        None => 0,
+    }
+}
+
+/// A minimal ALL_HEADERS with a transaction-descriptor header (type 2),
+/// carrying the connection's current descriptor (0 = no transaction).
+fn all_headers(descriptor: u64) -> Vec<u8> {
     // Header: length u32 | type u16 | transaction descriptor u64 | request count u32
     let mut header = Vec::new();
     let body_len = 4 + 2 + 8 + 4;
     header.extend_from_slice(&(body_len as u32).to_le_bytes());
     header.extend_from_slice(&2u16.to_le_bytes()); // transaction descriptor
-    header.extend_from_slice(&0u64.to_le_bytes());
+    header.extend_from_slice(&descriptor.to_le_bytes());
     header.extend_from_slice(&1u32.to_le_bytes());
     header
 }
@@ -192,7 +262,7 @@ enum Token {
     ColMetadata(Vec<ColType>),
     Row(Vec<Cell>),
     Error { number: i32 },
-    EnvChange { kind: u8 },
+    EnvChange { kind: u8, descriptor: u64 },
     Done { count: Option<u64>, in_xact: bool },
     Other(u8),
 }
@@ -239,7 +309,13 @@ fn parse_tokens(payload: &[u8]) -> Vec<Token> {
                     let number = i32::from_le_bytes(body[0..4].try_into().unwrap());
                     tokens.push(Token::Error { number });
                 } else if token == 0xe3 {
-                    tokens.push(Token::EnvChange { kind: body[0] });
+                    // Transaction ENVCHANGEs carry the descriptor as a
+                    // B_VARBYTE: type 8 (begin) in NewValue, types 9/10
+                    // (commit/rollback) in OldValue (NewValue empty).
+                    tokens.push(Token::EnvChange {
+                        kind: body[0],
+                        descriptor: envchange_descriptor(body),
+                    });
                 }
                 i += 2 + len;
             }
@@ -407,6 +483,7 @@ async fn connect(engine: EngineHandle) -> Client {
     });
     Client {
         stream: client_half,
+        tran_descriptor: 0,
     }
 }
 
@@ -518,7 +595,7 @@ const TM_ROLLBACK_XACT: u16 = 8;
 fn has_envchange(tokens: &[Token], kind: u8) -> bool {
     tokens
         .iter()
-        .any(|t| matches!(t, Token::EnvChange { kind: k } if *k == kind))
+        .any(|t| matches!(t, Token::EnvChange { kind: k, .. } if *k == kind))
 }
 
 fn row_ints(tokens: &[Token]) -> Vec<i64> {
@@ -532,6 +609,119 @@ fn row_ints(tokens: &[Token]) -> Vec<i64> {
             _ => None,
         })
         .collect()
+}
+
+/// Wraps a header block with its ALL_HEADERS TotalLength (which includes itself).
+fn headers_block(headers: &[u8]) -> Vec<u8> {
+    let mut out = Vec::new();
+    out.extend_from_slice(&((4 + headers.len()) as u32).to_le_bytes());
+    out.extend_from_slice(headers);
+    out
+}
+
+#[tokio::test]
+async fn malformed_all_headers_is_rejected() {
+    // A TotalLength that runs past the payload must be a protocol error. It was
+    // previously treated as "no headers", handing the header bytes to the SQL
+    // decoder as if they were the query.
+    for bad in [
+        // TotalLength beyond the payload.
+        {
+            let mut p = 9999u32.to_le_bytes().to_vec();
+            p.extend(ucs2le("SELECT 1"));
+            p
+        },
+        // TotalLength smaller than the field itself.
+        {
+            let mut p = 2u32.to_le_bytes().to_vec();
+            p.extend(ucs2le("SELECT 1"));
+            p
+        },
+        // A header whose HeaderLength is 0 (would stall the walk).
+        {
+            let mut h = 0u32.to_le_bytes().to_vec();
+            h.extend_from_slice(&2u16.to_le_bytes());
+            headers_block(&h)
+        },
+        // A header whose HeaderLength overruns the block.
+        {
+            let mut h = 999u32.to_le_bytes().to_vec();
+            h.extend_from_slice(&2u16.to_le_bytes());
+            headers_block(&h)
+        },
+        // A transaction-descriptor header with truncated data.
+        {
+            let mut h = (4u32 + 2 + 3).to_le_bytes().to_vec();
+            h.extend_from_slice(&2u16.to_le_bytes());
+            h.extend_from_slice(&[0, 0, 0]);
+            headers_block(&h)
+        },
+    ] {
+        let path = temp_path("bad-headers");
+        let engine = engine(&path);
+        let mut client = connect(engine).await;
+        client.prelogin().await;
+        client.login("sa", "secret").await;
+        client.write_packet(PKT_SQL_BATCH, &bad).await;
+        assert!(
+            client.try_read_message().await.is_none(),
+            "malformed ALL_HEADERS must close the connection, not answer"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+}
+
+#[tokio::test]
+async fn mismatched_transaction_descriptor_is_rejected() {
+    // A descriptor the server never handed out means the client's transaction
+    // view has desynchronised: the request must not run.
+    let path = temp_path("bad-descriptor");
+    let engine = engine(&path);
+    let mut client = connect(engine).await;
+    client.prelogin().await;
+    client.login("sa", "secret").await;
+
+    // No transaction is open, so the connection's descriptor is 0; claim 42.
+    client
+        .raw_batch(&headers_block(&all_headers(42)), "SELECT 1")
+        .await;
+    assert!(
+        client.try_read_message().await.is_none(),
+        "a mismatched transaction descriptor must close the connection"
+    );
+    let _ = std::fs::remove_file(path);
+}
+
+#[tokio::test]
+async fn transaction_descriptor_round_trips_through_envchange() {
+    // The server mints a descriptor on TM begin, the client echoes it on the
+    // next request, and it returns to 0 after commit. This is what the
+    // validation above enforces, so pin the values rather than only the flow.
+    let path = temp_path("descriptor-roundtrip");
+    let engine = engine(&path);
+    let mut client = connect(engine).await;
+    client.prelogin().await;
+    client.login("sa", "secret").await;
+    assert_eq!(client.tran_descriptor, 0, "no transaction at login");
+
+    client.tm_request(TM_BEGIN_XACT, 0).await;
+    let in_txn = client.tran_descriptor;
+    assert_ne!(in_txn, 0, "begin must mint a non-zero descriptor");
+
+    // The next request echoes it and is accepted (the server validates it).
+    let rows = client.batch("SELECT 1").await;
+    assert!(
+        rows.iter().any(|t| matches!(t, Token::Row(_))),
+        "echoing the descriptor must be accepted: {rows:?}"
+    );
+    assert_eq!(
+        client.tran_descriptor, in_txn,
+        "descriptor is stable in-txn"
+    );
+
+    client.tm_request(TM_COMMIT_XACT, 0).await;
+    assert_eq!(client.tran_descriptor, 0, "commit clears the descriptor");
+    let _ = std::fs::remove_file(path);
 }
 
 #[tokio::test]

--- a/crates/truthdb-tds/tests/tds_client.rs
+++ b/crates/truthdb-tds/tests/tds_client.rs
@@ -180,7 +180,14 @@ impl Client {
     /// byte for BEGIN) and returns the decoded response tokens.
     async fn tm_request(&mut self, request_type: u16, isolation: u8) -> Vec<Token> {
         let mut payload = Vec::new();
-        let headers = all_headers(self.tran_descriptor);
+        // Mirror go-mssqldb: a BEGIN carries a placeholder 0 descriptor (it
+        // names no transaction yet), while COMMIT/ROLLBACK carry the live one.
+        let descriptor = if request_type == TM_BEGIN_XACT {
+            0
+        } else {
+            self.tran_descriptor
+        };
+        let headers = all_headers(descriptor);
         let total = 4 + headers.len();
         payload.extend_from_slice(&(total as u32).to_le_bytes());
         payload.extend_from_slice(&headers);
@@ -721,6 +728,92 @@ async fn transaction_descriptor_round_trips_through_envchange() {
 
     client.tm_request(TM_COMMIT_XACT, 0).await;
     assert_eq!(client.tran_descriptor, 0, "commit clears the descriptor");
+    let _ = std::fs::remove_file(path);
+}
+
+#[tokio::test]
+async fn begin_after_a_batch_commit_is_accepted_with_a_placeholder_descriptor() {
+    // Regression: go-mssqldb hardcodes descriptor 0 on TM begin while using the
+    // live descriptor everywhere else. Committing via a SQL batch leaves the
+    // server's descriptor non-zero (the batch path emits no ENVCHANGE), so a
+    // following begin arrives claiming 0 against a non-zero descriptor.
+    // Validating a begin would kill this correct client's connection.
+    let path = temp_path("begin-placeholder");
+    let engine = engine(&path);
+    let mut client = connect(engine).await;
+    client.prelogin().await;
+    client.login("sa", "secret").await;
+    client
+        .batch("CREATE TABLE t (id INT NOT NULL PRIMARY KEY)")
+        .await;
+
+    // Begin via TM, then commit via a SQL batch: the server's descriptor stays
+    // non-zero because only TM requests move it.
+    client.tm_request(TM_BEGIN_XACT, 0).await;
+    assert_ne!(client.tran_descriptor, 0, "begin minted a descriptor");
+    client.batch("INSERT INTO t VALUES (1)").await;
+    client.batch("COMMIT TRANSACTION").await;
+
+    // A second begin, carrying go-mssqldb's placeholder 0, must be accepted.
+    let begin = client.tm_request(TM_BEGIN_XACT, 0).await;
+    assert!(
+        has_envchange(&begin, 8),
+        "a begin with a placeholder descriptor must be accepted: {begin:?}"
+    );
+    let rows = client.batch("SELECT id FROM t").await;
+    assert!(
+        rows.iter().any(|t| matches!(t, Token::Row(_))),
+        "the connection is still usable: {rows:?}"
+    );
+    client.tm_request(TM_ROLLBACK_XACT, 0).await;
+    let _ = std::fs::remove_file(path);
+}
+
+#[tokio::test]
+async fn nested_tm_commit_keeps_the_transaction_and_its_descriptor() {
+    // A nested COMMIT (@@TRANCOUNT 2 -> 1) does not end the transaction, so it
+    // must not announce one ending: emitting ENVCHANGE 9 here would contradict
+    // the same reply's DONE(INXACT) and zero a descriptor the client is still
+    // meant to send.
+    let path = temp_path("nested-tm-commit");
+    let engine = engine(&path);
+    let mut client = connect(engine).await;
+    client.prelogin().await;
+    client.login("sa", "secret").await;
+    client
+        .batch("CREATE TABLE t (id INT NOT NULL PRIMARY KEY)")
+        .await;
+
+    client.tm_request(TM_BEGIN_XACT, 0).await;
+    let descriptor = client.tran_descriptor;
+    assert_ne!(descriptor, 0);
+    // Nest a second transaction via SQL: @@TRANCOUNT is now 2.
+    client.batch("BEGIN TRANSACTION").await;
+
+    // The inner commit only decrements @@TRANCOUNT: still in a transaction.
+    let commit = client.tm_request(TM_COMMIT_XACT, 0).await;
+    assert!(
+        !has_envchange(&commit, 9),
+        "a nested commit must not announce the transaction ending: {commit:?}"
+    );
+    assert!(
+        commit
+            .iter()
+            .any(|t| matches!(t, Token::Done { in_xact: true, .. })),
+        "still in a transaction: {commit:?}"
+    );
+    assert_eq!(
+        client.tran_descriptor, descriptor,
+        "the descriptor survives a nested commit"
+    );
+
+    // The outer commit ends it: now the ENVCHANGE fires and clears it.
+    let commit = client.tm_request(TM_COMMIT_XACT, 0).await;
+    assert!(
+        has_envchange(&commit, 9),
+        "outer commit ends it: {commit:?}"
+    );
+    assert_eq!(client.tran_descriptor, 0);
     let _ = std::fs::remove_file(path);
 }
 


### PR DESCRIPTION
Closes the Stage 6 TDS gap: *"ALL_HEADERS skipped, not validated; transaction descriptor not checked"*.

## What
`skip_all_headers` read only the leading `TotalLength` and, when it was out of range, treated the payload as having **no headers at all** — handing the header bytes to the SQL/RPC decoder as if they were the request. It never walked the individual headers.

- **`parse_all_headers`** validates the block (MS-TDS 2.2.5.2): TotalLength must cover itself and fit the payload; each entry's HeaderLength must cover its own length+type and stay inside the block (so the walk always advances and cannot overrun); a Transaction Descriptor header (type 2) must carry its full u64 + u32. Unknown types skipped for forward-compat. Malformed ⇒ protocol error, not silently reinterpreted as request data.
- **`check_transaction_descriptor`** rejects a request whose descriptor disagrees with the transaction the connection is in. Absent header ⇒ not checked (a client that never sends one cannot desynchronise).
- The request loop parses headers once per SQLBatch/RPC/TM and passes the body down, so `run_rpc`/`parse_tm_request`/`batch_sql` take an already-stripped body.

## Adversarial review caught a critical interop bug
The first cut validated the descriptor on **every** TM request. Review found that breaks the driver CI actually pins:

> go-mssqldb v1.8.0 `sendBeginRequest` hardcodes `transDescrHdr{0, 1}` — a literal **0** — while `sendCommitRequest`/`sendRollbackRequest`/`sendQuery` use the live `sess.tranid`.

A begin's descriptor names no transaction yet — it's a placeholder. After a transaction committed via a SQL batch (the batch path emits no ENVCHANGE, so the server's descriptor stays non-zero), the next begin arrives claiming 0 and was **rejected, killing the connection of a correct client**. Now only COMMIT/ROLLBACK are validated — they name the transaction they end.

Review also confirmed a latent bug my change made load-bearing: a **nested** commit (`@@TRANCOUNT` 2→1) emitted ENVCHANGE 9 and zeroed the descriptor while ignoring `reply.in_transaction` — which the next line passes to DONE(INXACT). The reply contradicted itself. A terminating ENVCHANGE is now emitted only when the transaction actually ended.

The tests missed both because the test client echoed the descriptor everywhere; it now **models go-mssqldb's asymmetry**, so the suite exercises what CI sends.

## Verification
Both regressions are pinned by tests **verified to fail without their fix** (re-enabling the begin check fails the placeholder test; removing the `in_transaction` gate fails the nested-commit test). New tests also cover malformed blocks (bad TotalLength both ways, zero/oversized HeaderLength, truncated descriptor), a mismatched descriptor, and the descriptor round trip. All 16 suites green; fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)