### PR TITLE
Stage 6: reap transactions abandoned by idle sessions

### DIFF
--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -195,6 +195,13 @@ impl Engine {
         txn_ctx.abort(&self.storage);
     }
 
+    /// Rolls back a transaction the idle reaper is reclaiming. Unlike
+    /// [`Self::abort_session_txn`] the session lives on, so the rollback is
+    /// recorded and reported to its next batch.
+    pub fn abort_idle_session_txn(&self, txn_ctx: &mut crate::rel::TxnContext) {
+        txn_ctx.abort_idle(&self.storage);
+    }
+
     /// The table/database locks a SQL batch needs at the given isolation
     /// level (see [`crate::rel::analyze_locks`]). The session loop acquires
     /// these before running the batch.

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -68,6 +68,13 @@ pub struct TxnContext {
     /// nested `TRY`/`CATCH` restore the outer error on exit). `ERROR_*()` read
     /// the top; empty outside any `CATCH` block.
     error_stack: Vec<truthdb_sql::eval::ErrorInfo>,
+    /// Set when the idle reaper rolled this session's transaction back. The
+    /// session's next batch fails with 1205 and clears it, so a client that
+    /// comes back believing it is still in a transaction is told the
+    /// transaction is gone — rather than silently autocommitting statements it
+    /// means to be transactional, and only discovering it at a COMMIT that
+    /// errors 3902 long after the writes became durable.
+    reaped: bool,
 }
 
 /// Session isolation level (defaults to READ COMMITTED, like SQL Server).
@@ -154,13 +161,35 @@ impl TxnContext {
         self.isolation
     }
 
-    /// Rolls back and discards any open transaction (connection teardown).
+    /// Rolls back and discards any open transaction, resetting every piece of
+    /// transaction-scoped state.
+    ///
+    /// `savepoints` must be cleared here, not merely on the paths that discard
+    /// the context afterwards: a savepoint holds the *undo-log offset* of the
+    /// transaction that recorded it, so one surviving into the session's next
+    /// transaction would let `ROLLBACK TRANSACTION <name>` find a stale entry
+    /// instead of erroring 3908 — and hand a dead transaction's offset to
+    /// `rel_rollback_to`, which either truncates the new transaction's undo log
+    /// (silently discarding committed work) or panics on `split_off`.
     pub fn abort(&mut self, storage: &Storage) {
         if let Some(txn) = self.txn.take() {
             let _ = storage.rel_rollback(txn);
         }
         self.trancount = 0;
         self.doomed = false;
+        self.savepoints.clear();
+    }
+
+    /// Rolls back this session's transaction because it sat idle too long, and
+    /// records that it happened so the session's next batch can say so.
+    pub fn abort_idle(&mut self, storage: &Storage) {
+        self.abort(storage);
+        self.reaped = true;
+    }
+
+    /// Takes the "your transaction was reaped" flag, if set.
+    fn take_reaped(&mut self) -> bool {
+        std::mem::take(&mut self.reaped)
     }
 }
 
@@ -231,6 +260,22 @@ pub fn execute_batch_with_params(
     txn_ctx: &mut TxnContext,
     params: &[RpcParam],
 ) -> BatchOutcome {
+    // A transaction reaped for idleness is reported to the session's next batch
+    // (once). 1205 is the code this engine already uses for a server-initiated
+    // transaction abort (the parked deadlock victim), and every driver treats it
+    // as "the transaction is gone, retry it" — which is exactly the right
+    // recovery here.
+    if txn_ctx.take_reaped() {
+        return BatchOutcome {
+            results: Vec::new(),
+            error: Some(SqlError::new(
+                1205,
+                13,
+                51,
+                "The transaction was rolled back because the session was idle for too long. Rerun the transaction.",
+            )),
+        };
+    }
     // Variables are batch-scoped: each batch starts with none.
     txn_ctx.clear_variables();
     for param in params {

--- a/crates/truthdb-core/src/session.rs
+++ b/crates/truthdb-core/src/session.rs
@@ -448,9 +448,16 @@ fn worker_loop(shared: &Arc<Shared>) {
         // own releases.)
         {
             let mut sched = shared.scheduler.lock().expect("scheduler poisoned");
+            // A call we just dequeued proves its session is not idle. Stamp it
+            // before sweeping: the sweep runs in this same iteration, *before*
+            // the call below is dispatched, and would otherwise reap the
+            // transaction of a session whose next batch is already in hand.
+            if let Some(EngineCall::RunBatch { session, .. }) = &call {
+                sched.sessions.touch(*session);
+            }
             sched.reap_expired(&shared.engine);
-            // The loop above never blocks longer than `lock_wait_timeout`, so
-            // this sweep runs regularly even on a completely idle server.
+            // The loop above never blocks longer than `wake_cap`, so this sweep
+            // runs regularly even on a completely idle server.
             sched.reap_idle_txns(&shared.engine);
         }
         drain_ready(shared);
@@ -832,7 +839,11 @@ impl Scheduler {
             .collect();
         for session in &victims {
             if let Some(state) = self.sessions.get_mut(*session) {
-                engine.abort_session_txn(&mut state.txn_ctx);
+                // The session survives, so the rollback is recorded: its next
+                // batch is told the transaction is gone rather than silently
+                // autocommitting statements the client means to be
+                // transactional.
+                engine.abort_idle_session_txn(&mut state.txn_ctx);
                 state.last_activity = now;
             }
             self.locks.release_all(session.raw());
@@ -1071,6 +1082,18 @@ mod tests {
         Harness { handle, path }
     }
 
+    /// A single-worker harness. With one worker the loop's wait is the only
+    /// thing deciding when the sweep runs; with several, a sibling that
+    /// snapshotted an earlier deadline can wake and sweep on another's behalf,
+    /// masking a wait that is too long.
+    fn start_single_worker(idle: Option<Duration>) -> Harness {
+        let path = unique_temp_path("engine-1worker");
+        let storage = Storage::create(path.clone(), test_storage_options()).expect("create");
+        let engine = Engine::new(storage).expect("engine");
+        let (handle, _join) = spawn_engine_pool(engine, LOCK_WAIT_TIMEOUT, idle, 1);
+        Harness { handle, path }
+    }
+
     /// A harness whose idle-transaction reaper fires after `idle` (or never,
     /// when `None`), so the reaper is testable without a real 10 min wait.
     fn start_with_idle(idle: Option<Duration>) -> Harness {
@@ -1139,9 +1162,51 @@ mod tests {
         );
         assert_eq!(ids(&reply), Vec::<i64>::new(), "the reaped write is undone");
 
-        // A's transaction is gone: its COMMIT has nothing to commit (3902).
+        // A is told its transaction was reaped rather than left to discover it
+        // at a COMMIT that fails for a confusing reason.
+        let reply = h.handle.run_batch(a, "COMMIT".into()).await.unwrap();
+        assert_eq!(error_number(&reply), Some(1205));
+        // The signal fires once; the now-transactionless COMMIT then reports the
+        // ordinary 3902.
         let reply = h.handle.run_batch(a, "COMMIT".into()).await.unwrap();
         assert_eq!(error_number(&reply), Some(3902));
+    }
+
+    #[tokio::test]
+    async fn the_sweep_runs_on_time_even_with_a_batch_parked_further_out() {
+        // A worker must not sleep past the sweep just because the nearest parked
+        // deadline is further out: the abandoned transaction the parked batch is
+        // waiting on would not be reaped until that deadline, and the waiter
+        // would die of its own timeout (1205) first — the very lock it was
+        // waiting for having been reclaimable the whole time.
+        //
+        // Single-worker, because with several workers a sibling holding an
+        // earlier deadline snapshot can wake and sweep anyway, hiding this.
+        let h = start_single_worker(Some(Duration::from_millis(150)));
+        let a = h.handle.open_session("truthdb".into(), "sa".into()).await;
+        let b = h.handle.open_session("truthdb".into(), "sa".into()).await;
+        h.handle
+            .run_batch(a, "CREATE TABLE t (id INT NOT NULL PRIMARY KEY)".into())
+            .await
+            .unwrap();
+        // A abandons a transaction holding a write lock.
+        h.handle
+            .run_batch(a, "BEGIN TRAN; INSERT INTO t VALUES (1);".into())
+            .await
+            .unwrap();
+        // B parks on A's lock with a 5 s deadline — far beyond the 150 ms sweep.
+        let reply = h
+            .handle
+            .run_batch(b, "SELECT id FROM t".into())
+            .await
+            .unwrap();
+        assert_eq!(
+            error_number(&reply),
+            None,
+            "B must be unblocked by the sweep, not killed at its own deadline: {:?}",
+            reply.outcome.error
+        );
+        assert_eq!(ids(&reply), Vec::<i64>::new(), "A's write was rolled back");
     }
 
     #[tokio::test]
@@ -1208,28 +1273,208 @@ mod tests {
         assert_eq!(ids(&reply), vec![1]);
     }
 
+    /// A bare Scheduler + Engine, for pinning the sweep's guards directly
+    /// instead of racing real timers.
+    fn bare(label: &str, idle: Option<Duration>) -> (Engine, Scheduler, PathBuf) {
+        let path = unique_temp_path(label);
+        let storage = Storage::create(path.clone(), test_storage_options()).expect("create");
+        let engine = Engine::new(storage).expect("engine");
+        (engine, Scheduler::new(LOCK_WAIT_TIMEOUT, idle), path)
+    }
+
+    #[test]
+    fn a_running_batch_is_never_reaped_however_idle_the_session_looks() {
+        // The reaper's whole safety argument: while a batch runs its context has
+        // been moved out by take_ctx, so the session reports no open
+        // transaction and the sweep cannot select it. Pinned directly, with a
+        // zero idle timeout so that guard is the *only* thing protecting it.
+        let (engine, mut sched, path) = bare("reap-running", Some(Duration::ZERO));
+        let id = sched.sessions.open("truthdb".into(), "sa".into());
+        {
+            let ctx = &mut sched.sessions.get_mut(id).expect("session").txn_ctx;
+            engine
+                .sql_batch("CREATE TABLE t (id INT NOT NULL PRIMARY KEY)", ctx)
+                .expect("create");
+            engine
+                .sql_batch("BEGIN TRAN; INSERT INTO t VALUES (1);", ctx)
+                .expect("begin");
+        }
+        assert!(
+            sched
+                .sessions
+                .get(id)
+                .expect("session")
+                .txn_ctx
+                .has_open_transaction(),
+            "precondition: the session holds an open transaction"
+        );
+
+        // Simulate the batch being dispatched: the context moves to the worker.
+        let ctx = sched.take_ctx(id);
+        assert!(
+            !sched
+                .sessions
+                .get(id)
+                .expect("session")
+                .txn_ctx
+                .has_open_transaction(),
+            "take_ctx must leave the session reporting no open transaction"
+        );
+        assert!(
+            !sched.reap_idle_txns(&engine),
+            "a session whose batch is running must never be reaped"
+        );
+
+        // Restoring it makes the very same session reapable — proving the test
+        // above is not passing merely because nothing is ever reapable.
+        sched.finish(&engine, id, ctx);
+        assert!(
+            sched.reap_idle_txns(&engine),
+            "once idle again, the transaction is reaped"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn a_session_with_a_parked_batch_is_not_reaped() {
+        // A parked batch is waiting on locks, not abandoned; its own deadline
+        // reaps it. Reaping its transaction underneath it would run the batch
+        // against a rolled-back transaction.
+        let (engine, mut sched, path) = bare("reap-parked", Some(Duration::ZERO));
+        let id = sched.sessions.open("truthdb".into(), "sa".into());
+        {
+            let ctx = &mut sched.sessions.get_mut(id).expect("session").txn_ctx;
+            engine
+                .sql_batch("CREATE TABLE t (id INT NOT NULL PRIMARY KEY)", ctx)
+                .expect("create");
+            engine
+                .sql_batch("BEGIN TRAN; INSERT INTO t VALUES (1);", ctx)
+                .expect("begin");
+        }
+        let (reply, _rx) = oneshot::channel();
+        sched.parked.push_back(Parked {
+            session: id,
+            sql: "SELECT id FROM t".into(),
+            params: Vec::new(),
+            cancel: Arc::new(AtomicBool::new(false)),
+            reply,
+            needs: Vec::new(),
+            deadline: Instant::now() + Duration::from_secs(5),
+        });
+        assert!(
+            !sched.reap_idle_txns(&engine),
+            "a session with a parked batch must not be reaped"
+        );
+
+        // Drop the parked entry and the same session is reaped — the guard, not
+        // some other condition, is what protected it.
+        sched.parked.clear();
+        assert!(
+            sched.reap_idle_txns(&engine),
+            "with nothing parked, the idle transaction is reaped"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
     #[tokio::test]
-    async fn idle_session_without_a_transaction_is_untouched() {
-        // Only sessions holding a transaction are candidates; an idle session
-        // with none must keep working normally.
-        let h = start_with_idle(Some(Duration::from_millis(100)));
+    async fn reaped_session_is_told_instead_of_silently_autocommitting() {
+        // A client that comes back believing it is still in a transaction must
+        // not have its statements silently autocommit.
+        let h = start_with_idle(Some(Duration::from_millis(150)));
         let a = h.handle.open_session("truthdb".into(), "sa".into()).await;
         h.handle
             .run_batch(a, "CREATE TABLE t (id INT NOT NULL PRIMARY KEY)".into())
             .await
             .unwrap();
         h.handle
-            .run_batch(a, "INSERT INTO t VALUES (1)".into())
+            .run_batch(a, "BEGIN TRAN; INSERT INTO t VALUES (1);".into())
             .await
             .unwrap();
-        tokio::time::sleep(Duration::from_millis(250)).await;
+        tokio::time::sleep(Duration::from_millis(400)).await;
+
+        // The next batch is told the transaction is gone, and does not run.
+        let reply = h
+            .handle
+            .run_batch(a, "INSERT INTO t VALUES (2)".into())
+            .await
+            .unwrap();
+        assert_eq!(
+            error_number(&reply),
+            Some(1205),
+            "the reap must be reported, not swallowed"
+        );
+
+        // The signal fires once; the session is usable again afterwards.
         let reply = h
             .handle
             .run_batch(a, "SELECT id FROM t".into())
             .await
             .unwrap();
         assert_eq!(error_number(&reply), None);
-        assert_eq!(ids(&reply), vec![1], "autocommitted data is untouched");
+        assert_eq!(
+            ids(&reply),
+            Vec::<i64>::new(),
+            "the reaped write is undone, and the rejected INSERT never applied"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_reaped_transaction_leaves_no_savepoints_behind() {
+        // A savepoint holds the undo-log offset of the transaction that recorded
+        // it. One surviving a reap would let ROLLBACK TRANSACTION find a stale
+        // entry in the session's NEXT transaction and hand a dead offset to the
+        // undo log — silently discarding committed work, or panicking.
+        let h = start_with_idle(Some(Duration::from_millis(150)));
+        let a = h.handle.open_session("truthdb".into(), "sa".into()).await;
+        h.handle
+            .run_batch(a, "CREATE TABLE t (id INT NOT NULL PRIMARY KEY)".into())
+            .await
+            .unwrap();
+        h.handle
+            .run_batch(
+                a,
+                "BEGIN TRAN; INSERT INTO t VALUES (1); SAVE TRANSACTION sp1;".into(),
+            )
+            .await
+            .unwrap();
+        tokio::time::sleep(Duration::from_millis(400)).await;
+
+        // Drain the one-shot reap signal.
+        let reply = h.handle.run_batch(a, "SELECT 1".into()).await.unwrap();
+        assert_eq!(error_number(&reply), Some(1205));
+
+        // sp1 belonged to the reaped transaction: rolling back to it in a new
+        // transaction must error 3908, not silently truncate this one's work.
+        let reply = h
+            .handle
+            .run_batch(
+                a,
+                "BEGIN TRAN; INSERT INTO t VALUES (7); INSERT INTO t VALUES (8); ROLLBACK TRANSACTION sp1;"
+                    .into(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            error_number(&reply),
+            Some(3908),
+            "a savepoint from the reaped transaction must not survive"
+        );
+        h.handle.run_batch(a, "ROLLBACK".into()).await.unwrap();
+
+        // And the new transaction's work was never silently discarded.
+        h.handle
+            .run_batch(
+                a,
+                "BEGIN TRAN; INSERT INTO t VALUES (7); INSERT INTO t VALUES (8); COMMIT;".into(),
+            )
+            .await
+            .unwrap();
+        let reply = h
+            .handle
+            .run_batch(a, "SELECT id FROM t ORDER BY id".into())
+            .await
+            .unwrap();
+        assert_eq!(ids(&reply), vec![7, 8], "both committed rows survive");
     }
 
     #[tokio::test]

--- a/crates/truthdb-core/src/session.rs
+++ b/crates/truthdb-core/src/session.rs
@@ -56,6 +56,18 @@ use crate::rel::{BatchOutcome, Isolation, TxnContext};
 /// abort youngest").
 const LOCK_WAIT_TIMEOUT: Duration = Duration::from_secs(5);
 
+/// How long a session may sit idle with a transaction still open before the
+/// engine rolls it back and releases its locks.
+///
+/// This is a deliberate divergence from SQL Server, which never reaps an idle
+/// transaction: a client that dies without closing its TCP connection would
+/// otherwise hold its locks until the OS notices, which can take hours, and
+/// every conflicting batch fails with 1205 in the meantime. Ten minutes is far
+/// longer than any interactive transaction should stay idle, so a legitimate
+/// client is never reaped. `spawn_engine_pool` takes it as `Option`, so it can
+/// be disabled outright.
+const IDLE_TXN_TIMEOUT: Duration = Duration::from_secs(600);
+
 /// The result of running a batch for a session: its typed outcome plus
 /// whether the connection is still inside a transaction afterwards (so the
 /// TDS gateway can set `DONE_INXACT`).
@@ -78,9 +90,22 @@ impl SessionId {
 /// Per-connection engine-side state: the transaction context carried across a
 /// connection's batches (open transaction, `@@TRANCOUNT`, isolation, SET
 /// options).
-#[derive(Default)]
 struct Session {
     txn_ctx: TxnContext,
+    /// When this session last started or finished a batch. Only meaningful
+    /// while the session is idle: a running batch's context is moved out by
+    /// [`Scheduler::take_ctx`], so a session mid-batch reports no open
+    /// transaction and is never a reap candidate regardless of this stamp.
+    last_activity: Instant,
+}
+
+impl Default for Session {
+    fn default() -> Self {
+        Session {
+            txn_ctx: TxnContext::default(),
+            last_activity: Instant::now(),
+        }
+    }
 }
 
 struct SessionManager {
@@ -117,6 +142,18 @@ impl SessionManager {
 
     fn get_mut(&mut self, id: SessionId) -> Option<&mut Session> {
         self.sessions.get_mut(&id)
+    }
+
+    fn iter(&self) -> impl Iterator<Item = (&SessionId, &Session)> {
+        self.sessions.iter()
+    }
+
+    /// Marks a session as active now, so the idle reaper does not count time
+    /// spent running a batch against it.
+    fn touch(&mut self, id: SessionId) {
+        if let Some(state) = self.sessions.get_mut(&id) {
+            state.last_activity = Instant::now();
+        }
     }
 }
 
@@ -272,25 +309,41 @@ fn worker_count() -> usize {
 /// Spawns the engine worker pool and returns a handle plus a join handle for a
 /// supervisor thread that outlives every worker.
 pub fn spawn_engine(engine: Engine) -> (EngineHandle, JoinHandle<()>) {
-    spawn_engine_pool(engine, LOCK_WAIT_TIMEOUT, worker_count())
+    spawn_engine_pool(
+        engine,
+        LOCK_WAIT_TIMEOUT,
+        Some(IDLE_TXN_TIMEOUT),
+        worker_count(),
+    )
 }
 
 /// Like [`spawn_engine`] but with a custom lock-wait timeout, so tests can
 /// exercise the deadlock reaper without a real 5 s wait.
 #[cfg(test)]
 fn spawn_engine_with_timeout(engine: Engine, timeout: Duration) -> (EngineHandle, JoinHandle<()>) {
-    spawn_engine_pool(engine, timeout, worker_count())
+    spawn_engine_pool(engine, timeout, Some(IDLE_TXN_TIMEOUT), worker_count())
+}
+
+/// Like [`spawn_engine`] but with a custom idle-transaction timeout, so tests
+/// can exercise the idle reaper without a real 10 min wait.
+#[cfg(test)]
+fn spawn_engine_with_idle_timeout(
+    engine: Engine,
+    idle: Option<Duration>,
+) -> (EngineHandle, JoinHandle<()>) {
+    spawn_engine_pool(engine, LOCK_WAIT_TIMEOUT, idle, worker_count())
 }
 
 fn spawn_engine_pool(
     engine: Engine,
     timeout: Duration,
+    idle_txn_timeout: Option<Duration>,
     workers: usize,
 ) -> (EngineHandle, JoinHandle<()>) {
     let (tx, rx) = mpsc::channel();
     let shared = Arc::new(Shared {
         engine: Arc::new(engine),
-        scheduler: Mutex::new(Scheduler::new(timeout)),
+        scheduler: Mutex::new(Scheduler::new(timeout, idle_txn_timeout)),
         rx: Mutex::new(rx),
         stop: AtomicBool::new(false),
     });
@@ -371,10 +424,12 @@ fn worker_loop(shared: &Arc<Shared>) {
         // deadline, so it is reaped on time. (Only the brief `recv` holds rx.)
         let (deadline, cap) = {
             let sched = shared.scheduler.lock().expect("scheduler poisoned");
-            (sched.earliest_deadline(), sched.lock_wait_timeout)
+            (sched.earliest_deadline(), sched.wake_cap())
         };
         let wait = match deadline {
-            Some(deadline) => deadline.saturating_duration_since(Instant::now()),
+            // Never sleep past the periodic cap, even when the nearest parked
+            // deadline is further out: the idle sweep still has to run.
+            Some(deadline) => deadline.saturating_duration_since(Instant::now()).min(cap),
             None => cap,
         };
         let call = {
@@ -394,6 +449,9 @@ fn worker_loop(shared: &Arc<Shared>) {
         {
             let mut sched = shared.scheduler.lock().expect("scheduler poisoned");
             sched.reap_expired(&shared.engine);
+            // The loop above never blocks longer than `lock_wait_timeout`, so
+            // this sweep runs regularly even on a completely idle server.
+            sched.reap_idle_txns(&shared.engine);
         }
         drain_ready(shared);
         match call {
@@ -454,6 +512,7 @@ fn dispatch_batch(
         // locks the batch needs — analyse the statement text as usual.
         let needs = shared.engine.analyze_locks(&sql, isolation);
         if sched.try_acquire(session.raw(), &needs, true) {
+            sched.sessions.touch(session);
             let txn_ctx = sched.take_ctx(session);
             Some(Runnable {
                 session,
@@ -551,20 +610,39 @@ struct Scheduler {
     locks: LockManager,
     parked: VecDeque<Parked>,
     lock_wait_timeout: Duration,
+    /// How long a session may sit idle *with a transaction open* before that
+    /// transaction is rolled back and its locks released. `None` disables the
+    /// reaper.
+    idle_txn_timeout: Option<Duration>,
 }
 
 impl Scheduler {
-    fn new(lock_wait_timeout: Duration) -> Self {
+    fn new(lock_wait_timeout: Duration, idle_txn_timeout: Option<Duration>) -> Self {
         Scheduler {
             sessions: SessionManager::new(),
             locks: LockManager::new(),
             parked: VecDeque::new(),
             lock_wait_timeout,
+            idle_txn_timeout,
         }
     }
 
     fn earliest_deadline(&self) -> Option<Instant> {
         self.parked.iter().map(|p| p.deadline).min()
+    }
+
+    /// The longest a worker may block before re-evaluating. A worker has two
+    /// periodic duties — reaping a parked batch at its deadline and reaping a
+    /// transaction left idle — so it must wake for whichever comes first. With
+    /// the default timeouts the lock-wait bound (5 s) dominates the idle one
+    /// (10 min) and this is unchanged; a deployment (or test) that sets a short
+    /// idle timeout gets a correspondingly shorter cap instead of a reaper that
+    /// silently runs late.
+    fn wake_cap(&self) -> Duration {
+        match self.idle_txn_timeout {
+            Some(idle) => self.lock_wait_timeout.min(idle),
+            None => self.lock_wait_timeout,
+        }
     }
 
     /// A session's current isolation level (default if the session is unknown).
@@ -628,6 +706,9 @@ impl Scheduler {
         match self.sessions.get_mut(session) {
             Some(state) => {
                 state.txn_ctx = txn_ctx;
+                // The idle clock restarts when the batch finishes: time spent
+                // running is not time spent idle.
+                state.last_activity = Instant::now();
                 let open = state.txn_ctx.has_open_transaction();
                 let is_read_committed =
                     matches!(state.txn_ctx.isolation(), Isolation::ReadCommitted);
@@ -717,6 +798,46 @@ impl Scheduler {
         if let Some(idx) = victim_idx {
             self.abort_parked_victim(engine, idx);
         }
+    }
+
+    /// Rolls back transactions abandoned by idle sessions, releasing their
+    /// locks; returns whether anything was released (so the caller drains the
+    /// batches those locks unblock).
+    ///
+    /// A connection that opens a transaction and then goes silent *without
+    /// disconnecting* — a crashed client, a severed network — would otherwise
+    /// hold its locks indefinitely: the connection-drop path only covers a
+    /// connection that actually closed, and TCP may not notice for hours.
+    ///
+    /// Only genuinely idle sessions are candidates. A session running a batch
+    /// has had its context moved out by [`Self::take_ctx`], so it reports no
+    /// open transaction and cannot be reaped mid-batch; a session with a parked
+    /// batch is skipped explicitly, since that batch is only waiting on locks
+    /// (and its own deadline reaps it) rather than being abandoned.
+    fn reap_idle_txns(&mut self, engine: &Engine) -> bool {
+        let Some(timeout) = self.idle_txn_timeout else {
+            return false;
+        };
+        let now = Instant::now();
+        let parked: Vec<SessionId> = self.parked.iter().map(|p| p.session).collect();
+        let victims: Vec<SessionId> = self
+            .sessions
+            .iter()
+            .filter(|(id, state)| {
+                state.txn_ctx.has_open_transaction()
+                    && now.duration_since(state.last_activity) >= timeout
+                    && !parked.contains(id)
+            })
+            .map(|(id, _)| *id)
+            .collect();
+        for session in &victims {
+            if let Some(state) = self.sessions.get_mut(*session) {
+                engine.abort_session_txn(&mut state.txn_ctx);
+                state.last_activity = now;
+            }
+            self.locks.release_all(session.raw());
+        }
+        !victims.is_empty()
     }
 
     /// Aborts the parked batch at `idx` as a deadlock victim: rolls back its
@@ -950,6 +1071,16 @@ mod tests {
         Harness { handle, path }
     }
 
+    /// A harness whose idle-transaction reaper fires after `idle` (or never,
+    /// when `None`), so the reaper is testable without a real 10 min wait.
+    fn start_with_idle(idle: Option<Duration>) -> Harness {
+        let path = unique_temp_path("engine-idle");
+        let storage = Storage::create(path.clone(), test_storage_options()).expect("create");
+        let engine = Engine::new(storage).expect("engine");
+        let (handle, _join) = spawn_engine_with_idle_timeout(engine, idle);
+        Harness { handle, path }
+    }
+
     /// The `id` column (column 0) of the first rowset, as i64s.
     fn ids(reply: &BatchReply) -> Vec<i64> {
         for result in &reply.outcome.results {
@@ -972,6 +1103,133 @@ mod tests {
 
     fn error_number(reply: &BatchReply) -> Option<i32> {
         reply.outcome.error.as_ref().map(|e| e.number)
+    }
+
+    // ---- idle-transaction reaper ----------------------------------------
+
+    #[tokio::test]
+    async fn idle_transaction_is_reaped_and_its_locks_released() {
+        // A client that opens a transaction and goes silent without
+        // disconnecting must not hold its locks forever.
+        let h = start_with_idle(Some(Duration::from_millis(150)));
+        let a = h.handle.open_session("truthdb".into(), "sa".into()).await;
+        let b = h.handle.open_session("truthdb".into(), "sa".into()).await;
+        h.handle
+            .run_batch(a, "CREATE TABLE t (id INT NOT NULL PRIMARY KEY)".into())
+            .await
+            .unwrap();
+        // Session A takes a write lock and then abandons the transaction.
+        h.handle
+            .run_batch(a, "BEGIN TRAN; INSERT INTO t VALUES (1);".into())
+            .await
+            .unwrap();
+
+        // B blocks on A's lock while A still holds it, so wait for the reaper.
+        // Once it fires, A's write is rolled back and B sees an empty table.
+        let reply = h
+            .handle
+            .run_batch(b, "SELECT id FROM t".into())
+            .await
+            .unwrap();
+        assert_eq!(
+            error_number(&reply),
+            None,
+            "B must proceed once the abandoned transaction is reaped: {:?}",
+            reply.outcome.error
+        );
+        assert_eq!(ids(&reply), Vec::<i64>::new(), "the reaped write is undone");
+
+        // A's transaction is gone: its COMMIT has nothing to commit (3902).
+        let reply = h.handle.run_batch(a, "COMMIT".into()).await.unwrap();
+        assert_eq!(error_number(&reply), Some(3902));
+    }
+
+    #[tokio::test]
+    async fn active_transaction_is_not_reaped() {
+        // The reaper must only touch *idle* sessions: a session that keeps
+        // working keeps its transaction, however long it stays open.
+        let h = start_with_idle(Some(Duration::from_millis(150)));
+        let a = h.handle.open_session("truthdb".into(), "sa".into()).await;
+        h.handle
+            .run_batch(a, "CREATE TABLE t (id INT NOT NULL PRIMARY KEY)".into())
+            .await
+            .unwrap();
+        h.handle
+            .run_batch(a, "BEGIN TRAN; INSERT INTO t VALUES (1);".into())
+            .await
+            .unwrap();
+        // Keep touching the session across more than the idle timeout.
+        for i in 2..=6 {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            let reply = h
+                .handle
+                .run_batch(a, format!("INSERT INTO t VALUES ({i})"))
+                .await
+                .unwrap();
+            assert_eq!(
+                error_number(&reply),
+                None,
+                "an active session must keep its transaction"
+            );
+        }
+        // The transaction survived and commits everything it wrote.
+        let reply = h.handle.run_batch(a, "COMMIT".into()).await.unwrap();
+        assert_eq!(error_number(&reply), None, "{:?}", reply.outcome.error);
+        let reply = h
+            .handle
+            .run_batch(a, "SELECT id FROM t ORDER BY id".into())
+            .await
+            .unwrap();
+        assert_eq!(ids(&reply), vec![1, 2, 3, 4, 5, 6]);
+    }
+
+    #[tokio::test]
+    async fn idle_reaper_can_be_disabled() {
+        // With the reaper off, an idle transaction is left alone.
+        let h = start_with_idle(None);
+        let a = h.handle.open_session("truthdb".into(), "sa".into()).await;
+        h.handle
+            .run_batch(a, "CREATE TABLE t (id INT NOT NULL PRIMARY KEY)".into())
+            .await
+            .unwrap();
+        h.handle
+            .run_batch(a, "BEGIN TRAN; INSERT INTO t VALUES (1);".into())
+            .await
+            .unwrap();
+        tokio::time::sleep(Duration::from_millis(300)).await;
+        // The transaction is still open and still commits.
+        let reply = h.handle.run_batch(a, "COMMIT".into()).await.unwrap();
+        assert_eq!(error_number(&reply), None, "{:?}", reply.outcome.error);
+        let reply = h
+            .handle
+            .run_batch(a, "SELECT id FROM t".into())
+            .await
+            .unwrap();
+        assert_eq!(ids(&reply), vec![1]);
+    }
+
+    #[tokio::test]
+    async fn idle_session_without_a_transaction_is_untouched() {
+        // Only sessions holding a transaction are candidates; an idle session
+        // with none must keep working normally.
+        let h = start_with_idle(Some(Duration::from_millis(100)));
+        let a = h.handle.open_session("truthdb".into(), "sa".into()).await;
+        h.handle
+            .run_batch(a, "CREATE TABLE t (id INT NOT NULL PRIMARY KEY)".into())
+            .await
+            .unwrap();
+        h.handle
+            .run_batch(a, "INSERT INTO t VALUES (1)".into())
+            .await
+            .unwrap();
+        tokio::time::sleep(Duration::from_millis(250)).await;
+        let reply = h
+            .handle
+            .run_batch(a, "SELECT id FROM t".into())
+            .await
+            .unwrap();
+        assert_eq!(error_number(&reply), None);
+        assert_eq!(ids(&reply), vec![1], "autocommitted data is untouched");
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes half of the Stage 6 engine-actor gap (*"no idle/txn reaper"*). Connection **drop** already rolls back and releases locks — but that only covers a connection that actually closed. A client that opens a transaction and goes silent (crashed process, severed network) keeps its locks until the OS notices the dead socket, which can take hours; every conflicting batch fails 1205 meanwhile.

## What
- `Session` stamps `last_activity`; the worker loop sweeps sessions idle past `idle_txn_timeout` **with a transaction still open**, rolling them back and releasing their locks, then draining what that unblocks.
- Only genuinely idle sessions are candidates — a running batch has had its context moved out by `take_ctx`, so it reports no open transaction and cannot be reaped mid-batch; a parked batch's session is skipped (it's waiting on locks, not abandoned).
- Default **10 min**, a deliberate divergence from SQL Server (which never reaps); `Option`, so it can be disabled.
- **Wake cadence fixed**: a worker slept to the nearest parked deadline ignoring the periodic cap, and the cap only considered `lock_wait_timeout`. It now wakes for whichever duty comes first. With the defaults the 5 s bound still dominates, so the cadence is unchanged.

## Adversarial review found a critical bug this made reachable
`TxnContext::abort` never cleared `savepoints`. Invisible until now, because every existing caller discards the context right after — the reaper is the **first whose session survives and keeps using it**. A savepoint from the reaped transaction (holding that dead txn's undo-log offset) leaked into the next one: `ROLLBACK TRANSACTION sp1` then found the stale name instead of erroring 3908 and either **silently discarded committed rows** or **panicked the worker permanently** (no `catch_unwind` exists), leaking its locks. Fixed in `abort()`, which also closes the same latent hole in `abort_parked_victim`.

Review also caught that a reaped session **silently autocommitted** the client's subsequent work; the reap is now reported to the next batch as 1205 ("transaction is gone, retry").

## Verification
Every new test verified to **fail with its fix removed**. The guards the review found untested are now pinned deterministically against a bare Scheduler (no timing races), and the cadence fix by a single-worker test — with several workers a sibling's stale snapshot hides it. No flakes over 25 runs, nor under 8-way CPU load. All 16 suites green; fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)