### PR TITLE
Stage 9: make TDS encryption a policy (off | optional | required)

### DIFF
--- a/config/default.toml
+++ b/config/default.toml
@@ -25,5 +25,13 @@ snapshot_wal_threshold = 0.7
 # port = 1433
 # database = "truthdb"
 #
-# [tds.auth]           # username = password (plaintext; TLS arrives in Stage 9)
+#
+# encryption: "off" never encrypts; "optional" (default) encrypts when the
+# client asks; "required" refuses clients that will not encrypt, and needs
+# tls_cert/tls_key.
+# encryption = "optional"
+# tls_cert = "/etc/truthdb/tls.crt"
+# tls_key = "/etc/truthdb/tls.key"
+#
+# [tds.auth]           # username = password (send it over TLS: see encryption)
 # sa = "change-me"

--- a/crates/truthdb-tds/src/lib.rs
+++ b/crates/truthdb-tds/src/lib.rs
@@ -22,7 +22,7 @@ use tokio::sync::watch;
 use tracing::{debug, error, info};
 use truthdb_core::session::EngineHandle;
 
-pub use server::{TdsConfig, serve_connection};
+pub use server::{Encryption, TdsConfig, serve_connection};
 
 /// A TDS listener bound to an address; serves connections until shutdown.
 pub struct TdsListener {

--- a/crates/truthdb-tds/src/login.rs
+++ b/crates/truthdb-tds/src/login.rs
@@ -8,12 +8,15 @@ pub const ENCRYPT_REQ: u8 = 0x03;
 
 const TOKEN_ENCRYPTION: u8 = 0x01;
 
-/// Builds a PRELOGIN response: version, an ENCRYPTION option, MARS off. When
-/// `offer_tls` is set the server advertises `ENCRYPT_ON` (the whole session is
-/// encrypted after a tunneled TLS handshake); otherwise `ENCRYPT_NOT_SUP`
-/// (plaintext). The option table is a list of `token u8 | offset u16 (BE) |
-/// length u16 (BE)` entries ended by `0xFF`, followed by the option data.
-pub fn prelogin_response(offer_tls: bool) -> Vec<u8> {
+/// Builds a PRELOGIN response: version, an ENCRYPTION option, MARS off.
+///
+/// `encryption` is the byte the server advertises: `ENCRYPT_ON` (the whole
+/// session is encrypted after a tunneled TLS handshake), `ENCRYPT_NOT_SUP`
+/// (plaintext), or `ENCRYPT_REQ` (the server *demands* encryption, so a client
+/// that cannot encrypt must give up). The option table is a list of
+/// `token u8 | offset u16 (BE) | length u16 (BE)` entries ended by `0xFF`,
+/// followed by the option data.
+pub fn prelogin_response(encryption: u8) -> Vec<u8> {
     const TOKEN_VERSION: u8 = 0x00;
     const TOKEN_MARS: u8 = 0x04;
     const TERMINATOR: u8 = 0xff;
@@ -38,11 +41,7 @@ pub fn prelogin_response(offer_tls: bool) -> Vec<u8> {
     out.push(TERMINATOR);
 
     out.extend_from_slice(&version);
-    out.push(if offer_tls {
-        ENCRYPT_ON
-    } else {
-        ENCRYPT_NOT_SUP
-    });
+    out.push(encryption);
     out.push(0x00); // MARS off
     out
 }
@@ -209,7 +208,7 @@ mod tests {
 
     #[test]
     fn prelogin_response_is_well_formed() {
-        let resp = prelogin_response(false);
+        let resp = prelogin_response(ENCRYPT_NOT_SUP);
         // First option token is VERSION with a sane offset.
         assert_eq!(resp[0], 0x00);
         let version_off = u16::from_be_bytes([resp[1], resp[2]]) as usize;
@@ -226,9 +225,9 @@ mod tests {
     #[test]
     fn prelogin_response_advertises_encryption() {
         // The ENCRYPTION option value is the last byte before the MARS byte.
-        let off = prelogin_response(false);
+        let off = prelogin_response(ENCRYPT_NOT_SUP);
         assert_eq!(off[off.len() - 2], ENCRYPT_NOT_SUP);
-        let on = prelogin_response(true);
+        let on = prelogin_response(ENCRYPT_ON);
         assert_eq!(on[on.len() - 2], ENCRYPT_ON);
     }
 
@@ -236,11 +235,11 @@ mod tests {
     fn prelogin_client_encryption_parses_option() {
         // Round-trip: a response built with ENCRYPT_ON is read back as ON.
         assert_eq!(
-            prelogin_client_encryption(&prelogin_response(true)),
+            prelogin_client_encryption(&prelogin_response(ENCRYPT_ON)),
             ENCRYPT_ON
         );
         assert_eq!(
-            prelogin_client_encryption(&prelogin_response(false)),
+            prelogin_client_encryption(&prelogin_response(ENCRYPT_NOT_SUP)),
             ENCRYPT_NOT_SUP
         );
         // A payload without an ENCRYPTION option defaults to NOT_SUP.

--- a/crates/truthdb-tds/src/server.rs
+++ b/crates/truthdb-tds/src/server.rs
@@ -22,8 +22,23 @@ const TM_BEGIN_XACT: u16 = 5;
 const TM_COMMIT_XACT: u16 = 7;
 const TM_ROLLBACK_XACT: u16 = 8;
 
-/// Server-side TDS configuration: the login users, the reported database, and
-/// optional TLS.
+/// What the server does about encryption on a connection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Encryption {
+    /// Never encrypt: TLS is not offered even if certificates are configured.
+    Off,
+    /// Encrypt when the client asks to (the default, and what SQL Server calls
+    /// opportunistic): a client that does not ask is served in plaintext.
+    #[default]
+    Optional,
+    /// Refuse any client that will not encrypt. The server advertises
+    /// `ENCRYPT_REQ`, so a compliant client either encrypts or gives up, and a
+    /// client that says it cannot encrypt is dropped rather than served.
+    Required,
+}
+
+/// Server-side TDS configuration: the login users, the reported database,
+/// optional TLS, and the encryption policy.
 #[derive(Debug, Clone)]
 pub struct TdsConfig {
     /// username -> password (plaintext config auth for Stage 4).
@@ -34,6 +49,10 @@ pub struct TdsConfig {
     /// clients that request it (a tunneled TLS handshake, then an encrypted
     /// session).
     pub tls: Option<crate::tls::TlsConfig>,
+    /// Whether encryption is off, opportunistic, or mandatory. `Required`
+    /// needs `tls` to be configured; the server refuses to start otherwise,
+    /// since it could satisfy no one.
+    pub encryption: Encryption,
 }
 
 /// Handles one TDS connection to completion (or disconnect).
@@ -52,20 +71,34 @@ where
     if prelogin.kind != PKT_PRELOGIN {
         return Err(protocol_err("expected PRELOGIN"));
     }
-    // Offer TLS only when configured AND the client asks to encrypt (ENCRYPT_ON
-    // /REQ). We encrypt the whole session, not the login-only mode.
+    // Encryption policy. `Optional` (the default) is opportunistic: encrypt
+    // only when configured AND the client asks (ENCRYPT_ON/REQ). `Off` never
+    // encrypts. `Required` advertises ENCRYPT_REQ so a compliant client knows it
+    // must encrypt — and a client that answered "cannot" is dropped below rather
+    // than quietly served in plaintext. We encrypt the whole session, not the
+    // login-only mode.
     let client_enc = login::prelogin_client_encryption(&prelogin.payload);
-    let offer_tls =
-        config.tls.is_some() && matches!(client_enc, login::ENCRYPT_ON | login::ENCRYPT_REQ);
+    let (advertised, offer_tls) =
+        negotiate_encryption(config.encryption, config.tls.is_some(), client_enc);
     // The PRELOGIN *response* is sent as a REPLY (Tabular Result) packet;
     // clients (pytds/go-mssqldb) expect type 0x04 here, not 0x12.
     write_message(
         &mut stream,
         PKT_TABULAR_RESULT,
-        &login::prelogin_response(offer_tls),
+        &login::prelogin_response(advertised),
         packet_size,
     )
     .await?;
+    // The client was told encryption is mandatory but says it cannot: answer
+    // the PRELOGIN (so it learns why) and then refuse, rather than fall back to
+    // plaintext — a fallback would silently defeat the whole setting.
+    if config.encryption == Encryption::Required
+        && !matches!(client_enc, login::ENCRYPT_ON | login::ENCRYPT_REQ)
+    {
+        return Err(protocol_err(
+            "the server requires encryption; the client does not support it",
+        ));
+    }
 
     // If encryption was negotiated, complete the tunneled TLS handshake and run
     // the rest of the session over the encrypted stream.
@@ -619,6 +652,25 @@ fn batch_sql(text: &[u8]) -> io::Result<String> {
     String::from_utf16(&units).map_err(|_| protocol_err("SQLBatch text is not valid UTF-16"))
 }
 
+/// Decides what to advertise in PRELOGIN, and whether to run a TLS handshake.
+///
+/// Split out from the connection flow because the interesting cases are the
+/// combinations — notably `Off` while a certificate *is* configured, which an
+/// end-to-end test cannot reach without shipping a key.
+fn negotiate_encryption(policy: Encryption, tls_configured: bool, client: u8) -> (u8, bool) {
+    let client_wants_tls = matches!(client, login::ENCRYPT_ON | login::ENCRYPT_REQ);
+    match policy {
+        // Never encrypt, whatever is configured or asked for.
+        Encryption::Off => (login::ENCRYPT_NOT_SUP, false),
+        Encryption::Optional if tls_configured && client_wants_tls => (login::ENCRYPT_ON, true),
+        Encryption::Optional => (login::ENCRYPT_NOT_SUP, false),
+        // Startup refuses `Required` without a certificate, so offering here is
+        // always satisfiable; a client that will not encrypt is refused after
+        // the response tells it why.
+        Encryption::Required => (login::ENCRYPT_REQ, true),
+    }
+}
+
 fn protocol_err(message: &str) -> io::Error {
     io::Error::new(io::ErrorKind::InvalidData, message.to_string())
 }
@@ -678,5 +730,60 @@ mod attention_tests {
             .expect("not disconnected");
         assert!(!cancel.load(Ordering::Relaxed));
         assert_eq!(out, b"RESULT".to_vec(), "no attention -> the real result");
+    }
+}
+
+#[cfg(test)]
+mod encryption_tests {
+    use super::*;
+
+    const ON: u8 = login::ENCRYPT_ON;
+    const NOT_SUP: u8 = login::ENCRYPT_NOT_SUP;
+    const REQ: u8 = login::ENCRYPT_REQ;
+
+    #[test]
+    fn off_never_offers_tls_even_with_a_certificate_configured() {
+        // The setting overrides the certificate: this is the case the setting
+        // exists for, and the one an end-to-end test cannot reach.
+        for client in [ON, NOT_SUP, REQ] {
+            assert_eq!(
+                negotiate_encryption(Encryption::Off, true, client),
+                (NOT_SUP, false),
+                "client {client}"
+            );
+        }
+    }
+
+    #[test]
+    fn optional_encrypts_only_when_configured_and_asked() {
+        assert_eq!(
+            negotiate_encryption(Encryption::Optional, true, ON),
+            (ON, true)
+        );
+        assert_eq!(
+            negotiate_encryption(Encryption::Optional, true, REQ),
+            (ON, true)
+        );
+        // Asked for, but no certificate to offer.
+        assert_eq!(
+            negotiate_encryption(Encryption::Optional, false, ON),
+            (NOT_SUP, false)
+        );
+        // Configured, but the client does not want it.
+        assert_eq!(
+            negotiate_encryption(Encryption::Optional, true, NOT_SUP),
+            (NOT_SUP, false)
+        );
+    }
+
+    #[test]
+    fn required_always_demands_encryption() {
+        for client in [ON, NOT_SUP, REQ] {
+            assert_eq!(
+                negotiate_encryption(Encryption::Required, true, client),
+                (REQ, true),
+                "client {client}"
+            );
+        }
     }
 }

--- a/crates/truthdb-tds/tests/tds_client.rs
+++ b/crates/truthdb-tds/tests/tds_client.rs
@@ -51,6 +51,7 @@ fn config() -> TdsConfig {
         users,
         database: "truthdb".to_string(),
         tls: None,
+        encryption: truthdb_tds::Encryption::default(),
     }
 }
 
@@ -137,6 +138,21 @@ impl Client {
         self.write_packet(PKT_PRELOGIN, &[0xff]).await;
         let (kind, _) = self.read_message().await;
         assert!(kind == 0x04 || kind == PKT_PRELOGIN);
+    }
+
+    /// A PRELOGIN carrying an ENCRYPTION option, returning the byte the server
+    /// advertises back (or None if it hung up).
+    async fn prelogin_with_encryption(&mut self, client: u8) -> Option<u8> {
+        // One ENCRYPTION option: token | offset u16 BE | length u16 BE, then
+        // the terminator, then the data.
+        let mut payload = vec![0x01u8];
+        payload.extend_from_slice(&6u16.to_be_bytes());
+        payload.extend_from_slice(&1u16.to_be_bytes());
+        payload.push(0xff);
+        payload.push(client);
+        self.write_packet(PKT_PRELOGIN, &payload).await;
+        let (_, response) = self.try_read_message().await?;
+        Some(read_encryption_option(&response))
     }
 
     async fn login(&mut self, user: &str, password: &str) -> Vec<Token> {
@@ -482,6 +498,18 @@ fn parse_row(bytes: &[u8], meta: &[ColType]) -> (Vec<Cell>, usize) {
     (cells, i)
 }
 
+async fn connect_with(engine: EngineHandle, cfg: TdsConfig) -> Client {
+    let (client_half, server_half) = tokio::io::duplex(64 * 1024);
+    let cfg = Arc::new(cfg);
+    tokio::spawn(async move {
+        let _ = serve_connection(server_half, engine, cfg).await;
+    });
+    Client {
+        stream: client_half,
+        tran_descriptor: 0,
+    }
+}
+
 async fn connect(engine: EngineHandle) -> Client {
     let (client_half, server_half) = tokio::io::duplex(64 * 1024);
     let cfg = Arc::new(config());
@@ -492,6 +520,84 @@ async fn connect(engine: EngineHandle) -> Client {
         stream: client_half,
         tran_descriptor: 0,
     }
+}
+
+/// Reads the ENCRYPTION option out of a PRELOGIN response.
+fn read_encryption_option(payload: &[u8]) -> u8 {
+    let mut i = 0;
+    while i + 4 < payload.len() {
+        let token = payload[i];
+        if token == 0xff {
+            break;
+        }
+        let offset = u16::from_be_bytes([payload[i + 1], payload[i + 2]]) as usize;
+        if token == 0x01 {
+            return payload[offset];
+        }
+        i += 5;
+    }
+    panic!("no ENCRYPTION option in PRELOGIN response: {payload:?}");
+}
+
+#[tokio::test]
+async fn encryption_off_never_offers_tls_even_to_a_client_that_asks() {
+    let path = temp_path("enc-off");
+    let engine = engine(&path);
+    let mut cfg = config();
+    cfg.encryption = truthdb_tds::Encryption::Off;
+    let mut client = connect_with(engine, cfg).await;
+    let advertised = client
+        .prelogin_with_encryption(0x01) // ENCRYPT_ON: the client wants TLS
+        .await
+        .expect("server answered");
+    assert_eq!(advertised, 0x02, "must advertise NOT_SUP");
+    // ...and the session continues in plaintext.
+    client.login("sa", "secret").await;
+    let rows = client.batch("SELECT 1 AS n").await;
+    assert!(rows.iter().any(|t| matches!(t, Token::Row(_))), "{rows:?}");
+    let _ = std::fs::remove_file(path);
+}
+
+#[tokio::test]
+async fn encryption_optional_serves_a_plaintext_client() {
+    // The default: a client that does not ask to encrypt is served as before.
+    let path = temp_path("enc-optional");
+    let engine = engine(&path);
+    let mut client = connect_with(engine, config()).await;
+    let advertised = client
+        .prelogin_with_encryption(0x02) // NOT_SUP: the client will not encrypt
+        .await
+        .expect("server answered");
+    assert_eq!(advertised, 0x02);
+    client.login("sa", "secret").await;
+    let rows = client.batch("SELECT 1 AS n").await;
+    assert!(rows.iter().any(|t| matches!(t, Token::Row(_))), "{rows:?}");
+    let _ = std::fs::remove_file(path);
+}
+
+#[tokio::test]
+async fn encryption_required_refuses_a_client_that_cannot_encrypt() {
+    // The server must say encryption is mandatory and then refuse — falling
+    // back to plaintext would silently defeat the setting.
+    let path = temp_path("enc-required");
+    let engine = engine(&path);
+    let mut cfg = config();
+    cfg.encryption = truthdb_tds::Encryption::Required;
+    let mut client = connect_with(engine, cfg).await;
+    let advertised = client
+        .prelogin_with_encryption(0x02) // NOT_SUP
+        .await
+        .expect("server answers the PRELOGIN first");
+    assert_eq!(
+        advertised, 0x03,
+        "must advertise REQ so the client learns why"
+    );
+    // The connection is then dropped rather than served in plaintext.
+    assert!(
+        client.try_read_message().await.is_none(),
+        "a client that cannot encrypt must not be served"
+    );
+    let _ = std::fs::remove_file(path);
 }
 
 #[tokio::test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -43,6 +43,22 @@ pub struct TdsConfig {
     /// PEM private key path (paired with `tls_cert`).
     #[serde(default)]
     pub tls_key: Option<String>,
+
+    /// Encryption policy: `off` never encrypts, `optional` (the default)
+    /// encrypts when the client asks, `required` refuses clients that will not
+    /// encrypt. `required` needs `tls_cert`/`tls_key`.
+    #[serde(default)]
+    pub encryption: Encryption,
+}
+
+/// `[tds] encryption = "off" | "optional" | "required"`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Encryption {
+    Off,
+    #[default]
+    Optional,
+    Required,
 }
 
 impl Default for TdsConfig {
@@ -55,6 +71,7 @@ impl Default for TdsConfig {
             auth: HashMap::new(),
             tls_cert: None,
             tls_key: None,
+            encryption: Encryption::default(),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -131,10 +131,25 @@ async fn main() {
                 return;
             }
         };
+        let encryption = match config.tds.encryption {
+            crate::config::Encryption::Off => truthdb_tds::Encryption::Off,
+            crate::config::Encryption::Optional => truthdb_tds::Encryption::Optional,
+            crate::config::Encryption::Required => truthdb_tds::Encryption::Required,
+        };
+        // `required` with no certificate could satisfy nobody: every connection
+        // would be refused. Say so at startup rather than at each client.
+        if encryption == truthdb_tds::Encryption::Required && tls.is_none() {
+            eprintln!("TDS encryption = \"required\" needs tls_cert and tls_key");
+            return;
+        }
+        if encryption == truthdb_tds::Encryption::Off && tls.is_some() {
+            info!("TDS encryption = \"off\": the configured certificate will not be offered");
+        }
         let tds_config = truthdb_tds::TdsConfig {
             users: config.tds.auth.clone(),
             database: config.tds.database.clone(),
             tls,
+            encryption,
         };
         match truthdb_tds::TdsListener::bind(
             &config.tds.addr,


### PR DESCRIPTION
TLS and the cert paths shipped, but the server's encryption behaviour was **hardcoded opportunistic** — offer TLS iff certs happen to be configured *and* the client happens to ask. So an operator could not **require** encryption: nothing stopped a client from silently connecting in plaintext to a TLS-configured server. `config/default.toml` didn't mention encryption at all and still said *"TLS arrives in Stage 9"*.

## `[tds] encryption = off | optional | required`
- **off** — never encrypt, even with a certificate configured.
- **optional** — the default, and the previous behaviour: encrypt when the client asks.
- **required** — advertise `ENCRYPT_REQ` so a compliant client knows it must encrypt, and **drop** a client that answers "cannot" rather than falling back to plaintext (a fallback would silently defeat the setting).

`required` without a certificate could satisfy nobody → the server says so **at startup** instead of refusing every connection in turn.

`prelogin_response` now takes the byte to advertise rather than a bool — there are three answers (ON / NOT_SUP / REQ), not two.

## On testing this honestly
The decision is a **pure function**, so the interesting combinations are tested exhaustively — notably *"off while a certificate IS configured"*, which an end-to-end test can't reach without committing a private key.

That mattered: my first end-to-end "off" test **passed vacuously** (the test config has no certificate, so the old code also answered NOT_SUP). The matrix tests are verified to fail with the policy reverted; the e2e tests cover the wiring (required refuses a plaintext client; optional still serves one).

All 16 suites green; fmt clean; no clippy warnings in touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)