### PR TITLE
Give the B+ tree and heap a resumable scan cursor

### DIFF
--- a/crates/truthdb-core/src/relstore/btree.rs
+++ b/crates/truthdb-core/src/relstore/btree.rs
@@ -16,7 +16,7 @@
 //! page (redo is idempotent by page LSN), never undone.
 
 use crate::relstore::ctx::{LogMode, OpMode, RelCtx};
-use crate::relstore::page::PAGE_TYPE_TREE;
+use crate::relstore::page::{self, PAGE_TYPE_TREE};
 use crate::relstore::slotted::{NO_PAGE, SlottedPage, SlottedRead};
 use crate::storage::StorageError;
 use crate::storage_layout::PAGE_SIZE;
@@ -29,6 +29,49 @@ pub const TREE_MAX_CELL: usize = (PAGE_SIZE - crate::relstore::slotted::STRUCT_H
 
 /// A `(key bytes, row bytes)` pair from a scan.
 pub type KeyRow = (Vec<u8>, Vec<u8>);
+
+/// Where a batched scan resumes: the page to read next and the slot within it.
+/// `page: None` means "not started"; `done()` means the chain is exhausted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ScanCursor {
+    page: Option<u64>,
+    slot: usize,
+}
+
+impl ScanCursor {
+    pub fn start() -> Self {
+        ScanCursor {
+            page: None,
+            slot: 0,
+        }
+    }
+
+    pub fn done(&self) -> bool {
+        self.page == Some(NO_PAGE)
+    }
+
+    pub(crate) fn at(page: u64, slot: usize) -> Self {
+        ScanCursor {
+            page: Some(page),
+            slot,
+        }
+    }
+
+    pub(crate) fn finished() -> Self {
+        ScanCursor {
+            page: Some(NO_PAGE),
+            slot: 0,
+        }
+    }
+
+    pub(crate) fn page(&self) -> Option<u64> {
+        self.page
+    }
+
+    pub(crate) fn slot(&self) -> usize {
+        self.slot
+    }
+}
 
 pub(crate) struct BTree {
     pub object_id: u32,
@@ -368,32 +411,60 @@ impl BTree {
 
     /// Full scan in key order via the leaf chain: (key, row) pairs.
     pub fn scan(&self, ctx: &mut RelCtx<'_>) -> Result<Vec<KeyRow>, StorageError> {
-        // Find the leftmost leaf.
-        let mut page_no = self.root;
-        loop {
-            let frame = ctx.fetch(page_no)?;
-            let page = SlottedRead::new(ctx.pool.page(frame));
-            if page.level() == 0 {
-                ctx.pool.unpin(frame);
-                break;
-            }
-            let child = internal_cell_child(page.get(0).expect("sentinel entry"));
-            ctx.pool.unpin(frame);
-            page_no = child;
-        }
         let mut out = Vec::new();
+        let mut cursor = ScanCursor::start();
+        while !cursor.done() {
+            cursor = self.scan_from(ctx, cursor, usize::MAX, &mut out)?;
+        }
+        Ok(out)
+    }
+
+    /// Appends at most `budget` rows from `cursor` onward, returning where to
+    /// resume. Lets a caller walk a large table in bounded slices instead of
+    /// materializing it, so the storage mutex can be dropped between slices.
+    ///
+    /// A resumed page is checked against this tree's `object_id` before it is
+    /// read: nothing holds the page between calls, so a page freed and recycled
+    /// to another object in the meantime would otherwise be read as if it were
+    /// still ours. On a mismatch the scan stops rather than return another
+    /// object's rows. (Callers holding a table lock cannot see that happen; a
+    /// READ UNCOMMITTED scan takes no lock and can.)
+    pub fn scan_from(
+        &self,
+        ctx: &mut RelCtx<'_>,
+        cursor: ScanCursor,
+        budget: usize,
+        out: &mut Vec<KeyRow>,
+    ) -> Result<ScanCursor, StorageError> {
+        let mut page_no = match cursor.page {
+            Some(page) => page,
+            None => self.leftmost_leaf(ctx)?,
+        };
+        let mut slot = cursor.slot;
+        let mut taken = 0;
         while page_no != NO_PAGE {
             let frame = ctx.fetch(page_no)?;
+            if page::read_header(ctx.pool.page(frame)).object_id != self.object_id {
+                ctx.pool.unpin(frame);
+                return Ok(ScanCursor::finished());
+            }
             let page = SlottedRead::new(ctx.pool.page(frame));
-            for index in 0..page.slot_count() {
-                let cell = page.get(index).expect("tree pages have no tombstones");
+            while slot < page.slot_count() {
+                if taken == budget {
+                    ctx.pool.unpin(frame);
+                    return Ok(ScanCursor::at(page_no, slot));
+                }
+                let cell = page.get(slot).expect("tree pages have no tombstones");
                 out.push((cell_key(cell).to_vec(), leaf_cell_row(cell).to_vec()));
+                slot += 1;
+                taken += 1;
             }
             let next = page.next_page();
             ctx.pool.unpin(frame);
             page_no = next;
+            slot = 0;
         }
-        Ok(out)
+        Ok(ScanCursor::finished())
     }
 
     /// Range scan in key order: `(key, row)` pairs with `lower <= key <= upper`

--- a/crates/truthdb-core/src/relstore/heap.rs
+++ b/crates/truthdb-core/src/relstore/heap.rs
@@ -11,8 +11,9 @@
 //! All mutations are physical slot operations logged with physical undos
 //! (RIDs are stable, so physical undo is exact).
 
+use crate::relstore::btree::ScanCursor;
 use crate::relstore::ctx::{LogMode, RelCtx, TxnLink};
-use crate::relstore::page::PAGE_TYPE_HEAP;
+use crate::relstore::page::{self, PAGE_TYPE_HEAP};
 use crate::relstore::slotted::{NO_PAGE, STRUCT_HEADER_END, SlottedRead};
 use crate::storage::StorageError;
 use crate::storage_layout::PAGE_SIZE;
@@ -362,14 +363,52 @@ impl Heap {
     /// RID; stubs and tombstones are skipped.
     pub fn scan(&self, ctx: &mut RelCtx<'_>) -> Result<Vec<(Rid, Vec<u8>)>, StorageError> {
         let mut out = Vec::new();
-        let mut page_no = self.first_page;
+        let mut cursor = ScanCursor::start();
+        while !cursor.done() {
+            cursor = self.scan_from(ctx, cursor, usize::MAX, &mut out)?;
+        }
+        Ok(out)
+    }
+
+    /// Appends at most `budget` rows from `cursor` onward, returning where to
+    /// resume. Lets a caller walk a large heap in bounded slices instead of
+    /// materializing it, so the storage mutex can be dropped between slices.
+    ///
+    /// A resumed page is checked against this heap's `object_id` before it is
+    /// read: nothing holds the page between calls, so a page freed and recycled
+    /// to another object in the meantime would otherwise be read as if it were
+    /// still ours. On a mismatch the scan stops rather than return another
+    /// object's rows. (Callers holding a table lock cannot see that happen; a
+    /// READ UNCOMMITTED scan takes no lock and can.)
+    pub fn scan_from(
+        &self,
+        ctx: &mut RelCtx<'_>,
+        cursor: ScanCursor,
+        budget: usize,
+        out: &mut Vec<(Rid, Vec<u8>)>,
+    ) -> Result<ScanCursor, StorageError> {
+        let mut page_no = cursor.page().unwrap_or(self.first_page);
+        let mut slot = cursor.slot();
+        let mut taken = 0;
         while page_no != NO_PAGE {
             let frame = ctx.fetch(page_no)?;
+            if page::read_header(ctx.pool.page(frame)).object_id != self.object_id {
+                ctx.pool.unpin(frame);
+                return Ok(ScanCursor::finished());
+            }
             let page = SlottedRead::new(ctx.pool.page(frame));
             let next = page.next_page();
             let mut bad_tag = None;
-            for slot in 0..page.slot_count() {
-                let Some(cell) = page.get(slot) else { continue };
+            let mut stopped = None;
+            while slot < page.slot_count() {
+                if taken == budget {
+                    stopped = Some(ScanCursor::at(page_no, slot));
+                    break;
+                }
+                let Some(cell) = page.get(slot) else {
+                    slot += 1;
+                    continue;
+                };
                 match cell[0] {
                     TAG_ROW => out.push((
                         Rid {
@@ -379,12 +418,18 @@ impl Heap {
                         cell[1..].to_vec(),
                     )),
                     TAG_MOVED => out.push((parse_rid(&cell[1..]), cell[11..].to_vec())),
-                    TAG_STUB => {}
+                    TAG_STUB => {
+                        // A stub yields no row and must not spend the budget.
+                        slot += 1;
+                        continue;
+                    }
                     other => {
                         bad_tag = Some(other);
                         break;
                     }
                 }
+                slot += 1;
+                taken += 1;
             }
             ctx.pool.unpin(frame);
             if let Some(tag) = bad_tag {
@@ -392,9 +437,13 @@ impl Heap {
                     "unknown heap cell tag {tag}"
                 )));
             }
+            if let Some(at) = stopped {
+                return Ok(at);
+            }
             page_no = next;
+            slot = 0;
         }
-        Ok(out)
+        Ok(ScanCursor::finished())
     }
 }
 

--- a/crates/truthdb-core/src/relstore/tests.rs
+++ b/crates/truthdb-core/src/relstore/tests.rs
@@ -738,3 +738,102 @@ fn heap_update_on_stub_starved_page_fails_cleanly() {
     drop(storage);
     let _ = std::fs::remove_file(path);
 }
+
+// ---- batched scans (ScanCursor) -------------------------------------------
+
+/// Walks a table in slices of `budget` rows, as a streaming reader would.
+fn scan_batched_ids(storage: &mut Storage, table: &str, budget: usize) -> Vec<i32> {
+    use crate::relstore::btree::{BTree, ScanCursor};
+    use crate::relstore::heap::Heap;
+    let (def, schema) = storage.rel_def_for_test(table).expect("def");
+    let mut raw: Vec<Vec<u8>> = Vec::new();
+    let mut cursor = ScanCursor::start();
+    let mut slices = 0;
+    while !cursor.done() {
+        // One lock acquisition per slice, released between: what lets a large
+        // scan stop holding the storage mutex for its whole duration.
+        let (next, got) = storage.with_rel_ctx_for_test(|ctx| {
+            let mut got = Vec::new();
+            let next = if def.is_tree() {
+                let tree = BTree {
+                    object_id: def.object_id,
+                    root: def.root_page,
+                };
+                let mut keyed = Vec::new();
+                let next = tree
+                    .scan_from(ctx, cursor, budget, &mut keyed)
+                    .expect("scan_from");
+                got.extend(keyed.into_iter().map(|(_, row)| row));
+                next
+            } else {
+                let heap = Heap {
+                    object_id: def.object_id,
+                    first_page: def.root_page,
+                };
+                let mut located = Vec::new();
+                let next = heap
+                    .scan_from(ctx, cursor, budget, &mut located)
+                    .expect("scan_from");
+                got.extend(located.into_iter().map(|(_, row)| row));
+                next
+            };
+            (next, got)
+        });
+        assert!(got.len() <= budget, "a slice must respect its budget");
+        raw.extend(got);
+        cursor = next;
+        slices += 1;
+        assert!(slices < 100_000, "the cursor must always advance");
+    }
+    raw.iter()
+        .map(
+            |r| match crate::relstore::row::decode_row(&schema, r).expect("decode")[0] {
+                Datum::Int(v) => v,
+                ref other => panic!("expected int id, got {other:?}"),
+            },
+        )
+        .collect()
+}
+
+#[test]
+fn batched_scan_matches_a_whole_scan_at_every_budget() {
+    // A slice boundary must fall anywhere without losing or repeating a row —
+    // including mid-page and exactly on a page boundary.
+    let path = unique_temp_path("scan-batched");
+    let mut storage = create_storage(&path);
+    create_tree_table(&mut storage, "t");
+    create_heap_table(&mut storage, "h");
+    // Enough rows, each large, to span many pages.
+    for i in 0..200 {
+        storage
+            .rel_insert("t", row(i, &"x".repeat(200)))
+            .expect("insert t");
+        storage
+            .rel_insert("h", row(i, &"x".repeat(200)))
+            .expect("insert h");
+    }
+    for table in ["t", "h"] {
+        let whole = scan_ids(&mut storage, table);
+        assert_eq!(whole.len(), 200, "{table}: precondition");
+        for budget in [1, 2, 7, 199, 200, 201, 1000] {
+            assert_eq!(
+                scan_batched_ids(&mut storage, table, budget),
+                whole,
+                "{table}: budget {budget} must agree with a whole scan"
+            );
+        }
+    }
+    let _ = std::fs::remove_file(path);
+}
+
+#[test]
+fn batched_scan_of_an_empty_table_terminates() {
+    let path = unique_temp_path("scan-empty");
+    let mut storage = create_storage(&path);
+    create_tree_table(&mut storage, "t");
+    create_heap_table(&mut storage, "h");
+    for table in ["t", "h"] {
+        assert_eq!(scan_batched_ids(&mut storage, table, 4), Vec::<i32>::new());
+    }
+    let _ = std::fs::remove_file(path);
+}

--- a/crates/truthdb-core/src/storage.rs
+++ b/crates/truthdb-core/src/storage.rs
@@ -391,6 +391,34 @@ impl Storage {
         self.lock().rel_scan(name)
     }
 
+    /// Test hook: a table's definition + schema, for driving a batched scan.
+    #[cfg(test)]
+    pub(crate) fn rel_def_for_test(
+        &self,
+        name: &str,
+    ) -> Result<
+        (
+            crate::relstore::catalog::TableDef,
+            crate::relstore::row::Schema,
+        ),
+        StorageError,
+    > {
+        self.lock().rel_def(name)
+    }
+
+    /// Test hook: runs `f` against a page context, taking the storage lock for
+    /// that call only — the shape a batched scan uses, one acquisition per
+    /// slice rather than one across the whole table.
+    #[cfg(test)]
+    pub(crate) fn with_rel_ctx_for_test<R>(
+        &self,
+        f: impl FnOnce(&mut crate::relstore::ctx::RelCtx<'_>) -> R,
+    ) -> R {
+        let mut guard = self.lock();
+        let mut ctx = guard.rel_ctx();
+        f(&mut ctx)
+    }
+
     pub fn rel_delete_where(
         &self,
         name: &str,


### PR DESCRIPTION
First leg of streaming results out of the engine (the Stage 6 engine-actor bullet: *"results fully materialized in BatchOutcome, not streamed via bounded sinks"*).

## Why here first
The materialization starts at the bottom: `BTree::scan` and `Heap::scan` each walk the page chain into a `Vec`, and `Storage::rel_scan` holds the coarse storage mutex for that whole walk. Nothing above them can stream while the bottom cannot.

## What
`scan_from(ctx, cursor, budget, out)` appends at most `budget` rows and returns where to resume, so a caller can walk a table in bounded slices and take the storage lock **once per slice** instead of once for the whole table. Both scans already walk their page chain via `next_page()`, so the cursor is just the next page plus the slot within it.

`scan()` is reimplemented on top of `scan_from` with an unbounded budget — which is what keeps every existing caller, and the whole existing suite, exercising the new path (280 core tests pass unchanged).

## Correctness
- **Recycled pages**: nothing pins a page between slices, so a page freed and recycled to another object would otherwise be read as if still ours. The page header carries `object_id` as self-identity for exactly this; a mismatch ends the scan rather than returning another object's rows. A caller holding a table lock cannot see this (no writer can run); a READ UNCOMMITTED scan takes no lock and can.
- **Heap stubs consume no budget** — they yield no row, so counting one would let a slice return short and, at budget 1, stall.

## Verification
Tables walked at budgets falling mid-page, exactly on a page boundary, and past the end; each agrees with a whole scan and no slice exceeds its budget. **Verified to fail** against a cursor that resumes at the wrong slot, and one that drops the slot across a page boundary. All 16 suites green; fmt clean.

## Next legs
Push-based source into a bounded sink; actor protocol carrying that sink instead of one `oneshot<BatchReply>`; TDS writer emitting COLMETADATA/ROW incrementally.

Note for the next leg: a computed column's type is inferred from **all** its values (`infer_type` after evaluating every row), but TDS requires COLMETADATA *before* any row — so computed columns cannot stream without static type derivation. Source columns take their type from the schema and can.

🤖 Generated with [Claude Code](https://claude.com/claude-code)