### PR TITLE
Upgrade icu_collator to 2.2 and give Collation a sort key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,14 +278,14 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "icu_collator"
-version = "1.5.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d370371887d31d56f361c3eaa15743e54f13bc677059c9191c77e099ed6966b2"
+checksum = "8bbdf98e5e0aa827770acee171ebb568aaab975a36b56afdb5fd0e2f525750bb"
 dependencies = [
- "displaydoc",
  "icu_collator_data",
  "icu_collections",
- "icu_locid_transform",
+ "icu_locale",
+ "icu_locale_core",
  "icu_normalizer",
  "icu_properties",
  "icu_provider",
@@ -297,62 +297,65 @@ dependencies = [
 
 [[package]]
 name = "icu_collator_data"
-version = "1.5.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b353986d77d28991eca4dea5ef2b8982f639342ae19ca81edc44f048bc38ebb"
+checksum = "038ed8e5817f2059c2f3efb0945ba78d060d3d25e8f1a1bea5139f821a21a2f0"
 
 [[package]]
 name = "icu_collections"
-version = "1.5.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
+ "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
 ]
 
 [[package]]
-name = "icu_locid"
-version = "1.5.0"
+name = "icu_locale"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+checksum = "d5a396343c7208121dc86e35623d3dfe19814a7613cfd14964994cdc9c9a2e26"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_locale_data",
+ "icu_provider",
+ "potential_utf",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
+ "serde",
  "tinystr",
  "writeable",
  "zerovec",
 ]
 
 [[package]]
-name = "icu_locid_transform"
-version = "1.5.0"
+name = "icu_locale_data"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_locid_transform_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform_data"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7515e6d781098bf9f7205ab3fc7e9709d34554ae0b21ddbcb5febfa4bc7df11d"
+checksum = "d5fdcc9ac77c6d74ff5cf6e65ef3181d6af32003b16fce3a77fb451d2f695993"
 
 [[package]]
 name = "icu_normalizer"
-version = "1.5.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
- "displaydoc",
  "icu_collections",
  "icu_normalizer_data",
  "icu_properties",
@@ -366,57 +369,45 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "1.5.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e8338228bdc8ab83303f16b797e177953730f601a96c25d10cb3ab0daa0cb7"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "1.5.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
- "displaydoc",
  "icu_collections",
- "icu_locid_transform",
+ "icu_locale_core",
  "icu_properties_data",
  "icu_provider",
- "tinystr",
+ "zerotrie",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "1.5.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85fb8799753b75aee8d2a21d7c14d9f38921b54b3dbda10f5a3c7a7b82dba5e2"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "1.5.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
- "icu_locid",
- "icu_provider_macros",
+ "icu_locale_core",
+ "serde",
  "stable_deref_trait",
- "tinystr",
  "writeable",
  "yoke",
  "zerofrom",
+ "zerotrie",
  "zerovec",
-]
-
-[[package]]
-name = "icu_provider_macros"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -476,9 +467,9 @@ dependencies = [
 
 [[package]]
 name = "litemap"
-version = "0.7.5"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -582,6 +573,17 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "serde_core",
+ "writeable",
+ "zerovec",
+]
 
 [[package]]
 name = "proc-macro-crate"
@@ -963,11 +965,12 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.7.6"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
+ "serde_core",
  "zerovec",
 ]
 
@@ -1188,7 +1191,7 @@ version = "0.1.0"
 dependencies = [
  "bincode",
  "icu_collator",
- "icu_locid",
+ "icu_locale_core",
  "io-uring",
  "libc",
  "rstest",
@@ -1522,9 +1525,9 @@ checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
 
 [[package]]
 name = "writeable"
-version = "0.5.5"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "xxhash-rust"
@@ -1534,11 +1537,10 @@ checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "yoke"
-version = "0.7.5"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
- "serde",
  "stable_deref_trait",
  "yoke-derive",
  "zerofrom",
@@ -1546,9 +1548,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.7.5"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1584,11 +1586,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
-name = "zerovec"
-version = "0.10.4"
+name = "zerotrie"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "serde",
  "yoke",
  "zerofrom",
  "zerovec-derive",
@@ -1596,9 +1611,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.10.3"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/truthdb-core/Cargo.toml
+++ b/crates/truthdb-core/Cargo.toml
@@ -15,8 +15,8 @@ serde_json = { workspace = true }
 bincode = { workspace = true }
 libc = { workspace = true }
 io-uring = { workspace = true }
-icu_collator = { version = "1.5", features = ["compiled_data"] }
-icu_locid = "1.5"
+icu_collator = { version = "2.2", features = ["compiled_data", "unstable"] }
+icu_locale_core = "2.0"
 
 [dev-dependencies]
 rstest = { workspace = true }

--- a/crates/truthdb-core/src/rel/collation.rs
+++ b/crates/truthdb-core/src/rel/collation.rs
@@ -1,23 +1,55 @@
-//! Collation: maps SQL Server collation names to icu4x collators for
-//! ORDER BY (and, later, index sort keys). Comparison strength encodes the
-//! case/accent sensitivity suffixes (`_CI`/`_CS`, `_AI`/`_AS`); the locale
-//! encodes the linguistic family (e.g. `Finnish_Swedish` -> Swedish, where
-//! å/ä/ö sort after z).
+//! Collation: maps SQL Server collation names to icu4x collators, for ORDER BY
+//! comparison and for index sort keys. Strength encodes the case/accent
+//! sensitivity suffixes (`_CI`/`_CS`, `_AI`/`_AS`); the locale encodes the
+//! linguistic family (e.g. `Finnish_Swedish` -> Swedish, where å/ä/ö sort after
+//! z).
+//!
+//! A [`Collation::sort_key`] is what carries linguistic order into the storage
+//! layer: two sort keys built at the same strength compare bytewise exactly as
+//! the collator compares the strings they came from, so a B+ tree ordered by
+//! sort-key bytes is ordered linguistically. Case- and accent-insensitivity
+//! fall out of the same mechanism — at primary strength `é` and `e` produce
+//! identical keys — so an index over them matches insensitively with no
+//! separate folding step.
 
 use std::cmp::Ordering;
 
-use icu_collator::{Collator, CollatorOptions, Strength};
-use icu_locid::Locale;
+use icu_collator::options::{CollatorOptions, Strength};
+use icu_collator::{CollationKeySink, CollatorBorrowed, CollatorPreferences};
+use icu_locale_core::Locale;
 
 /// The default database collation when none is configured or named.
 pub const DEFAULT_COLLATION: &str = "SQL_Latin1_General_CP1_CI_AS";
 
 pub struct Collation {
-    collator: Collator,
+    collator: CollatorBorrowed<'static>,
     /// A binary (`*_BIN`/`*_BIN2`) collation orders by code point, bypassing
     /// the linguistic collator.
     binary: bool,
     name: String,
+}
+
+/// Sink state icu4x threads through a sort-key write. We need none of our own.
+#[derive(Default)]
+struct KeyState;
+
+/// Collects sort-key bytes: icu4x writes a key through a sink rather than
+/// returning a buffer.
+struct KeyBuf(Vec<u8>);
+
+impl CollationKeySink for KeyBuf {
+    type Error = core::convert::Infallible;
+    type State = KeyState;
+    type Output = ();
+
+    fn write(&mut self, _state: &mut KeyState, buf: &[u8]) -> Result<(), Self::Error> {
+        self.0.extend_from_slice(buf);
+        Ok(())
+    }
+
+    fn finish(&mut self, _state: KeyState) -> Result<Self::Output, Self::Error> {
+        Ok(())
+    }
 }
 
 impl Collation {
@@ -27,10 +59,12 @@ impl Collation {
         let lower = name.to_ascii_lowercase();
         let binary = lower.contains("_bin");
         let (locale, strength) = parse_sql_collation(&lower);
-        let mut options = CollatorOptions::new();
+        let mut options = CollatorOptions::default();
         options.strength = Some(strength);
-        let collator = Collator::try_new(&locale.into(), options).unwrap_or_else(|_| {
-            Collator::try_new(&Locale::UND.into(), CollatorOptions::new()).expect("root collator")
+        let prefs: CollatorPreferences = locale.into();
+        let collator = CollatorBorrowed::try_new(prefs, options).unwrap_or_else(|_| {
+            CollatorBorrowed::try_new(Locale::UNKNOWN.into(), CollatorOptions::default())
+                .expect("root collator")
         });
         Collation {
             collator,
@@ -47,6 +81,22 @@ impl Collation {
         } else {
             self.collator.compare(a, b)
         }
+    }
+
+    /// The collation's sort key for `s`: bytes that compare bytewise the way
+    /// [`Self::compare`] compares strings.
+    ///
+    /// A binary collation has no linguistic key — its order *is* code-point
+    /// order — so it yields the string's own UTF-8 bytes, which compare
+    /// identically.
+    pub fn sort_key(&self, s: &str) -> Vec<u8> {
+        if self.binary {
+            return s.as_bytes().to_vec();
+        }
+        let mut buf = KeyBuf(Vec::new());
+        // The sink is infallible, so this cannot fail.
+        let _ = self.collator.write_sort_key_to(s, &mut buf);
+        buf.0
     }
 
     pub fn name(&self) -> &str {
@@ -69,12 +119,13 @@ fn parse_sql_collation(lower: &str) -> (Locale, Strength) {
         "is".parse().unwrap()
     } else {
         // Latin1_General / SQL_Latin1_General and unknowns use the root locale.
-        Locale::UND
+        Locale::UNKNOWN
     };
-    // Case-sensitive (`_CS`) keeps case at tertiary strength; `_CI` with `_AI`
-    // ignores both (primary); `_CI` alone keeps accents but ignores case
-    // (secondary). (icu cannot express case-sensitive+accent-insensitive, so a
-    // `_CS_AI` collation stays accent-sensitive, preserving the case order.)
+    // `_CS` keeps case at tertiary strength; `_AI` ignores accents (and, at
+    // primary, case along with them); `_CI` alone keeps accents but ignores
+    // case (secondary). icu strength is a single ladder, so it cannot express
+    // case-sensitive-but-accent-insensitive: a `_CS_AI` collation stays
+    // accent-sensitive, preserving the case distinction the name asks for.
     let strength = if lower.contains("_cs") {
         Strength::Tertiary
     } else if lower.contains("_ai") {
@@ -117,5 +168,69 @@ mod tests {
     fn case_sensitive_variant() {
         let coll = Collation::from_name("Latin1_General_CS_AS");
         assert_ne!(coll.compare("abc", "ABC"), Ordering::Equal);
+    }
+
+    /// The property the storage layer rests on: ordering sort-key bytes is the
+    /// same as asking the collator, so an index keyed on them is in linguistic
+    /// order.
+    #[test]
+    fn sort_keys_order_bytewise_exactly_as_compare_does() {
+        for name in [
+            "Finnish_Swedish_CI_AS",
+            "SQL_Latin1_General_CP1_CI_AS",
+            "Latin1_General_CS_AS",
+            "Latin1_General_CI_AI",
+            "Latin1_General_BIN2",
+        ] {
+            let coll = Collation::from_name(name);
+            let words = [
+                "a", "A", "b", "z", "å", "ä", "ö", "é", "e", "Ee", "ee", "", "zz",
+            ];
+            for x in words {
+                for y in words {
+                    assert_eq!(
+                        coll.sort_key(x).cmp(&coll.sort_key(y)),
+                        coll.compare(x, y),
+                        "{name}: sort keys must order {x:?} vs {y:?} as compare does"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn swedish_sort_keys_put_a_ring_after_z() {
+        // The point of keying an index on sort keys: this ordering holds in raw
+        // bytes, where a code-point comparison gets it wrong.
+        let coll = Collation::from_name("Finnish_Swedish_CI_AS");
+        assert!(coll.sort_key("z") < coll.sort_key("å"));
+        // The root collation disagrees, which is what makes the key linguistic
+        // rather than one fixed byte order.
+        let root = Collation::from_name(DEFAULT_COLLATION);
+        assert!(root.sort_key("å") < root.sort_key("z"));
+    }
+
+    #[test]
+    fn insensitivity_falls_out_of_the_sort_key() {
+        // Case-insensitive: 'a' and 'A' share a key, so an index over them
+        // matches insensitively with no separate folding step.
+        let ci = Collation::from_name("SQL_Latin1_General_CP1_CI_AS");
+        assert_eq!(ci.sort_key("abc"), ci.sort_key("ABC"));
+        // Accent-insensitive: 'é' and 'e' share a key.
+        let ai = Collation::from_name("Latin1_General_CI_AI");
+        assert_eq!(ai.sort_key("é"), ai.sort_key("e"));
+        assert_eq!(ai.sort_key("Résumé"), ai.sort_key("resume"));
+        // Case-sensitive keeps them apart...
+        let cs = Collation::from_name("Latin1_General_CS_AS");
+        assert_ne!(cs.sort_key("abc"), cs.sort_key("ABC"));
+        // ...and accent-sensitive keeps accents apart.
+        assert_ne!(ci.sort_key("é"), ci.sort_key("e"));
+    }
+
+    #[test]
+    fn binary_sort_key_is_the_string_itself() {
+        let bin = Collation::from_name("Latin1_General_BIN2");
+        assert_eq!(bin.sort_key("abc"), b"abc".to_vec());
+        assert!(bin.sort_key("A") < bin.sort_key("a"), "code-point order");
     }
 }


### PR DESCRIPTION
The Stage 5 collation bullet has carried *"blocked: icu_collator 1.5 exposes no public sort-key API"* since #82. That was only ever checked against 1.5 — the version we pin.

**icu_collator 2.2 has `write_sort_key_to`** (plus utf8/utf16 variants), behind the crate's `unstable` feature (icu4x graduation issue #7178). The bullet is not blocked.

## What

`Collation::sort_key` returns the bytes that carry linguistic order into the storage layer: two keys built at the same strength compare bytewise exactly as the collator compares the strings. Proven, not taken from the docs:

```
sv : z < å bytewise ? true    (Swedish sorts å after z — in raw bytes)
en : å < z bytewise ? true    (English sorts it near a)
_AI: key(é) == key(e) ? true  (primary strength)
_CI: key(A) == key(a) ? true
_CS: key(A) != key(a) ? true  (tertiary)
```

A test asserts the ordering property exhaustively over Swedish, root, `_CS`, `_AI` and binary collations.

Case- and accent-insensitivity fall out of the same mechanism — at primary strength `é` and `e` produce identical keys. That is what the current key-folding exists to approximate, and what `_AI` has had no answer for at all.

A binary collation has no linguistic key (its order *is* code-point order), so it yields the string's own UTF-8 bytes, which compare identically.

## The upgrade

Contained: 1.5 → 2.2 renames `icu_locid` to `icu_locale_core`, moves `CollatorOptions`/`Strength` under `options::`, replaces `Locale::UND` with `Locale::UNKNOWN`, and builds via `CollatorPreferences`/`CollatorBorrowed`. No caller outside the module changed. All 16 suites pass across the major bump; fmt clean.

## Next

Key character index bytes on sort keys instead of case-folding them — an on-disk key-format change, and `key.rs` will need a cached `Collation` since it sits on every insert and seek.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
