### PR TITLE
Stage 5: make the database's default collation configurable

### DIFF
--- a/config/default.toml
+++ b/config/default.toml
@@ -16,6 +16,11 @@ group_sync_ms = 5
 backpressure_timeout_ms = 50
 snapshot_min_interval_ms = 1000
 snapshot_wal_threshold = 0.7
+# The database's default collation: what a character column declared without an
+# explicit COLLATE gets. Applied when the database file is created and stamped
+# into it — an existing file keeps the collation it was created with, since its
+# index keys are already encoded under it. Default: SQL_Latin1_General_CP1_CI_AS.
+# default_collation = "Finnish_Swedish_CI_AS"
 
 # TDS (SQL Server protocol) gateway. Disabled by default. When enabled, real
 # SQL Server drivers (pytds, go-mssqldb with encrypt=disable) can connect.

--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -5262,6 +5262,7 @@ mod tests {
             snapshot_ratio: 0.02,
             allocator_ratio: 0.02,
             reserved_ratio: 0.17,
+            default_collation: None,
         }
     }
 

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -2264,6 +2264,9 @@ fn data_type_to_column_type(data_type: &DataType, name: &str) -> Result<ColumnTy
     })
 }
 
+/// Binds a declared column. A character column left without an explicit
+/// `COLLATE` keeps `None` here and is resolved to the database default by
+/// `rel_create_table`, the one point every CREATE TABLE passes through.
 fn bind_column(column: &ColumnDef) -> Result<Column, SqlError> {
     let column_type = data_type_to_column_type(&column.data_type, &column.name.value)?;
     // A COLLATE clause is only meaningful on character columns.

--- a/crates/truthdb-core/src/relstore/spill.rs
+++ b/crates/truthdb-core/src/relstore/spill.rs
@@ -363,6 +363,7 @@ mod tests {
                 snapshot_ratio: 0.02,
                 allocator_ratio: 0.02,
                 reserved_ratio: 0.17,
+                default_collation: None,
             },
             8 * 1024 * 1024,
             8 * 1024 * 1024,

--- a/crates/truthdb-core/src/relstore/tests.rs
+++ b/crates/truthdb-core/src/relstore/tests.rs
@@ -21,6 +21,7 @@ fn storage_options() -> StorageOptions {
         snapshot_ratio: 0.02,
         allocator_ratio: 0.02,
         reserved_ratio: 0.17,
+        default_collation: None,
     }
 }
 
@@ -834,6 +835,132 @@ fn batched_scan_of_an_empty_table_terminates() {
     create_heap_table(&mut storage, "h");
     for table in ["t", "h"] {
         assert_eq!(scan_batched_ids(&mut storage, table, 4), Vec::<i32>::new());
+    }
+    let _ = std::fs::remove_file(path);
+}
+
+// ---- the database's default collation ------------------------------------
+
+fn storage_options_with_collation(name: &str) -> StorageOptions {
+    StorageOptions {
+        default_collation: Some(name.to_string()),
+        ..storage_options()
+    }
+}
+
+#[test]
+fn the_database_default_collation_survives_a_reopen() {
+    // It decides the sort-key bytes of every column that inherits it, so it
+    // belongs to the file, not to the config of whoever opens it next.
+    let path = unique_temp_path("default-collation");
+    {
+        let storage = Storage::create_with_wal_bounds(
+            path.clone(),
+            storage_options_with_collation("Finnish_Swedish_CI_AS"),
+            REL_TEST_WAL_BYTES,
+            REL_TEST_WAL_BYTES,
+        )
+        .expect("create");
+        assert_eq!(
+            storage.default_collation().as_deref(),
+            Some("Finnish_Swedish_CI_AS")
+        );
+    }
+    let storage = Storage::open(path.clone()).expect("reopen");
+    assert_eq!(
+        storage.default_collation().as_deref(),
+        Some("Finnish_Swedish_CI_AS"),
+        "the default must be read back from the file"
+    );
+    let _ = std::fs::remove_file(path);
+}
+
+#[test]
+fn a_column_keeps_the_default_it_was_created_under() {
+    // The column stores the collation by name at CREATE TABLE. A database
+    // created later with a different default must not re-key this one.
+    let path = unique_temp_path("default-collation-column");
+    let mut storage = Storage::create_with_wal_bounds(
+        path.clone(),
+        storage_options_with_collation("Finnish_Swedish_CI_AS"),
+        REL_TEST_WAL_BYTES,
+        REL_TEST_WAL_BYTES,
+    )
+    .expect("create");
+    storage
+        .rel_create_table(
+            "t",
+            vec![
+                Column {
+                    nullable: false,
+                    ..varchar_column("w", 20)
+                },
+                int_column("n", true),
+            ],
+            &["w".to_string()],
+            Vec::new(),
+            None,
+            Vec::new(),
+            Vec::new(),
+        )
+        .expect("create table");
+    let (_, schema) = storage.rel_def_for_test("t").expect("def");
+    assert_eq!(
+        schema.columns[0].collation.as_deref(),
+        Some("Finnish_Swedish_CI_AS"),
+        "a character column inherits the database default, by name"
+    );
+    assert_eq!(
+        schema.columns[1].collation, None,
+        "a non-character column has no collation to inherit"
+    );
+    let _ = std::fs::remove_file(path);
+}
+
+#[test]
+fn no_configured_default_leaves_columns_on_the_builtin() {
+    let path = unique_temp_path("default-collation-none");
+    let mut storage = create_storage(&path);
+    assert_eq!(storage.default_collation(), None);
+    storage
+        .rel_create_table(
+            "t",
+            vec![Column {
+                nullable: false,
+                ..varchar_column("w", 20)
+            }],
+            &["w".to_string()],
+            Vec::new(),
+            None,
+            Vec::new(),
+            Vec::new(),
+        )
+        .expect("create table");
+    let (_, schema) = storage.rel_def_for_test("t").expect("def");
+    assert_eq!(
+        schema.columns[0].collation, None,
+        "built-in default applies"
+    );
+    let _ = std::fs::remove_file(path);
+}
+
+#[test]
+fn a_collation_name_too_long_for_the_header_is_refused() {
+    // Better to refuse than to stamp a truncated name and key columns under a
+    // collation nobody asked for.
+    let path = unique_temp_path("default-collation-long");
+    let result = Storage::create_with_wal_bounds(
+        path.clone(),
+        storage_options_with_collation(&"x".repeat(9000)),
+        REL_TEST_WAL_BYTES,
+        REL_TEST_WAL_BYTES,
+    );
+    match result {
+        Ok(_) => panic!("a name that cannot fit the header must be refused"),
+        Err(err) => assert!(
+            format!("{err:?}").contains("too long"),
+            "unexpected error: {err:?}"
+        ),
     }
     let _ = std::fs::remove_file(path);
 }

--- a/crates/truthdb-core/src/session.rs
+++ b/crates/truthdb-core/src/session.rs
@@ -1048,6 +1048,7 @@ mod tests {
             snapshot_ratio: 0.02,
             allocator_ratio: 0.02,
             reserved_ratio: 0.17,
+            default_collation: None,
         }
     }
 

--- a/crates/truthdb-core/src/storage.rs
+++ b/crates/truthdb-core/src/storage.rs
@@ -39,7 +39,7 @@ impl From<TypeError> for StorageError {
 /// kinds inside).
 const REL_WAL_ENTRY_VERSION: u16 = 1;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct StorageOptions {
     pub size_gib: u64,
     pub wal_ratio: f64,
@@ -47,6 +47,14 @@ pub struct StorageOptions {
     pub snapshot_ratio: f64,
     pub allocator_ratio: f64,
     pub reserved_ratio: f64,
+    /// The database's default collation: what a character column declared
+    /// without an explicit `COLLATE` gets. `None` uses the built-in default.
+    ///
+    /// It is stamped into the file at creation and read back on open, never
+    /// taken from the running config, because it decides the sort-key bytes of
+    /// every column that inherited it — changing it under existing data would
+    /// silently invalidate their keys.
+    pub default_collation: Option<String>,
 }
 
 impl StorageOptions {
@@ -326,6 +334,15 @@ impl Storage {
 
     pub fn rel_table(&self, name: &str) -> Option<TableDef> {
         self.lock().rel_table(name)
+    }
+
+    /// The database's default collation, as stamped into the file at creation.
+    /// `None` means the built-in default. A character column declared without an
+    /// explicit `COLLATE` is resolved to this at CREATE TABLE and stored with
+    /// it, so a column keeps the collation it was created under even if a later
+    /// database is created with a different default.
+    pub fn default_collation(&self) -> Option<String> {
+        self.lock().default_collation.clone()
     }
 
     pub fn rel_tables(&self) -> Vec<TableDef> {
@@ -689,6 +706,11 @@ struct StorageFile {
     rel: RelState,
     /// WAL records recovered at open, waiting for the engine to replay them.
     replay_cache: Vec<WalRecord>,
+    /// The database's default collation, read from the file header at open. A
+    /// character column declared without an explicit `COLLATE` is resolved to
+    /// this at CREATE TABLE and stored with it, so the column keeps the
+    /// collation it was created under even if the default later changes.
+    default_collation: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -747,7 +769,7 @@ impl StorageFile {
     pub fn rel_create_table(
         &mut self,
         name: &str,
-        columns: Vec<Column>,
+        mut columns: Vec<Column>,
         key_names: &[String],
         defaults: Vec<Option<String>>,
         identity: Option<catalog::IdentitySpec>,
@@ -755,6 +777,25 @@ impl StorageFile {
         foreign_keys: Vec<catalog::ForeignKeyDef>,
     ) -> Result<(), StorageError> {
         self.ensure_rel_usable()?;
+        // A character column declared without an explicit COLLATE inherits the
+        // database default *by name*, recorded now rather than resolved on each
+        // read: the column's key bytes are that collation's sort keys, so it has
+        // to keep the collation it was created under. Resolved here, at the one
+        // point every CREATE TABLE passes through, so the SQL path and the
+        // native path cannot disagree.
+        if let Some(default) = self.default_collation.clone() {
+            for column in &mut columns {
+                if column.collation.is_none()
+                    && matches!(
+                        column.column_type,
+                        crate::relstore::types::ColumnType::VarChar { .. }
+                            | crate::relstore::types::ColumnType::NVarChar { .. }
+                    )
+                {
+                    column.collation = Some(default.clone());
+                }
+            }
+        }
         if self.rel.tables.contains_key(name) {
             return Err(StorageError::Constraint(format!(
                 "table '{name}' already exists"
@@ -1853,6 +1894,7 @@ impl StorageFile {
         }
 
         let mut storage = StorageFile {
+            default_collation: header.default_collation(),
             file,
             wal,
             layout,
@@ -1894,9 +1936,17 @@ impl StorageFile {
         wal_min_bytes: u64,
         wal_max_bytes: u64,
     ) -> Result<Self, StorageError> {
-        let layout = compute_layout(opts, wal_min_bytes, wal_max_bytes)?;
+        let layout = compute_layout(opts.clone(), wal_min_bytes, wal_max_bytes)?;
         validate_allocator_region(&layout)?;
         let mut header = FileHeader::default();
+        // Stamp the database's default collation into the file. Every character
+        // column declared without an explicit COLLATE is keyed under it, so it
+        // belongs to the data, not to whatever the config says at the next boot.
+        if let Some(name) = opts.default_collation.as_deref() {
+            header
+                .set_default_collation(name)
+                .map_err(StorageError::InvalidConfig)?;
+        }
         header.superblock_a_offset = layout.superblock_a_offset;
         header.superblock_b_offset = layout.superblock_b_offset;
         header.wal_offset = layout.wal_offset;
@@ -1935,6 +1985,7 @@ impl StorageFile {
         let wal = WalWriter::open(log_file, layout.wal_offset, layout.wal_size, 0, 0)?;
 
         Ok(StorageFile {
+            default_collation: header.default_collation(),
             file,
             wal,
             layout,
@@ -2912,6 +2963,7 @@ mod tests {
             snapshot_ratio: 0.02,
             allocator_ratio: 0.02,
             reserved_ratio: 0.17,
+            default_collation: None,
         }
     }
 

--- a/crates/truthdb-core/src/storage_layout.rs
+++ b/crates/truthdb-core/src/storage_layout.rs
@@ -168,6 +168,42 @@ impl FileHeader {
         header
     }
 
+    /// The database's default collation, from the reserved area: a `u16` length
+    /// then UTF-8 bytes. Empty (a fresh zeroed header, or a file created before
+    /// this was recorded) means the built-in default.
+    ///
+    /// It lives in the file because it decides the sort-key bytes of every
+    /// character column declared without an explicit `COLLATE`. Changing it
+    /// under existing data would silently invalidate their keys, so a database
+    /// is stamped with one at creation and reads it back on open rather than
+    /// taking it from whatever the current config happens to say.
+    pub fn default_collation(&self) -> Option<String> {
+        let len = u16::from_le_bytes(self.reserved[0..2].try_into().unwrap()) as usize;
+        if len == 0 || len > self.reserved.len() - 2 {
+            return None;
+        }
+        std::str::from_utf8(&self.reserved[2..2 + len])
+            .ok()
+            .map(str::to_string)
+    }
+
+    /// Stamps the database's default collation into the reserved area. Fails if
+    /// the name cannot fit, rather than storing a truncated one that would key
+    /// columns under a collation nobody asked for.
+    pub fn set_default_collation(&mut self, name: &str) -> Result<(), String> {
+        let bytes = name.as_bytes();
+        if bytes.len() + 2 > self.reserved.len() {
+            return Err(format!(
+                "collation name is too long for the file header: {} bytes, room for {}",
+                bytes.len(),
+                self.reserved.len() - 2
+            ));
+        }
+        self.reserved[0..2].copy_from_slice(&(bytes.len() as u16).to_le_bytes());
+        self.reserved[2..2 + bytes.len()].copy_from_slice(bytes);
+        Ok(())
+    }
+
     pub fn compute_checksum(self) -> u64 {
         let mut out = self.to_le_bytes_with_checksum();
         out[64..72].copy_from_slice(&0u64.to_le_bytes());

--- a/crates/truthdb-core/tests/slt.rs
+++ b/crates/truthdb-core/tests/slt.rs
@@ -36,6 +36,7 @@ fn new_engine(path: &Path) -> Engine {
         snapshot_ratio: 0.02,
         allocator_ratio: 0.02,
         reserved_ratio: 0.17,
+        default_collation: None,
     };
     let storage = Storage::create(path.to_path_buf(), opts).expect("create storage");
     Engine::new(storage).expect("engine")

--- a/crates/truthdb-tds/tests/tds_client.rs
+++ b/crates/truthdb-tds/tests/tds_client.rs
@@ -37,6 +37,7 @@ fn engine(path: &std::path::Path) -> EngineHandle {
         snapshot_ratio: 0.02,
         allocator_ratio: 0.02,
         reserved_ratio: 0.17,
+        default_collation: None,
     };
     let storage = Storage::create(path.to_path_buf(), opts).expect("storage");
     // The JoinHandle is dropped; the engine thread exits when the last

--- a/src/config.rs
+++ b/src/config.rs
@@ -130,6 +130,13 @@ pub struct StorageConfig {
 
     #[serde(default = "default_storage_snapshot_wal_threshold")]
     pub snapshot_wal_threshold: f64,
+
+    /// The database's default collation: what a character column declared
+    /// without an explicit COLLATE gets. Applied when the database file is
+    /// created and stamped into it; an existing file keeps the collation it was
+    /// created with, since its keys are already encoded under it.
+    #[serde(default)]
+    pub default_collation: Option<String>,
 }
 
 fn default_addr() -> String {
@@ -212,6 +219,7 @@ impl Default for StorageConfig {
             backpressure_timeout_ms: default_storage_backpressure_timeout_ms(),
             snapshot_min_interval_ms: default_storage_snapshot_min_interval_ms(),
             snapshot_wal_threshold: default_storage_snapshot_wal_threshold(),
+            default_collation: None,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,6 +65,7 @@ async fn main() {
         snapshot_ratio: config.storage.snapshot_ratio,
         allocator_ratio: config.storage.allocator_ratio,
         reserved_ratio: config.storage.reserved_ratio,
+        default_collation: config.storage.default_collation.clone(),
     };
 
     let storage = if storage_path.exists() {


### PR DESCRIPTION
The last of the Stage 5 collation bullet's three gaps. The default was a `const`, so every character column declared without an explicit `COLLATE` was `SQL_Latin1_General_CP1_CI_AS` and nothing could say otherwise.

## Why it belongs to the database, not the config
It decides the sort-key bytes of every column that inherits it. Changing it under existing data would silently invalidate their keys, and a process can hold several databases open at once (the tests do), so a mutable process-wide setting is wrong.

So a file is **stamped with one at creation** — in the file header's reserved area, length-prefixed — and reads it back on open, rather than taking it from whatever the config says at the next boot. This is how SQL Server treats it. A name that cannot fit is **refused outright** rather than truncated into a collation nobody asked for.

Columns resolve it at CREATE TABLE and store it **by name**, so a column keeps the collation it was created under.

## A test caught a real mistake
I first resolved the default in the SQL binder. That left tables created through the storage API (the native path) on the built-in default — two entry points, two answers. The resolution now sits in `rel_create_table`, the one point every CREATE TABLE passes through.

## Verification
- the default survives a reopen;
- a character column inherits it by name, a non-character column does not;
- no configured default leaves columns on the built-in;
- an oversized name is refused.

Each **verified to fail with its mechanism removed**. All 16 suites green; fmt clean.

`StorageOptions` loses `Copy` (the name is a `String`); only one non-test caller constructs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
