### PR TITLE
Scan a table in slices on the read path, releasing the storage lock between

### DIFF
--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -3166,6 +3166,12 @@ fn predicate_true(
 
 // ---- SELECT -------------------------------------------------------------
 
+/// Rows a table scan reads per slice before dropping the storage lock and
+/// letting another session in. Large enough that the per-slice overhead (a lock
+/// acquisition and a catalog lookup) is noise against decoding the rows, small
+/// enough that a big scan yields often.
+const SCAN_SLICE_ROWS: usize = 1024;
+
 struct Source {
     columns: Vec<ResultColumn>,
     /// Per-column table qualifier (alias or table name; `None` = virtual/
@@ -5583,8 +5589,11 @@ fn build_table_source(
             // An index seek narrows the candidate set; the WHERE filter later
             // re-checks, so results match a full scan.
             let rows = match plan::choose(&def, &schema, where_clause, eval_ctx) {
+                // Sliced: a read holds the table's lock, so it need not also
+                // hold the storage lock for the whole table and block every
+                // other session while it walks.
                 plan::AccessPath::TableScan => storage
-                    .rel_scan(&def.name)
+                    .rel_scan_sliced(&def.name, SCAN_SLICE_ROWS)
                     .map_err(|err| map_storage_err(err, &def.name))?,
                 plan::AccessPath::IndexSeek {
                     index_object_id,

--- a/crates/truthdb-core/src/relstore/tests.rs
+++ b/crates/truthdb-core/src/relstore/tests.rs
@@ -964,3 +964,91 @@ fn a_collation_name_too_long_for_the_header_is_refused() {
     }
     let _ = std::fs::remove_file(path);
 }
+
+#[test]
+fn a_sliced_scan_reads_the_same_rows_as_a_whole_one() {
+    // The SELECT path reads through rel_scan_sliced; it must agree with the
+    // atomic rel_scan the integrity checks still use, at any slice size.
+    let path = unique_temp_path("scan-sliced");
+    let mut storage = create_storage(&path);
+    create_tree_table(&mut storage, "t");
+    create_heap_table(&mut storage, "h");
+    for i in 0..300 {
+        storage
+            .rel_insert("t", row(i, &"x".repeat(150)))
+            .expect("insert t");
+        storage
+            .rel_insert("h", row(i, &"x".repeat(150)))
+            .expect("insert h");
+    }
+    for table in ["t", "h"] {
+        let whole = scan_ids(&mut storage, table);
+        assert_eq!(whole.len(), 300, "{table}: precondition");
+        for budget in [1, 3, 64, 299, 300, 301, 4096] {
+            let sliced: Vec<i32> = storage
+                .rel_scan_sliced(table, budget)
+                .expect("sliced scan")
+                .iter()
+                .map(|r| match r[0] {
+                    Datum::Int(v) => v,
+                    ref other => panic!("expected int id, got {other:?}"),
+                })
+                .collect();
+            assert_eq!(sliced, whole, "{table}: slice budget {budget}");
+        }
+    }
+    let _ = std::fs::remove_file(path);
+}
+
+#[test]
+fn a_sliced_scan_lets_another_thread_take_the_storage_lock_mid_scan() {
+    // The point of slicing: one large read must stop blocking every other
+    // session for its whole duration. With a single lock hold, the probe below
+    // cannot run until the scan finishes.
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+    let path = unique_temp_path("scan-sliced-lock");
+    let mut storage = Storage::create_with_wal_bounds(
+        path.clone(),
+        storage_options(),
+        64 * 1024 * 1024,
+        64 * 1024 * 1024,
+    )
+    .expect("create");
+    create_tree_table(&mut storage, "t");
+    for i in 0..1500 {
+        storage
+            .rel_insert("t", row(i, &"x".repeat(400)))
+            .expect("insert");
+    }
+    let storage = Arc::new(storage);
+
+    let stop = Arc::new(AtomicBool::new(false));
+    let probes = Arc::new(AtomicUsize::new(0));
+    let probe = {
+        let storage = Arc::clone(&storage);
+        let stop = Arc::clone(&stop);
+        let probes = Arc::clone(&probes);
+        std::thread::spawn(move || {
+            // Each rel_get takes the storage lock briefly. If the scan held it
+            // throughout, none of these could complete while it ran.
+            while !stop.load(Ordering::Relaxed) {
+                let _ = storage.rel_get("t", &[Datum::Int(0)]);
+                probes.fetch_add(1, Ordering::Relaxed);
+            }
+        })
+    };
+
+    let rows = storage.rel_scan_sliced("t", 8).expect("sliced scan");
+    let during = probes.load(Ordering::Relaxed);
+    stop.store(true, Ordering::Relaxed);
+    probe.join().expect("probe thread");
+
+    assert_eq!(rows.len(), 1500, "the scan still reads everything");
+    assert!(
+        during > 0,
+        "another thread must get the storage lock while a sliced scan runs"
+    );
+    let _ = std::fs::remove_file(path);
+}

--- a/crates/truthdb-core/src/storage.rs
+++ b/crates/truthdb-core/src/storage.rs
@@ -9,7 +9,7 @@ use crate::allocator::{EXTENT_PAGES, PageAllocator};
 use crate::direct_io::{AlignedPageBuf, DirectFile};
 use crate::group_commit::GroupCommit;
 use crate::relstore::RelState;
-use crate::relstore::btree::{BTree, TreeInsert};
+use crate::relstore::btree::{BTree, ScanCursor, TreeInsert};
 use crate::relstore::buffer_pool::DEFAULT_CAPACITY_BYTES;
 use crate::relstore::catalog::{self, FIRST_USER_OBJECT_ID, IndexDef, TableDef};
 use crate::relstore::ctx::{OpMode, PoolIo, RelCtx, TxnLink};
@@ -406,6 +406,32 @@ impl Storage {
 
     pub fn rel_scan(&self, name: &str) -> Result<Vec<Vec<Datum>>, StorageError> {
         self.lock().rel_scan(name)
+    }
+
+    /// Scans a table in bounded slices, dropping the storage lock between them,
+    /// so one large read stops blocking every other session for its whole
+    /// duration.
+    ///
+    /// Only for readers that hold the table's lock — which a SELECT does at
+    /// every isolation level except READ UNCOMMITTED, whose whole contract is
+    /// that it sees in-flight change. Nothing pins a page between slices, so a
+    /// concurrent writer could restructure the tree; the cursor checks each
+    /// resumed page still belongs to the table and stops rather than read
+    /// another object's rows. The integrity checks (FK probes, WITH CHECK) keep
+    /// using [`Self::rel_scan`], whose single lock hold makes them atomic — a
+    /// validation that missed a row because a page split mid-walk would admit a
+    /// violating row.
+    pub fn rel_scan_sliced(
+        &self,
+        name: &str,
+        budget: usize,
+    ) -> Result<Vec<Vec<Datum>>, StorageError> {
+        let mut out = Vec::new();
+        let mut cursor = ScanCursor::start();
+        while !cursor.done() {
+            cursor = self.lock().rel_scan_slice(name, cursor, budget, &mut out)?;
+        }
+        Ok(out)
     }
 
     /// Test hook: a table's definition + schema, for driving a batched scan.
@@ -1228,6 +1254,45 @@ impl StorageFile {
 
     /// Full scan: rows as typed datums (key order for trees, chain order
     /// for heaps).
+    /// One slice of a scan: appends at most `budget` rows from `cursor` and
+    /// returns where to resume. The caller loops, so the storage lock is taken
+    /// once per slice instead of once for the whole table.
+    pub(crate) fn rel_scan_slice(
+        &mut self,
+        name: &str,
+        cursor: ScanCursor,
+        budget: usize,
+        out: &mut Vec<Vec<Datum>>,
+    ) -> Result<ScanCursor, StorageError> {
+        self.ensure_rel_usable()?;
+        let (def, schema) = self.rel_def(name)?;
+        let mut ctx = self.rel_ctx();
+        let mut raw: Vec<Vec<u8>> = Vec::new();
+        let next = if def.is_tree() {
+            let tree = BTree {
+                object_id: def.object_id,
+                root: def.root_page,
+            };
+            let mut keyed = Vec::new();
+            let next = tree.scan_from(&mut ctx, cursor, budget, &mut keyed)?;
+            raw.extend(keyed.into_iter().map(|(_, row)| row));
+            next
+        } else {
+            let heap = Heap {
+                object_id: def.object_id,
+                first_page: def.root_page,
+            };
+            let mut located = Vec::new();
+            let next = heap.scan_from(&mut ctx, cursor, budget, &mut located)?;
+            raw.extend(located.into_iter().map(|(_, row)| row));
+            next
+        };
+        for row in raw {
+            out.push(decode_row(&schema, &row)?);
+        }
+        Ok(next)
+    }
+
     pub fn rel_scan(&mut self, name: &str) -> Result<Vec<Vec<Datum>>, StorageError> {
         self.ensure_rel_usable()?;
         let (def, schema) = self.rel_def(name)?;


### PR DESCRIPTION
Second leg of streaming results out of the engine (Stage 6 engine-actor bullet).

## Why
`rel_scan` walks the whole table under **one hold of the coarse storage mutex**, so one large SELECT blocks every other session for its entire duration. The read has to stop doing that before anything above it can stream.

## What
`rel_scan_sliced` walks through the #92 cursor in bounded slices (1024 rows), taking the lock **once per slice**. The SELECT scan path uses it.

A test pins the actual property rather than the mechanism: while a sliced scan runs, another thread **does** get the storage lock — and it fails if the walk is put back under a single hold.

## What it deliberately is *not*
It does not replace `rel_scan`. The integrity checks — the FK parent-side probe fallback, the FK self-reference path in UPDATE, `ALTER TABLE` WITH CHECK for FK and CHECK constraints — keep the atomic single-hold scan. **A validation that missed a row because a page split mid-walk would admit a violating row.**

Only a reader holding the table's lock may slice, which a SELECT does at every isolation level except READ UNCOMMITTED — whose contract is already that it sees in-flight change. Even there the cursor checks each resumed page still belongs to the table and stops rather than read another object's rows.

## Verification
Agrees with the atomic scan at slice sizes falling mid-page, exactly on a page boundary and past the end, on both a tree and a heap. All 16 suites green; fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
