### PR TITLE
Sweep idle transactions on a thread of their own

### DIFF
--- a/crates/truthdb-core/src/session.rs
+++ b/crates/truthdb-core/src/session.rs
@@ -39,7 +39,7 @@
 use std::collections::{HashMap, VecDeque};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Condvar, Mutex};
 use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 
@@ -346,6 +346,8 @@ fn spawn_engine_pool(
         scheduler: Mutex::new(Scheduler::new(timeout, idle_txn_timeout)),
         rx: Mutex::new(rx),
         stop: AtomicBool::new(false),
+        idle: Mutex::new(()),
+        wake: Condvar::new(),
     });
     // A supervisor thread spawns the workers and joins them; its handle is what
     // callers join at shutdown. When all workers have exited, any batch still
@@ -354,6 +356,11 @@ fn spawn_engine_pool(
     let join = std::thread::Builder::new()
         .name("truthdb-engine".to_string())
         .spawn(move || {
+            let keeper = Arc::clone(&supervisor);
+            let maintenance = std::thread::Builder::new()
+                .name("truthdb-maintenance".to_string())
+                .spawn(move || maintenance_loop(&keeper))
+                .expect("spawn maintenance thread");
             let handles: Vec<_> = (0..workers)
                 .map(|i| {
                     let shared = Arc::clone(&supervisor);
@@ -366,6 +373,17 @@ fn spawn_engine_pool(
             for handle in handles {
                 let _ = handle.join();
             }
+            // The workers are gone — either on a Shutdown pill, or because the
+            // last handle dropped and the channel disconnected, which sets no
+            // flag. Tell the maintenance thread either way, or it would outlive
+            // the pool. Setting the flag under `idle` is what makes the wake
+            // reliable rather than a race against its next sleep.
+            {
+                let _idle = supervisor.idle.lock().expect("idle mutex poisoned");
+                supervisor.stop.store(true, Ordering::Release);
+            }
+            supervisor.wake.notify_all();
+            let _ = maintenance.join();
             let mut sched = supervisor.scheduler.lock().expect("scheduler poisoned");
             for parked in sched.parked.drain(..) {
                 let _ = parked.reply.send(Err(EngineError::Unavailable));
@@ -388,6 +406,12 @@ struct Shared {
     /// Set when a `Shutdown` is seen, so a worker between calls exits promptly
     /// rather than picking up more work.
     stop: AtomicBool,
+    /// Companion mutex for [`Self::wake`]. Guards nothing — a `Condvar` needs
+    /// one.
+    idle: Mutex<()>,
+    /// Wakes the maintenance thread out of its sleep at shutdown, so the pool
+    /// does not wait out a whole sweep interval before exiting.
+    wake: Condvar,
 }
 
 // The pool shares `Arc<Engine>` across worker threads, so the engine — and thus
@@ -407,6 +431,55 @@ struct Runnable {
     cancel: Arc<AtomicBool>,
     reply: oneshot::Sender<Result<BatchReply, EngineError>>,
     txn_ctx: TxnContext,
+}
+
+/// The engine's housekeeping, on a thread that never runs a batch: the
+/// deadlock backstop (reap a lock wait past its deadline) and the idle-
+/// transaction reaper.
+///
+/// The workers sweep too, between calls, and that is still where a reap and the
+/// drain it unblocks happen in one pass. This thread is what makes the sweep
+/// *punctual*. A worker only reaches it between batches, so the reapers were
+/// only ever as prompt as the pool was free — and the pool is `cores-2`
+/// threads, two on a four-core box. A few long scans already delayed the sweep
+/// for as long as they ran, which is backwards: the idle reaper exists to
+/// release the locks of a client that has stopped responding, and a loaded
+/// engine is exactly when that matters most. Nothing a client does can delay
+/// this thread, because it never executes anything on their behalf.
+///
+/// It only *releases* locks; running whatever that unblocks still needs a
+/// worker, and always did.
+fn maintenance_loop(shared: &Arc<Shared>) {
+    while !shared.stop.load(Ordering::Acquire) {
+        // Sleep until the nearest parked deadline, but never past the sweep
+        // cap: an idle transaction has no deadline in the parked queue, so with
+        // nothing parked the cap is the only thing that brings us back.
+        let wait = {
+            let sched = shared.scheduler.lock().expect("scheduler poisoned");
+            let cap = sched.wake_cap();
+            match sched.earliest_deadline() {
+                Some(deadline) => deadline.saturating_duration_since(Instant::now()).min(cap),
+                None => cap,
+            }
+        };
+        {
+            // `stop` is read and written under this mutex, so a shutdown that
+            // lands between the check and the wait cannot be missed — it would
+            // otherwise be slept through for a whole sweep interval, and the
+            // supervisor is joining this thread.
+            let idle = shared.idle.lock().expect("idle mutex poisoned");
+            if shared.stop.load(Ordering::Acquire) {
+                break;
+            }
+            let _ = shared
+                .wake
+                .wait_timeout(idle, wait)
+                .expect("idle mutex poisoned");
+        }
+        let mut sched = shared.scheduler.lock().expect("scheduler poisoned");
+        sched.reap_expired(&shared.engine);
+        sched.reap_idle_txns(&shared.engine);
+    }
 }
 
 /// One worker thread: pull a call, dispatch it, repeat until shutdown.
@@ -1390,6 +1463,73 @@ mod tests {
         assert!(
             sched.reap_idle_txns(&engine),
             "with nothing parked, the idle transaction is reaped"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn housekeeping_runs_with_no_worker_free_to_do_it() {
+        // The reapers are the engine's safety valves and must not be hostage to
+        // the pool: a worker only sweeps between batches, so a busy pool used to
+        // mean no sweep. Pinned in its strongest form — a pool with *no workers
+        // at all*, which no amount of load can distinguish itself from — where
+        // only the maintenance thread can do it.
+        let (engine, mut sched, path) = bare("maintenance", Some(Duration::from_millis(50)));
+        let id = sched.sessions.open("truthdb".into(), "sa".into());
+        {
+            let ctx = &mut sched.sessions.get_mut(id).expect("session").txn_ctx;
+            engine
+                .sql_batch("CREATE TABLE t (id INT NOT NULL PRIMARY KEY)", ctx)
+                .expect("create");
+            engine
+                .sql_batch("BEGIN TRAN; INSERT INTO t VALUES (1);", ctx)
+                .expect("begin");
+            assert!(
+                ctx.has_open_transaction(),
+                "the session starts with an open txn"
+            );
+        }
+        // Keep the sender alive so the (worker-less) channel stays open.
+        let (_tx, rx) = mpsc::channel();
+        let shared = Arc::new(Shared {
+            engine: Arc::new(engine),
+            scheduler: Mutex::new(sched),
+            rx: Mutex::new(rx),
+            stop: AtomicBool::new(false),
+            idle: Mutex::new(()),
+            wake: Condvar::new(),
+        });
+        let keeper = Arc::clone(&shared);
+        let maintenance = std::thread::spawn(move || maintenance_loop(&keeper));
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let reaped = loop {
+            {
+                let sched = shared.scheduler.lock().expect("scheduler poisoned");
+                if !sched
+                    .sessions
+                    .get(id)
+                    .expect("session")
+                    .txn_ctx
+                    .has_open_transaction()
+                {
+                    break true;
+                }
+            }
+            if Instant::now() > deadline {
+                break false;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        };
+        {
+            let _idle = shared.idle.lock().expect("idle mutex poisoned");
+            shared.stop.store(true, Ordering::Release);
+        }
+        shared.wake.notify_all();
+        maintenance.join().expect("maintenance thread");
+        assert!(
+            reaped,
+            "the idle transaction was reaped with no worker to do it"
         );
         let _ = std::fs::remove_file(path);
     }

--- a/crates/truthdb-core/src/session.rs
+++ b/crates/truthdb-core/src/session.rs
@@ -433,6 +433,12 @@ struct Runnable {
     txn_ctx: TxnContext,
 }
 
+/// Counts maintenance threads that have started, so a test can prove the pool
+/// actually spawns one — the reaping itself is pinned against a hand-built
+/// `Shared`, which would not notice the supervisor forgetting to wire it up.
+#[cfg(test)]
+static MAINTENANCE_STARTS: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+
 /// The engine's housekeeping, on a thread that never runs a batch: the
 /// deadlock backstop (reap a lock wait past its deadline) and the idle-
 /// transaction reaper.
@@ -450,6 +456,8 @@ struct Runnable {
 /// It only *releases* locks; running whatever that unblocks still needs a
 /// worker, and always did.
 fn maintenance_loop(shared: &Arc<Shared>) {
+    #[cfg(test)]
+    MAINTENANCE_STARTS.fetch_add(1, Ordering::Relaxed);
     while !shared.stop.load(Ordering::Acquire) {
         // Sleep until the nearest parked deadline, but never past the sweep
         // cap: an idle transaction has no deadline in the parked queue, so with
@@ -1465,6 +1473,26 @@ mod tests {
             "with nothing parked, the idle transaction is reaped"
         );
         let _ = std::fs::remove_file(path);
+    }
+
+    #[tokio::test]
+    async fn the_pool_actually_spawns_a_maintenance_thread() {
+        // `housekeeping_runs_with_no_worker_free_to_do_it` builds `Shared` by
+        // hand and starts the thread itself, so it would pass just as happily
+        // if the supervisor never spawned one. This covers the wiring: run the
+        // real `spawn_engine` path and wait for a maintenance thread to report
+        // in. (A sibling test's pool satisfying this is fine — it is the same
+        // supervisor code either way; what fails is nobody spawning one at all.)
+        let h = start_with_idle(Some(Duration::from_millis(150)));
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while MAINTENANCE_STARTS.load(Ordering::Relaxed) == 0 && Instant::now() < deadline {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        assert!(
+            MAINTENANCE_STARTS.load(Ordering::Relaxed) > 0,
+            "the pool spawns a maintenance thread"
+        );
+        drop(h);
     }
 
     #[test]

--- a/crates/truthdb-core/src/session.rs
+++ b/crates/truthdb-core/src/session.rs
@@ -68,6 +68,10 @@ const LOCK_WAIT_TIMEOUT: Duration = Duration::from_secs(5);
 /// be disabled outright.
 const IDLE_TXN_TIMEOUT: Duration = Duration::from_secs(600);
 
+/// Floor on the maintenance thread's sleep, so no configuration of the timeouts
+/// can turn its loop into a spin.
+const MIN_SWEEP_INTERVAL: Duration = Duration::from_millis(10);
+
 /// The result of running a batch for a session: its typed outcome plus
 /// whether the connection is still inside a transaction afterwards (so the
 /// TDS gateway can set `DONE_INXACT`).
@@ -439,41 +443,46 @@ struct Runnable {
 #[cfg(test)]
 static MAINTENANCE_STARTS: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
 
-/// The engine's housekeeping, on a thread that never runs a batch: the
-/// deadlock backstop (reap a lock wait past its deadline) and the idle-
-/// transaction reaper.
+/// Counts maintenance sweeps, so a test can prove the thread sleeps between
+/// them rather than spinning.
+#[cfg(test)]
+static MAINTENANCE_SWEEPS: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+
+/// The idle-transaction reaper, on a thread that never runs a batch.
 ///
-/// The workers sweep too, between calls, and that is still where a reap and the
-/// drain it unblocks happen in one pass. This thread is what makes the sweep
-/// *punctual*. A worker only reaches it between batches, so the reapers were
-/// only ever as prompt as the pool was free — and the pool is `cores-2`
-/// threads, two on a four-core box. A few long scans already delayed the sweep
-/// for as long as they ran, which is backwards: the idle reaper exists to
-/// release the locks of a client that has stopped responding, and a loaded
-/// engine is exactly when that matters most. Nothing a client does can delay
-/// this thread, because it never executes anything on their behalf.
+/// It used to run only on the workers, between calls, which made it exactly as
+/// punctual as the pool was free — and the pool is `cores-2` threads, two on a
+/// four-core box. A few long scans deferred it for as long as they ran, which
+/// is backwards: it exists to release the locks of a client that has stopped
+/// responding, and a loaded engine is when that matters most. Nothing a client
+/// does can delay this thread, because it never executes anything on anyone's
+/// behalf.
 ///
-/// It only *releases* locks; running whatever that unblocks still needs a
-/// worker, and always did.
+/// **Only the idle reaper lives here.** The deadlock backstop
+/// ([`Scheduler::reap_expired`]) stays on the workers, because it is coupled to
+/// draining: reaping a victim releases locks that rescue the waiters behind it,
+/// and its contract is that the same pass then runs them. A sweeper that reaps
+/// without draining is worse than none — it re-reaps the waiters a drain would
+/// have rescued, and (since a waiter it must *not* reap keeps a deadline in the
+/// past) it spins doing so. The idle reaper has no such coupling: it is purely
+/// a function of `last_activity`, and the locks it frees are drained by
+/// whichever worker gets there, exactly as before.
+///
+/// Its cadence therefore never depends on the parked queue — see
+/// [`Scheduler::sweep_interval`].
 fn maintenance_loop(shared: &Arc<Shared>) {
     #[cfg(test)]
     MAINTENANCE_STARTS.fetch_add(1, Ordering::Relaxed);
     while !shared.stop.load(Ordering::Acquire) {
-        // Sleep until the nearest parked deadline, but never past the sweep
-        // cap: an idle transaction has no deadline in the parked queue, so with
-        // nothing parked the cap is the only thing that brings us back.
-        let wait = {
-            let sched = shared.scheduler.lock().expect("scheduler poisoned");
-            let cap = sched.wake_cap();
-            match sched.earliest_deadline() {
-                Some(deadline) => deadline.saturating_duration_since(Instant::now()).min(cap),
-                None => cap,
-            }
-        };
+        let wait = shared
+            .scheduler
+            .lock()
+            .expect("scheduler poisoned")
+            .sweep_interval();
         {
             // `stop` is read and written under this mutex, so a shutdown that
             // lands between the check and the wait cannot be missed — it would
-            // otherwise be slept through for a whole sweep interval, and the
+            // otherwise be slept through for a whole interval, and the
             // supervisor is joining this thread.
             let idle = shared.idle.lock().expect("idle mutex poisoned");
             if shared.stop.load(Ordering::Acquire) {
@@ -484,8 +493,9 @@ fn maintenance_loop(shared: &Arc<Shared>) {
                 .wait_timeout(idle, wait)
                 .expect("idle mutex poisoned");
         }
+        #[cfg(test)]
+        MAINTENANCE_SWEEPS.fetch_add(1, Ordering::Relaxed);
         let mut sched = shared.scheduler.lock().expect("scheduler poisoned");
-        sched.reap_expired(&shared.engine);
         sched.reap_idle_txns(&shared.engine);
     }
 }
@@ -726,6 +736,26 @@ impl Scheduler {
     /// (10 min) and this is unchanged; a deployment (or test) that sets a short
     /// idle timeout gets a correspondingly shorter cap instead of a reaper that
     /// silently runs late.
+    /// How long the maintenance thread sleeps between idle sweeps.
+    ///
+    /// Deliberately a function of the timeouts alone, never of the parked
+    /// queue: a deadline in the past — which [`Self::reap_expired`] leaves
+    /// there on purpose, for a waiter that is grantable and so must not be
+    /// reaped — would drive the wait to zero and spin a core against the
+    /// scheduler mutex. The idle reaper has no business with parked deadlines
+    /// anyway.
+    ///
+    /// Floored, because `idle_txn_timeout` is a tuning knob and tests already
+    /// pass `Duration::ZERO`; without it, that setting alone would peg a core.
+    fn sweep_interval(&self) -> Duration {
+        match self.idle_txn_timeout {
+            Some(idle) => idle.min(self.lock_wait_timeout),
+            // The reaper is disabled; there is nothing to be prompt for.
+            None => self.lock_wait_timeout,
+        }
+        .max(MIN_SWEEP_INTERVAL)
+    }
+
     fn wake_cap(&self) -> Duration {
         match self.idle_txn_timeout {
             Some(idle) => self.lock_wait_timeout.min(idle),
@@ -1493,6 +1523,67 @@ mod tests {
             "the pool spawns a maintenance thread"
         );
         drop(h);
+    }
+
+    #[test]
+    fn the_maintenance_thread_sleeps_between_sweeps_whatever_is_parked() {
+        // An expired waiter that `reap_expired` must NOT reap (its locks are
+        // free, so it is queued for a worker rather than blocked) keeps a
+        // deadline in the past for as long as it sits there. A sweeper that
+        // derived its sleep from that deadline would compute zero and spin,
+        // taking the scheduler mutex thousands of times a second — and would do
+        // it precisely while every worker was busy, which is the case this
+        // thread exists for.
+        let (engine, mut sched, path) = bare("no-spin", Some(Duration::from_millis(50)));
+        let id = sched.sessions.open("truthdb".into(), "sa".into());
+        let (reply, _rx) = oneshot::channel();
+        sched.parked.push_back(Parked {
+            session: id,
+            sql: "SELECT 1".into(),
+            params: Vec::new(),
+            cancel: Arc::new(AtomicBool::new(false)),
+            reply,
+            needs: vec![(Resource::Table(1), LockMode::Shared)],
+            deadline: Instant::now() - Duration::from_secs(60),
+        });
+        let (_tx, rx) = mpsc::channel();
+        let shared = Arc::new(Shared {
+            engine: Arc::new(engine),
+            scheduler: Mutex::new(sched),
+            rx: Mutex::new(rx),
+            stop: AtomicBool::new(false),
+            idle: Mutex::new(()),
+            wake: Condvar::new(),
+        });
+        MAINTENANCE_SWEEPS.store(0, Ordering::Relaxed);
+        let keeper = Arc::clone(&shared);
+        let maintenance = std::thread::spawn(move || maintenance_loop(&keeper));
+        std::thread::sleep(Duration::from_millis(200));
+        let sweeps = MAINTENANCE_SWEEPS.load(Ordering::Relaxed);
+        {
+            let _idle = shared.idle.lock().expect("idle mutex poisoned");
+            shared.stop.store(true, Ordering::Release);
+        }
+        shared.wake.notify_all();
+        maintenance.join().expect("maintenance thread");
+
+        // 200ms at a 50ms interval is ~4 sweeps. A spin measures in thousands,
+        // so the bound is loose enough not to be a timing test.
+        assert!(
+            sweeps <= 20,
+            "the thread slept between sweeps; it ran {sweeps} in 200ms"
+        );
+        assert!(
+            shared
+                .scheduler
+                .lock()
+                .expect("scheduler poisoned")
+                .parked
+                .len()
+                == 1,
+            "and it left the grantable waiter for a worker, rather than reaping it"
+        );
+        let _ = std::fs::remove_file(path);
     }
 
     #[test]


### PR DESCRIPTION
## The problem

`reap_idle_txns` — which rolls back a transaction abandoned by a client that stopped responding, releasing its locks — ran **only on the worker threads, between calls**. So it was exactly as punctual as the pool was free, and the pool is `cores-2` threads, **two on a four-core box**. A few long scans deferred it for as long as they ran. That is backwards: it exists for a client that has gone silent, and a loaded engine is when that matters most.

## The fix

Give it a thread that never runs a batch, so nothing a client does can delay it. The locks it frees are drained by whichever worker gets there, exactly as before.

## What this PR does *not* do, and why

The first version moved **both** reapers. Adversarial review caught that making its own target case worse, and it was right:

`reap_expired` refuses to reap a waiter whose locks are free (#98 — it is queued for a worker, not blocked, so 1205 would name a conflict that doesn't exist). That waiter keeps a deadline **in the past** for as long as it sits there. Deriving the sleep from the earliest parked deadline then computes zero, so the loop re-swept without ever sleeping — **3109 sweeps in 200ms**, each taking the scheduler mutex — and *only while every worker was busy*, because a free worker drains the waiter away in microseconds. The one case the thread exists for was the one case it pegged a core and hammered the mutex workers need for every lock decision.

The spin was the symptom. The cause is that **`reap_expired` is coupled to draining**: reaping a victim releases locks that rescue the waiters behind it, and its contract is that the same pass then runs them. Every other releaser in this file drains. A sweeper that reaps without draining also re-reaps waiters a drain would have rescued — for a chain of three, killing a second victim where one would do.

So the deadlock backstop **stays on the workers**, where the reap-then-drain pairing holds. It remains as punctual as the pool is free; making it independent needs a way to hand a drain to a worker, which is its own work. The idle reaper has no such coupling — it is purely a function of `last_activity` — so it moves cleanly.

The sweep cadence is now a function of the timeouts alone and never of the parked queue, floored so no setting of a tuning knob can turn the loop into a spin (a test already passes `Duration::ZERO`).

## Tests, all teeth-checked

- `housekeeping_runs_with_no_worker_free_to_do_it` — the property in its strongest form: a pool with **no workers at all**, which no amount of load can distinguish itself from. Fails against a thread that sleeps without sweeping.
- `the_maintenance_thread_sleeps_between_sweeps_whatever_is_parked` — reproduces the reviewed bug exactly: **3109 sweeps with the deadline-driven wait restored, ~4 without**. Also asserts the grantable waiter is left for a worker rather than reaped.
- `the_pool_actually_spawns_a_maintenance_thread` — the other two build `Shared` by hand, so they would pass if the supervisor never spawned one. Fails against a supervisor that spawns a thread doing nothing.

## Shutdown

`stop` is read and written under the sleep's mutex, so a shutdown landing between the check and the wait cannot be slept through (the supervisor joins this thread). The supervisor sets the flag itself once workers exit, because the usual shutdown here is the last `EngineHandle` dropping — which disconnects the channel and sets no flag. (`EngineHandle::shutdown()` is never called anywhere; shutdown is drop-based.)

## Verification

- `cargo test --workspace` — 417 passed, 0 failed; run 2× consecutively, no flakes
- `cargo fmt -- --check` — clean
- `cargo clippy --all-targets --all-features` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)