### PR TITLE
Scan a single-table SELECT a row at a time instead of materializing it

### DIFF
--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -5662,4 +5662,284 @@ mod tests {
         assert_eq!(rows, vec![vec![Some("abc".into())]], "UPDATE applied");
         let _ = std::fs::remove_file(path);
     }
+
+    // ---- Stage 6: the row-at-a-time single-table scan ------------------------
+
+    /// The first rowset in an outcome.
+    fn first_rowset(outcome: &BatchOutcome) -> &crate::rel::RowSet {
+        for result in &outcome.results {
+            if let StatementResult::Rows(rowset) = result {
+                return rowset;
+            }
+        }
+        panic!("no rowset in outcome: {:?}", outcome.results);
+    }
+
+    #[test]
+    fn the_scan_path_returns_exactly_what_the_collecting_path_returns() {
+        // The whole compatibility claim of the row-at-a-time path is that a
+        // caller cannot tell it apart, so the oracle is the collecting path
+        // itself: every shape the gate accepts must produce the identical
+        // RowSet — same columns, same types, same rows, same order — through
+        // both. `without_scan_path` makes the gate decline, which is the only
+        // difference between the two runs.
+        let path = unique_temp_path("scan-ab");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+
+        batch(
+            &engine,
+            &mut ctx,
+            "CREATE TABLE ab (id INT PRIMARY KEY, v INT, s VARCHAR(20), n INT NULL)",
+        );
+        for i in 0..300 {
+            let s = format!("row{i}");
+            let n = if i % 3 == 0 {
+                "NULL".to_string()
+            } else {
+                i.to_string()
+            };
+            batch(
+                &engine,
+                &mut ctx,
+                &format!("INSERT INTO ab VALUES ({i}, {}, '{s}', {n})", i * 2),
+            );
+        }
+        // A heap (no PK) as well, since the two take different cursors.
+        batch(&engine, &mut ctx, "CREATE TABLE hp (id INT, v INT)");
+        for i in 0..300 {
+            batch(
+                &engine,
+                &mut ctx,
+                &format!("INSERT INTO hp VALUES ({i}, {i})"),
+            );
+        }
+
+        let queries = [
+            // Bare columns, wildcards, aliases, qualified names.
+            "SELECT * FROM ab",
+            "SELECT id FROM ab",
+            "SELECT v, id FROM ab",
+            "SELECT ab.* FROM ab",
+            "SELECT a.* FROM ab a",
+            "SELECT id AS ident, v AS value FROM ab",
+            "SELECT a.v FROM ab a",
+            "SELECT a.v AS vv FROM ab a",
+            "SELECT * FROM ab a",
+            // The projection may repeat and reorder columns.
+            "SELECT v, v, id, s FROM ab",
+            // WHERE, including NULL/3VL and a non-sargable predicate on a PK.
+            "SELECT id FROM ab WHERE v > 100",
+            "SELECT id FROM ab WHERE n IS NULL",
+            "SELECT id FROM ab WHERE n > 50",
+            "SELECT id FROM ab WHERE s = 'ROW7'",
+            "SELECT id FROM ab WHERE id + 0 > 297",
+            "SELECT id FROM ab WHERE v > 100 AND n IS NOT NULL",
+            "SELECT id FROM ab WHERE 1 = 0",
+            // TOP, with and without a filter, at and past the row count.
+            "SELECT TOP 5 id FROM ab",
+            "SELECT TOP 0 id FROM ab",
+            "SELECT TOP 5 id FROM ab WHERE v > 100",
+            "SELECT TOP 1000 id FROM ab",
+            "SELECT TOP 5 * FROM ab",
+            // Slice boundaries: 300 rows is well inside one 1024-row slice, so
+            // exercise a table that spans several as well.
+            "SELECT id FROM hp",
+            "SELECT TOP 3 id FROM hp",
+            "SELECT id FROM hp WHERE v > 290",
+        ];
+
+        for query in queries {
+            let before = engine.storage.scan_selects();
+            let streamed = batch(&engine, &mut ctx, query);
+            assert!(
+                engine.storage.scan_selects() > before,
+                "{query} did not take the scan path, so comparing it proves nothing"
+            );
+            let collected = crate::rel::without_scan_path(|| batch(&engine, &mut ctx, query));
+            assert!(streamed.error.is_none(), "{query}: {:?}", streamed.error);
+            assert!(collected.error.is_none(), "{query}: {:?}", collected.error);
+            assert_eq!(
+                first_rowset(&streamed),
+                first_rowset(&collected),
+                "{query} differs between the scan path and the collecting path"
+            );
+        }
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn top_stops_the_scan_rather_than_reading_the_table_and_truncating() {
+        // The collecting path reads every row, then truncates. Counting slices
+        // is what tells the two apart: the rows returned are identical either
+        // way, so a result-only assertion would pass without the early exit.
+        let path = unique_temp_path("scan-top");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        batch(
+            &engine,
+            &mut ctx,
+            "CREATE TABLE big (id INT PRIMARY KEY, v INT)",
+        );
+        // Several slices' worth (SCAN_SLICE_ROWS is 1024), so "stopped early"
+        // and "read it all" differ by more than rounding.
+        for i in 0..3000 {
+            batch(
+                &engine,
+                &mut ctx,
+                &format!("INSERT INTO big VALUES ({i}, {i})"),
+            );
+        }
+
+        let before = engine.storage.scan_slices();
+        let out = batch(&engine, &mut ctx, "SELECT TOP 1 id FROM big");
+        let slices = engine.storage.scan_slices() - before;
+        assert_eq!(first_rowset(&out).rows.len(), 1, "TOP 1 returns one row");
+        assert_eq!(
+            slices, 1,
+            "TOP 1 must read one slice, not walk the whole table"
+        );
+
+        // TOP 0 reads nothing at all — the loop never starts.
+        let before = engine.storage.scan_slices();
+        let out = batch(&engine, &mut ctx, "SELECT TOP 0 id FROM big");
+        assert_eq!(
+            engine.storage.scan_slices() - before,
+            0,
+            "TOP 0 must not read a slice"
+        );
+        assert!(first_rowset(&out).rows.is_empty(), "TOP 0 returns no rows");
+
+        // The counter means what the assertions above assume: an unlimited scan
+        // of the same table reads every slice. Without this the two could pass
+        // against a scan that never ran.
+        let before = engine.storage.scan_slices();
+        let out = batch(&engine, &mut ctx, "SELECT id FROM big");
+        assert_eq!(first_rowset(&out).rows.len(), 3000);
+        assert!(
+            engine.storage.scan_slices() - before >= 3,
+            "3000 rows at 1024 per slice is at least three slices"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn a_sargable_where_still_seeks_its_index_instead_of_scanning() {
+        // The gate declines an index seek: reading the whole table to filter it
+        // down would trade the planner's work for this path's. A results-only
+        // test cannot see the difference — the slice counter can.
+        let path = unique_temp_path("scan-seek");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        batch(
+            &engine,
+            &mut ctx,
+            "CREATE TABLE sk (id INT PRIMARY KEY, v INT)",
+        );
+        for i in 0..2000 {
+            batch(
+                &engine,
+                &mut ctx,
+                &format!("INSERT INTO sk VALUES ({i}, {i})"),
+            );
+        }
+        // A secondary index: `plan::choose` only considers those, so the
+        // clustered PK is not a seekable path here.
+        batch(&engine, &mut ctx, "CREATE INDEX ix_sk_v ON sk (v)");
+
+        let before = engine.storage.scan_slices();
+        let out = batch(&engine, &mut ctx, "SELECT id FROM sk WHERE v = 1500");
+        assert_eq!(
+            engine.storage.scan_slices() - before,
+            0,
+            "an equality on an indexed column must seek, not scan"
+        );
+        assert_eq!(first_rowset(&out).rows.len(), 1, "the seek finds the row");
+
+        // The same column, with the predicate made non-sargable, does scan — so
+        // the assertion above is about the plan, not about a dead counter.
+        let before = engine.storage.scan_slices();
+        let out = batch(&engine, &mut ctx, "SELECT id FROM sk WHERE v + 0 = 1500");
+        assert!(
+            engine.storage.scan_slices() - before > 0,
+            "a non-sargable predicate scans"
+        );
+        assert_eq!(first_rowset(&out).rows.len(), 1, "and finds the same row");
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn a_sys_catalog_view_is_not_answered_with_a_user_table_of_the_same_name() {
+        // `build_table_source` answers `sys.tables` by its full name *before*
+        // any catalog lookup. The gate has to apply that precedence itself: a
+        // quoted `[sys.tables]` is a creatable, insertable user table, so a gate
+        // that resolved the catalog first would scan it and answer the query
+        // with its columns — silently, since both are perfectly good rowsets.
+        let path = unique_temp_path("scan-sys");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "CREATE TABLE [sys.tables] (id INT PRIMARY KEY, decoy INT)",
+        );
+        assert!(out.error.is_none(), "{:?}", out.error);
+        batch(&engine, &mut ctx, "INSERT INTO [sys.tables] VALUES (1, 9)");
+
+        let out = batch(&engine, &mut ctx, "SELECT * FROM sys.tables");
+        assert!(out.error.is_none(), "{:?}", out.error);
+        let columns: Vec<&str> = first_rowset(&out)
+            .columns
+            .iter()
+            .map(|c| c.name.as_str())
+            .collect();
+        assert_eq!(
+            columns,
+            vec!["object_id", "name"],
+            "sys.tables is the catalog view, not the user table shadowing its name"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn a_view_is_not_scanned_as_if_it_were_its_own_base_table() {
+        // A view's rows come from running its SELECT; its `root_page` is not a
+        // table's. Scanning one as a base table would read whatever object that
+        // page belongs to.
+        let path = unique_temp_path("scan-view");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        batch(
+            &engine,
+            &mut ctx,
+            "CREATE TABLE vt (id INT PRIMARY KEY, v INT)",
+        );
+        for i in 0..10 {
+            batch(
+                &engine,
+                &mut ctx,
+                &format!("INSERT INTO vt VALUES ({i}, {})", i * 10),
+            );
+        }
+        batch(
+            &engine,
+            &mut ctx,
+            "CREATE VIEW vv AS SELECT id, v FROM vt WHERE v >= 50",
+        );
+
+        // `SELECT *` is the query that finds this: a view's TableDef carries no
+        // columns, so the wildcard expands to none and the gate would accept a
+        // plan that projects nothing — then scan the view's `root_page` of 0,
+        // which is the catalog root, not the view.
+        let out = batch(&engine, &mut ctx, "SELECT * FROM vv");
+        assert!(out.error.is_none(), "{:?}", out.error);
+        assert_eq!(
+            first_rowset(&out).columns.len(),
+            2,
+            "the view's columns: {:?}",
+            first_rowset(&out).columns
+        );
+        assert_eq!(first_rowset(&out).rows.len(), 5, "the view's own rows");
+        let _ = std::fs::remove_file(path);
+    }
 }

--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -5714,6 +5714,10 @@ mod tests {
                 &format!("INSERT INTO hp VALUES ({i}, {i})"),
             );
         }
+        // A secondary index, so the seek access path is compared as well as the
+        // scan — `plan::choose` only considers secondary indexes, so a PK
+        // equality is not a seek here.
+        batch(&engine, &mut ctx, "CREATE INDEX ix_ab_v ON ab (v)");
 
         let queries = [
             // Bare columns, wildcards, aliases, qualified names.
@@ -5738,25 +5742,44 @@ mod tests {
             "SELECT id FROM ab WHERE 1 = 0",
             // TOP, with and without a filter, at and past the row count.
             "SELECT TOP 5 id FROM ab",
-            "SELECT TOP 0 id FROM ab",
+            "SELECT TOP 1 id FROM ab",
             "SELECT TOP 5 id FROM ab WHERE v > 100",
             "SELECT TOP 1000 id FROM ab",
             "SELECT TOP 5 * FROM ab",
-            // Slice boundaries: 300 rows is well inside one 1024-row slice, so
-            // exercise a table that spans several as well.
+            // The seek access path: `v` is indexed, so these choose IndexSeek
+            // and its candidates are re-filtered and projected the same way.
+            "SELECT id FROM ab WHERE v = 100",
+            "SELECT id, v FROM ab WHERE v = 100",
+            "SELECT * FROM ab WHERE v > 500",
+            "SELECT * FROM ab WHERE v >= 100 AND v <= 200",
+            "SELECT TOP 3 id FROM ab WHERE v > 100",
+            "SELECT id FROM ab WHERE v = 99999",
+            // The heap: 300 rows is inside one 1024-row slice either way.
             "SELECT id FROM hp",
             "SELECT TOP 3 id FROM hp",
             "SELECT id FROM hp WHERE v > 290",
         ];
 
         for query in queries {
+            // Both guards are needed, and for the same reason: an A/B whose two
+            // sides run the same code agrees with itself. The first proves the
+            // scan path ran; the second proves `without_scan_path` really took
+            // it away, which nothing else here would notice if it stopped
+            // working.
             let before = engine.storage.scan_selects();
             let streamed = batch(&engine, &mut ctx, query);
-            assert!(
-                engine.storage.scan_selects() > before,
+            assert_eq!(
+                engine.storage.scan_selects(),
+                before + 1,
                 "{query} did not take the scan path, so comparing it proves nothing"
             );
+            let before = engine.storage.scan_selects();
             let collected = crate::rel::without_scan_path(|| batch(&engine, &mut ctx, query));
+            assert_eq!(
+                engine.storage.scan_selects(),
+                before,
+                "{query} took the scan path for both runs, so it was compared with itself"
+            );
             assert!(streamed.error.is_none(), "{query}: {:?}", streamed.error);
             assert!(collected.error.is_none(), "{query}: {:?}", collected.error);
             assert_eq!(
@@ -5800,16 +5823,6 @@ mod tests {
             "TOP 1 must read one slice, not walk the whole table"
         );
 
-        // TOP 0 reads nothing at all — the loop never starts.
-        let before = engine.storage.scan_slices();
-        let out = batch(&engine, &mut ctx, "SELECT TOP 0 id FROM big");
-        assert_eq!(
-            engine.storage.scan_slices() - before,
-            0,
-            "TOP 0 must not read a slice"
-        );
-        assert!(first_rowset(&out).rows.is_empty(), "TOP 0 returns no rows");
-
         // The counter means what the assertions above assume: an unlimited scan
         // of the same table reads every slice. Without this the two could pass
         // against a scan that never ran.
@@ -5824,10 +5837,63 @@ mod tests {
     }
 
     #[test]
+    fn top_0_is_left_to_the_collecting_path_so_an_invalid_where_still_errors() {
+        // The engine has no separate binding pass: an unresolvable column (207)
+        // and a non-boolean predicate (4145) are both raised by *evaluating* the
+        // predicate on a row. `TOP 0` wants no rows, so a scan path that honours
+        // it evaluates nothing and answers an invalid query with an empty result
+        // set instead of rejecting it. The gate declines TOP 0 for that reason.
+        let path = unique_temp_path("scan-top0");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        batch(
+            &engine,
+            &mut ctx,
+            "CREATE TABLE p (id INT PRIMARY KEY, v INT)",
+        );
+        for i in 1..4 {
+            batch(
+                &engine,
+                &mut ctx,
+                &format!("INSERT INTO p VALUES ({i}, {i})"),
+            );
+        }
+
+        for (query, expected) in [
+            ("SELECT TOP 0 id FROM p WHERE bogus = 1", 207),
+            ("SELECT TOP 0 id FROM p WHERE id", 4145),
+        ] {
+            assert_eq!(
+                batch(&engine, &mut ctx, query).error.map(|e| e.number),
+                Some(expected),
+                "{query} must still be rejected, not answered with no rows"
+            );
+        }
+        // The same errors without TOP, so the cases above are about TOP 0 and
+        // not about a query that is broken some other way.
+        for (query, expected) in [
+            ("SELECT id FROM p WHERE bogus = 1", 207),
+            ("SELECT id FROM p WHERE id", 4145),
+        ] {
+            assert_eq!(
+                batch(&engine, &mut ctx, query).error.map(|e| e.number),
+                Some(expected),
+                "{query}"
+            );
+        }
+        // And a valid TOP 0 still answers with an empty result set.
+        let out = batch(&engine, &mut ctx, "SELECT TOP 0 id FROM p");
+        assert!(out.error.is_none(), "{:?}", out.error);
+        assert!(first_rowset(&out).rows.is_empty(), "TOP 0 returns no rows");
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
     fn a_sargable_where_still_seeks_its_index_instead_of_scanning() {
-        // The gate declines an index seek: reading the whole table to filter it
-        // down would trade the planner's work for this path's. A results-only
-        // test cannot see the difference — the slice counter can.
+        // The scan path takes the planner's access path rather than declining a
+        // seek — declining would throw away the table definition, the schema and
+        // the choice, all of which build_table_source would then recompute. A
+        // results-only test cannot see which path ran; the slice counter can.
         let path = unique_temp_path("scan-seek");
         let engine = new_engine(&path);
         let mut ctx = TxnContext::default();
@@ -5847,12 +5913,18 @@ mod tests {
         // clustered PK is not a seekable path here.
         batch(&engine, &mut ctx, "CREATE INDEX ix_sk_v ON sk (v)");
 
-        let before = engine.storage.scan_slices();
+        let slices = engine.storage.scan_slices();
+        let selects = engine.storage.scan_selects();
         let out = batch(&engine, &mut ctx, "SELECT id FROM sk WHERE v = 1500");
         assert_eq!(
-            engine.storage.scan_slices() - before,
+            engine.storage.scan_slices() - slices,
             0,
             "an equality on an indexed column must seek, not scan"
+        );
+        assert_eq!(
+            engine.storage.scan_selects() - selects,
+            1,
+            "and the seek is still answered on the scan path, not handed back"
         );
         assert_eq!(first_rowset(&out).rows.len(), 1, "the seek finds the row");
 

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -29,6 +29,7 @@ use truthdb_sql::{ast, eval};
 use xxhash_rust::xxh64::xxh64;
 
 use crate::lock::{LockMode, Resource};
+use crate::relstore::btree::ScanCursor;
 use crate::relstore::catalog::{self, TableDef};
 use crate::relstore::row::{Column, Schema};
 use crate::relstore::types::{ColumnType, Datum};
@@ -4393,6 +4394,28 @@ fn substitute_correlated_in_expr(
     })
 }
 
+/// Whether a WHERE/ON predicate keeps a row. The predicate must be
+/// boolean-typed (SQL Server 4145): a bare numeric/string expression is
+/// rejected rather than silently coerced, and UNKNOWN drops the row (3VL).
+fn where_keeps(
+    predicate: &Expr,
+    row: &[SqlValue],
+    resolver: &JoinScope,
+    eval_ctx: &EvalContext,
+) -> Result<bool, SqlError> {
+    match eval::eval(predicate, row, resolver, eval_ctx)? {
+        SqlValue::Bool(b) => Ok(b),
+        SqlValue::Null => Ok(false),
+        _ => Err(SqlError::new(
+            4145,
+            15,
+            1,
+            "An expression of non-boolean type specified in a context where a condition is expected, near 'WHERE'.",
+        )
+        .at(predicate.span)),
+    }
+}
+
 fn exec_select(
     storage: &Storage,
     select: &Select,
@@ -4410,6 +4433,15 @@ fn exec_select(
             "A SELECT that assigns to a variable cannot be used inside a query expression.",
         ));
     }
+    // A single-table scan whose every output column comes from the schema needs
+    // no stage that waits for the whole input, so it runs row by row instead.
+    // The gate goes before the CTE expansion and the subquery rewrite because it
+    // excludes both — and the rewrite would otherwise clone the whole statement
+    // and run any subquery eagerly.
+    if let Some(plan) = scan_plan(storage, select, eval_ctx) {
+        return scan_select(storage, &plan, select, eval_ctx);
+    }
+
     // Inline any WITH common table expressions (as derived tables) first.
     let expanded;
     let select = if select.ctes.is_empty() {
@@ -4453,20 +4485,7 @@ fn exec_select(
                 } else {
                     predicate
                 };
-                let value = eval::eval(predicate, &sql_row, &resolver, eval_ctx)?;
-                match value {
-                    SqlValue::Bool(b) => b,
-                    SqlValue::Null => false,
-                    _ => {
-                        return Err(SqlError::new(
-                            4145,
-                            15,
-                            1,
-                            "An expression of non-boolean type specified in a context where a condition is expected, near 'WHERE'.",
-                        )
-                        .at(predicate.span));
-                    }
-                }
+                where_keeps(predicate, &sql_row, &resolver, eval_ctx)?
             }
         };
         if keep {
@@ -4542,6 +4561,253 @@ fn exec_select(
         &resolver,
         eval_ctx,
     )
+}
+
+#[cfg(test)]
+thread_local! {
+    /// Test hook: makes [`scan_plan`] decline everything, so a test can run one
+    /// query down both paths and compare. Thread-local, not a `static`: a batch
+    /// runs on one thread, and the suite runs its tests in parallel in a single
+    /// binary — a global would force every other test's queries onto the
+    /// collecting path for as long as this one was set.
+    static FORCE_COLLECTING: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+#[cfg(test)]
+fn force_collecting() -> bool {
+    FORCE_COLLECTING.with(|c| c.get())
+}
+
+/// Runs `f` with [`scan_select`]'s path disabled, so `f`'s queries take the
+/// collecting path. Restores on drop, so a panicking `f` cannot leave the flag
+/// set for the next test to run on this thread.
+#[cfg(test)]
+pub(crate) fn without_scan_path<R>(f: impl FnOnce() -> R) -> R {
+    struct Restore;
+    impl Drop for Restore {
+        fn drop(&mut self) {
+            FORCE_COLLECTING.with(|c| c.set(false));
+        }
+    }
+    FORCE_COLLECTING.with(|c| c.set(true));
+    let _restore = Restore;
+    f()
+}
+
+/// A `SELECT` that can be answered a row at a time: one base table, scanned,
+/// filtered and projected without any stage that must see the whole input
+/// first. Produced by [`scan_plan`], consumed by [`scan_select`].
+struct ScanPlan {
+    /// The base table's catalog name — what the scan reads.
+    table: String,
+    /// Source column metadata, in table order.
+    source: Vec<ResultColumn>,
+    /// Resolves the WHERE clause's column references against the source.
+    resolver: JoinScope,
+    /// Output columns. Every type here is the schema's, which is what makes the
+    /// shape work: a computed column's type comes from `infer_type` over every
+    /// value in it, so it cannot be known until the last row has been seen.
+    columns: Vec<ResultColumn>,
+    /// The source column each output column reads.
+    picks: Vec<usize>,
+}
+
+/// Recognises the shape [`scan_select`] can run, or `None` for everything else
+/// — which then takes the collecting path unchanged.
+///
+/// Every rejection here is a stage that cannot answer until it has the whole
+/// input: `ORDER BY` sorts it, `DISTINCT` dedups it, an aggregate folds it, a
+/// computed column types it, and a join/derived table/CTE/view is another query
+/// underneath. An `IndexSeek` is excluded for the opposite reason — it reads
+/// *less* than a scan, and reading the whole table to filter it down would
+/// trade the planner's work for this one's.
+fn scan_plan(storage: &Storage, select: &Select, eval_ctx: &EvalContext) -> Option<ScanPlan> {
+    #[cfg(test)]
+    if force_collecting() {
+        return None;
+    }
+    if !select.ctes.is_empty()
+        || select.distinct
+        || !select.order_by.is_empty()
+        || aggregate::is_aggregated(select)
+    {
+        return None;
+    }
+    // An uncorrelated subquery is executed by the rewrite this path skips; a
+    // correlated one runs a query per row. (A subquery in the SELECT list is
+    // already excluded: it is not a bare column.)
+    if select
+        .where_clause
+        .as_ref()
+        .is_some_and(expr_has_subquery)
+    {
+        return None;
+    }
+    let Some(TableRef::Table { name, alias }) = select.from.as_ref() else {
+        return None;
+    };
+    // The `sys.*` virtual tables build their rows in Rust and have no cursor to
+    // scan. They are matched by their full name *before* catalog resolution, so
+    // this check has to come first for the same reason: `resolve_table` strips a
+    // schema prefix, so it would answer `sys.tables` with a user table called
+    // `tables`.
+    if is_sys_view(&name.value) {
+        return None;
+    }
+    let def = resolve_table(storage, &name.value)?;
+    // A view is its own SELECT, expanded as a derived table — and its TableDef
+    // has no columns and a `root_page` of 0, so a wildcard over it would project
+    // nothing and the scan would read the catalog root instead of the view.
+    if def.view_query.is_some() {
+        return None;
+    }
+    let schema = def.schema().ok()?;
+    // A sargable WHERE seeks the index instead; this path only replaces a scan.
+    if !matches!(
+        plan::choose(&def, &schema, &select.where_clause, eval_ctx),
+        plan::AccessPath::TableScan
+    ) {
+        return None;
+    }
+
+    let qualifier = alias
+        .as_ref()
+        .map(|a| a.value.clone())
+        .unwrap_or_else(|| strip_schema(&name.value).to_string());
+    let source: Vec<ResultColumn> = schema
+        .columns
+        .iter()
+        .map(|c| ResultColumn {
+            name: c.name.clone(),
+            column_type: c.column_type,
+        })
+        .collect();
+    let collations: Vec<Option<String>> =
+        schema.columns.iter().map(|c| c.collation.clone()).collect();
+    let resolver = JoinScope {
+        columns: source
+            .iter()
+            .map(|c| (Some(qualifier.clone()), c.name.clone()))
+            .collect(),
+        collations,
+    };
+
+    // The projection plan, mirroring `project`'s: every item must resolve to a
+    // source column, so the output's types are the schema's.
+    let mut columns = Vec::new();
+    let mut picks = Vec::new();
+    for item in &select.items {
+        match item {
+            SelectItem::Wildcard => {
+                for (index, column) in source.iter().enumerate() {
+                    picks.push(index);
+                    columns.push(column.clone());
+                }
+            }
+            SelectItem::QualifiedWildcard(q) => {
+                let indices = resolver.indices_for_qualifier(&q.value);
+                // Unbound (4104): leave the error to the collecting path.
+                if indices.is_empty() {
+                    return None;
+                }
+                for index in indices {
+                    picks.push(index);
+                    columns.push(source[index].clone());
+                }
+            }
+            SelectItem::Expr { expr, alias } => {
+                let index = bare_column_index(expr, &resolver)?;
+                let name = alias
+                    .as_ref()
+                    .map(|a| a.value.clone())
+                    .or_else(|| bare_column_name(expr))
+                    .unwrap_or_default();
+                picks.push(index);
+                columns.push(ResultColumn {
+                    name,
+                    column_type: source[index].column_type,
+                });
+            }
+            // Rejected before projection on both paths.
+            SelectItem::Assign { .. } => return None,
+        }
+    }
+
+    Some(ScanPlan {
+        table: def.name,
+        source,
+        resolver,
+        columns,
+        picks,
+    })
+}
+
+/// The `sys.*` catalog views, which [`build_table_source`] answers by name
+/// ahead of any catalog lookup.
+fn is_sys_view(name: &str) -> bool {
+    matches!(
+        name.to_ascii_lowercase().as_str(),
+        "sys.tables"
+            | "sys.views"
+            | "sys.sql_modules"
+            | "sys.columns"
+            | "sys.indexes"
+            | "sys.check_constraints"
+            | "sys.foreign_keys"
+            | "sys.default_constraints"
+    )
+}
+
+/// Scans, filters and projects one base table a row at a time.
+///
+/// The collecting path builds the whole table into `Source.rows`, filters that
+/// into a second vector, converts *every* row to `SqlValue` in `project`, and
+/// projects into a third — four copies of the input alive at once, before TOP
+/// has discarded any of them. Here a slice is the only input in hand, each row
+/// is projected or dropped as it is read, and `TOP n` stops the scan rather
+/// than truncating afterwards.
+///
+/// The result is still collected; what this drops is the *input's*
+/// materialization, which is the part that has no upper bound.
+fn scan_select(
+    storage: &Storage,
+    plan: &ScanPlan,
+    select: &Select,
+    eval_ctx: &EvalContext,
+) -> Result<RowSet, SqlError> {
+    #[cfg(test)]
+    storage.count_scan_select();
+    let types: Vec<ColumnType> = plan.source.iter().map(|c| c.column_type).collect();
+    let mut out = RowSet {
+        columns: plan.columns.clone(),
+        rows: Vec::new(),
+    };
+    // TOP counts rows *kept*, matching the collecting path's truncation of the
+    // filtered rows. `TOP 0` therefore reads nothing at all.
+    let enough = |kept: usize| select.top.is_some_and(|top| kept as u64 >= top);
+    let mut cursor = ScanCursor::start();
+    let mut slice: Vec<Vec<Datum>> = Vec::new();
+    while !cursor.done() && !enough(out.rows.len()) {
+        slice.clear();
+        cursor = storage
+            .rel_scan_slice(&plan.table, cursor, SCAN_SLICE_ROWS, &mut slice)
+            .map_err(|err| map_storage_err(err, &plan.table))?;
+        for row in slice.drain(..) {
+            if enough(out.rows.len()) {
+                break;
+            }
+            check_cancelled()?;
+            if let Some(predicate) = &select.where_clause {
+                let sql_row = row_values(&row, &types);
+                if !where_keeps(predicate, &sql_row, &plan.resolver, eval_ctx)? {
+                    continue;
+                }
+            }
+            out.rows
+                .push(plan.picks.iter().map(|i| row[*i].clone()).collect());
+        }
+    }
+    Ok(out)
 }
 
 /// `SELECT @a = expr, @b = expr2 [FROM ...]` — an assignment SELECT. The value

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -4600,6 +4600,8 @@ pub(crate) fn without_scan_path<R>(f: impl FnOnce() -> R) -> R {
 struct ScanPlan {
     /// The base table's catalog name — what the scan reads.
     table: String,
+    /// How to read it: the planner's choice, made once (see [`scan_plan`]).
+    access: plan::AccessPath,
     /// Source column metadata, in table order.
     source: Vec<ResultColumn>,
     /// Resolves the WHERE clause's column references against the source.
@@ -4633,14 +4635,38 @@ fn scan_plan(storage: &Storage, select: &Select, eval_ctx: &EvalContext) -> Opti
     {
         return None;
     }
+    // `TOP 0` wants no rows, so this path would never evaluate the WHERE — and
+    // the engine reports an unresolvable column (207) or a non-boolean predicate
+    // (4145) from that evaluation, having no separate binding pass. Reading a
+    // table to discard all of it is not worth answering an invalid query with an
+    // empty result set, so the degenerate case stays on the collecting path.
+    if select.top == Some(0) {
+        return None;
+    }
     // An uncorrelated subquery is executed by the rewrite this path skips; a
     // correlated one runs a query per row. (A subquery in the SELECT list is
     // already excluded: it is not a bare column.)
-    if select
-        .where_clause
-        .as_ref()
-        .is_some_and(expr_has_subquery)
-    {
+    if select.where_clause.as_ref().is_some_and(expr_has_subquery) {
+        return None;
+    }
+    // Whether every output column *could* be a source column, which is a
+    // property of the syntax alone. Deciding it before the catalog is read keeps
+    // `SELECT id + 1 FROM t` from paying for a table definition, a schema and a
+    // resolver it is only going to discard.
+    if !select.items.iter().all(|item| {
+        matches!(
+            item,
+            SelectItem::Wildcard
+                | SelectItem::QualifiedWildcard(_)
+                | SelectItem::Expr {
+                    expr: Expr {
+                        kind: ExprKind::Column(_),
+                        ..
+                    },
+                    ..
+                }
+        )
+    }) {
         return None;
     }
     let Some(TableRef::Table { name, alias }) = select.from.as_ref() else {
@@ -4662,13 +4688,11 @@ fn scan_plan(storage: &Storage, select: &Select, eval_ctx: &EvalContext) -> Opti
         return None;
     }
     let schema = def.schema().ok()?;
-    // A sargable WHERE seeks the index instead; this path only replaces a scan.
-    if !matches!(
-        plan::choose(&def, &schema, &select.where_clause, eval_ctx),
-        plan::AccessPath::TableScan
-    ) {
-        return None;
-    }
+    // The same access path `build_table_source` would take. Taking it here too,
+    // rather than declining a seek, is what keeps this gate free for the queries
+    // it rejects: a decline would have thrown away the definition, the schema
+    // and this choice, and `build_table_source` would compute all three again.
+    let access = plan::choose(&def, &schema, &select.where_clause, eval_ctx);
 
     let qualifier = alias
         .as_ref()
@@ -4735,6 +4759,7 @@ fn scan_plan(storage: &Storage, select: &Select, eval_ctx: &EvalContext) -> Opti
 
     Some(ScanPlan {
         table: def.name,
+        access,
         source,
         resolver,
         columns,
@@ -4768,7 +4793,16 @@ fn is_sys_view(name: &str) -> bool {
 /// than truncating afterwards.
 ///
 /// The result is still collected; what this drops is the *input's*
-/// materialization, which is the part that has no upper bound.
+/// materialization, which is the part that has no upper bound. An index seek
+/// keeps its input materialized — `rel_index_scan` has no cursor — so it gains
+/// the per-row savings but not that one; a seek's candidate set is bounded by
+/// the seek.
+///
+/// `TOP n` therefore stops the scan without evaluating the predicate on rows
+/// past the nth kept one, where the collecting path evaluated every source row
+/// before truncating. A predicate that errors on one of those rows (a divide by
+/// zero, an overflow) now goes unraised — which is SQL Server's behaviour, whose
+/// Top operator likewise stops asking its child for rows.
 fn scan_select(
     storage: &Storage,
     plan: &ScanPlan,
@@ -4783,28 +4817,55 @@ fn scan_select(
         rows: Vec::new(),
     };
     // TOP counts rows *kept*, matching the collecting path's truncation of the
-    // filtered rows. `TOP 0` therefore reads nothing at all.
-    let enough = |kept: usize| select.top.is_some_and(|top| kept as u64 >= top);
-    let mut cursor = ScanCursor::start();
-    let mut slice: Vec<Vec<Datum>> = Vec::new();
-    while !cursor.done() && !enough(out.rows.len()) {
-        slice.clear();
-        cursor = storage
-            .rel_scan_slice(&plan.table, cursor, SCAN_SLICE_ROWS, &mut slice)
-            .map_err(|err| map_storage_err(err, &plan.table))?;
-        for row in slice.drain(..) {
-            if enough(out.rows.len()) {
-                break;
+    // filtered rows. `TOP 0` never reaches here (the gate declines it).
+    let enough = |out: &RowSet| select.top.is_some_and(|top| out.rows.len() as u64 >= top);
+
+    // One row: filter it, and project it or drop it. `Ok(false)` once TOP is
+    // satisfied and the caller should stop reading.
+    let take = |row: Vec<Datum>, out: &mut RowSet| -> Result<bool, SqlError> {
+        check_cancelled()?;
+        if let Some(predicate) = &select.where_clause {
+            let sql_row = row_values(&row, &types);
+            if !where_keeps(predicate, &sql_row, &plan.resolver, eval_ctx)? {
+                return Ok(true);
             }
-            check_cancelled()?;
-            if let Some(predicate) = &select.where_clause {
-                let sql_row = row_values(&row, &types);
-                if !where_keeps(predicate, &sql_row, &plan.resolver, eval_ctx)? {
-                    continue;
+        }
+        out.rows
+            .push(plan.picks.iter().map(|i| row[*i].clone()).collect());
+        Ok(!enough(out))
+    };
+
+    match &plan.access {
+        plan::AccessPath::TableScan => {
+            let mut cursor = ScanCursor::start();
+            let mut slice: Vec<Vec<Datum>> = Vec::new();
+            'scan: while !cursor.done() {
+                cursor = storage
+                    .rel_scan_slice(&plan.table, cursor, SCAN_SLICE_ROWS, &mut slice)
+                    .map_err(|err| map_storage_err(err, &plan.table))?;
+                for row in slice.drain(..) {
+                    if !take(row, &mut out)? {
+                        break 'scan;
+                    }
                 }
             }
-            out.rows
-                .push(plan.picks.iter().map(|i| row[*i].clone()).collect());
+        }
+        plan::AccessPath::IndexSeek {
+            index_object_id,
+            lower,
+            upper,
+            ..
+        } => {
+            // The seek narrows the candidates; the predicate still re-checks
+            // each one, so the result matches a full scan.
+            let rows = storage
+                .rel_index_scan(&plan.table, *index_object_id, lower.clone(), upper.clone())
+                .map_err(|err| map_storage_err(err, &plan.table))?;
+            for row in rows {
+                if !take(row, &mut out)? {
+                    break;
+                }
+            }
         }
     }
     Ok(out)

--- a/crates/truthdb-core/src/storage.rs
+++ b/crates/truthdb-core/src/storage.rs
@@ -133,6 +133,17 @@ pub struct Storage {
     gc: Arc<GroupCommit>,
     /// The log-writer thread's join handle, taken in `Drop` after signalling it.
     log_writer: Option<JoinHandle<()>>,
+    /// Scan slices read, so a test can prove a scan stopped early rather than
+    /// reading the table and discarding the rest. On the instance and not in a
+    /// `static`: the suite runs in parallel in one binary, so a static would
+    /// count every other test's scans as well as this one's.
+    #[cfg(test)]
+    scan_slices: std::sync::atomic::AtomicUsize,
+    /// Times a SELECT took the row-at-a-time path, so a test comparing it with
+    /// the collecting path can prove it actually ran — an A/B whose two sides
+    /// are the same code agrees with itself. Per-instance for the same reason.
+    #[cfg(test)]
+    scan_selects: std::sync::atomic::AtomicUsize,
 }
 
 // The point of the mutex: `Storage` is shareable across worker threads. Assert
@@ -168,7 +179,30 @@ impl Storage {
             inner: std::sync::Mutex::new(file),
             gc,
             log_writer: Some(log_writer),
+            #[cfg(test)]
+            scan_slices: std::sync::atomic::AtomicUsize::new(0),
+            #[cfg(test)]
+            scan_selects: std::sync::atomic::AtomicUsize::new(0),
         })
+    }
+
+    /// Scan slices this store has read.
+    #[cfg(test)]
+    pub(crate) fn scan_slices(&self) -> usize {
+        self.scan_slices.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// SELECTs this store has answered on the row-at-a-time path.
+    #[cfg(test)]
+    pub(crate) fn scan_selects(&self) -> usize {
+        self.scan_selects.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// Counts one row-at-a-time SELECT (called by `rel::scan_select`).
+    #[cfg(test)]
+    pub(crate) fn count_scan_select(&self) {
+        self.scan_selects
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     }
 
     pub fn open(path: PathBuf) -> Result<Self, StorageError> {
@@ -429,9 +463,32 @@ impl Storage {
         let mut out = Vec::new();
         let mut cursor = ScanCursor::start();
         while !cursor.done() {
-            cursor = self.lock().rel_scan_slice(name, cursor, budget, &mut out)?;
+            cursor = self.rel_scan_slice(name, cursor, budget, &mut out)?;
         }
         Ok(out)
+    }
+
+    /// One slice of a scan: reads up to `budget` rows from `cursor`, appends
+    /// them to `out`, and returns where to resume (`done()` once the table is
+    /// exhausted).
+    ///
+    /// The storage lock is taken for this call alone, so a caller that loops
+    /// lets other sessions in between slices. That is [`Self::rel_scan_sliced`]
+    /// with the loop handed to the caller — for a reader that consumes rows as
+    /// it goes rather than wanting them all at once — and it carries the same
+    /// contract: only for readers holding the table's lock, since nothing pins
+    /// a page between slices.
+    pub(crate) fn rel_scan_slice(
+        &self,
+        name: &str,
+        cursor: ScanCursor,
+        budget: usize,
+        out: &mut Vec<Vec<Datum>>,
+    ) -> Result<ScanCursor, StorageError> {
+        #[cfg(test)]
+        self.scan_slices
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        self.lock().rel_scan_slice(name, cursor, budget, out)
     }
 
     /// Test hook: a table's definition + schema, for driving a batched scan.


### PR DESCRIPTION
Stage 6's **Engine actor** bullet, the "bounded sinks stream result rows" gap — the executor half.

## What

A plain `SELECT cols FROM t [WHERE ...] [TOP n]` had four copies of its input alive at once before TOP had discarded any of them: `build_source` read the whole table into `Source.rows`, the WHERE loop filtered that into a second vector, `project` converted *every* row to `SqlValue` into a third, and projected into a fourth. Nothing in that shape needs to see the whole input.

`scan_plan` recognises the shape; `scan_select` runs it. A slice is the only input in hand, each row is projected or dropped as it is read, and `TOP n` stops the scan rather than truncating afterwards.

Measured (peak live heap, 50k-row table): `SELECT * FROM t` 21.4 MiB → 6.9 MiB; `SELECT TOP 1 * FROM t` 8.4 MiB → **158 KiB, constant in table size** where the old path is linear. `SELECT TOP 1` also goes 16.3 ms → 0.30 ms.

The result is still collected — what this drops is the *input's* materialization, the part with no upper bound.

## The gate is where the work is

Every rejection is a stage that cannot answer until it has the whole input: ORDER BY sorts it, DISTINCT dedups it, an aggregate folds it, and a computed column **types** it (`infer_type` runs over every value in the column). A bare source column takes its type from the schema, which is what makes the shape work at all.

Four rejections are less obvious, and each is pinned by a test that fails without it:

- **`sys.*`** is matched by full name ahead of any catalog lookup. A quoted `[sys.tables]` is a creatable, insertable user table, so a gate that resolved first answered `SELECT * FROM sys.tables` with *its* columns — silently, since both are perfectly good rowsets.
- **A view** has no columns in its TableDef and a `root_page` of 0, so a wildcard over one expanded to zero columns and the scan read the catalog root: `SELECT * FROM vv` returned 0 columns and 0 rows instead of the view's.
- **`TOP 0`** would evaluate no rows, and this engine raises 207/4145 *from* predicate evaluation (there is no separate binding pass) — so `SELECT TOP 0 id FROM p WHERE bogus = 1` came back empty and successful instead of erroring.
- **An assignment SELECT**, rejected before projection on both paths.

`TOP n` for n > 0 keeps its early exit, and with it one deliberate divergence: a predicate that would error on a row past the nth kept one no longer raises. That is SQL Server's behaviour — its Top operator likewise stops asking its child for rows — and it is documented on `scan_select`.

An **index seek** is not rejected: `scan_select` takes whichever access path `plan::choose` picked, so nothing is computed twice. Declining one cost point lookups 13-23% (the gate discarded the TableDef, Schema and choice that `build_table_source` then recomputed); taking it makes the same lookup ~23% *faster* than main — 4.38/4.41/4.44 µs → 3.23/3.41/3.43 µs, release, 3000 iterations after warmup — because a seek's candidates now skip `row_sql` and the double projection too. A seek keeps its input materialized (`rel_index_scan` has no cursor); its candidate set is bounded by the seek.

## Not in this PR

The reply is still a whole `BatchOutcome`. That leg is **not** the bounded channel the plan describes — a worker `blocking_send`ing into a bounded channel would hold its table locks at the client's pace, and the scheduler's stated invariant is that a running batch never blocks. The refutation and what replaces it are in the parallel docs PR.

## Testing

- **A/B over 31 query shapes** (scan and seek, tree and heap, wildcards, aliases, qualified names, NULL/3VL, TOP, collations) asserting the two paths return the identical `RowSet`. It refuses to compare unless the scan path actually ran *and* `without_scan_path` actually took it away — an A/B whose two sides are the same code agrees with itself, and the first version of this guard was one-sided.
- **`TOP` stops the scan**: a slice counter, since the rows are identical either way and a result-only assertion passes without the early exit.
- The counters live on the `Storage` instance, not in a `static`: the suite runs in parallel in one binary, so a global would count every other test's scans.
- Every new test verified to fail with its fix removed. `cargo test --workspace`: **426 passed, 0 failed**. fmt + clippy `-D warnings` clean.

An adversarial review (4 lenses, each in its own worktree, every finding independently refuted before being believed) found the TOP 0, seek-cost and projection-ordering defects above; all three are fixed in the second commit and pinned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)