### PR TITLE
Decode only the columns a query reads

### DIFF
--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -5718,6 +5718,26 @@ mod tests {
         // scan — `plan::choose` only considers secondary indexes, so a PK
         // equality is not a seek here.
         batch(&engine, &mut ctx, "CREATE INDEX ix_ab_v ON ab (v)");
+        // A wide table, where projection pruning has something to prune.
+        batch(
+            &engine,
+            &mut ctx,
+            "CREATE TABLE wd (id INT PRIMARY KEY, a VARCHAR(20), b VARCHAR(20), c INT, d VARCHAR(20), e INT NULL)",
+        );
+        for i in 0..200 {
+            batch(
+                &engine,
+                &mut ctx,
+                &format!(
+                    "INSERT INTO wd VALUES ({i}, 'a{i}', 'b{i}', {i}, 'd{i}', {})",
+                    if i % 4 == 0 {
+                        "NULL".into()
+                    } else {
+                        i.to_string()
+                    }
+                ),
+            );
+        }
 
         let queries = [
             // Bare columns, wildcards, aliases, qualified names.
@@ -5754,6 +5774,22 @@ mod tests {
             "SELECT * FROM ab WHERE v >= 100 AND v <= 200",
             "SELECT TOP 3 id FROM ab WHERE v > 100",
             "SELECT id FROM ab WHERE v = 99999",
+            // Projection pruning: the scan decodes only what the query reads,
+            // so a WHERE on a column that is *not* projected must still keep
+            // that column — these are the shapes that catch a pruned-away
+            // predicate column.
+            "SELECT id FROM wd",
+            "SELECT id FROM wd WHERE a = 'a7'",
+            "SELECT a FROM wd WHERE c > 100",
+            "SELECT id, d FROM wd WHERE b = 'b3' AND e IS NULL",
+            "SELECT e FROM wd WHERE e IS NOT NULL",
+            "SELECT id FROM wd WHERE CASE WHEN c > 100 THEN a ELSE d END = 'a150'",
+            "SELECT id FROM wd WHERE a LIKE 'a1%'",
+            "SELECT id FROM wd WHERE c IN (1, 2, 3)",
+            "SELECT id FROM wd WHERE c BETWEEN 10 AND 12",
+            "SELECT id FROM wd WHERE LEN(a) > 3",
+            "SELECT d, c, a FROM wd WHERE id = 5",
+            "SELECT * FROM wd WHERE c = 5",
             // The heap: 300 rows is inside one 1024-row slice either way.
             "SELECT id FROM hp",
             "SELECT TOP 3 id FROM hp",
@@ -5833,6 +5869,169 @@ mod tests {
             engine.storage.scan_slices() - before >= 3,
             "3000 rows at 1024 per slice is at least three slices"
         );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn a_scan_decodes_only_the_columns_the_query_reads() {
+        // The rows returned are identical whether or not the projection is
+        // pruned, so nothing about the result can see this — the width the scan
+        // asked for is the only observable.
+        let path = unique_temp_path("scan-prune");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        batch(
+            &engine,
+            &mut ctx,
+            "CREATE TABLE w (id INT PRIMARY KEY, a VARCHAR(20), b VARCHAR(20), c INT)",
+        );
+        for i in 0..50 {
+            batch(
+                &engine,
+                &mut ctx,
+                &format!("INSERT INTO w VALUES ({i}, 'a{i}', 'b{i}', {i})"),
+            );
+        }
+
+        for (query, expected, why) in [
+            ("SELECT id FROM w", 1, "one projected column"),
+            ("SELECT id, c FROM w", 2, "two projected columns"),
+            ("SELECT * FROM w", 4, "a wildcard needs every column"),
+            // The WHERE's columns are read even when nothing projects them.
+            (
+                "SELECT id FROM w WHERE a = 'a1'",
+                2,
+                "id + the predicate's a",
+            ),
+            (
+                "SELECT id FROM w WHERE a = 'a1' AND c > 2",
+                3,
+                "id + both predicate columns",
+            ),
+            // A column named twice costs one decode.
+            ("SELECT id, id FROM w WHERE id > 1", 1, "id, deduped"),
+            // A predicate column that is also projected is not counted twice.
+            ("SELECT a FROM w WHERE a = 'a1'", 1, "a, deduped"),
+        ] {
+            let out = batch(&engine, &mut ctx, query);
+            assert!(out.error.is_none(), "{query}: {:?}", out.error);
+            assert_eq!(
+                engine.storage.last_scan_width(),
+                expected,
+                "{query} should decode {expected} columns ({why})"
+            );
+        }
+
+        // The counter reports the whole row when nothing prunes, so the numbers
+        // above are a pruned width and not a stuck reading.
+        crate::rel::without_scan_path(|| batch(&engine, &mut ctx, "SELECT id FROM w"));
+        assert_eq!(
+            engine.storage.last_scan_width(),
+            usize::MAX,
+            "the collecting path decodes the whole row"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn pruning_carries_each_kept_column_its_own_type_and_collation() {
+        // `needed` renumbers the columns, so `types` and `collations` are
+        // rebuilt in the scanned row's coordinates. Both are silent when wrong:
+        // a misindexed type mis-restores a DECIMAL's scale, and a misindexed
+        // collation makes a _CS column compare case-insensitively. The columns
+        // that matter sit at HIGH schema indices and are projected/filtered from
+        // LOW ones, so a rebuild that kept the schema's numbering reads the
+        // wrong entry rather than coincidentally the right one.
+        let path = unique_temp_path("scan-prune-types");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        batch(
+            &engine,
+            &mut ctx,
+            "CREATE TABLE tc (id INT PRIMARY KEY, pad1 VARCHAR(10), pad2 VARCHAR(10), \
+             amount DECIMAL(10,4), cs VARCHAR(20) COLLATE SQL_Latin1_General_CP1_CS_AS, \
+             ci VARCHAR(20))",
+        );
+        batch(
+            &engine,
+            &mut ctx,
+            "INSERT INTO tc VALUES (1, 'p', 'q', 12.3456, 'Match', 'Match')",
+        );
+        batch(
+            &engine,
+            &mut ctx,
+            "INSERT INTO tc VALUES (2, 'p', 'q', 0.5000, 'other', 'other')",
+        );
+
+        // A _CS column is exact; a default (_CI) one is not. Both are read via
+        // the WHERE only, so both live at a remapped position.
+        let out = batch(&engine, &mut ctx, "SELECT id FROM tc WHERE cs = 'MATCH'");
+        assert!(out.error.is_none(), "{:?}", out.error);
+        assert!(
+            first_rowset(&out).rows.is_empty(),
+            "a _CS column must not match a different casing"
+        );
+        let out = batch(&engine, &mut ctx, "SELECT id FROM tc WHERE cs = 'Match'");
+        assert_eq!(
+            first_rowset(&out).rows.len(),
+            1,
+            "_CS matches its own casing"
+        );
+        let out = batch(&engine, &mut ctx, "SELECT id FROM tc WHERE ci = 'MATCH'");
+        assert_eq!(
+            first_rowset(&out).rows.len(),
+            1,
+            "the default collation is case-insensitive"
+        );
+
+        // The DECIMAL's scale survives the `types` remap. It has to be read
+        // through the WHERE to test that: `datum_to_sql` consults the column
+        // type for a DECIMAL's precision/scale and for nothing else, so this is
+        // the only shape a misindexed `types` is visible in. (Asserting the
+        // *output* column's type would prove nothing — that comes from
+        // `plan.columns`, which is not remapped.) Read at position 1 of
+        // [id, amount] while the schema puts it at 3, so a rebuild that kept the
+        // schema's numbering finds `pad1` and falls back to scale 0 — turning
+        // 12.3456 into 123456.
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "SELECT id FROM tc WHERE amount = 12.3456",
+        );
+        assert!(out.error.is_none(), "{:?}", out.error);
+        assert_eq!(
+            first_rowset(&out).rows.len(),
+            1,
+            "a DECIMAL in the WHERE keeps its scale through the remap"
+        );
+        let out = batch(&engine, &mut ctx, "SELECT amount FROM tc WHERE id = 1");
+        assert_eq!(
+            first_rowset(&out).columns[0].column_type,
+            crate::relstore::types::ColumnType::Decimal {
+                precision: 10,
+                scale: 4
+            },
+            "the projected column keeps its schema type"
+        );
+
+        // And every one of these agrees with the collecting path, which reads
+        // the whole row and so cannot be remapped wrong.
+        for query in [
+            "SELECT id FROM tc WHERE cs = 'MATCH'",
+            "SELECT id FROM tc WHERE cs = 'Match'",
+            "SELECT id FROM tc WHERE ci = 'MATCH'",
+            "SELECT amount FROM tc WHERE id = 1",
+            "SELECT id FROM tc WHERE amount = 12.3456",
+            "SELECT amount, cs FROM tc WHERE ci = 'match'",
+        ] {
+            let streamed = batch(&engine, &mut ctx, query);
+            let collected = crate::rel::without_scan_path(|| batch(&engine, &mut ctx, query));
+            assert_eq!(
+                first_rowset(&streamed),
+                first_rowset(&collected),
+                "{query} differs between the pruned scan and the collecting path"
+            );
+        }
         let _ = std::fs::remove_file(path);
     }
 

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -2166,7 +2166,13 @@ fn enforce_parent_fks(
                         Ok(lower) => {
                             let upper = crate::relstore::index::prefix_upper_bound(&lower);
                             let matches = storage
-                                .rel_index_scan(&child.name, index.object_id, Some(lower), upper)
+                                .rel_index_scan(
+                                    &child.name,
+                                    index.object_id,
+                                    Some(lower),
+                                    upper,
+                                    None,
+                                )
                                 .map_err(|e| map_storage_err(e, &child.name))?;
                             if !matches.is_empty() {
                                 return Err(reference_conflict(verb, &fk.name, &child.name));
@@ -4602,15 +4608,21 @@ struct ScanPlan {
     table: String,
     /// How to read it: the planner's choice, made once (see [`scan_plan`]).
     access: plan::AccessPath,
-    /// Source column metadata, in table order.
-    source: Vec<ResultColumn>,
-    /// Resolves the WHERE clause's column references against the source.
+    /// The schema columns this query reads at all — its projection plus the
+    /// WHERE clause's — ascending and distinct. Everything below is expressed
+    /// in *these* coordinates, not the table's: the storage layer decodes only
+    /// these, so a scanned row has exactly this width.
+    needed: Vec<usize>,
+    /// Type of each needed column, parallel to `needed`.
+    types: Vec<ColumnType>,
+    /// Resolves the WHERE clause's column references against a scanned row.
     resolver: JoinScope,
     /// Output columns. Every type here is the schema's, which is what makes the
     /// shape work: a computed column's type comes from `infer_type` over every
     /// value in it, so it cannot be known until the last row has been seen.
     columns: Vec<ResultColumn>,
-    /// The source column each output column reads.
+    /// The scanned-row position each output column reads (an index into
+    /// `needed`, not into the table's columns).
     picks: Vec<usize>,
 }
 
@@ -4708,12 +4720,15 @@ fn scan_plan(storage: &Storage, select: &Select, eval_ctx: &EvalContext) -> Opti
         .collect();
     let collations: Vec<Option<String>> =
         schema.columns.iter().map(|c| c.collation.clone()).collect();
+    // The full-width scope, used to plan the projection and resolve the WHERE's
+    // references. What the scan actually runs on is the pruned scope built
+    // below, once the needed columns are known.
     let resolver = JoinScope {
         columns: source
             .iter()
             .map(|c| (Some(qualifier.clone()), c.name.clone()))
             .collect(),
-        collations,
+        collations: collations.clone(),
     };
 
     // The projection plan, mirroring `project`'s: every item must resolve to a
@@ -4757,14 +4772,126 @@ fn scan_plan(storage: &Storage, select: &Select, eval_ctx: &EvalContext) -> Opti
         }
     }
 
+    // Projection pruning. The query reads the columns it projects plus the ones
+    // its WHERE names, and nothing else — so those are the only ones the storage
+    // layer decodes, and a scanned row is exactly that wide. A character column
+    // costs a `String` allocation to decode, so on a wide table this is most of
+    // the per-row work.
+    //
+    // A WHERE reference that does not resolve is simply not collected: it is not
+    // a column of this table, so there is nothing to decode for it, and `eval`
+    // still reports it (207) against the same resolver as before.
+    let mut needed = picks.clone();
+    let mut where_columns = Vec::new();
+    if let Some(predicate) = &select.where_clause {
+        collect_column_refs(predicate, &mut where_columns);
+    }
+    needed.extend(
+        where_columns
+            .iter()
+            .filter_map(|name| resolver.resolve(name)),
+    );
+    needed.sort_unstable();
+    needed.dedup();
+
+    // Everything downstream now speaks in the scanned row's coordinates.
+    let position = |index: usize| {
+        needed
+            .binary_search(&index)
+            .expect("a needed column is in `needed`")
+    };
+    let picks = picks.into_iter().map(position).collect();
+    let types = needed.iter().map(|&i| source[i].column_type).collect();
+    let resolver = JoinScope {
+        columns: needed
+            .iter()
+            .map(|&i| (Some(qualifier.clone()), source[i].name.clone()))
+            .collect(),
+        collations: needed.iter().map(|&i| collations[i].clone()).collect(),
+    };
+
     Some(ScanPlan {
         table: def.name,
         access,
-        source,
+        needed,
+        types,
         resolver,
         columns,
         picks,
     })
+}
+
+/// Every column name a predicate references, in no particular order (duplicates
+/// included — the caller dedups after resolving).
+///
+/// Exhaustive by construction: no wildcard arm, so a new [`ExprKind`] is a
+/// compile error here rather than a column silently left undecoded.
+fn collect_column_refs(expr: &Expr, out: &mut Vec<String>) {
+    match &expr.kind {
+        ExprKind::Column(name) => out.push(name.value.clone()),
+        ExprKind::Null
+        | ExprKind::Int(_)
+        | ExprKind::Number(_)
+        | ExprKind::Str(_)
+        | ExprKind::Bool(_)
+        | ExprKind::Literal(_)
+        | ExprKind::GlobalVar(_)
+        | ExprKind::LocalVar(_) => {}
+        ExprKind::Unary { expr: e, .. }
+        | ExprKind::IsNull { expr: e, .. }
+        | ExprKind::Cast { expr: e, .. } => collect_column_refs(e, out),
+        ExprKind::Binary { left, right, .. } => {
+            collect_column_refs(left, out);
+            collect_column_refs(right, out);
+        }
+        ExprKind::Like {
+            expr: e, pattern, ..
+        } => {
+            collect_column_refs(e, out);
+            collect_column_refs(pattern, out);
+        }
+        ExprKind::InList { expr: e, list, .. } => {
+            collect_column_refs(e, out);
+            for item in list {
+                collect_column_refs(item, out);
+            }
+        }
+        ExprKind::Between {
+            expr: e, low, high, ..
+        } => {
+            collect_column_refs(e, out);
+            collect_column_refs(low, out);
+            collect_column_refs(high, out);
+        }
+        ExprKind::Function { args, .. } => {
+            for arg in args {
+                collect_column_refs(arg, out);
+            }
+        }
+        ExprKind::Aggregate { arg, .. } => {
+            if let Some(arg) = arg {
+                collect_column_refs(arg, out);
+            }
+        }
+        ExprKind::Case {
+            operand,
+            branches,
+            else_result,
+        } => {
+            if let Some(operand) = operand {
+                collect_column_refs(operand, out);
+            }
+            for (when, then) in branches {
+                collect_column_refs(when, out);
+                collect_column_refs(then, out);
+            }
+            if let Some(else_result) = else_result {
+                collect_column_refs(else_result, out);
+            }
+        }
+        // The gate rejects a subquery before this runs.
+        ExprKind::Subquery(_) | ExprKind::Exists(_) | ExprKind::InSubquery { .. } => {}
+    }
 }
 
 /// The `sys.*` catalog views, which [`build_table_source`] answers by name
@@ -4811,7 +4938,7 @@ fn scan_select(
 ) -> Result<RowSet, SqlError> {
     #[cfg(test)]
     storage.count_scan_select();
-    let types: Vec<ColumnType> = plan.source.iter().map(|c| c.column_type).collect();
+    let types = &plan.types;
     let mut out = RowSet {
         columns: plan.columns.clone(),
         rows: Vec::new(),
@@ -4825,7 +4952,7 @@ fn scan_select(
     let take = |row: Vec<Datum>, out: &mut RowSet| -> Result<bool, SqlError> {
         check_cancelled()?;
         if let Some(predicate) = &select.where_clause {
-            let sql_row = row_values(&row, &types);
+            let sql_row = row_values(&row, types);
             if !where_keeps(predicate, &sql_row, &plan.resolver, eval_ctx)? {
                 return Ok(true);
             }
@@ -4841,7 +4968,13 @@ fn scan_select(
             let mut slice: Vec<Vec<Datum>> = Vec::new();
             'scan: while !cursor.done() {
                 cursor = storage
-                    .rel_scan_slice(&plan.table, cursor, SCAN_SLICE_ROWS, &mut slice)
+                    .rel_scan_slice(
+                        &plan.table,
+                        cursor,
+                        SCAN_SLICE_ROWS,
+                        Some(&plan.needed),
+                        &mut slice,
+                    )
                     .map_err(|err| map_storage_err(err, &plan.table))?;
                 for row in slice.drain(..) {
                     if !take(row, &mut out)? {
@@ -4859,7 +4992,13 @@ fn scan_select(
             // The seek narrows the candidates; the predicate still re-checks
             // each one, so the result matches a full scan.
             let rows = storage
-                .rel_index_scan(&plan.table, *index_object_id, lower.clone(), upper.clone())
+                .rel_index_scan(
+                    &plan.table,
+                    *index_object_id,
+                    lower.clone(),
+                    upper.clone(),
+                    Some(&plan.needed),
+                )
                 .map_err(|err| map_storage_err(err, &plan.table))?;
             for row in rows {
                 if !take(row, &mut out)? {
@@ -5928,7 +6067,7 @@ fn build_table_source(
                     upper,
                     ..
                 } => storage
-                    .rel_index_scan(&def.name, index_object_id, lower, upper)
+                    .rel_index_scan(&def.name, index_object_id, lower, upper, None)
                     .map_err(|err| map_storage_err(err, &def.name))?,
             };
             let columns = schema

--- a/crates/truthdb-core/src/relstore/row.rs
+++ b/crates/truthdb-core/src/relstore/row.rs
@@ -146,6 +146,49 @@ pub fn encode_row(schema: &Schema, values: &[Datum]) -> Result<Vec<u8>, TypeErro
 }
 
 pub fn decode_row(schema: &Schema, bytes: &[u8]) -> Result<Vec<Datum>, TypeError> {
+    decode_columns(schema, bytes, None)
+}
+
+/// Decodes only `projection`'s columns — schema indices, **ascending and
+/// distinct** — returning them in that order, so the result is indexed by
+/// position within `projection` rather than by schema index.
+///
+/// Every column's position is derived from the schema, not from the data: a
+/// fixed column's slot is the running sum of the fixed sizes before it, and a
+/// variable column's span is `[var_ends[k-1], var_ends[k])`, a direct index. So
+/// the columns to skip cost only their offset arithmetic, and what is saved is
+/// the decode itself — which for a character column is a `String` allocation.
+///
+/// The row's *structure* is validated exactly as [`decode_row`] validates it —
+/// the header's length, the var section's, and every column's offsets, skipped
+/// or not — so the columns that are read cannot be shifted by damage elsewhere
+/// in the row.
+///
+/// A skipped column's *content* is not validated, because validating it is the
+/// decode this exists to avoid: a row whose VARBINARY holds bytes that are not
+/// the UTF-8 its column claims is rejected by [`decode_row`] and accepted here
+/// by a query that does not select it. That is the deal projection pruning
+/// makes — what is not read is not looked at — and it is why the structural
+/// checks above are not part of it.
+pub fn decode_row_projected(
+    schema: &Schema,
+    bytes: &[u8],
+    projection: &[usize],
+) -> Result<Vec<Datum>, TypeError> {
+    debug_assert!(
+        projection.windows(2).all(|w| w[0] < w[1]),
+        "projection must be ascending and distinct"
+    );
+    decode_columns(schema, bytes, Some(projection))
+}
+
+/// [`decode_row`] and [`decode_row_projected`] over one body: `None` decodes
+/// every column, `Some` only the listed ones.
+fn decode_columns(
+    schema: &Schema,
+    bytes: &[u8],
+    projection: Option<&[usize]>,
+) -> Result<Vec<Datum>, TypeError> {
     let bitmap_len = schema.null_bitmap_len();
     let fixed_len = schema.fixed_section_len();
     let var_count = schema.var_column_count();
@@ -173,19 +216,35 @@ pub fn decode_row(schema: &Schema, bytes: &[u8]) -> Result<Vec<Datum>, TypeError
         return Err(TypeError("var section length mismatch".to_string()));
     }
 
-    let mut values = Vec::with_capacity(schema.columns.len());
+    let wanted_count = projection.map_or(schema.columns.len(), <[usize]>::len);
+    let mut values = Vec::with_capacity(wanted_count);
+    // The next projected index still to be reached. `projection` is ascending,
+    // so one cursor decides every column in a single pass.
+    let mut next_wanted = 0usize;
     let mut fixed_cursor = bitmap_len;
     let mut var_index = 0usize;
     for (index, column) in schema.columns.iter().enumerate() {
+        let wanted = match projection {
+            None => true,
+            Some(projection) => {
+                let hit = projection.get(next_wanted) == Some(&index);
+                if hit {
+                    next_wanted += 1;
+                }
+                hit
+            }
+        };
         match column.column_type.fixed_size() {
             Some(size) => {
                 let raw = &bytes[fixed_cursor..fixed_cursor + size];
                 fixed_cursor += size;
-                values.push(if is_null(index) {
-                    Datum::Null
-                } else {
-                    Datum::decode_fixed(&column.column_type, raw)?
-                });
+                if wanted {
+                    values.push(if is_null(index) {
+                        Datum::Null
+                    } else {
+                        Datum::decode_fixed(&column.column_type, raw)?
+                    });
+                }
             }
             None => {
                 let start = if var_index == 0 {
@@ -195,16 +254,26 @@ pub fn decode_row(schema: &Schema, bytes: &[u8]) -> Result<Vec<Datum>, TypeError
                 };
                 let end = var_ends[var_index];
                 var_index += 1;
+                // Checked for every column, wanted or not: a corrupt row is
+                // corrupt whichever columns the query happens to read.
                 if start > end || end > var_data.len() {
                     return Err(TypeError("corrupt var offsets".to_string()));
                 }
-                values.push(if is_null(index) {
-                    Datum::Null
-                } else {
-                    Datum::decode_var(&column.column_type, &var_data[start..end])?
-                });
+                if wanted {
+                    values.push(if is_null(index) {
+                        Datum::Null
+                    } else {
+                        Datum::decode_var(&column.column_type, &var_data[start..end])?
+                    });
+                }
             }
         }
+    }
+    if next_wanted != wanted_count && projection.is_some() {
+        return Err(TypeError(format!(
+            "projection names a column outside the schema's {} columns",
+            schema.columns.len()
+        )));
     }
     Ok(values)
 }
@@ -265,6 +334,148 @@ mod tests {
         ];
         let bytes = encode_row(&schema, &values).expect("encode");
         assert_eq!(decode_row(&schema, &bytes).expect("decode"), values);
+    }
+
+    #[test]
+    fn a_projected_decode_reads_exactly_the_whole_decode_would_have() {
+        // The oracle is the whole decode: every subset must equal the same
+        // positions of it. Every subset, because the interesting cases are
+        // structural — skipping a variable-width column must not disturb the
+        // next one's offset, and skipping a fixed one must not disturb the
+        // fixed cursor. The schema mixes both, and NULLs sit in both sections.
+        let schema = schema();
+        for values in [
+            vec![
+                Datum::Int(42),
+                Datum::NVarChar("åäö".to_string()),
+                Datum::Decimal(12345),
+                Datum::VarBinary(vec![1, 2, 3]),
+                Datum::Bit(true),
+            ],
+            // NULLs everywhere they are allowed: a NULL var column still owns
+            // its offset slot, which is exactly what a skip could get wrong.
+            vec![
+                Datum::Int(7),
+                Datum::Null,
+                Datum::Null,
+                Datum::Null,
+                Datum::Null,
+            ],
+            // Empty (not NULL) variable-width values: zero-length spans.
+            vec![
+                Datum::Int(0),
+                Datum::NVarChar(String::new()),
+                Datum::Decimal(0),
+                Datum::VarBinary(Vec::new()),
+                Datum::Bit(false),
+            ],
+        ] {
+            let bytes = encode_row(&schema, &values).expect("encode");
+            let whole = decode_row(&schema, &bytes).expect("decode");
+            // Every subset of the five columns, in ascending order.
+            for mask in 0u32..(1 << 5) {
+                let projection: Vec<usize> = (0..5).filter(|i| mask & (1 << i) != 0).collect();
+                let expected: Vec<Datum> = projection.iter().map(|&i| whole[i].clone()).collect();
+                assert_eq!(
+                    decode_row_projected(&schema, &bytes, &projection).expect("decode"),
+                    expected,
+                    "projection {projection:?} of {values:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn a_projected_decode_still_rejects_a_structurally_corrupt_row() {
+        // Structural damage shifts the columns that ARE read, so it must be
+        // caught whatever the projection. The offset check inside the decode
+        // loop is the one a `wanted` guard could plausibly skip, so the row here
+        // is corrupted to reach *that* check specifically: a truncated row trips
+        // the header-length check before the loop even starts, which would leave
+        // the interesting branch untested.
+        let schema = schema();
+        let values = vec![
+            Datum::Int(42),
+            Datum::NVarChar("abc".to_string()),
+            Datum::Decimal(1),
+            Datum::VarBinary(vec![9]),
+            Datum::Bit(true),
+        ];
+        let bytes = encode_row(&schema, &values).expect("encode");
+
+        // Push the first variable column's end offset past the var section. The
+        // *last* end still matches, so the pre-loop length check passes and only
+        // the per-column check can catch this.
+        let mut corrupt = bytes.clone();
+        let var_offsets_start = schema.null_bitmap_len() + schema.fixed_section_len();
+        corrupt[var_offsets_start] = 0xff;
+        corrupt[var_offsets_start + 1] = 0xff;
+
+        assert!(
+            decode_row(&schema, &corrupt).is_err(),
+            "the whole decode rejects it"
+        );
+        // Column 0 is the fixed INT — the projection never reads the damaged
+        // column, and must still refuse the row.
+        assert!(
+            decode_row_projected(&schema, &corrupt, &[0]).is_err(),
+            "a projection that skips the damaged column must still reject it"
+        );
+        // The same row, uncorrupted, decodes — so the assertions above are about
+        // the damage and not about a projection that always errors.
+        assert!(decode_row_projected(&schema, &bytes, &[0]).is_ok());
+    }
+
+    #[test]
+    fn a_projected_decode_does_not_validate_what_it_does_not_read() {
+        // The other half of the deal, and the point of pruning: a skipped
+        // column's *content* is never looked at, so a row the whole decode
+        // rejects is answered by a query that does not select the bad column.
+        // Recorded as a test because it is a real behaviour change, not an
+        // oversight — validating the column would be the decode being skipped.
+        let schema = Schema {
+            columns: vec![
+                Column {
+                    name: "id".to_string(),
+                    column_type: ColumnType::Int,
+                    nullable: false,
+                    collation: None,
+                },
+                Column {
+                    name: "text".to_string(),
+                    column_type: ColumnType::VarChar { max_len: 20 },
+                    nullable: true,
+                    collation: None,
+                },
+            ],
+        };
+        // Encode through a VARBINARY-shaped schema so the bytes are laid out
+        // legally, then read them back as the VARCHAR schema above: the row is
+        // structurally perfect and its second column is not valid UTF-8.
+        let binary_schema = Schema {
+            columns: vec![
+                schema.columns[0].clone(),
+                Column {
+                    column_type: ColumnType::VarBinary { max_len: 20 },
+                    ..schema.columns[1].clone()
+                },
+            ],
+        };
+        let bytes = encode_row(
+            &binary_schema,
+            &[Datum::Int(7), Datum::VarBinary(vec![0xff, 0xfe, 0xff])],
+        )
+        .expect("encode");
+
+        assert!(
+            decode_row(&schema, &bytes).is_err(),
+            "the whole decode reads the bad column and rejects it"
+        );
+        assert_eq!(
+            decode_row_projected(&schema, &bytes, &[0]).expect("id decodes"),
+            vec![Datum::Int(7)],
+            "a projection that skips it answers with the column it was asked for"
+        );
     }
 
     #[test]

--- a/crates/truthdb-core/src/storage.rs
+++ b/crates/truthdb-core/src/storage.rs
@@ -17,7 +17,7 @@ use crate::relstore::heap::{Heap, Rid};
 use crate::relstore::index::{self, Locator};
 use crate::relstore::key::encode_key;
 use crate::relstore::recovery as rel_recovery;
-use crate::relstore::row::{Column, Schema, decode_row, encode_row};
+use crate::relstore::row::{Column, Schema, decode_row, decode_row_projected, encode_row};
 use crate::relstore::types::{Datum, TypeError};
 use crate::storage_layout::{
     FileHeader, PAGE_SIZE, SNAPSHOT_DESCRIPTOR_SIZE, SUPERBLOCK_ACTIVE_A, SUPERBLOCK_ACTIVE_B,
@@ -144,6 +144,11 @@ pub struct Storage {
     /// are the same code agrees with itself. Per-instance for the same reason.
     #[cfg(test)]
     scan_selects: std::sync::atomic::AtomicUsize,
+    /// Columns the last scan slice asked for (`usize::MAX` = the whole row), so
+    /// a test can prove the planner pruned the projection. The rows returned are
+    /// identical either way, so nothing else can see the difference.
+    #[cfg(test)]
+    last_scan_width: std::sync::atomic::AtomicUsize,
 }
 
 // The point of the mutex: `Storage` is shareable across worker threads. Assert
@@ -161,6 +166,22 @@ impl Drop for Storage {
         if let Some(writer) = self.log_writer.take() {
             let _ = writer.join();
         }
+    }
+}
+
+/// Decodes a row, honouring a caller's projection: `None` means every column.
+///
+/// The read paths take `Option<&[usize]>` rather than always being handed a
+/// full list, so a caller that wants the whole row neither builds one nor pays
+/// to walk it.
+fn decode_projected(
+    schema: &Schema,
+    row: &[u8],
+    projection: Option<&[usize]>,
+) -> Result<Vec<Datum>, crate::relstore::types::TypeError> {
+    match projection {
+        Some(projection) => decode_row_projected(schema, row, projection),
+        None => decode_row(schema, row),
     }
 }
 
@@ -183,6 +204,8 @@ impl Storage {
             scan_slices: std::sync::atomic::AtomicUsize::new(0),
             #[cfg(test)]
             scan_selects: std::sync::atomic::AtomicUsize::new(0),
+            #[cfg(test)]
+            last_scan_width: std::sync::atomic::AtomicUsize::new(usize::MAX),
         })
     }
 
@@ -196,6 +219,13 @@ impl Storage {
     #[cfg(test)]
     pub(crate) fn scan_selects(&self) -> usize {
         self.scan_selects.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// Columns the last scan slice decoded per row (`usize::MAX` = every one).
+    #[cfg(test)]
+    pub(crate) fn last_scan_width(&self) -> usize {
+        self.last_scan_width
+            .load(std::sync::atomic::Ordering::Relaxed)
     }
 
     /// Counts one row-at-a-time SELECT (called by `rel::scan_select`).
@@ -412,9 +442,10 @@ impl Storage {
         index_object_id: u32,
         lower: Option<Vec<u8>>,
         upper: Option<Vec<u8>>,
+        projection: Option<&[usize]>,
     ) -> Result<Vec<Vec<Datum>>, StorageError> {
         self.lock()
-            .rel_index_scan(table, index_object_id, lower, upper)
+            .rel_index_scan(table, index_object_id, lower, upper, projection)
     }
 
     pub fn rel_insert(&self, name: &str, values: Vec<Datum>) -> Result<(), StorageError> {
@@ -463,7 +494,7 @@ impl Storage {
         let mut out = Vec::new();
         let mut cursor = ScanCursor::start();
         while !cursor.done() {
-            cursor = self.rel_scan_slice(name, cursor, budget, &mut out)?;
+            cursor = self.rel_scan_slice(name, cursor, budget, None, &mut out)?;
         }
         Ok(out)
     }
@@ -483,12 +514,20 @@ impl Storage {
         name: &str,
         cursor: ScanCursor,
         budget: usize,
+        projection: Option<&[usize]>,
         out: &mut Vec<Vec<Datum>>,
     ) -> Result<ScanCursor, StorageError> {
         #[cfg(test)]
-        self.scan_slices
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        self.lock().rel_scan_slice(name, cursor, budget, out)
+        {
+            self.scan_slices
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            self.last_scan_width.store(
+                projection.map_or(usize::MAX, <[usize]>::len),
+                std::sync::atomic::Ordering::Relaxed,
+            );
+        }
+        self.lock()
+            .rel_scan_slice(name, cursor, budget, projection, out)
     }
 
     /// Test hook: a table's definition + schema, for driving a batched scan.
@@ -1150,6 +1189,7 @@ impl StorageFile {
         index_object_id: u32,
         lower: Option<Vec<u8>>,
         upper: Option<Vec<u8>>,
+        projection: Option<&[usize]>,
     ) -> Result<Vec<Vec<Datum>>, StorageError> {
         self.ensure_rel_usable()?;
         let (def, schema) = self.rel_def(table)?;
@@ -1175,7 +1215,7 @@ impl StorageFile {
                 if let Locator::Key(pk) = index::decode_locator(&value)
                     && let Some(row) = base.get(&mut ctx, &pk)?
                 {
-                    rows.push(decode_row(&schema, &row)?);
+                    rows.push(decode_projected(&schema, &row, projection)?);
                 }
             }
         } else {
@@ -1187,7 +1227,7 @@ impl StorageFile {
                 if let Locator::Rid(rid) = index::decode_locator(&value)
                     && let Some(row) = heap.read_row(&mut ctx, rid)?
                 {
-                    rows.push(decode_row(&schema, &row)?);
+                    rows.push(decode_projected(&schema, &row, projection)?);
                 }
             }
         }
@@ -1319,6 +1359,7 @@ impl StorageFile {
         name: &str,
         cursor: ScanCursor,
         budget: usize,
+        projection: Option<&[usize]>,
         out: &mut Vec<Vec<Datum>>,
     ) -> Result<ScanCursor, StorageError> {
         self.ensure_rel_usable()?;
@@ -1345,7 +1386,7 @@ impl StorageFile {
             next
         };
         for row in raw {
-            out.push(decode_row(&schema, &row)?);
+            out.push(decode_projected(&schema, &row, projection)?);
         }
         Ok(next)
     }


### PR DESCRIPTION
Stage 7's planner bullet, the **projection pruning** gap.

## What

A scan decoded every column of every row and threw most away. `SELECT id FROM wide` on a 21-column table (20 of them VARCHAR) spent its time allocating 20 Strings per row to discard them.

**20k rows: 23.6 ms → 4.8 ms (4.9×).** `SELECT *` unchanged (40.7 → 38.0), as it must be — it reads every column.

`scan_plan` already knew the projection; it now also collects the WHERE's column references, and the union is the only thing the storage layer decodes. The plan then speaks in the **scanned row's** coordinates rather than the table's: `picks`, `types` and the resolver are all rebuilt over `needed`.

The invariant that makes the rebuild safe: `needed` is built by applying the *same* `resolve` to the *same* name strings that `eval` later resolves, so a name eval looks up cannot be absent from it.

`decode_row_projected` is where the saving lands — every column's position is schema-derived, not data-derived, so a skipped column costs only its offset arithmetic while the decode (and for a character column, its allocation) is what goes.

## The one deliberate behaviour change

The row's **structure** is validated exactly as before, skipped columns included, so the columns that are read cannot be shifted by damage elsewhere. A skipped column's **content** is not: a row whose VARCHAR holds non-UTF-8 is rejected by `decode_row` and accepted by a query that does not select it.

That is the deal pruning makes — what is not read is not looked at — and it is why the structural checks are *not* part of it. It is also unreachable through the engine: `encode_row` takes a Rust `String`, and pages are xxh64-verified before the decoder sees them.

## Not in this PR — the other two gaps in the bullet

Both because the recon says they are not possible, not because they are large:

- **A covering-index seek** (the bullet's "KeyLookup folded into IndexSeek") cannot work for the common string case. #94 keyed index leaves on the collation's **sort key**, which is one-way by construction — `'ABC'` and `'abc'` are the same key — so the original value is not recoverable from the leaf, which carries no values at all. It would work only for non-character types and `_BIN` collations.
- **Row-count tie-breaks** have nothing to read: there is no statistics facility anywhere in the tree — no row count on `TableDef`, no cardinality, no histogram. Its own piece of work.

## Testing

- `decode_row_projected` pinned against the whole decode as its oracle, over **every subset** of a 5-column mixed fixed/variable schema × three row shapes (values, NULLs, empty-but-not-NULL). Both offset-drift mutants are caught by it.
- The A/B matrix gains 12 shapes whose **WHERE reads a column the projection does not** — the case that breaks if the predicate's columns get pruned away.
- Pruning itself is proven by the width the scan asks for, since the rows returned are identical either way.
- `cargo test --workspace`: **431 passed, 0 failed**. fmt + clippy `-D warnings` clean.

**Two tests exist because an adversarial review showed the first versions could not fail.** The structural-corruption test now damages a var offset rather than truncating the row — truncation trips the header check *before* the decode loop, leaving the one check a `wanted` guard could actually skip untested. And the remap test reads a DECIMAL *through the WHERE*, because `datum_to_sql` consults the column type for a DECIMAL's scale and nothing else; asserting the output column's type proved nothing, since that comes from `plan.columns`, which is not remapped.

The review (3 lenses, own worktrees, every finding independently refuted before being believed) found **no code defect**: the coordinate remap survived ~1250 A/B queries with teeth-checked probes, and a 20,000-case property test (random schema × random row × random subset, oracled against `decode_row`) passed clean. Everything it did find was about the claim and the tests, and is fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
