### PR TITLE
Stream a batch's results as the statements produce them

### DIFF
--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -180,13 +180,30 @@ impl Engine {
         txn_ctx: &mut crate::rel::TxnContext,
         params: &[crate::rel::RpcParam],
     ) -> Result<crate::rel::BatchOutcome, EngineError> {
+        let mut collector = crate::rel::Collector::default();
+        let error = self.sql_batch_streamed(input, txn_ctx, params, &mut collector)?;
+        Ok(collector.into_outcome(error))
+    }
+
+    /// Like [`Self::sql_batch_with_params`], but each statement's result
+    /// leaves through `emitter` as it is produced (see
+    /// [`crate::rel::execute_batch_streamed`]). Returns the batch's terminal
+    /// error, which the caller reports after the statement events.
+    pub fn sql_batch_streamed(
+        &self,
+        input: &str,
+        txn_ctx: &mut crate::rel::TxnContext,
+        params: &[crate::rel::RpcParam],
+        emitter: &mut dyn crate::rel::BatchEmitter,
+    ) -> Result<Option<truthdb_sql::error::SqlError>, EngineError> {
         // Hold the execution gate shared for the whole batch: concurrent
         // relational batches run together, but a native writer is excluded (see
         // [`Engine`]). The guard also gives the checkpointer its `meta` read.
         let meta = self.meta.read().expect("engine meta poisoned");
-        let outcome = crate::rel::execute_batch_with_params(&self.storage, input, txn_ctx, params);
+        let error =
+            crate::rel::execute_batch_streamed(&self.storage, input, txn_ctx, params, emitter);
         self.maybe_checkpoint(&meta)?;
-        Ok(outcome)
+        Ok(error)
     }
 
     /// Rolls back and discards a session's open transaction (connection

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -262,21 +262,45 @@ pub fn execute_batch_with_params(
     txn_ctx: &mut TxnContext,
     params: &[RpcParam],
 ) -> BatchOutcome {
+    let mut collector = Collector::default();
+    let error = execute_batch_streamed(storage, sql, txn_ctx, params, &mut collector);
+    collector.into_outcome(error)
+}
+
+/// Like [`execute_batch_with_params`], but each statement's result leaves
+/// through `emitter` as the statement produces it instead of accumulating into
+/// a [`BatchOutcome`]: a result set opens with its columns, its rows follow (in
+/// chunks read straight off the scan for the streamed shape), and each
+/// statement's DONE carries the transaction state *after that statement* —
+/// which is what TDS `DONE_INXACT` means per statement. The returned error is
+/// the batch's terminal error (what `BatchOutcome::error` carried), reported by
+/// the caller after the statement events.
+///
+/// Durability keeps its ordering: a DONE that acknowledges a commit the client
+/// may rely on (an autocommit write, DDL, the outermost `COMMIT`) is never
+/// emitted before that commit is fsync-durable. DONEs queue in the run and
+/// flush — fsyncing first if any of them acknowledges a commit — before the
+/// next result set opens and at the end of the batch, so a batch of writes
+/// with nothing to stream between them still costs one fsync, as before.
+pub fn execute_batch_streamed(
+    storage: &Storage,
+    sql: &str,
+    txn_ctx: &mut TxnContext,
+    params: &[RpcParam],
+    emitter: &mut dyn BatchEmitter,
+) -> Option<SqlError> {
     // A transaction reaped for idleness is reported to the session's next batch
     // (once). 1205 is the code this engine already uses for a server-initiated
     // transaction abort (the parked deadlock victim), and every driver treats it
     // as "the transaction is gone, retry it" — which is exactly the right
     // recovery here.
     if txn_ctx.take_reaped() {
-        return BatchOutcome {
-            results: Vec::new(),
-            error: Some(SqlError::new(
-                1205,
-                13,
-                51,
-                "The transaction was rolled back because the session was idle for too long. Rerun the transaction.",
-            )),
-        };
+        return Some(SqlError::new(
+            1205,
+            13,
+            51,
+            "The transaction was rolled back because the session was idle for too long. Rerun the transaction.",
+        ));
     }
     // Variables are batch-scoped: each batch starts with none.
     txn_ctx.clear_variables();
@@ -289,15 +313,14 @@ pub fn execute_batch_with_params(
     }
     let statements = match truthdb_sql::parse(sql) {
         Ok(statements) => statements,
-        Err(error) => {
-            return BatchOutcome {
-                results: Vec::new(),
-                error: Some(error),
-            };
-        }
+        Err(error) => return Some(error),
     };
     let mut run = BatchRun {
-        results: Vec::with_capacity(statements.len()),
+        emitter,
+        deferred: Vec::new(),
+        ack_pending: false,
+        rowset_open: false,
+        durability_failed: false,
         committed: false,
         last_error: None,
     };
@@ -305,25 +328,217 @@ pub fn execute_batch_with_params(
     // dooming/uncaught error outside any TRY); a non-dooming error under
     // `XACT_ABORT OFF` is recorded in `run.last_error` and the batch continues.
     let terminating = run_block(storage, &statements, txn_ctx, &mut run, false).err();
-    let prior = terminating.or(run.last_error);
-    let error = finalize_durability(storage, run.committed, prior);
-    BatchOutcome {
-        results: run.results,
-        error,
+    // The batch-end durability point, and the DONEs it was holding back. A
+    // durability failure outranks any statement error: a lost commit is more
+    // severe than an error the client asked about, and a benign continued error
+    // must not mask one.
+    let durability = run.finish(storage);
+    durability.or(terminating).or(run.last_error)
+}
+
+/// Receives a batch's results as the executor produces them. The session layer
+/// forwards each call as a `BatchEvent` onto the reply channel; buffered
+/// callers (the native command path, the SLT runner, tests) use [`Collector`]
+/// to reassemble a [`BatchOutcome`].
+pub trait BatchEmitter {
+    /// Opens a result set: its column metadata.
+    fn columns(&mut self, columns: Vec<ResultColumn>);
+    /// A chunk of rows for the open result set.
+    fn rows(&mut self, rows: Vec<Vec<Datum>>);
+    /// Ends one statement: its row count / rows-affected (`None` for DDL), and
+    /// the transaction state after it ran.
+    fn statement_done(&mut self, count: Option<u64>, in_transaction: bool);
+    /// Ends a statement that failed after its result set had begun streaming:
+    /// the set is closed with an error-flagged DONE so the stream stays framed
+    /// for the statements that follow. The error itself is reported separately
+    /// — at the end of the batch for a continued error, or not at all for one
+    /// a `CATCH` handled.
+    fn statement_aborted(&mut self, in_transaction: bool);
+}
+
+/// Reassembles emitted results into the whole-batch [`BatchOutcome`] for the
+/// callers that want everything at once.
+#[derive(Default)]
+pub struct Collector {
+    results: Vec<StatementResult>,
+    /// The result set currently streaming, if a statement opened one.
+    open: Option<RowSet>,
+}
+
+impl Collector {
+    /// The collected outcome. A result set still open belongs to a statement
+    /// that failed after its rows started streaming; a failed statement
+    /// contributes no result, so it is dropped.
+    pub fn into_outcome(self, error: Option<SqlError>) -> BatchOutcome {
+        BatchOutcome {
+            results: self.results,
+            error,
+        }
     }
 }
 
-/// The mutable accumulator threaded through [`run_block`] across a batch and its
-/// nested `TRY`/`CATCH` blocks.
-struct BatchRun {
-    results: Vec<StatementResult>,
+impl BatchEmitter for Collector {
+    fn columns(&mut self, columns: Vec<ResultColumn>) {
+        self.open = Some(RowSet {
+            columns,
+            rows: Vec::new(),
+        });
+    }
+
+    fn rows(&mut self, mut rows: Vec<Vec<Datum>>) {
+        if let Some(rowset) = self.open.as_mut() {
+            rowset.rows.append(&mut rows);
+        }
+    }
+
+    fn statement_done(&mut self, count: Option<u64>, _in_transaction: bool) {
+        self.results.push(match self.open.take() {
+            Some(rowset) => StatementResult::Rows(rowset),
+            None => match count {
+                Some(n) => StatementResult::RowsAffected(n),
+                None => StatementResult::Done,
+            },
+        });
+    }
+
+    fn statement_aborted(&mut self, _in_transaction: bool) {
+        self.open = None;
+    }
+}
+
+/// The mutable accumulator threaded through [`run_block`] across a batch and
+/// its nested `TRY`/`CATCH` blocks: the emitter results leave through, the
+/// DONEs held back for durability, and the batch's error state.
+struct BatchRun<'a> {
+    emitter: &'a mut dyn BatchEmitter,
+    /// Finished statements' DONEs, held back until the next durability point
+    /// (the next result set opening, or the end of the batch) so a DONE that
+    /// acknowledges a commit is never emitted before that commit is durable.
+    deferred: Vec<DeferredDone>,
+    /// Some deferred DONE acknowledges a commit (a write/DDL/`COMMIT` completed
+    /// with no transaction left open), so the next flush must fsync first.
+    ack_pending: bool,
+    /// A result set's columns have been emitted but its statement has not
+    /// finished — the state [`BatchRun::abort_open_rowset`] closes on failure.
+    rowset_open: bool,
+    /// A durability (fsync) failure wedged the store. The error terminates the
+    /// batch and is never catchable: the old batch-end fsync ran past every
+    /// TRY, and a CATCH must not be able to swallow a lost commit.
+    durability_failed: bool,
     /// Whether any executed statement may have made a durable commit: group
-    /// commit defers the WAL fsync to one call at the end of the batch.
+    /// commit defers the WAL fsync, so the end of the batch fsyncs once if so.
     committed: bool,
     /// The last non-dooming statement error under `SET XACT_ABORT OFF` (outside
     /// any TRY) — the batch continues past it (SQL Server default) and it is
     /// reported alongside the results rather than terminating the batch.
     last_error: Option<SqlError>,
+}
+
+/// A statement's DONE, parked until the next durability point.
+struct DeferredDone {
+    count: Option<u64>,
+    in_transaction: bool,
+}
+
+impl BatchRun<'_> {
+    /// Opens a result set. [`run_block`] flushed the deferred DONEs before any
+    /// statement that can produce one, so statement order on the stream holds.
+    fn open_rowset(&mut self, columns: Vec<ResultColumn>) {
+        debug_assert!(
+            self.deferred.is_empty(),
+            "a result set opened over deferred DONEs"
+        );
+        self.rowset_open = true;
+        self.emitter.columns(columns);
+    }
+
+    /// Emits a chunk of rows for the open result set.
+    fn rows(&mut self, rows: Vec<Vec<Datum>>) {
+        if !rows.is_empty() {
+            self.emitter.rows(rows);
+        }
+    }
+
+    /// Ends a statement. Its DONE is deferred to the next durability point;
+    /// `acks_commit` marks one that acknowledges a durable commit, which
+    /// forces that point to fsync first.
+    fn done(&mut self, count: Option<u64>, acks_commit: bool, in_transaction: bool) {
+        self.rowset_open = false;
+        self.ack_pending |= acks_commit;
+        self.deferred.push(DeferredDone {
+            count,
+            in_transaction,
+        });
+    }
+
+    /// Closes the open result set of a statement that failed after its columns
+    /// (and possibly rows) were already emitted, so the stream stays framed for
+    /// the statements that follow (a caught or continued error). No-op when
+    /// nothing is open — a statement that failed before emitting anything
+    /// leaves no trace, as before.
+    fn abort_open_rowset(&mut self, in_transaction: bool) {
+        if self.rowset_open {
+            self.rowset_open = false;
+            self.emitter.statement_aborted(in_transaction);
+        }
+    }
+
+    /// Emits the deferred DONEs, fsyncing first when one of them acknowledges
+    /// a commit. On a durability failure the DONEs it can no longer stand
+    /// behind are dropped and the batch terminates (see [`Self::make_durable`]).
+    fn flush(&mut self, storage: &Storage) -> Result<(), SqlError> {
+        if self.ack_pending {
+            self.ack_pending = false;
+            if let Some(error) = self.make_durable(storage) {
+                return Err(error);
+            }
+            // Everything appended so far is durable; the batch-end fsync is
+            // owed only for what later statements append.
+            self.committed = false;
+        }
+        for done in self.deferred.drain(..) {
+            self.emitter.statement_done(done.count, done.in_transaction);
+        }
+        Ok(())
+    }
+
+    /// The end of the batch: one fsync if any statement may have committed —
+    /// by kind, not transaction state, so a hidden mini-commit (an identity
+    /// reservation, even inside an open transaction or under a statement that
+    /// then failed) is never missed — then the remaining DONEs. Returns the
+    /// durability error, if any.
+    fn finish(&mut self, storage: &Storage) -> Option<SqlError> {
+        // An acknowledgment implies a commit, so `committed` alone gates.
+        debug_assert!(!self.ack_pending || self.committed);
+        if self.committed {
+            self.committed = false;
+            self.ack_pending = false;
+            if let Some(error) = self.make_durable(storage) {
+                return Some(error);
+            }
+        }
+        for done in self.deferred.drain(..) {
+            self.emitter.statement_done(done.count, done.in_transaction);
+        }
+        None
+    }
+
+    /// Blocks until the batch's commit records are fsync-durable (group
+    /// commit). A durability failure wedges the store — the in-memory state is
+    /// now ahead of the log, so no further op may serve it — and drops the
+    /// deferred DONEs, which would otherwise acknowledge commits a restart is
+    /// about to undo.
+    fn make_durable(&mut self, storage: &Storage) -> Option<SqlError> {
+        match storage.ensure_durable(storage.wal_tail()) {
+            Ok(()) => None,
+            Err(err) => {
+                storage.wedge();
+                self.deferred.clear();
+                self.durability_failed = true;
+                Some(map_storage_err(err, ""))
+            }
+        }
+    }
 }
 
 /// Runs a statement list, recursing into `TRY`/`CATCH`. `in_try` is true while
@@ -336,7 +551,7 @@ fn run_block(
     storage: &Storage,
     statements: &[Statement],
     txn_ctx: &mut TxnContext,
-    run: &mut BatchRun,
+    run: &mut BatchRun<'_>,
     in_try: bool,
 ) -> Result<(), SqlError> {
     for statement in statements {
@@ -353,6 +568,9 @@ fn run_block(
                 Ok(()) => {}
                 // An Attention that landed inside the TRY block is not caught.
                 Err(cancel) if cancel.number == CANCEL_ERROR => return Err(cancel),
+                // A durability failure wedged the store: no CATCH swallows a
+                // lost commit (the old batch-end fsync ran past every TRY).
+                Err(error) if run.durability_failed => return Err(error),
                 Err(error) => {
                     // The failed statement's own writes were already undone to
                     // its savepoint (`rel_statement_scoped`). `SET XACT_ABORT`
@@ -375,24 +593,58 @@ fn run_block(
             }
             continue;
         }
+        // A statement that can open a result set is a durability point: the
+        // deferred DONEs — and the fsync a commit acknowledgment among them
+        // owes — must reach the stream before its columns do.
+        if produces_rowset(statement) {
+            run.flush(storage)?;
+        }
         // Flag durability by statement kind, before matching the result: a
         // write/DDL/COMMIT can commit even when it then errors — an autocommit
         // statement, an identity reservation (its own mini-commit, made even
         // inside an open transaction and even if the row insert later fails),
         // or the outermost COMMIT.
         run.committed |= statement_may_commit(statement);
-        match exec_statement(storage, statement, txn_ctx) {
-            Ok(result) => run.results.push(result),
+        match exec_statement_streamed(storage, statement, txn_ctx, run) {
+            Ok(outcome) => {
+                let in_transaction = txn_ctx.in_txn();
+                // This statement's DONE acknowledges a durable commit when it
+                // could commit and no transaction remains open to take it back
+                // (autocommit, DDL, or the outermost COMMIT itself). An in-
+                // transaction write's DONE promises nothing durable yet.
+                let acks_commit = statement_may_commit(statement) && !in_transaction;
+                match outcome {
+                    StatementOutcome::Streamed { rows } => {
+                        run.done(Some(rows), acks_commit, in_transaction);
+                    }
+                    StatementOutcome::Result(StatementResult::Rows(rowset)) => {
+                        let count = rowset.rows.len() as u64;
+                        run.open_rowset(rowset.columns);
+                        run.rows(rowset.rows);
+                        run.done(Some(count), acks_commit, in_transaction);
+                    }
+                    StatementOutcome::Result(StatementResult::RowsAffected(n)) => {
+                        run.done(Some(n), acks_commit, in_transaction);
+                    }
+                    StatementOutcome::Result(StatementResult::Done) => {
+                        run.done(None, acks_commit, in_transaction);
+                    }
+                }
+            }
             Err(error) => {
                 // A cancelled statement aborts the batch immediately (see above):
                 // key on the cancel marker, not any flag, so an Attention landing
                 // concurrently with an unrelated failure cannot suppress that
-                // failure's dooming.
+                // failure's dooming. (No rowset close: the batch ends here, and
+                // its terminal DONE closes anything the statement left open.)
                 if error.number == CANCEL_ERROR {
                     return Err(error);
                 }
-                // Inside a TRY, any error transfers to the matching CATCH.
+                // Inside a TRY, any error transfers to the matching CATCH. The
+                // CATCH runs more statements, so a result set this one already
+                // started streaming must be closed first.
                 if in_try {
+                    run.abort_open_rowset(txn_ctx.in_txn());
                     return Err(error);
                 }
                 // Outside a TRY: `SET XACT_ABORT` (and error severity) decides
@@ -402,6 +654,7 @@ fn run_block(
                 // (only ROLLBACK is then accepted, error 3930).
                 let dooms = txn_ctx.xact_abort || error.level >= XACT_ABORT_SEVERITY;
                 if txn_ctx.in_txn() && !dooms {
+                    run.abort_open_rowset(txn_ctx.in_txn());
                     run.last_error = Some(error);
                     continue;
                 }
@@ -413,6 +666,59 @@ fn run_block(
         }
     }
     Ok(())
+}
+
+/// Whether a statement can open a result set on the stream: a `SELECT` that
+/// returns rows (an assignment `SELECT @v = ...` returns none). `SET
+/// SHOWPLAN_TEXT`'s plan rows ride the same `SELECT` arm.
+fn produces_rowset(statement: &Statement) -> bool {
+    match statement {
+        Statement::Select(select) => !select
+            .items
+            .iter()
+            .any(|i| matches!(i, SelectItem::Assign { .. })),
+        _ => false,
+    }
+}
+
+/// One executed statement's outcome, from [`exec_statement_streamed`].
+enum StatementOutcome {
+    /// The statement's whole result, for the caller to emit.
+    Result(StatementResult),
+    /// A streamed `SELECT`: its columns and rows already left through the
+    /// emitter as the scan produced them; only its DONE remains.
+    Streamed { rows: u64 },
+}
+
+/// Runs one statement. A plain `SELECT` the scan planner accepts streams its
+/// rows through `run` as the scan reads them — the whole point of the event
+/// stream: the client sees rows while the scan runs, and the statement's peak
+/// memory is one chunk, not the result. Everything else executes exactly as
+/// before and returns its materialized result.
+fn exec_statement_streamed(
+    storage: &Storage,
+    statement: &Statement,
+    txn_ctx: &mut TxnContext,
+    run: &mut BatchRun<'_>,
+) -> Result<StatementOutcome, SqlError> {
+    // The streamed shape: a plain SELECT — no SHOWPLAN (its rows are the plan's,
+    // not the table's), no assignment (routed to exec_select_assign) — that
+    // `scan_plan` accepts. A doomed transaction still allows reads, so the gate
+    // needs no doomed check for a SELECT.
+    if let Statement::Select(select) = statement
+        && !txn_ctx.showplan_text
+        && !select
+            .items
+            .iter()
+            .any(|i| matches!(i, SelectItem::Assign { .. }))
+    {
+        let eval_ctx = txn_ctx.eval_context();
+        if let Some(plan) = scan_plan(storage, select, &eval_ctx) {
+            let rows = scan_select_streamed(storage, &plan, select, &eval_ctx, run)?;
+            return Ok(StatementOutcome::Streamed { rows });
+        }
+    }
+    exec_statement(storage, statement, txn_ctx).map(StatementOutcome::Result)
 }
 
 /// Whether a statement can make a durable commit that the batch must fsync: any
@@ -435,32 +741,6 @@ fn statement_may_commit(statement: &Statement) -> bool {
             | Statement::AlterTable(_)
             | Statement::Commit { .. }
     )
-}
-
-/// Blocks until the batch's commit records are fsync-durable (group commit),
-/// when the batch may have committed anything. A durability (fsync) failure
-/// wedges the store — the in-memory state is now ahead of the log, so no further
-/// op may serve it — and *takes precedence over any `prior` statement error*: a
-/// lost commit is more severe than a statement error the client asked about, and
-/// a benign, continued error (e.g. a duplicate-key under `XACT_ABORT OFF` that
-/// the batch ran past before a real `COMMIT`) must not mask it — otherwise the
-/// client would be told the transaction committed while its data is silently
-/// undone as a loser on restart.
-fn finalize_durability(
-    storage: &Storage,
-    committed: bool,
-    prior: Option<SqlError>,
-) -> Option<SqlError> {
-    if !committed {
-        return prior;
-    }
-    match storage.ensure_durable(storage.wal_tail()) {
-        Ok(()) => prior,
-        Err(err) => {
-            storage.wedge();
-            Some(map_storage_err(err, ""))
-        }
-    }
 }
 
 /// The table/database locks a batch needs, from its statements and the
@@ -4936,20 +5216,67 @@ fn scan_select(
     select: &Select,
     eval_ctx: &EvalContext,
 ) -> Result<RowSet, SqlError> {
-    #[cfg(test)]
-    storage.count_scan_select();
-    let types = &plan.types;
     let mut out = RowSet {
         columns: plan.columns.clone(),
         rows: Vec::new(),
     };
-    // TOP counts rows *kept*, matching the collecting path's truncation of the
-    // filtered rows. `TOP 0` never reaches here (the gate declines it).
-    let enough = |out: &RowSet| select.top.is_some_and(|top| out.rows.len() as u64 >= top);
+    scan_select_rows(storage, plan, select, eval_ctx, &mut |row| {
+        out.rows.push(row);
+    })?;
+    Ok(out)
+}
+
+/// Rows per [`BatchEmitter::rows`] chunk on the streamed scan path: enough to
+/// amortize the per-event cost, small enough that the statement's peak memory
+/// is a chunk, not the result.
+const STREAM_CHUNK_ROWS: usize = 256;
+
+/// The streamed shape of [`scan_select`]: opens the result set, then emits
+/// kept rows in [`STREAM_CHUNK_ROWS`] chunks as the scan produces them, so the
+/// client sees rows while the scan is still running. On a mid-scan error the
+/// full chunks already emitted stand — the caller closes the set (see
+/// [`BatchRun::abort_open_rowset`]) — and the partial chunk is dropped.
+fn scan_select_streamed(
+    storage: &Storage,
+    plan: &ScanPlan,
+    select: &Select,
+    eval_ctx: &EvalContext,
+    run: &mut BatchRun<'_>,
+) -> Result<u64, SqlError> {
+    run.open_rowset(plan.columns.clone());
+    let mut chunk: Vec<Vec<Datum>> = Vec::new();
+    let kept = scan_select_rows(storage, plan, select, eval_ctx, &mut |row| {
+        chunk.push(row);
+        if chunk.len() >= STREAM_CHUNK_ROWS {
+            run.rows(std::mem::take(&mut chunk));
+        }
+    })?;
+    run.rows(chunk);
+    Ok(kept)
+}
+
+/// Walks the plan's access path, filters, projects, and hands each kept row to
+/// `sink`, stopping once `TOP` is satisfied. Returns the number of rows kept
+/// (which `TOP` counts, matching the collecting path's truncation of the
+/// filtered rows — `TOP 0` never reaches here, the gate declines it). Both
+/// executions of the scan shape ride this walk: [`scan_select`] collects into
+/// a `RowSet`, [`scan_select_streamed`] emits chunks as slices are read.
+fn scan_select_rows(
+    storage: &Storage,
+    plan: &ScanPlan,
+    select: &Select,
+    eval_ctx: &EvalContext,
+    sink: &mut dyn FnMut(Vec<Datum>),
+) -> Result<u64, SqlError> {
+    #[cfg(test)]
+    storage.count_scan_select();
+    let types = &plan.types;
+    let mut kept: u64 = 0;
+    let enough = |kept: u64| select.top.is_some_and(|top| kept >= top);
 
     // One row: filter it, and project it or drop it. `Ok(false)` once TOP is
     // satisfied and the caller should stop reading.
-    let take = |row: Vec<Datum>, out: &mut RowSet| -> Result<bool, SqlError> {
+    let mut take = |row: Vec<Datum>| -> Result<bool, SqlError> {
         check_cancelled()?;
         if let Some(predicate) = &select.where_clause {
             let sql_row = row_values(&row, types);
@@ -4957,9 +5284,9 @@ fn scan_select(
                 return Ok(true);
             }
         }
-        out.rows
-            .push(plan.picks.iter().map(|i| row[*i].clone()).collect());
-        Ok(!enough(out))
+        sink(plan.picks.iter().map(|i| row[*i].clone()).collect());
+        kept += 1;
+        Ok(!enough(kept))
     };
 
     match &plan.access {
@@ -4977,7 +5304,7 @@ fn scan_select(
                     )
                     .map_err(|err| map_storage_err(err, &plan.table))?;
                 for row in slice.drain(..) {
-                    if !take(row, &mut out)? {
+                    if !take(row)? {
                         break 'scan;
                     }
                 }
@@ -5001,13 +5328,13 @@ fn scan_select(
                 )
                 .map_err(|err| map_storage_err(err, &plan.table))?;
             for row in rows {
-                if !take(row, &mut out)? {
+                if !take(row)? {
                     break;
                 }
             }
         }
     }
-    Ok(out)
+    Ok(kept)
 }
 
 /// `SELECT @a = expr, @b = expr2 [FROM ...]` — an assignment SELECT. The value

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -276,12 +276,14 @@ pub fn execute_batch_with_params(
 /// the batch's terminal error (what `BatchOutcome::error` carried), reported by
 /// the caller after the statement events.
 ///
-/// Durability keeps its ordering: a DONE that acknowledges a commit the client
-/// may rely on (an autocommit write, DDL, the outermost `COMMIT`) is never
-/// emitted before that commit is fsync-durable. DONEs queue in the run and
-/// flush — fsyncing first if any of them acknowledges a commit — before the
-/// next result set opens and at the end of the batch, so a batch of writes
-/// with nothing to stream between them still costs one fsync, as before.
+/// Durability keeps its ordering: nothing the client can rely on — a DONE
+/// acknowledging a commit, or rows carrying commit-derived state such as a
+/// reserved identity value — is emitted before the commit behind it is
+/// fsync-durable. DONEs queue in the run and flush before the next result set
+/// opens and at the end of the batch; both points fsync first when any
+/// statement since the last one may have committed (the same kind-based test
+/// as before), so a batch of writes with nothing to stream between them still
+/// costs one fsync.
 pub fn execute_batch_streamed(
     storage: &Storage,
     sql: &str,
@@ -318,7 +320,6 @@ pub fn execute_batch_streamed(
     let mut run = BatchRun {
         emitter,
         deferred: Vec::new(),
-        ack_pending: false,
         rowset_open: false,
         durability_failed: false,
         committed: false,
@@ -349,10 +350,9 @@ pub trait BatchEmitter {
     /// the transaction state after it ran.
     fn statement_done(&mut self, count: Option<u64>, in_transaction: bool);
     /// Ends a statement that failed after its result set had begun streaming:
-    /// the set is closed with an error-flagged DONE so the stream stays framed
-    /// for the statements that follow. The error itself is reported separately
-    /// — at the end of the batch for a continued error, or not at all for one
-    /// a `CATCH` handled.
+    /// the set is closed so the stream stays framed for the statements that
+    /// follow. The error itself is reported separately — at the end of the
+    /// batch for a continued error, or not at all for one a `CATCH` handled.
     fn statement_aborted(&mut self, in_transaction: bool);
 }
 
@@ -415,9 +415,6 @@ struct BatchRun<'a> {
     /// (the next result set opening, or the end of the batch) so a DONE that
     /// acknowledges a commit is never emitted before that commit is durable.
     deferred: Vec<DeferredDone>,
-    /// Some deferred DONE acknowledges a commit (a write/DDL/`COMMIT` completed
-    /// with no transaction left open), so the next flush must fsync first.
-    ack_pending: bool,
     /// A result set's columns have been emitted but its statement has not
     /// finished — the state [`BatchRun::abort_open_rowset`] closes on failure.
     rowset_open: bool,
@@ -459,12 +456,9 @@ impl BatchRun<'_> {
         }
     }
 
-    /// Ends a statement. Its DONE is deferred to the next durability point;
-    /// `acks_commit` marks one that acknowledges a durable commit, which
-    /// forces that point to fsync first.
-    fn done(&mut self, count: Option<u64>, acks_commit: bool, in_transaction: bool) {
+    /// Ends a statement. Its DONE is deferred to the next durability point.
+    fn done(&mut self, count: Option<u64>, in_transaction: bool) {
         self.rowset_open = false;
-        self.ack_pending |= acks_commit;
         self.deferred.push(DeferredDone {
             count,
             in_transaction,
@@ -483,18 +477,23 @@ impl BatchRun<'_> {
         }
     }
 
-    /// Emits the deferred DONEs, fsyncing first when one of them acknowledges
-    /// a commit. On a durability failure the DONEs it can no longer stand
-    /// behind are dropped and the batch terminates (see [`Self::make_durable`]).
+    /// Emits the deferred DONEs, fsyncing first when any statement since the
+    /// last durability point may have committed. The gate is the same
+    /// kind-based `committed` flag the batch-end fsync uses — not "does some
+    /// DONE acknowledge a commit" — because commit-derived state escapes
+    /// through the *rows* of whatever result set opens next, not only through
+    /// DONEs: an identity value reserved by an in-transaction INSERT (a
+    /// mini-commit) is readable one statement later via `SELECT
+    /// SCOPE_IDENTITY()`, and a value the client has seen must never be
+    /// reissued after a crash. On a durability failure the DONEs the batch
+    /// can no longer stand behind are dropped and the batch terminates (see
+    /// [`Self::make_durable`]).
     fn flush(&mut self, storage: &Storage) -> Result<(), SqlError> {
-        if self.ack_pending {
-            self.ack_pending = false;
+        if self.committed {
+            self.committed = false;
             if let Some(error) = self.make_durable(storage) {
                 return Err(error);
             }
-            // Everything appended so far is durable; the batch-end fsync is
-            // owed only for what later statements append.
-            self.committed = false;
         }
         for done in self.deferred.drain(..) {
             self.emitter.statement_done(done.count, done.in_transaction);
@@ -502,17 +501,14 @@ impl BatchRun<'_> {
         Ok(())
     }
 
-    /// The end of the batch: one fsync if any statement may have committed —
-    /// by kind, not transaction state, so a hidden mini-commit (an identity
-    /// reservation, even inside an open transaction or under a statement that
-    /// then failed) is never missed — then the remaining DONEs. Returns the
-    /// durability error, if any.
+    /// The end of the batch: one fsync if any statement may have committed
+    /// since the last durability point — by kind, not transaction state, so a
+    /// hidden mini-commit (an identity reservation, even inside an open
+    /// transaction or under a statement that then failed) is never missed —
+    /// then the remaining DONEs. Returns the durability error, if any.
     fn finish(&mut self, storage: &Storage) -> Option<SqlError> {
-        // An acknowledgment implies a commit, so `committed` alone gates.
-        debug_assert!(!self.ack_pending || self.committed);
         if self.committed {
             self.committed = false;
-            self.ack_pending = false;
             if let Some(error) = self.make_durable(storage) {
                 return Some(error);
             }
@@ -594,8 +590,9 @@ fn run_block(
             continue;
         }
         // A statement that can open a result set is a durability point: the
-        // deferred DONEs — and the fsync a commit acknowledgment among them
-        // owes — must reach the stream before its columns do.
+        // deferred DONEs must reach the stream before its columns do, and any
+        // commit made so far must be fsync-durable before rows that can carry
+        // its state (an identity value, via SCOPE_IDENTITY()) leave the server.
         if produces_rowset(statement) {
             run.flush(storage)?;
         }
@@ -608,26 +605,21 @@ fn run_block(
         match exec_statement_streamed(storage, statement, txn_ctx, run) {
             Ok(outcome) => {
                 let in_transaction = txn_ctx.in_txn();
-                // This statement's DONE acknowledges a durable commit when it
-                // could commit and no transaction remains open to take it back
-                // (autocommit, DDL, or the outermost COMMIT itself). An in-
-                // transaction write's DONE promises nothing durable yet.
-                let acks_commit = statement_may_commit(statement) && !in_transaction;
                 match outcome {
                     StatementOutcome::Streamed { rows } => {
-                        run.done(Some(rows), acks_commit, in_transaction);
+                        run.done(Some(rows), in_transaction);
                     }
                     StatementOutcome::Result(StatementResult::Rows(rowset)) => {
                         let count = rowset.rows.len() as u64;
                         run.open_rowset(rowset.columns);
                         run.rows(rowset.rows);
-                        run.done(Some(count), acks_commit, in_transaction);
+                        run.done(Some(count), in_transaction);
                     }
                     StatementOutcome::Result(StatementResult::RowsAffected(n)) => {
-                        run.done(Some(n), acks_commit, in_transaction);
+                        run.done(Some(n), in_transaction);
                     }
                     StatementOutcome::Result(StatementResult::Done) => {
-                        run.done(None, acks_commit, in_transaction);
+                        run.done(None, in_transaction);
                     }
                 }
             }

--- a/crates/truthdb-core/src/session.rs
+++ b/crates/truthdb-core/src/session.rs
@@ -105,10 +105,11 @@ pub enum BatchEvent {
         in_transaction: bool,
     },
     /// Ends a statement that failed after its result set had begun streaming:
-    /// closes the set with an error-flagged DONE so the stream stays framed
-    /// for the statements that follow. The error itself travels separately —
-    /// in the batch-final [`BatchEvent::Error`] for a continued error, or not
-    /// at all for one a `CATCH` handled.
+    /// closes the set (with a clean DONE — an error-flagged DONE without an
+    /// ERROR token reads as "severe failure" to real drivers) so the stream
+    /// stays framed for the statements that follow. The error itself travels
+    /// separately — in the batch-final [`BatchEvent::Error`] for a continued
+    /// error, or not at all for one a `CATCH` handled.
     StatementAborted { in_transaction: bool },
     /// A SQL error that stopped the batch. The statements before it kept their
     /// results, which were already sent.

--- a/crates/truthdb-core/src/session.rs
+++ b/crates/truthdb-core/src/session.rs
@@ -90,6 +90,7 @@ const EVENT_ROWS: usize = 256;
 /// row count). A batch-stopping `Error` may follow the statements that ran.
 /// Every stream ends with exactly one terminal event — `Complete` or `Failed` —
 /// unless the receiver is dropped first.
+#[derive(Debug)]
 pub enum BatchEvent {
     /// Starts a result set: its column metadata.
     Columns(Vec<ResultColumn>),
@@ -103,6 +104,12 @@ pub enum BatchEvent {
         /// (`DONE_INXACT`).
         in_transaction: bool,
     },
+    /// Ends a statement that failed after its result set had begun streaming:
+    /// closes the set with an error-flagged DONE so the stream stays framed
+    /// for the statements that follow. The error itself travels separately —
+    /// in the batch-final [`BatchEvent::Error`] for a continued error, or not
+    /// at all for one a `CATCH` handled.
+    StatementAborted { in_transaction: bool },
     /// A SQL error that stopped the batch. The statements before it kept their
     /// results, which were already sent.
     Error(SqlError),
@@ -144,12 +151,11 @@ impl BatchSink {
         self.tx.send(event).is_ok()
     }
 
-    /// Sends a finished outcome as events.
-    ///
-    /// The executor still materializes each statement's rows before this runs,
-    /// so `in_transaction` is the batch's final state for every DONE — exactly
-    /// what the non-streaming path stamped. Once statements emit rows as they
-    /// produce them, each DONE will carry its own statement's state.
+    /// Sends a finished outcome as events — the reply of a batch that never
+    /// ran (the parked deadlock victim) and the tests' shorthand. A batch that
+    /// runs streams through the [`crate::rel::BatchEmitter`] impl below
+    /// instead, stamping each DONE with its own statement's state; here every
+    /// DONE carries the one final state, which is all an error-only reply has.
     fn send_outcome(&self, outcome: BatchOutcome, in_transaction: bool) {
         for result in outcome.results {
             let sent = match result {
@@ -199,6 +205,44 @@ impl BatchSink {
             in_transaction,
         })
     }
+
+    /// Sends a batch's terminal events: its error, if it ended with one, then
+    /// `Complete` with the post-batch transaction state (which the TDS
+    /// transaction-manager path reads — it stays batch-final by design).
+    fn send_tail(&self, error: Option<truthdb_sql::error::SqlError>, in_transaction: bool) {
+        if let Some(error) = error
+            && !self.send(BatchEvent::Error(error))
+        {
+            return;
+        }
+        self.send(BatchEvent::Complete { in_transaction });
+    }
+}
+
+/// The worker-side face of the reply channel: the executor emits each
+/// statement's results through this as it runs, which is what puts rows on
+/// the wire while the batch still executes. Send failures mean the client is
+/// gone; the batch still runs to completion (its effects do not depend on
+/// anyone listening) and the disconnect path's cancel flag stops it early.
+impl crate::rel::BatchEmitter for BatchSink {
+    fn columns(&mut self, columns: Vec<ResultColumn>) {
+        self.send(BatchEvent::Columns(columns));
+    }
+
+    fn rows(&mut self, rows: Vec<Vec<Datum>>) {
+        self.send(BatchEvent::Rows(rows));
+    }
+
+    fn statement_done(&mut self, count: Option<u64>, in_transaction: bool) {
+        self.send(BatchEvent::StatementDone {
+            count,
+            in_transaction,
+        });
+    }
+
+    fn statement_aborted(&mut self, in_transaction: bool) {
+        self.send(BatchEvent::StatementAborted { in_transaction });
+    }
 }
 
 /// Reassembles an event stream into a whole [`BatchReply`] — the shape every
@@ -232,6 +276,9 @@ async fn collect_reply(
                     None => StatementResult::Done,
                 },
             }),
+            // The aborted statement contributes no result; its partly-streamed
+            // rowset is dropped, which is what the buffered path returned too.
+            BatchEvent::StatementAborted { .. } => open = None,
             BatchEvent::Error(err) => error = Some(err),
             BatchEvent::Complete { in_transaction } => {
                 return Ok(BatchReply {
@@ -956,18 +1003,21 @@ fn run_and_finish(shared: &Arc<Shared>, work: Runnable) {
     // Bind the cancel flag to this worker thread for the batch, so the executor's
     // `check_cancelled` polls see a TDS Attention; the guard clears it on return.
     let _cancel_guard = crate::rel::CancelScope::enter(cancel);
+    // Statement events stream out *while the batch runs* — the executor emits
+    // each result as it is produced, and the send never blocks, so a client
+    // that reads slowly delays neither this worker nor the locks it holds.
+    let mut reply = reply;
     let outcome = shared
         .engine
-        .sql_batch_with_params(&sql, &mut txn_ctx, &params);
+        .sql_batch_streamed(&sql, &mut txn_ctx, &params, &mut reply);
     let in_transaction = {
         let mut sched = shared.scheduler.lock().expect("scheduler poisoned");
         sched.finish(&shared.engine, session, txn_ctx)
     };
-    // The reply goes out after the batch's locks are settled, and the send
-    // never blocks, so a client that reads slowly delays neither this worker nor
-    // the locks it held.
+    // The terminal events wait for the locks to settle: `Complete` carries the
+    // post-batch transaction state, which only `finish` knows.
     match outcome {
-        Ok(outcome) => reply.send_outcome(outcome, in_transaction),
+        Ok(error) => reply.send_tail(error, in_transaction),
         Err(err) => {
             reply.send(BatchEvent::Failed(err));
         }
@@ -1587,6 +1637,178 @@ mod tests {
         // ordinary 3902.
         let reply = h.handle.run_batch(a, "COMMIT".into()).await.unwrap();
         assert_eq!(error_number(&reply), Some(3902));
+    }
+
+    /// Drains a batch's event stream through its terminal event.
+    async fn drain_events(mut rx: mpsc::UnboundedReceiver<BatchEvent>) -> Vec<BatchEvent> {
+        let mut events = Vec::new();
+        while let Some(event) = rx.recv().await {
+            let terminal = matches!(event, BatchEvent::Complete { .. } | BatchEvent::Failed(_));
+            events.push(event);
+            if terminal {
+                break;
+            }
+        }
+        events
+    }
+
+    fn no_cancel() -> Arc<AtomicBool> {
+        Arc::new(AtomicBool::new(false))
+    }
+
+    /// The `in_transaction` flag of every StatementDone, in stream order.
+    fn done_flags(events: &[BatchEvent]) -> Vec<bool> {
+        events
+            .iter()
+            .filter_map(|event| match event {
+                BatchEvent::StatementDone { in_transaction, .. } => Some(*in_transaction),
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn statement_dones_carry_their_own_transaction_state() {
+        // Each DONE reports the transaction state after *its own* statement —
+        // BEGIN and the SELECT inside the transaction say so, the COMMIT says
+        // it ended — instead of the batch's final state stamped on all three.
+        let h = start(LOCK_WAIT_TIMEOUT);
+        let s = h.handle.open_session("truthdb".into(), "sa".into()).await;
+        let events = drain_events(h.handle.stream_batch(
+            s,
+            "BEGIN TRANSACTION; SELECT 1 AS one; COMMIT".into(),
+            no_cancel(),
+        ))
+        .await;
+        assert_eq!(done_flags(&events), [true, true, false]);
+        assert!(
+            matches!(
+                events.last(),
+                Some(BatchEvent::Complete {
+                    in_transaction: false
+                })
+            ),
+            "Complete carries the batch-final state: {events:?}"
+        );
+    }
+
+    /// Fills `t` with `1..=n` single-column PK rows.
+    async fn fill(h: &Harness, s: SessionId, n: usize) {
+        h.handle
+            .run_batch(s, "CREATE TABLE t (id INT NOT NULL PRIMARY KEY)".into())
+            .await
+            .unwrap();
+        let mut insert = String::from("INSERT INTO t VALUES (1)");
+        for i in 2..=n {
+            insert.push_str(&format!(", ({i})"));
+        }
+        let reply = h.handle.run_batch(s, insert).await.unwrap();
+        assert!(reply.outcome.error.is_none(), "{:?}", reply.outcome.error);
+    }
+
+    #[tokio::test]
+    async fn a_mid_scan_error_keeps_the_rows_already_streamed() {
+        // A streamed SELECT that fails part-way has already emitted the rows
+        // that preceded the failure — rows leave while the statement is still
+        // running. The buffered path emitted nothing for a failed statement,
+        // so any Columns/Rows here prove the stream is real.
+        let h = start(LOCK_WAIT_TIMEOUT);
+        let s = h.handle.open_session("truthdb".into(), "sa".into()).await;
+        fill(&h, s, 600).await;
+        // The WHERE divides by zero at id = 600, after 599 kept rows: two full
+        // 256-row chunks are already out, the partial third is dropped.
+        let events = drain_events(h.handle.stream_batch(
+            s,
+            "SELECT id FROM t WHERE 10 / (id - 600) > -100".into(),
+            no_cancel(),
+        ))
+        .await;
+        let streamed: usize = events
+            .iter()
+            .map(|event| match event {
+                BatchEvent::Rows(rows) => rows.len(),
+                _ => 0,
+            })
+            .sum();
+        assert_eq!(streamed, 512, "two full chunks precede the failure");
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, BatchEvent::Error(err) if err.number == 8134)),
+            "the divide-by-zero still reaches the client: {events:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_caught_mid_scan_error_closes_the_open_rowset() {
+        // A TRY/CATCH swallows the error, but the failed SELECT's result set
+        // had already started streaming — it must be closed (StatementAborted)
+        // before the CATCH's own result set opens, and no Error event follows.
+        let h = start(LOCK_WAIT_TIMEOUT);
+        let s = h.handle.open_session("truthdb".into(), "sa".into()).await;
+        fill(&h, s, 300).await;
+        let events = drain_events(
+            h.handle.stream_batch(
+                s,
+                "BEGIN TRY SELECT id FROM t WHERE 10 / (id - 300) > -100 END TRY \
+             BEGIN CATCH SELECT 99 AS caught END CATCH"
+                    .into(),
+                no_cancel(),
+            ),
+        )
+        .await;
+        let aborted = events
+            .iter()
+            .position(|e| matches!(e, BatchEvent::StatementAborted { .. }))
+            .expect("the failed SELECT's rowset is closed");
+        let caught = events
+            .iter()
+            .position(
+                |e| matches!(e, BatchEvent::Columns(cols) if cols.first().is_some_and(|c| c.name == "caught")),
+            )
+            .expect("the CATCH's rowset follows");
+        assert!(aborted < caught, "close before reopening: {events:?}");
+        assert!(
+            !events.iter().any(|e| matches!(e, BatchEvent::Error(_))),
+            "a caught error never surfaces: {events:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_continued_mid_scan_error_closes_the_rowset_and_reports_last() {
+        // Under XACT_ABORT OFF a non-fatal in-transaction error rolls back only
+        // its statement and the batch continues — so the half-streamed rowset
+        // closes, the following statements run, and the error is reported at
+        // the end of the batch, exactly where the buffered path put it.
+        let h = start(LOCK_WAIT_TIMEOUT);
+        let s = h.handle.open_session("truthdb".into(), "sa".into()).await;
+        fill(&h, s, 300).await;
+        let events = drain_events(
+            h.handle.stream_batch(
+                s,
+                "BEGIN TRANSACTION; SELECT id FROM t WHERE 10 / (id - 300) > -100; \
+             SELECT 7 AS after; COMMIT"
+                    .into(),
+                no_cancel(),
+            ),
+        )
+        .await;
+        assert!(
+            events.iter().any(|e| matches!(
+                e,
+                BatchEvent::StatementAborted {
+                    in_transaction: true
+                }
+            )),
+            "the failed SELECT's rowset closes, still in-transaction: {events:?}"
+        );
+        // BEGIN, the surviving SELECT, then COMMIT — each DONE with its own state.
+        assert_eq!(done_flags(&events), [true, true, false]);
+        let error = events
+            .iter()
+            .position(|e| matches!(e, BatchEvent::Error(err) if err.number == 8134))
+            .expect("the continued error is still reported");
+        assert_eq!(error, events.len() - 2, "after every result: {events:?}");
     }
 
     #[tokio::test]

--- a/crates/truthdb-core/src/storage.rs
+++ b/crates/truthdb-core/src/storage.rs
@@ -3227,6 +3227,85 @@ mod tests {
         let _ = std::fs::remove_file(&path);
     }
 
+    /// An identity value reserved by an in-transaction INSERT (a mini-commit,
+    /// durable independently of the transaction) must not stream to the client
+    /// before its reservation is fsynced: a value the client has seen must
+    /// never be reissued after a crash, and it escapes through the *rows* of a
+    /// following SELECT, not through any commit-acknowledging DONE. This is
+    /// why the mid-batch flush gates on the kind-based `committed` flag rather
+    /// than on "some DONE acknowledges a commit".
+    #[test]
+    fn an_identity_value_never_streams_before_its_reservation_fsync() {
+        use crate::rel::{
+            BatchEmitter, ResultColumn, TxnContext, execute_batch, execute_batch_streamed,
+        };
+        use crate::relstore::types::Datum;
+
+        struct Probe<'a> {
+            storage: &'a Storage,
+            log: Vec<(&'static str, u64)>,
+        }
+        impl Probe<'_> {
+            fn note(&mut self, what: &'static str) {
+                self.log.push((what, self.storage.group_commit_fsyncs()));
+            }
+        }
+        impl BatchEmitter for Probe<'_> {
+            fn columns(&mut self, _columns: Vec<ResultColumn>) {
+                self.note("columns");
+            }
+            fn rows(&mut self, _rows: Vec<Vec<Datum>>) {
+                self.note("rows");
+            }
+            fn statement_done(&mut self, _count: Option<u64>, _in_transaction: bool) {
+                self.note("done");
+            }
+            fn statement_aborted(&mut self, _in_transaction: bool) {
+                self.note("aborted");
+            }
+        }
+
+        let path = unique_temp_path("stream-identity");
+        let storage = Storage::create(path.clone(), test_storage_options()).expect("create");
+        let mut setup = TxnContext::default();
+        let create = execute_batch(
+            &storage,
+            "CREATE TABLE t (id INT IDENTITY(1,1) PRIMARY KEY, v INT NOT NULL)",
+            &mut setup,
+        );
+        assert!(create.error.is_none(), "create table: {:?}", create.error);
+        let baseline = storage.group_commit_fsyncs();
+
+        let mut ctx = TxnContext::default();
+        let mut probe = Probe {
+            storage: &storage,
+            log: Vec::new(),
+        };
+        // The INSERT's own DONE promises nothing durable (the transaction is
+        // open), but its identity reservation is already a mini-commit — and
+        // the SELECT's rows carry the reserved value out of the server.
+        let error = execute_batch_streamed(
+            &storage,
+            "BEGIN TRANSACTION; INSERT INTO t (v) VALUES (10); SELECT id FROM t; ROLLBACK",
+            &mut ctx,
+            &[],
+            &mut probe,
+        );
+        assert!(error.is_none(), "{error:?}");
+        for (what, fsyncs) in &probe.log {
+            if *what == "columns" || *what == "rows" {
+                assert!(
+                    *fsyncs > baseline,
+                    "the rowset streamed before the reservation's fsync: {:?}",
+                    probe.log
+                );
+            }
+        }
+
+        drop(storage);
+        let _ = std::fs::remove_file(&path);
+    }
+
     /// A batch of autocommit writes with nothing to stream between them still
     /// coalesces to a single fsync at the end of the batch: the DONEs are
     /// deferred to that durability point rather than each buying an fsync.

--- a/crates/truthdb-core/src/storage.rs
+++ b/crates/truthdb-core/src/storage.rs
@@ -3150,6 +3150,114 @@ mod tests {
         .expect("create storage")
     }
 
+    /// The DONE acknowledging an autocommit write is never emitted before the
+    /// write's commit record is fsync-durable: the executor's deferred DONEs
+    /// flush — fsyncing first — before the next result set opens, so a client
+    /// can never act on an acknowledgment a crash then silently revokes.
+    #[test]
+    fn a_commit_acknowledgement_never_precedes_its_fsync() {
+        use crate::rel::{
+            BatchEmitter, ResultColumn, TxnContext, execute_batch, execute_batch_streamed,
+        };
+        use crate::relstore::types::Datum;
+
+        /// Logs each emitted event alongside the fsync count at that moment.
+        struct Probe<'a> {
+            storage: &'a Storage,
+            log: Vec<(&'static str, u64)>,
+        }
+        impl Probe<'_> {
+            fn note(&mut self, what: &'static str) {
+                self.log.push((what, self.storage.group_commit_fsyncs()));
+            }
+        }
+        impl BatchEmitter for Probe<'_> {
+            fn columns(&mut self, _columns: Vec<ResultColumn>) {
+                self.note("columns");
+            }
+            fn rows(&mut self, _rows: Vec<Vec<Datum>>) {
+                self.note("rows");
+            }
+            fn statement_done(&mut self, _count: Option<u64>, _in_transaction: bool) {
+                self.note("done");
+            }
+            fn statement_aborted(&mut self, _in_transaction: bool) {
+                self.note("aborted");
+            }
+        }
+
+        let path = unique_temp_path("stream-durability");
+        let storage = Storage::create(path.clone(), test_storage_options()).expect("create");
+        let mut setup = TxnContext::default();
+        let create = execute_batch(&storage, "CREATE TABLE t (v INT NOT NULL)", &mut setup);
+        assert!(create.error.is_none(), "create table: {:?}", create.error);
+        let baseline = storage.group_commit_fsyncs();
+
+        let mut ctx = TxnContext::default();
+        let mut probe = Probe {
+            storage: &storage,
+            log: Vec::new(),
+        };
+        let error = execute_batch_streamed(
+            &storage,
+            "INSERT INTO t VALUES (1); SELECT v FROM t",
+            &mut ctx,
+            &[],
+            &mut probe,
+        );
+        assert!(error.is_none(), "{error:?}");
+        // The INSERT's DONE comes first — already past its fsync — and only
+        // then does the SELECT's result set open.
+        assert_eq!(
+            probe.log.first(),
+            Some(&("done", baseline + 1)),
+            "the write's acknowledgment waits for its fsync: {:?}",
+            probe.log
+        );
+        assert_eq!(
+            probe.log.get(1).map(|(what, _)| *what),
+            Some("columns"),
+            "the rowset opens after the acknowledgment: {:?}",
+            probe.log
+        );
+        // One fsync total: the mid-batch flush covered the batch's only commit.
+        assert_eq!(storage.group_commit_fsyncs(), baseline + 1);
+
+        drop(storage);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// A batch of autocommit writes with nothing to stream between them still
+    /// coalesces to a single fsync at the end of the batch: the DONEs are
+    /// deferred to that durability point rather than each buying an fsync.
+    #[test]
+    fn a_write_only_batch_still_fsyncs_once() {
+        use crate::rel::{TxnContext, execute_batch};
+
+        let path = unique_temp_path("stream-one-fsync");
+        let storage = Storage::create(path.clone(), test_storage_options()).expect("create");
+        let mut setup = TxnContext::default();
+        let create = execute_batch(&storage, "CREATE TABLE t (v INT NOT NULL)", &mut setup);
+        assert!(create.error.is_none(), "create table: {:?}", create.error);
+        let baseline = storage.group_commit_fsyncs();
+
+        let mut ctx = TxnContext::default();
+        let outcome = execute_batch(
+            &storage,
+            "INSERT INTO t VALUES (1); INSERT INTO t VALUES (2); INSERT INTO t VALUES (3)",
+            &mut ctx,
+        );
+        assert!(outcome.error.is_none(), "{:?}", outcome.error);
+        assert_eq!(
+            storage.group_commit_fsyncs(),
+            baseline + 1,
+            "three autocommit writes, one batch-end fsync"
+        );
+
+        drop(storage);
+        let _ = std::fs::remove_file(&path);
+    }
+
     /// Group commit: many transactions whose commit records are already in the
     /// WAL, all waiting for durability up to the same point, are made durable by
     /// a single log-writer fsync. Deterministic (independent of fsync latency):

--- a/crates/truthdb-tds/src/server.rs
+++ b/crates/truthdb-tds/src/server.rs
@@ -592,6 +592,9 @@ struct BatchRender {
 struct PendingDone {
     count: Option<u64>,
     in_transaction: bool,
+    /// `DONE_ERROR`: the statement failed after its result set began
+    /// streaming, and this DONE closes that set.
+    error: bool,
 }
 
 impl BatchRender {
@@ -628,6 +631,20 @@ impl BatchRender {
                 self.pending = Some(PendingDone {
                     count,
                     in_transaction,
+                    error: false,
+                });
+            }
+            BatchEvent::StatementAborted { in_transaction } => {
+                // Closes a result set whose statement failed mid-stream, with
+                // an error-flagged DONE. The error text, if the client gets
+                // one at all, follows at the end of the batch — a caught
+                // (TRY/CATCH) error never surfaces, and the batch's final DONE
+                // then stays clean.
+                self.flush_pending(out, true).await?;
+                self.pending = Some(PendingDone {
+                    count: None,
+                    in_transaction,
+                    error: true,
                 });
             }
             BatchEvent::Error(error) => {
@@ -677,7 +694,7 @@ impl BatchRender {
         more: bool,
     ) -> io::Result<()> {
         if let Some(done) = self.pending.take() {
-            self.done(out, more, false, done.in_transaction, done.count)
+            self.done(out, more, done.error, done.in_transaction, done.count)
                 .await?;
         }
         Ok(())
@@ -897,7 +914,15 @@ mod render_tests {
     /// the deferred DONE has to settle `DONE_MORE` by lookahead, which is the
     /// part most likely to disagree with the oracle.
     async fn rendered(outcome: &BatchOutcome, in_xact: bool, packet_size: usize) -> Vec<u8> {
-        let events = events_for(outcome, in_xact);
+        rendered_events(events_for(outcome, in_xact), packet_size).await
+    }
+
+    /// Renders an event stream through the real `stream_reply` and reassembles
+    /// the message payload.
+    async fn rendered_events(
+        events: mpsc::UnboundedReceiver<BatchEvent>,
+        packet_size: usize,
+    ) -> Vec<u8> {
         let mut wire = Duplex {
             read: std::io::Cursor::new(Vec::new()),
             written: Vec::new(),
@@ -957,6 +982,70 @@ mod render_tests {
         })
         .unwrap();
         rx
+    }
+
+    /// Each DONE carries the transaction state of *its own* statement on the
+    /// wire — `BEGIN TRAN; SELECT ...; COMMIT` reads INXACT 1, 1, 0 — instead
+    /// of the batch's final state stamped on all of them retroactively.
+    #[tokio::test]
+    async fn done_inxact_is_per_statement() {
+        let (tx, rx) = mpsc::unbounded_channel();
+        for (count, in_transaction) in [(None, true), (Some(1), true), (None, false)] {
+            tx.send(BatchEvent::StatementDone {
+                count,
+                in_transaction,
+            })
+            .unwrap();
+        }
+        tx.send(BatchEvent::Complete {
+            in_transaction: false,
+        })
+        .unwrap();
+        drop(tx);
+
+        let mut expected = Vec::new();
+        token::done(&mut expected, true, false, true, None);
+        token::done(&mut expected, true, false, true, Some(1));
+        token::done(&mut expected, false, false, false, None);
+        assert_eq!(rendered_events(rx, 4096).await, expected);
+    }
+
+    /// A statement that fails after its result set began streaming closes the
+    /// set with an error-flagged DONE, and the stream stays framed for what
+    /// follows — here a CATCH block's own result set, with no ERROR token at
+    /// all (the error was caught) and a clean final DONE.
+    #[tokio::test]
+    async fn an_aborted_statement_closes_its_rowset_with_an_error_done() {
+        let (tx, rx) = mpsc::unbounded_channel();
+        tx.send(BatchEvent::Columns(columns())).unwrap();
+        tx.send(BatchEvent::Rows(vec![vec![Datum::Int(1)]]))
+            .unwrap();
+        tx.send(BatchEvent::StatementAborted {
+            in_transaction: false,
+        })
+        .unwrap();
+        tx.send(BatchEvent::Columns(columns())).unwrap();
+        tx.send(BatchEvent::Rows(vec![vec![Datum::Int(9)]]))
+            .unwrap();
+        tx.send(BatchEvent::StatementDone {
+            count: Some(1),
+            in_transaction: false,
+        })
+        .unwrap();
+        tx.send(BatchEvent::Complete {
+            in_transaction: false,
+        })
+        .unwrap();
+        drop(tx);
+
+        let mut expected = Vec::new();
+        token::colmetadata(&mut expected, &columns());
+        token::row(&mut expected, &[Datum::Int(1)], &columns());
+        token::done(&mut expected, true, true, false, None);
+        token::colmetadata(&mut expected, &columns());
+        token::row(&mut expected, &[Datum::Int(9)], &columns());
+        token::done(&mut expected, false, false, false, Some(1));
+        assert_eq!(rendered_events(rx, 4096).await, expected);
     }
 
     /// A stream whose read half never yields (no Attention ever arrives) and

--- a/crates/truthdb-tds/src/server.rs
+++ b/crates/truthdb-tds/src/server.rs
@@ -447,8 +447,24 @@ where
                     if attention {
                         continue;
                     }
-                    if render.event(&mut out, event).await? {
-                        break;
+                    match render.event(&mut out, event).await {
+                        Ok(terminal) => {
+                            if terminal {
+                                break;
+                            }
+                        }
+                        // A socket write failed mid-batch — the ordinary way a
+                        // client dies while a result streams. The batch is
+                        // still RUNNING and holds its locks, and the caller
+                        // will close the session the moment this returns —
+                        // which releases those locks out from under it. Same
+                        // contract as every other early exit: cancel the
+                        // batch, wait for it to actually end, then leave.
+                        Err(err) => {
+                            cancel.store(true, Ordering::Relaxed);
+                            drain_to_end(&mut events).await;
+                            return Err(err);
+                        }
                     }
                 }
                 // The stream ended without a terminal event: the worker panicked,
@@ -469,14 +485,22 @@ where
                     break;
                 }
             },
-            read = rd.read(&mut hdr[got..]) => match read? {
-                0 => {
+            read = rd.read(&mut hdr[got..]) => match read {
+                // A read error is a disconnect with an errno: same treatment
+                // as the clean EOF below, or the still-running batch would
+                // have its locks released by the caller's close_session.
+                Err(err) => {
+                    cancel.store(true, Ordering::Relaxed);
+                    drain_to_end(&mut events).await;
+                    return Err(err);
+                }
+                Ok(0) => {
                     // Client disconnected mid-batch.
                     cancel.store(true, Ordering::Relaxed);
                     drain_to_end(&mut events).await;
                     return Ok(false);
                 }
-                n => {
+                Ok(n) => {
                     got += n;
                     if got == HEADER_LEN {
                         // Only an Attention (a header-only packet) is legal during
@@ -592,9 +616,6 @@ struct BatchRender {
 struct PendingDone {
     count: Option<u64>,
     in_transaction: bool,
-    /// `DONE_ERROR`: the statement failed after its result set began
-    /// streaming, and this DONE closes that set.
-    error: bool,
 }
 
 impl BatchRender {
@@ -631,20 +652,25 @@ impl BatchRender {
                 self.pending = Some(PendingDone {
                     count,
                     in_transaction,
-                    error: false,
                 });
             }
             BatchEvent::StatementAborted { in_transaction } => {
-                // Closes a result set whose statement failed mid-stream, with
-                // an error-flagged DONE. The error text, if the client gets
-                // one at all, follows at the end of the batch — a caught
-                // (TRY/CATCH) error never surfaces, and the batch's final DONE
-                // then stays clean.
+                // Closes a result set whose statement failed mid-stream — with
+                // a CLEAN done, deliberately. Setting `DONE_ERROR` here without
+                // a preceding ERROR token reads as "severe failure, discard
+                // results" to every real driver: pytds raises "Request failed,
+                // server didn't send error message" (`process_end` raises on
+                // the flag with no accumulated messages), go-mssqldb v1.8.0
+                // synthesizes "Request failed but didn't provide reason" and
+                // strands the result sets behind it, and SqlClient's
+                // equivalent branch is documented as covering server aborts.
+                // The error itself, when the client gets one at all, travels
+                // as the batch-final ERROR token exactly as before; a caught
+                // (TRY/CATCH) error never surfaces at all.
                 self.flush_pending(out, true).await?;
                 self.pending = Some(PendingDone {
                     count: None,
                     in_transaction,
-                    error: true,
                 });
             }
             BatchEvent::Error(error) => {
@@ -694,7 +720,7 @@ impl BatchRender {
         more: bool,
     ) -> io::Result<()> {
         if let Some(done) = self.pending.take() {
-            self.done(out, more, done.error, done.in_transaction, done.count)
+            self.done(out, more, false, done.in_transaction, done.count)
                 .await?;
         }
         Ok(())
@@ -1011,11 +1037,12 @@ mod render_tests {
     }
 
     /// A statement that fails after its result set began streaming closes the
-    /// set with an error-flagged DONE, and the stream stays framed for what
-    /// follows — here a CATCH block's own result set, with no ERROR token at
-    /// all (the error was caught) and a clean final DONE.
+    /// set with a CLEAN done — never `DONE_ERROR` without an ERROR token,
+    /// which pytds and go-mssqldb both turn into a synthesized "request
+    /// failed" error that strands every result set behind it — and the stream
+    /// stays framed for what follows, here a CATCH block's own result set.
     #[tokio::test]
-    async fn an_aborted_statement_closes_its_rowset_with_an_error_done() {
+    async fn an_aborted_statement_closes_its_rowset_with_a_clean_done() {
         let (tx, rx) = mpsc::unbounded_channel();
         tx.send(BatchEvent::Columns(columns())).unwrap();
         tx.send(BatchEvent::Rows(vec![vec![Datum::Int(1)]]))
@@ -1041,11 +1068,116 @@ mod render_tests {
         let mut expected = Vec::new();
         token::colmetadata(&mut expected, &columns());
         token::row(&mut expected, &[Datum::Int(1)], &columns());
-        token::done(&mut expected, true, true, false, None);
+        token::done(&mut expected, true, false, false, None);
         token::colmetadata(&mut expected, &columns());
         token::row(&mut expected, &[Datum::Int(9)], &columns());
         token::done(&mut expected, false, false, false, Some(1));
         assert_eq!(rendered_events(rx, 4096).await, expected);
+    }
+
+    /// An abort as the batch's LAST statement event (an empty CATCH at the end
+    /// of the batch): its pending DONE becomes the batch-final DONE and must
+    /// be clean — the batch succeeded, its one error was caught. The buffered
+    /// path sent a single clean final DONE for this batch; a final
+    /// `DONE_ERROR` with no ERROR token would read as a failed batch.
+    #[tokio::test]
+    async fn an_abort_ending_the_batch_leaves_the_final_done_clean() {
+        let (tx, rx) = mpsc::unbounded_channel();
+        tx.send(BatchEvent::Columns(columns())).unwrap();
+        tx.send(BatchEvent::Rows(vec![vec![Datum::Int(1)]]))
+            .unwrap();
+        tx.send(BatchEvent::StatementAborted {
+            in_transaction: false,
+        })
+        .unwrap();
+        tx.send(BatchEvent::Complete {
+            in_transaction: false,
+        })
+        .unwrap();
+        drop(tx);
+
+        let mut expected = Vec::new();
+        token::colmetadata(&mut expected, &columns());
+        token::row(&mut expected, &[Datum::Int(1)], &columns());
+        token::done(&mut expected, false, false, false, None);
+        assert_eq!(rendered_events(rx, 4096).await, expected);
+    }
+
+    /// A write half that fails on the first socket write, read half pending
+    /// forever — a client that died while a result was streaming to it.
+    struct FailingWrite;
+
+    impl AsyncRead for FailingWrite {
+        fn poll_read(
+            self: std::pin::Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+            _buf: &mut tokio::io::ReadBuf<'_>,
+        ) -> std::task::Poll<io::Result<()>> {
+            std::task::Poll::Pending
+        }
+    }
+
+    impl AsyncWrite for FailingWrite {
+        fn poll_write(
+            self: std::pin::Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+            _buf: &[u8],
+        ) -> std::task::Poll<io::Result<usize>> {
+            std::task::Poll::Ready(Err(io::Error::from(io::ErrorKind::BrokenPipe)))
+        }
+        fn poll_flush(
+            self: std::pin::Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<io::Result<()>> {
+            std::task::Poll::Ready(Ok(()))
+        }
+        fn poll_shutdown(
+            self: std::pin::Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<io::Result<()>> {
+            std::task::Poll::Ready(Ok(()))
+        }
+    }
+
+    /// A socket write failure mid-stream must cancel the batch and wait for
+    /// it to end before returning — the caller closes the session the moment
+    /// `stream_reply` returns, which releases the batch's locks, so returning
+    /// while the batch still runs would let another session read its
+    /// uncommitted writes. `stream_reply` returning at all proves the drain
+    /// ran (it waits for the channel to close), and the sender task below
+    /// only closes the channel once it observes the cancel flag.
+    #[tokio::test]
+    async fn a_write_error_mid_stream_cancels_and_drains_the_batch() {
+        let (tx, rx) = mpsc::unbounded_channel();
+        // Enough rows that rendering must write a packet to the (dead) socket.
+        tx.send(BatchEvent::Columns(columns())).unwrap();
+        tx.send(BatchEvent::Rows(
+            (0..200).map(|i| vec![Datum::Int(i)]).collect(),
+        ))
+        .unwrap();
+
+        let cancel = Arc::new(AtomicBool::new(false));
+        let observed = cancel.clone();
+        // The "worker": keeps the batch open until it sees the cancel, then
+        // ends it — as the real executor's check_cancelled poll does.
+        let worker = tokio::spawn(async move {
+            while !observed.load(Ordering::Relaxed) {
+                tokio::task::yield_now().await;
+            }
+            let _ = tx.send(BatchEvent::Complete {
+                in_transaction: false,
+            });
+            drop(tx);
+        });
+
+        let mut wire = FailingWrite;
+        let result = stream_reply(&mut wire, rx, cancel.clone(), MIN_PACKET_SIZE).await;
+        assert!(result.is_err(), "the write error surfaces");
+        assert!(
+            cancel.load(Ordering::Relaxed),
+            "the running batch was cancelled before stream_reply returned"
+        );
+        worker.await.expect("worker");
     }
 
     /// A stream whose read half never yields (no Attention ever arrives) and

--- a/scripts/tds_conformance.go
+++ b/scripts/tds_conformance.go
@@ -183,7 +183,89 @@ func main() {
 	parameterizedQueries(db)
 	blockingDemo(db, host, port, user, pass)
 
+	// 14. A statement failing after its result set began streaming (rows are
+	// emitted as the scan runs since #105). The failed set must close with a
+	// clean DONE: an error-flagged DONE with no ERROR token makes this driver
+	// synthesize "Request failed but didn't provide reason" and strand every
+	// result set behind it.
+	midStreamFailures(db)
+
 	fmt.Println("tds conformance (go-mssqldb): OK")
+}
+
+// midStreamFailures exercises statements that fail after their result set has
+// started streaming: caught by TRY/CATCH (batch succeeds, CATCH set intact),
+// caught by an empty CATCH (batch succeeds outright), and continued under
+// XACT_ABORT OFF inside a transaction (the real error text arrives at the end
+// of the batch).
+func midStreamFailures(db *sql.DB) {
+	mustExec(db, "CREATE TABLE stream_err_go (id INT NOT NULL PRIMARY KEY)")
+	values := make([]string, 0, 400)
+	for i := 1; i <= 400; i++ {
+		values = append(values, fmt.Sprintf("(%d)", i))
+	}
+	mustExec(db, "INSERT INTO stream_err_go VALUES "+strings.Join(values, ", "))
+
+	// Caught: a partial first set, then the CATCH's set, no error anywhere.
+	rows, err := db.Query("BEGIN TRY SELECT id FROM stream_err_go WHERE 10 / (id - 300) > -100 END TRY " +
+		"BEGIN CATCH SELECT 99 AS caught END CATCH")
+	if err != nil {
+		fail("caught mid-stream query: %v", err)
+	}
+	partial := drainInts(rows)
+	if len(partial) >= 300 {
+		fail("caught mid-stream error returned %d rows, expected a partial set", len(partial))
+	}
+	if !rows.NextResultSet() {
+		fail("the CATCH result set is unreachable after a caught mid-stream error: %v", rows.Err())
+	}
+	if caught := drainInts(rows); len(caught) != 1 || caught[0] != 99 {
+		fail("the CATCH result set did not arrive intact: %v", caught)
+	}
+	if err := rows.Err(); err != nil {
+		fail("caught mid-stream batch reported an error: %v", err)
+	}
+	rows.Close()
+
+	// Empty CATCH: the whole batch reads as success.
+	rows, err = db.Query("BEGIN TRY SELECT id FROM stream_err_go WHERE 10 / (id - 300) > -100 END TRY " +
+		"BEGIN CATCH END CATCH")
+	if err != nil {
+		fail("empty-catch query: %v", err)
+	}
+	drainInts(rows)
+	for rows.NextResultSet() {
+		drainInts(rows)
+	}
+	if err := rows.Err(); err != nil {
+		fail("empty-catch batch reported an error: %v", err)
+	}
+	rows.Close()
+
+	// Continued (in-transaction, XACT_ABORT OFF): the batch runs on and the
+	// divide-by-zero arrives as a real error with its text, not a synthesized
+	// "didn't provide reason".
+	rows, err = db.Query("BEGIN TRANSACTION; " +
+		"SELECT id FROM stream_err_go WHERE 10 / (id - 300) > -100; " +
+		"SELECT 7 AS after; COMMIT")
+	var continuedErr error
+	if err != nil {
+		continuedErr = err
+	} else {
+		drainInts(rows)
+		for rows.NextResultSet() {
+			drainInts(rows)
+		}
+		continuedErr = rows.Err()
+		rows.Close()
+	}
+	if continuedErr == nil {
+		fail("the continued divide-by-zero never surfaced")
+	}
+	if !strings.Contains(strings.ToLower(continuedErr.Error()), "divide") &&
+		!strings.Contains(continuedErr.Error(), "8134") {
+		fail("continued error lost its text: %v", continuedErr)
+	}
 }
 
 // parameterizedQueries exercises the sp_executesql RPC path: go-mssqldb sends

--- a/scripts/tds_conformance.py
+++ b/scripts/tds_conformance.py
@@ -160,6 +160,53 @@ def main() -> int:
         print(f"FAIL: session intrinsics: db={db!r} login={login!r} spid={spid!r}")
         return 1
 
+    # A statement that fails after its result set began streaming (the server
+    # emits rows as the scan runs since #105). The failed set is closed with a
+    # clean DONE — an error-flagged DONE without an ERROR token would make
+    # this driver raise "Request failed, server didn't send error message"
+    # and strand the results behind it.
+    cur.execute("CREATE TABLE stream_err (id INT NOT NULL PRIMARY KEY)")
+    cur.execute("INSERT INTO stream_err VALUES " +
+                ", ".join(f"({i})" for i in range(1, 401)))
+
+    # Caught mid-stream error: the batch succeeds, the CATCH set is readable.
+    cur.execute("BEGIN TRY SELECT id FROM stream_err WHERE 10 / (id - 300) > -100 END TRY "
+                "BEGIN CATCH SELECT 99 AS caught END CATCH")
+    partial = cur.fetchall()
+    if len(partial) >= 300:
+        print(f"FAIL: caught mid-stream error returned {len(partial)} rows, expected a partial set")
+        return 1
+    if not cur.nextset():
+        print("FAIL: the CATCH result set is unreachable after a caught mid-stream error")
+        return 1
+    if cur.fetchall() != [(99,)]:
+        print("FAIL: the CATCH result set did not arrive intact")
+        return 1
+
+    # Caught mid-stream error with an EMPTY catch: the whole batch reads as
+    # success (the buffered path sent one clean final DONE for this shape).
+    cur.execute("BEGIN TRY SELECT id FROM stream_err WHERE 10 / (id - 300) > -100 END TRY "
+                "BEGIN CATCH END CATCH")
+    cur.fetchall()
+    while cur.nextset():
+        cur.fetchall()
+
+    # Continued mid-stream error (XACT_ABORT OFF, in-transaction): the batch
+    # runs to the end and the real error text arrives with the final DONE.
+    try:
+        cur.execute("BEGIN TRANSACTION; "
+                    "SELECT id FROM stream_err WHERE 10 / (id - 300) > -100; "
+                    "SELECT 7 AS after; COMMIT")
+        cur.fetchall()
+        while cur.nextset():
+            cur.fetchall()
+        print("FAIL: the continued divide-by-zero never surfaced")
+        return 1
+    except pytds.tds_base.Error as e:
+        if "divide" not in str(e).lower() and "8134" not in str(e):
+            print(f"FAIL: continued error lost its text: {e}")
+            return 1
+
     conn.close()
     print("tds conformance: OK")
     return 0


### PR DESCRIPTION
Closes the executor leg of Stage 6's result streaming: #103 plumbed the event channel but `send_outcome` still streamed a *finished* `BatchOutcome`. Now each statement emits its events as it runs — a result set opens with its columns, rows follow in chunks straight off the sliced scan for the single-table shape (#101's scan path), and each statement's DONE carries the transaction state after that statement.

**Wire changes, decided deliberately:**
- `DONE_INXACT` is per statement (`BEGIN TRAN; SELECT 1; COMMIT` reads 1,1,0 — the faithful behaviour). `Complete{in_transaction}` stays batch-final: `handle_tm_request` reads it (#88).
- A statement that fails after its result set began streaming cannot take the rows back: a new `StatementAborted` event closes the set with a **clean** DONE so the stream stays framed for what follows. Clean deliberately — both CI drivers treat `DONE_ERROR` with no ERROR token as a severe failure (pytds raises "Request failed, server didn't send error message", reproduced live in review; go-mssqldb synthesizes "Request failed but didn't provide reason"). Error text still travels as the batch-final ERROR token, exactly where the buffered path put it; a caught error surfaces nothing.

**Durability keeps its ordering without a per-statement fsync:** DONEs queue in the run and flush — fsyncing first if any statement since the last durability point may have committed (kind-based, same as the old `finalize_durability`) — before the next result set opens and at batch end. A write-only batch still costs one fsync; nothing the client can rely on (a commit-acking DONE, rows carrying a reserved identity value) is emitted before the commit behind it is durable. A durability failure wedges the store, drops the DONEs it can no longer stand behind, and is uncatchable by TRY/CATCH.

**Liveness:** `stream_reply`'s io-error exits now cancel and drain the running batch like every other early exit — without that, `close_session` released a running batch's table locks and another session could read its uncommitted writes (a mid-batch socket write failure is the ordinary way a client dies mid-query, newly reachable now that rows stream during execution).

**Compatibility:** every buffered caller (`Engine::sql_batch`, native path, SLT runner) collects the same stream through `rel::Collector` into byte-identical `BatchOutcome`s; the #97 oracle still pins the renderer; the full suite passes unchanged. Conformance scripts gained TRY/CATCH mid-stream-failure cases so both real drivers adjudicate the new shapes in CI.

**Verification:** adversarial review (4 lenses, own worktrees, every finding refuted independently by 2 agents — 5 findings survived, reducing to 3 defects, all fixed and pinned by tests); every new test proven to fail with its fix removed; session test module 25/25 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)