### PR TITLE
CREATE INDEX ... INCLUDE: covering seeks over value-carrying leaves

### DIFF
--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -1431,9 +1431,16 @@ fn showplan_rows(
         {
             match resolve_table(storage, &name.value) {
                 Some(def) => {
-                    let schema = def.schema().map_err(|e| map_storage_err(e, &def.name))?;
-                    let path = plan::choose(&def, &schema, &select.where_clause, eval_ctx);
-                    plan::plan_text(&path, &def.name)
+                    // The scan shape carries the covering decision (it knows
+                    // which columns the query reads); other shapes never
+                    // cover, so the plain choose() answer is exact for them.
+                    if let Some(plan) = scan_plan(storage, select, eval_ctx) {
+                        plan::plan_text(&plan.access, &def.name, plan.covering)
+                    } else {
+                        let schema = def.schema().map_err(|e| map_storage_err(e, &def.name))?;
+                        let path = plan::choose(&def, &schema, &select.where_clause, eval_ctx);
+                        plan::plan_text(&path, &def.name, false)
+                    }
                 }
                 None => vec![format!("Table Scan({})", name.value)],
             }
@@ -1824,7 +1831,7 @@ fn exec_create_table(storage: &Storage, create: &CreateTable) -> Result<Statemen
         .map_err(|err| map_storage_err(err, table_name))?;
     for (name, cols) in unique_indexes {
         storage
-            .rel_create_index(table_name, name, cols, true)
+            .rel_create_index(table_name, name, cols, true, Vec::new())
             .map_err(|err| map_storage_err(err, table_name))?;
     }
     Ok(StatementResult::Done)
@@ -2444,6 +2451,7 @@ fn enforce_parent_fks(
                                     Some(lower),
                                     upper,
                                     None,
+                                    false,
                                 )
                                 .map_err(|e| map_storage_err(e, &child.name))?;
                             if !matches.is_empty() {
@@ -2729,8 +2737,40 @@ fn exec_create_index(storage: &Storage, create: &CreateIndex) -> Result<Statemen
             .ok_or_else(|| SqlError::invalid_column(&col.name.value).at(col.name.span))?;
         columns.push((index, col.ascending));
     }
+    // INCLUDE columns: resolved against the schema, no duplicates (1909, as
+    // SQL Server). A *key* column may be INCLUDEd — a deliberate divergence
+    // from SQL Server, which rejects that: our index keys are one-way
+    // collation sort keys, so a query reading the key column itself can only
+    // be covered by also storing its original value.
+    let mut include = Vec::with_capacity(create.include.len());
+    for col in &create.include {
+        let index = schema
+            .columns
+            .iter()
+            .position(|c| c.name.eq_ignore_ascii_case(&col.value))
+            .ok_or_else(|| SqlError::invalid_column(&col.value).at(col.span))?;
+        if include.contains(&index) {
+            return Err(SqlError::new(
+                1909,
+                16,
+                1,
+                format!(
+                    "Cannot use duplicate column names in index. Column name '{}' listed more than once.",
+                    col.value
+                ),
+            )
+            .at(col.span));
+        }
+        include.push(index);
+    }
     storage
-        .rel_create_index(&def.name, create.name.value.clone(), columns, create.unique)
+        .rel_create_index(
+            &def.name,
+            create.name.value.clone(),
+            columns,
+            create.unique,
+            include,
+        )
         .map_err(|e| map_storage_err(e, &def.name))?;
     Ok(StatementResult::Done)
 }
@@ -4896,6 +4936,11 @@ struct ScanPlan {
     /// The scanned-row position each output column reads (an index into
     /// `needed`, not into the table's columns).
     picks: Vec<usize>,
+    /// An index seek that is *covering*: every needed column's original value
+    /// is stored in the index leaves (`INCLUDE`), so the scan answers from the
+    /// index alone — no per-row base-table lookup. Never true for a table
+    /// scan.
+    covering: bool,
 }
 
 /// Recognises the shape [`scan_select`] can run, or `None` for everything else
@@ -5082,6 +5127,20 @@ fn scan_plan(storage: &Storage, select: &Select, eval_ctx: &EvalContext) -> Opti
         collations: needed.iter().map(|&i| collations[i].clone()).collect(),
     };
 
+    // A seek covers when every column the query reads is INCLUDEd in the
+    // index — original values in the leaf, since the key bytes are one-way
+    // collation sort keys and cannot serve.
+    let covering = match &access {
+        plan::AccessPath::IndexSeek {
+            index_object_id, ..
+        } => def
+            .indexes
+            .iter()
+            .find(|i| i.object_id == *index_object_id)
+            .is_some_and(|i| needed.iter().all(|c| i.include.contains(c))),
+        plan::AccessPath::TableScan => false,
+    };
+
     Some(ScanPlan {
         table: def.name,
         access,
@@ -5090,6 +5149,7 @@ fn scan_plan(storage: &Storage, select: &Select, eval_ctx: &EvalContext) -> Opti
         resolver,
         columns,
         picks,
+        covering,
     })
 }
 
@@ -5317,6 +5377,7 @@ fn scan_select_rows(
                     lower.clone(),
                     upper.clone(),
                     Some(&plan.needed),
+                    plan.covering,
                 )
                 .map_err(|err| map_storage_err(err, &plan.table))?;
             for row in rows {
@@ -6386,7 +6447,7 @@ fn build_table_source(
                     upper,
                     ..
                 } => storage
-                    .rel_index_scan(&def.name, index_object_id, lower, upper, None)
+                    .rel_index_scan(&def.name, index_object_id, lower, upper, None, false)
                     .map_err(|err| map_storage_err(err, &def.name))?,
             };
             let columns = schema

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -1438,7 +1438,8 @@ fn showplan_rows(
                         plan::plan_text(&plan.access, &def.name, plan.covering)
                     } else {
                         let schema = def.schema().map_err(|e| map_storage_err(e, &def.name))?;
-                        let path = plan::choose(&def, &schema, &select.where_clause, eval_ctx);
+                        let path =
+                            plan::choose(&def, &schema, &select.where_clause, eval_ctx, None);
                         plan::plan_text(&path, &def.name, false)
                     }
                 }
@@ -2734,7 +2735,7 @@ fn exec_create_index(storage: &Storage, create: &CreateIndex) -> Result<Statemen
             .columns
             .iter()
             .position(|c| c.name.eq_ignore_ascii_case(&col.name.value))
-            .ok_or_else(|| SqlError::invalid_column(&col.name.value).at(col.name.span))?;
+            .ok_or_else(|| index_column_missing(&col.name.value, &def.name).at(col.name.span))?;
         columns.push((index, col.ascending));
     }
     // INCLUDE columns: resolved against the schema, no duplicates (1909, as
@@ -2748,7 +2749,7 @@ fn exec_create_index(storage: &Storage, create: &CreateIndex) -> Result<Statemen
             .columns
             .iter()
             .position(|c| c.name.eq_ignore_ascii_case(&col.value))
-            .ok_or_else(|| SqlError::invalid_column(&col.value).at(col.span))?;
+            .ok_or_else(|| index_column_missing(&col.value, &def.name).at(col.span))?;
         if include.contains(&index) {
             return Err(SqlError::new(
                 1909,
@@ -2773,6 +2774,17 @@ fn exec_create_index(storage: &Storage, create: &CreateIndex) -> Result<Statemen
         )
         .map_err(|e| map_storage_err(e, &def.name))?;
     Ok(StatementResult::Done)
+}
+
+/// SQL Server's 1911 for a `CREATE INDEX` column (key or `INCLUDE`) that does
+/// not exist on the target table — where most statements answer 207.
+fn index_column_missing(column: &str, table: &str) -> SqlError {
+    SqlError::new(
+        1911,
+        16,
+        1,
+        format!("Column name '{column}' does not exist in the target table or view '{table}'."),
+    )
 }
 
 fn exec_drop_index(storage: &Storage, drop: &DropIndex) -> Result<StatementResult, SqlError> {
@@ -5017,11 +5029,6 @@ fn scan_plan(storage: &Storage, select: &Select, eval_ctx: &EvalContext) -> Opti
         return None;
     }
     let schema = def.schema().ok()?;
-    // The same access path `build_table_source` would take. Taking it here too,
-    // rather than declining a seek, is what keeps this gate free for the queries
-    // it rejects: a decline would have thrown away the definition, the schema
-    // and this choice, and `build_table_source` would compute all three again.
-    let access = plan::choose(&def, &schema, &select.where_clause, eval_ctx);
 
     let qualifier = alias
         .as_ref()
@@ -5110,6 +5117,16 @@ fn scan_plan(storage: &Storage, select: &Select, eval_ctx: &EvalContext) -> Opti
     );
     needed.sort_unstable();
     needed.dedup();
+
+    // The same access path `build_table_source` would take (it passes no
+    // `needed`, so its choice can differ only toward a covering index — and it
+    // never reaches this shape). Choosing here, rather than declining a seek,
+    // is what keeps this gate free for the queries it rejects: a decline would
+    // have thrown away the definition, the schema and this choice, and
+    // `build_table_source` would compute all three again. Chosen after
+    // `needed` is known so a covering index can win its tie (see
+    // [`plan::choose`]).
+    let access = plan::choose(&def, &schema, &select.where_clause, eval_ctx, Some(&needed));
 
     // Everything downstream now speaks in the scanned row's coordinates.
     let position = |index: usize| {
@@ -6434,7 +6451,7 @@ fn build_table_source(
             let schema = def.schema().map_err(|e| map_storage_err(e, &def.name))?;
             // An index seek narrows the candidate set; the WHERE filter later
             // re-checks, so results match a full scan.
-            let rows = match plan::choose(&def, &schema, where_clause, eval_ctx) {
+            let rows = match plan::choose(&def, &schema, where_clause, eval_ctx, None) {
                 // Sliced: a read holds the table's lock, so it need not also
                 // hold the storage lock for the whole table and block every
                 // other session while it walks.

--- a/crates/truthdb-core/src/rel/plan.rs
+++ b/crates/truthdb-core/src/rel/plan.rs
@@ -72,8 +72,10 @@ pub fn choose(
     best.map(|(_, path)| path).unwrap_or(AccessPath::TableScan)
 }
 
-/// Renders the plan as `SHOWPLAN_TEXT` rows.
-pub fn plan_text(path: &AccessPath, table: &str) -> Vec<String> {
+/// Renders the plan as `SHOWPLAN_TEXT` rows. A covering seek (every needed
+/// column INCLUDEd in the leaf) answers from the index alone, so it has no
+/// Key Lookup line.
+pub fn plan_text(path: &AccessPath, table: &str, covering: bool) -> Vec<String> {
     match path {
         AccessPath::TableScan => vec![format!("Table Scan({table})")],
         AccessPath::IndexSeek {
@@ -82,18 +84,19 @@ pub fn plan_text(path: &AccessPath, table: &str) -> Vec<String> {
             unique,
             ..
         } => {
-            let kind = if *unique {
-                "Index Seek (unique)"
-            } else {
-                "Index Seek"
+            let kind = match (covering, *unique) {
+                (true, _) => "Index Seek (covering)",
+                (false, true) => "Index Seek (unique)",
+                (false, false) => "Index Seek",
             };
-            vec![
-                format!(
-                    "{kind}({table}.{index_name}), SEEK: {}",
-                    predicates.join(", ")
-                ),
-                format!("Key Lookup({table})"),
-            ]
+            let mut lines = vec![format!(
+                "{kind}({table}.{index_name}), SEEK: {}",
+                predicates.join(", ")
+            )];
+            if !covering {
+                lines.push(format!("Key Lookup({table})"));
+            }
+            lines
         }
     }
 }

--- a/crates/truthdb-core/src/rel/plan.rs
+++ b/crates/truthdb-core/src/rel/plan.rs
@@ -43,12 +43,18 @@ type Bounds = (Option<Vec<u8>>, Option<Vec<u8>>);
 
 /// Chooses the access path for a table read given its WHERE clause. Prefers
 /// the index matching the most equality columns (a fully-matched UNIQUE index
-/// — a unique seek — wins outright), else a range seek, else a scan.
+/// — a unique seek — wins outright), else a range seek, else a scan. Among
+/// equality-equal candidates, one whose `INCLUDE` list covers every column
+/// the query reads (`needed`, when the caller knows it) wins: it answers
+/// from its leaves with no per-row base-table lookup. Coverage never
+/// outranks a better equality match or a fully-matched UNIQUE seek — a
+/// single-row lookup beats a covering scan of many.
 pub fn choose(
     def: &TableDef,
     schema: &Schema,
     where_clause: &Option<Expr>,
     eval_ctx: &EvalContext,
+    needed: Option<&[usize]>,
 ) -> AccessPath {
     let Some(predicate) = where_clause else {
         return AccessPath::TableScan;
@@ -63,10 +69,18 @@ pub fn choose(
     }
     let mut best: Option<(u32, AccessPath)> = None;
     for index in &def.indexes {
-        if let Some((score, path)) = try_index(index, schema, &sargs)
-            && best.as_ref().is_none_or(|(s, _)| score > *s)
-        {
-            best = Some((score, path));
+        if let Some((mut score, path)) = try_index(index, schema, &sargs) {
+            let covers =
+                needed.is_some_and(|needed| needed.iter().all(|c| index.include.contains(c)));
+            if covers {
+                // Between the range bonus (+1) and an extra equality column
+                // (+10): an avoided lookup per row outranks a somewhat
+                // narrower range, never a more selective seek.
+                score += 5;
+            }
+            if best.as_ref().is_none_or(|(s, _)| score > *s) {
+                best = Some((score, path));
+            }
         }
     }
     best.map(|(_, path)| path).unwrap_or(AccessPath::TableScan)

--- a/crates/truthdb-core/src/relstore/catalog.rs
+++ b/crates/truthdb-core/src/relstore/catalog.rs
@@ -45,6 +45,14 @@ pub struct IndexDef {
     pub unique: bool,
     /// The index tree's root page.
     pub root_page: u64,
+    /// Schema column indices of `INCLUDE`d columns: their *original* values are
+    /// stored in the leaf (after the locator), so a query whose every column is
+    /// included can be answered from the index alone — the key bytes cannot
+    /// serve, being one-way collation sort keys. Empty for an index created
+    /// without `INCLUDE` (and for every pre-existing index: `serde(default)`),
+    /// which also keeps the old locator-only leaf-value format for them.
+    #[serde(default)]
+    pub include: Vec<usize>,
 }
 
 /// A `CHECK` constraint. The predicate is stored as source text (re-parsed and

--- a/crates/truthdb-core/src/relstore/index.rs
+++ b/crates/truthdb-core/src/relstore/index.rs
@@ -16,6 +16,7 @@
 
 use crate::relstore::heap::Rid;
 use crate::relstore::key::encode_datum_collated;
+use crate::relstore::row::{Schema, decode_row, encode_row};
 use crate::relstore::types::{Datum, TypeError};
 
 /// The collation of the schema column at `index` (empty/short slice → the
@@ -135,19 +136,81 @@ pub fn decode_locator(bytes: &[u8]) -> Locator {
 }
 
 /// The `(leaf key, leaf value)` an index entry stores for one row, given the
-/// row's index-column encoding and its locator. Non-unique indexes append the
-/// locator to the key for uniqueness; unique indexes do not.
-pub fn leaf_entry(index_key: &[u8], locator: &Locator, unique: bool) -> (Vec<u8>, Vec<u8>) {
-    let value = encode_locator(locator);
+/// row's index-column encoding, its locator, and — for an `INCLUDE` index —
+/// the encoded included-column values. Non-unique indexes append the locator
+/// to the key for uniqueness; unique indexes do not. The key never carries
+/// include bytes (they would break both dedup semantics and seek bounds).
+///
+/// Value format: a bare locator for an index without `INCLUDE` (the
+/// pre-INCLUDE format, unchanged for every existing index), or
+/// `locator_len u16 LE | locator | include row bytes` when include values are
+/// present. The reader picks the format from the catalog's
+/// [`IndexDef::include`](crate::relstore::catalog::IndexDef::include), so the
+/// two never mix within one index — a `Locator::Key` payload otherwise
+/// consumes the rest of the value, which is why the length prefix exists.
+pub fn leaf_entry(
+    index_key: &[u8],
+    locator: &Locator,
+    unique: bool,
+    include: Option<&[u8]>,
+) -> (Vec<u8>, Vec<u8>) {
+    let locator_bytes = encode_locator(locator);
     let key = if unique {
         index_key.to_vec()
     } else {
-        let mut key = Vec::with_capacity(index_key.len() + value.len());
+        let mut key = Vec::with_capacity(index_key.len() + locator_bytes.len());
         key.extend_from_slice(index_key);
-        key.extend_from_slice(&value);
+        key.extend_from_slice(&locator_bytes);
         key
     };
+    let value = match include {
+        None => locator_bytes,
+        Some(bytes) => {
+            let mut value = Vec::with_capacity(2 + locator_bytes.len() + bytes.len());
+            value.extend_from_slice(&(locator_bytes.len() as u16).to_le_bytes());
+            value.extend_from_slice(&locator_bytes);
+            value.extend_from_slice(bytes);
+            value
+        }
+    };
     (key, value)
+}
+
+/// Splits an `INCLUDE` index's leaf value into its locator and the included
+/// columns' row bytes (inverse of the `Some` arm of [`leaf_entry`]).
+pub fn decode_leaf_value_with_include(bytes: &[u8]) -> (Locator, &[u8]) {
+    let locator_len = u16::from_le_bytes(bytes[0..2].try_into().unwrap()) as usize;
+    let locator = decode_locator(&bytes[2..2 + locator_len]);
+    (locator, &bytes[2 + locator_len..])
+}
+
+/// The included columns' sub-schema, in `include` order. Their values are
+/// stored through the ordinary row codec over this schema, so NULLs and
+/// variable-length values need no special casing.
+pub fn include_schema(schema: &Schema, include: &[usize]) -> Schema {
+    Schema {
+        columns: include.iter().map(|&i| schema.columns[i].clone()).collect(),
+    }
+}
+
+/// Encodes a row's included-column values (original values, not key-folded —
+/// recoverability is the whole point of `INCLUDE`).
+pub fn encode_include(
+    schema: &Schema,
+    include: &[usize],
+    values: &[Datum],
+) -> Result<Vec<u8>, TypeError> {
+    let sub: Vec<Datum> = include.iter().map(|&i| values[i].clone()).collect();
+    encode_row(&include_schema(schema, include), &sub)
+}
+
+/// Decodes an `INCLUDE` leaf's stored values, in `include` order.
+pub fn decode_include(
+    schema: &Schema,
+    include: &[usize],
+    bytes: &[u8],
+) -> Result<Vec<Datum>, TypeError> {
+    decode_row(&include_schema(schema, include), bytes)
 }
 
 #[cfg(test)]
@@ -217,10 +280,58 @@ mod tests {
     fn unique_key_omits_locator_but_non_unique_appends_it() {
         let index_key = vec![0x01, 0x2a];
         let locator = Locator::Rid(Rid { page: 7, slot: 3 });
-        let (uk, uv) = leaf_entry(&index_key, &locator, true);
+        let (uk, uv) = leaf_entry(&index_key, &locator, true, None);
         assert_eq!(uk, index_key, "unique index key is the columns alone");
         assert_eq!(decode_locator(&uv), locator);
-        let (nk, _) = leaf_entry(&index_key, &locator, false);
+        let (nk, _) = leaf_entry(&index_key, &locator, false, None);
         assert!(nk.starts_with(&index_key) && nk.len() > index_key.len());
+    }
+
+    #[test]
+    fn include_value_round_trips_and_key_stays_locator_only() {
+        use crate::relstore::row::Column;
+        use crate::relstore::types::ColumnType;
+
+        let schema = Schema {
+            columns: vec![
+                Column {
+                    name: "id".into(),
+                    column_type: ColumnType::Int,
+                    nullable: false,
+                    collation: None,
+                },
+                Column {
+                    name: "name".into(),
+                    column_type: ColumnType::VarChar { max_len: 20 },
+                    nullable: true,
+                    collation: None,
+                },
+                Column {
+                    name: "v".into(),
+                    column_type: ColumnType::Int,
+                    nullable: true,
+                    collation: None,
+                },
+            ],
+        };
+        let include = vec![2usize, 1usize];
+        let row = vec![Datum::Int(7), Datum::VarChar("MiXeD".into()), Datum::Null];
+        let bytes = encode_include(&schema, &include, &row).expect("encode");
+        // Both locator kinds round-trip through the length-prefixed value —
+        // a Key locator's payload would otherwise swallow the include bytes.
+        for locator in [
+            Locator::Rid(Rid { page: 7, slot: 3 }),
+            Locator::Key(vec![9, 9, 9, 9]),
+        ] {
+            let index_key = vec![0x01, 0x2a];
+            let (key, value) = leaf_entry(&index_key, &locator, false, Some(&bytes));
+            let bare = leaf_entry(&index_key, &locator, false, None).0;
+            assert_eq!(key, bare, "include bytes never reach the key");
+            let (got_locator, got_bytes) = decode_leaf_value_with_include(&value);
+            assert_eq!(got_locator, locator);
+            let decoded = decode_include(&schema, &include, got_bytes).expect("decode");
+            // Original values, in include order, case preserved.
+            assert_eq!(decoded, vec![Datum::Null, Datum::VarChar("MiXeD".into())]);
+        }
     }
 }

--- a/crates/truthdb-core/src/storage.rs
+++ b/crates/truthdb-core/src/storage.rs
@@ -3300,6 +3300,79 @@ mod tests {
         let _ = std::fs::remove_file(&path);
     }
 
+    /// A covering index wins its tie against an equal-scoring non-INCLUDE
+    /// index — the "add a covering index to an existing database" workflow.
+    /// Coverage breaks equality ties only: it never outranks a fully-matched
+    /// UNIQUE seek (one row plus one lookup beats a covering scan).
+    #[test]
+    fn a_covering_index_wins_the_tie_against_an_older_plain_index() {
+        use crate::rel::{TxnContext, execute_batch};
+
+        let path = unique_temp_path("include-tiebreak");
+        let storage = Storage::create(path.clone(), test_storage_options()).expect("create");
+        let mut ctx = TxnContext::default();
+        // The plain index is created FIRST, so a first-wins tie keeps it.
+        let setup = execute_batch(
+            &storage,
+            "CREATE TABLE t (id INT NOT NULL PRIMARY KEY, email VARCHAR(40) NOT NULL, v INT); \
+             CREATE INDEX ix ON t (email); \
+             CREATE INDEX ix2 ON t (email) INCLUDE (email, v); \
+             INSERT INTO t VALUES (1, 'a@x.com', 10)",
+            &mut ctx,
+        );
+        assert!(setup.error.is_none(), "{:?}", setup.error);
+        let outcome = execute_batch(
+            &storage,
+            "SELECT email, v FROM t WHERE email = 'a@x.com'",
+            &mut ctx,
+        );
+        assert!(outcome.error.is_none(), "{:?}", outcome.error);
+        assert_eq!(
+            storage.covering_scans(),
+            1,
+            "the covering index wins the equality tie"
+        );
+
+        drop(storage);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// CREATE INDEX with a column that does not exist on the table reports
+    /// SQL Server's 1911 (not the generic 207) — for the key list and the
+    /// INCLUDE list alike; a duplicate INCLUDE column reports 1909.
+    #[test]
+    fn create_index_errors_carry_sql_server_numbers() {
+        use crate::rel::{TxnContext, execute_batch};
+
+        let path = unique_temp_path("include-errors");
+        let storage = Storage::create(path.clone(), test_storage_options()).expect("create");
+        let mut ctx = TxnContext::default();
+        let setup = execute_batch(
+            &storage,
+            "CREATE TABLE t (id INT NOT NULL PRIMARY KEY, email VARCHAR(40) NOT NULL)",
+            &mut ctx,
+        );
+        assert!(setup.error.is_none(), "{:?}", setup.error);
+
+        let cases = [
+            ("CREATE INDEX ix ON t (nope)", 1911),
+            ("CREATE INDEX ix ON t (email) INCLUDE (nope)", 1911),
+            ("CREATE INDEX ix ON t (email) INCLUDE (id, id)", 1909),
+        ];
+        for (sql, number) in cases {
+            let outcome = execute_batch(&storage, sql, &mut ctx);
+            assert_eq!(
+                outcome.error.as_ref().map(|e| e.number),
+                Some(number),
+                "{sql}: {:?}",
+                outcome.error
+            );
+        }
+
+        drop(storage);
+        let _ = std::fs::remove_file(&path);
+    }
+
     /// Included leaf values follow UPDATE and DELETE, and survive a restart
     /// (the include list rides the catalog; the leaf format rides the pages).
     #[test]

--- a/crates/truthdb-core/src/storage.rs
+++ b/crates/truthdb-core/src/storage.rs
@@ -144,6 +144,8 @@ pub struct Storage {
     /// are the same code agrees with itself. Per-instance for the same reason.
     #[cfg(test)]
     scan_selects: std::sync::atomic::AtomicUsize,
+    #[cfg(test)]
+    covering_scans: std::sync::atomic::AtomicUsize,
     /// Columns the last scan slice asked for (`usize::MAX` = the whole row), so
     /// a test can prove the planner pruned the projection. The rows returned are
     /// identical either way, so nothing else can see the difference.
@@ -205,6 +207,8 @@ impl Storage {
             #[cfg(test)]
             scan_selects: std::sync::atomic::AtomicUsize::new(0),
             #[cfg(test)]
+            covering_scans: std::sync::atomic::AtomicUsize::new(0),
+            #[cfg(test)]
             last_scan_width: std::sync::atomic::AtomicUsize::new(usize::MAX),
         })
     }
@@ -219,6 +223,13 @@ impl Storage {
     #[cfg(test)]
     pub(crate) fn scan_selects(&self) -> usize {
         self.scan_selects.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// Index scans answered from the leaves alone (covering, no base lookup).
+    #[cfg(test)]
+    pub(crate) fn covering_scans(&self) -> usize {
+        self.covering_scans
+            .load(std::sync::atomic::Ordering::Relaxed)
     }
 
     /// Columns the last scan slice decoded per row (`usize::MAX` = every one).
@@ -423,9 +434,10 @@ impl Storage {
         index_name: String,
         columns: Vec<(usize, bool)>,
         unique: bool,
+        include: Vec<usize>,
     ) -> Result<(), StorageError> {
         self.lock()
-            .rel_create_index(table, index_name, columns, unique)
+            .rel_create_index(table, index_name, columns, unique, include)
     }
 
     pub(crate) fn rel_drop_index(
@@ -443,9 +455,15 @@ impl Storage {
         lower: Option<Vec<u8>>,
         upper: Option<Vec<u8>>,
         projection: Option<&[usize]>,
+        covering: bool,
     ) -> Result<Vec<Vec<Datum>>, StorageError> {
+        #[cfg(test)]
+        if covering {
+            self.covering_scans
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        }
         self.lock()
-            .rel_index_scan(table, index_object_id, lower, upper, projection)
+            .rel_index_scan(table, index_object_id, lower, upper, projection, covering)
     }
 
     pub fn rel_insert(&self, name: &str, values: Vec<Datum>) -> Result<(), StorageError> {
@@ -687,6 +705,7 @@ fn index_insert_row(
     ctx: &mut RelCtx<'_>,
     txn: &mut TxnLink,
     indexes: &[IndexDef],
+    schema: &Schema,
     collations: &[Option<String>],
     values: &[Datum],
     locator: &Locator,
@@ -694,7 +713,15 @@ fn index_insert_row(
     for index in indexes {
         let index_key = index::encode_index_columns(values, &index.columns, collations)
             .map_err(|err| StorageError::InvalidConfig(err.0))?;
-        let (key, value) = index::leaf_entry(&index_key, locator, index.unique);
+        let include = if index.include.is_empty() {
+            None
+        } else {
+            Some(
+                index::encode_include(schema, &index.include, values)
+                    .map_err(|err| StorageError::InvalidConfig(err.0))?,
+            )
+        };
+        let (key, value) = index::leaf_entry(&index_key, locator, index.unique, include.as_deref());
         let tree = BTree {
             object_id: index.object_id,
             root: index.root_page,
@@ -719,6 +746,7 @@ fn apply_index_updates(
     ctx: &mut RelCtx<'_>,
     txn: &mut TxnLink,
     indexes: &[IndexDef],
+    schema: &Schema,
     collations: &[Option<String>],
     ops: &[(Vec<Datum>, Locator, Vec<Datum>, Locator)],
 ) -> Result<(), StorageError> {
@@ -729,7 +757,15 @@ fn apply_index_updates(
         index_delete_row(ctx, txn, indexes, collations, old_values, old_locator)?;
     }
     for (_, _, new_values, new_locator) in ops {
-        index_insert_row(ctx, txn, indexes, collations, new_values, new_locator)?;
+        index_insert_row(
+            ctx,
+            txn,
+            indexes,
+            schema,
+            collations,
+            new_values,
+            new_locator,
+        )?;
     }
     Ok(())
 }
@@ -746,7 +782,7 @@ fn index_delete_row(
     for index in indexes {
         let index_key = index::encode_index_columns(values, &index.columns, collations)
             .map_err(|err| StorageError::InvalidConfig(err.0))?;
-        let (key, _) = index::leaf_entry(&index_key, locator, index.unique);
+        let (key, _) = index::leaf_entry(&index_key, locator, index.unique, None);
         let tree = BTree {
             object_id: index.object_id,
             root: index.root_page,
@@ -1078,6 +1114,7 @@ impl StorageFile {
         index_name: String,
         columns: Vec<(usize, bool)>,
         unique: bool,
+        include: Vec<usize>,
     ) -> Result<(), StorageError> {
         self.ensure_rel_usable()?;
         let mut def = self
@@ -1103,6 +1140,7 @@ impl StorageFile {
         // Snapshot the rows to backfill (materialized before any mutation).
         let located = self.rel_scan_located(table)?;
 
+        let schema = def.schema()?;
         let updated = self.rel_statement(move |ctx, txn| {
             let tree = BTree::create(ctx, object_id)?;
             for (loc, values) in &located {
@@ -1112,7 +1150,16 @@ impl StorageFile {
                 };
                 let index_key = index::encode_index_columns(values, &columns, &def.collations)
                     .map_err(|err| StorageError::InvalidConfig(err.0))?;
-                let (key, value) = index::leaf_entry(&index_key, &locator, unique);
+                let include_bytes = if include.is_empty() {
+                    None
+                } else {
+                    Some(
+                        index::encode_include(&schema, &include, values)
+                            .map_err(|err| StorageError::InvalidConfig(err.0))?,
+                    )
+                };
+                let (key, value) =
+                    index::leaf_entry(&index_key, &locator, unique, include_bytes.as_deref());
                 // Backfill is system-logged: the fresh tree is not in the
                 // rollback roots, so a failure leaks it (the catalog entry
                 // below is undone, leaving it unreferenced).
@@ -1131,6 +1178,7 @@ impl StorageFile {
                 columns,
                 unique,
                 root_page: tree.root,
+                include,
             });
             catalog::update_table(ctx, &mut OpMode::Txn(txn), catalog_root, &def)?;
             Ok(def)
@@ -1190,6 +1238,7 @@ impl StorageFile {
         lower: Option<Vec<u8>>,
         upper: Option<Vec<u8>>,
         projection: Option<&[usize]>,
+        covering: bool,
     ) -> Result<Vec<Vec<Datum>>, StorageError> {
         self.ensure_rel_usable()?;
         let (def, schema) = self.rel_def(table)?;
@@ -1206,28 +1255,66 @@ impl StorageFile {
         };
         let entries = index_tree.scan_range(&mut ctx, lower.as_deref(), upper.as_deref())?;
         let mut rows = Vec::with_capacity(entries.len());
-        if def.is_tree() {
-            let base = BTree {
-                object_id: def.object_id,
-                root: def.root_page,
-            };
+        if covering {
+            // Answer from the leaves alone: every projected column's original
+            // value is stored in the entry (after the length-prefixed
+            // locator), so the base-table lookup is skipped entirely. The
+            // planner only chooses covering when projection ⊆ include; this
+            // re-checks so a planner bug reads as an error, not wrong data.
+            let projection = projection.ok_or_else(|| {
+                StorageError::InvalidConfig("covering scan requires a projection".to_string())
+            })?;
+            let positions: Vec<usize> = projection
+                .iter()
+                .map(|col| {
+                    index.include.iter().position(|i| i == col).ok_or_else(|| {
+                        StorageError::InvalidConfig(format!(
+                            "column {col} is not included in index '{}'",
+                            index.name
+                        ))
+                    })
+                })
+                .collect::<Result<_, _>>()?;
             for (_, value) in entries {
-                if let Locator::Key(pk) = index::decode_locator(&value)
-                    && let Some(row) = base.get(&mut ctx, &pk)?
-                {
-                    rows.push(decode_projected(&schema, &row, projection)?);
-                }
+                let (_, include_bytes) = index::decode_leaf_value_with_include(&value);
+                let decoded = index::decode_include(&schema, &index.include, include_bytes)
+                    .map_err(|err| StorageError::InvalidFile(err.0))?;
+                rows.push(positions.iter().map(|&p| decoded[p].clone()).collect());
             }
         } else {
-            let heap = Heap {
-                object_id: def.object_id,
-                first_page: def.root_page,
+            // The leaf-value format depends on the index: an INCLUDE index
+            // length-prefixes its locator (a Key locator's payload would
+            // otherwise swallow the include bytes that follow it).
+            let locator_of = |value: &[u8]| -> Locator {
+                if index.include.is_empty() {
+                    index::decode_locator(value)
+                } else {
+                    index::decode_leaf_value_with_include(value).0
+                }
             };
-            for (_, value) in entries {
-                if let Locator::Rid(rid) = index::decode_locator(&value)
-                    && let Some(row) = heap.read_row(&mut ctx, rid)?
-                {
-                    rows.push(decode_projected(&schema, &row, projection)?);
+            if def.is_tree() {
+                let base = BTree {
+                    object_id: def.object_id,
+                    root: def.root_page,
+                };
+                for (_, value) in entries {
+                    if let Locator::Key(pk) = locator_of(&value)
+                        && let Some(row) = base.get(&mut ctx, &pk)?
+                    {
+                        rows.push(decode_projected(&schema, &row, projection)?);
+                    }
+                }
+            } else {
+                let heap = Heap {
+                    object_id: def.object_id,
+                    first_page: def.root_page,
+                };
+                for (_, value) in entries {
+                    if let Locator::Rid(rid) = locator_of(&value)
+                        && let Some(row) = heap.read_row(&mut ctx, rid)?
+                    {
+                        rows.push(decode_projected(&schema, &row, projection)?);
+                    }
                 }
             }
         }
@@ -1286,6 +1373,7 @@ impl StorageFile {
                         ctx,
                         txn,
                         &indexes,
+                        &schema,
                         &collations,
                         values,
                         &Locator::Key(key.clone()),
@@ -1302,7 +1390,15 @@ impl StorageFile {
                 for ((_, row), values) in encoded.iter().zip(rows.iter()) {
                     // Heap rows locate by their home RID.
                     let rid = heap.insert(ctx, txn, row)?;
-                    index_insert_row(ctx, txn, &indexes, &collations, values, &Locator::Rid(rid))?;
+                    index_insert_row(
+                        ctx,
+                        txn,
+                        &indexes,
+                        &schema,
+                        &collations,
+                        values,
+                        &Locator::Rid(rid),
+                    )?;
                 }
                 Ok(())
             })
@@ -1747,7 +1843,7 @@ impl StorageFile {
                 for (key, row) in &in_place {
                     tree.update(ctx, &mut OpMode::Txn(txn), key, row)?;
                 }
-                apply_index_updates(ctx, txn, &indexes, &collations, &idx_ops)?;
+                apply_index_updates(ctx, txn, &indexes, &schema, &collations, &idx_ops)?;
                 Ok(())
             })?;
         } else {
@@ -1773,7 +1869,7 @@ impl StorageFile {
                 for (rid, row) in &encoded {
                     heap.update(ctx, txn, *rid, row)?;
                 }
-                apply_index_updates(ctx, txn, &indexes, &collations, &idx_ops)?;
+                apply_index_updates(ctx, txn, &indexes, &schema, &collations, &idx_ops)?;
                 Ok(())
             })?;
         }
@@ -3148,6 +3244,179 @@ mod tests {
             TEST_WAL_BYTES,
         )
         .expect("create storage")
+    }
+
+    /// A covering seek (every read column INCLUDEd) answers from the index
+    /// leaves alone — the counter proves the covering path ran — and returns
+    /// exactly what a table scan returns, original case and NULLs included.
+    #[test]
+    fn a_covering_seek_answers_from_the_index_alone_and_matches_a_scan() {
+        use crate::rel::{StatementResult, TxnContext, execute_batch};
+
+        let path = unique_temp_path("include-covering");
+        let storage = Storage::create(path.clone(), test_storage_options()).expect("create");
+        let mut ctx = TxnContext::default();
+        let setup = execute_batch(
+            &storage,
+            "CREATE TABLE t (id INT NOT NULL PRIMARY KEY, email VARCHAR(40) NOT NULL, v INT); \
+             CREATE INDEX ix ON t (email) INCLUDE (email, v); \
+             INSERT INTO t VALUES (1, 'a@x.com', 10), (2, 'B@X.com', NULL), (3, 'c@x.com', 30)",
+            &mut ctx,
+        );
+        assert!(setup.error.is_none(), "{:?}", setup.error);
+
+        let rows_of = |outcome: &crate::rel::BatchOutcome| match &outcome.results[0] {
+            StatementResult::Rows(rowset) => rowset.rows.clone(),
+            other => panic!("expected rows, got {other:?}"),
+        };
+
+        // Sought case-insensitively, answered with the stored ORIGINAL value.
+        let covered = execute_batch(
+            &storage,
+            "SELECT email, v FROM t WHERE email = 'b@x.com'",
+            &mut ctx,
+        );
+        assert!(covered.error.is_none(), "{:?}", covered.error);
+        assert_eq!(storage.covering_scans(), 1, "the covering path answered");
+        let covered = rows_of(&covered);
+        assert_eq!(
+            covered,
+            vec![vec![Datum::VarChar("B@X.com".into()), Datum::Null]]
+        );
+
+        // A/B: without the index the same query scans — identical rows.
+        let dropped = execute_batch(&storage, "DROP INDEX ix ON t", &mut ctx);
+        assert!(dropped.error.is_none(), "{:?}", dropped.error);
+        let scanned = execute_batch(
+            &storage,
+            "SELECT email, v FROM t WHERE email = 'b@x.com'",
+            &mut ctx,
+        );
+        assert!(scanned.error.is_none(), "{:?}", scanned.error);
+        assert_eq!(rows_of(&scanned), covered, "covering == scan");
+        assert_eq!(storage.covering_scans(), 1, "the scan path took over");
+
+        drop(storage);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// Included leaf values follow UPDATE and DELETE, and survive a restart
+    /// (the include list rides the catalog; the leaf format rides the pages).
+    #[test]
+    fn included_values_survive_update_delete_and_restart() {
+        use crate::rel::{StatementResult, TxnContext, execute_batch};
+
+        let path = unique_temp_path("include-restart");
+        let storage = Storage::create(path.clone(), test_storage_options()).expect("create");
+        let mut ctx = TxnContext::default();
+        let setup = execute_batch(
+            &storage,
+            "CREATE TABLE t (id INT NOT NULL PRIMARY KEY, email VARCHAR(40) NOT NULL, v INT); \
+             CREATE INDEX ix ON t (email) INCLUDE (email, v); \
+             INSERT INTO t VALUES (1, 'a@x.com', 10), (2, 'b@x.com', 20); \
+             UPDATE t SET v = 99 WHERE id = 1; \
+             DELETE FROM t WHERE id = 2",
+            &mut ctx,
+        );
+        assert!(setup.error.is_none(), "{:?}", setup.error);
+        drop(storage);
+
+        let storage = Storage::open(path.clone()).expect("reopen");
+        let mut ctx = TxnContext::default();
+        let outcome = execute_batch(
+            &storage,
+            "SELECT email, v FROM t WHERE email = 'a@x.com'",
+            &mut ctx,
+        );
+        assert!(outcome.error.is_none(), "{:?}", outcome.error);
+        assert_eq!(storage.covering_scans(), 1, "covering after reopen");
+        match &outcome.results[0] {
+            StatementResult::Rows(rowset) => assert_eq!(
+                rowset.rows,
+                vec![vec![Datum::VarChar("a@x.com".into()), Datum::Int(99)]],
+                "the UPDATE reached the leaf; the DELETEd row is gone"
+            ),
+            other => panic!("expected rows, got {other:?}"),
+        }
+        let gone = execute_batch(
+            &storage,
+            "SELECT email, v FROM t WHERE email = 'b@x.com'",
+            &mut ctx,
+        );
+        match &gone.results[0] {
+            StatementResult::Rows(rowset) => assert!(rowset.rows.is_empty()),
+            other => panic!("expected rows, got {other:?}"),
+        }
+
+        drop(storage);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// A query reading a column that is NOT included falls back to the key
+    /// lookup — through the INCLUDE index's length-prefixed leaf value, whose
+    /// `Locator::Key` payload would be swallowed by the old bare decode.
+    /// SHOWPLAN tells the two apart: covering has no Key Lookup line.
+    #[test]
+    fn a_non_covering_read_on_an_include_index_still_finds_rows() {
+        use crate::rel::{StatementResult, TxnContext, execute_batch};
+
+        let path = unique_temp_path("include-fallback");
+        let storage = Storage::create(path.clone(), test_storage_options()).expect("create");
+        let mut ctx = TxnContext::default();
+        let setup = execute_batch(
+            &storage,
+            "CREATE TABLE t (id INT NOT NULL PRIMARY KEY, email VARCHAR(40) NOT NULL, name VARCHAR(20)); \
+             CREATE INDEX ix ON t (email) INCLUDE (email, id); \
+             INSERT INTO t VALUES (1, 'a@x.com', 'Alice')",
+            &mut ctx,
+        );
+        assert!(setup.error.is_none(), "{:?}", setup.error);
+
+        // `name` is not included: the seek fetches the base row by PK key.
+        let outcome = execute_batch(
+            &storage,
+            "SELECT name FROM t WHERE email = 'a@x.com'",
+            &mut ctx,
+        );
+        assert!(outcome.error.is_none(), "{:?}", outcome.error);
+        assert_eq!(storage.covering_scans(), 0, "not covering");
+        match &outcome.results[0] {
+            StatementResult::Rows(rowset) => {
+                assert_eq!(rowset.rows, vec![vec![Datum::VarChar("Alice".into())]]);
+            }
+            other => panic!("expected rows, got {other:?}"),
+        }
+
+        // SHOWPLAN: the covering shape has no Key Lookup; the fallback does.
+        let plans = execute_batch(
+            &storage,
+            "SET SHOWPLAN_TEXT ON; \
+             SELECT id FROM t WHERE email = 'a@x.com'; \
+             SELECT name FROM t WHERE email = 'a@x.com'",
+            &mut ctx,
+        );
+        assert!(plans.error.is_none(), "{:?}", plans.error);
+        let lines_of = |result: &StatementResult| -> Vec<String> {
+            match result {
+                StatementResult::Rows(rowset) => {
+                    rowset.rows.iter().map(|r| format!("{:?}", r[0])).collect()
+                }
+                other => panic!("expected plan rows, got {other:?}"),
+            }
+        };
+        let covering = lines_of(&plans.results[1]).join("\n");
+        assert!(
+            covering.contains("Index Seek (covering)") && !covering.contains("Key Lookup"),
+            "covering plan: {covering}"
+        );
+        let lookup = lines_of(&plans.results[2]).join("\n");
+        assert!(
+            lookup.contains("Key Lookup"),
+            "non-covering plan keeps the lookup: {lookup}"
+        );
+
+        drop(storage);
+        let _ = std::fs::remove_file(&path);
     }
 
     /// The DONE acknowledging an autocommit write is never emitted before the

--- a/crates/truthdb-core/tests/slt/include_index.slt
+++ b/crates/truthdb-core/tests/slt/include_index.slt
@@ -1,0 +1,85 @@
+# CREATE INDEX ... INCLUDE (Stage 7): included columns' original values are
+# stored in the index leaves, so a query over key + included columns is
+# answered from the index alone (a covering seek). A key column may be
+# INCLUDEd — a deliberate divergence from SQL Server, whose two-way keys make
+# that redundant; ours are one-way collation sort keys.
+
+statement ok
+CREATE TABLE users (id INT NOT NULL PRIMARY KEY, email VARCHAR(50) NOT NULL, display VARCHAR(30), score INT)
+
+statement ok
+CREATE INDEX ix_email ON users (email) INCLUDE (email, id, score)
+
+statement ok
+INSERT INTO users VALUES (1, 'a@x.com', 'Alice', 10), (2, 'B@X.com', 'Bob', NULL), (3, 'c@x.com', NULL, 30)
+
+# Covering: every read column is INCLUDEd. NULLs in included columns survive.
+query TII rowsort
+SELECT email, id, score FROM users WHERE email = 'b@x.com'
+----
+B@X.com 2 NULL
+
+# The stored value is the ORIGINAL (case preserved), found case-insensitively.
+query T
+SELECT email FROM users WHERE email = 'B@X.COM'
+----
+B@X.com
+
+# Not covering (display is not included): the key lookup still answers.
+query TT
+SELECT email, display FROM users WHERE email = 'a@x.com'
+----
+a@x.com Alice
+
+# Included values follow UPDATEs.
+statement ok
+UPDATE users SET score = 99 WHERE id = 2
+
+query I
+SELECT score FROM users WHERE email = 'b@x.com'
+----
+99
+
+# And DELETEs.
+statement ok
+DELETE FROM users WHERE id = 3
+
+query I rowsort
+SELECT id FROM users WHERE email = 'c@x.com'
+----
+
+# A UNIQUE index with INCLUDE still enforces uniqueness on the key alone.
+statement ok
+CREATE TABLE codes (id INT NOT NULL PRIMARY KEY, code VARCHAR(10) NOT NULL, label VARCHAR(20))
+
+statement ok
+CREATE UNIQUE INDEX ux_code ON codes (code) INCLUDE (label)
+
+statement ok
+INSERT INTO codes VALUES (1, 'A1', 'first')
+
+statement error
+INSERT INTO codes VALUES (2, 'A1', 'different label')
+
+# A heap table (no PK) covers through RID locators the same way.
+statement ok
+CREATE TABLE notes (tag VARCHAR(10), body VARCHAR(40))
+
+statement ok
+CREATE INDEX ix_tag ON notes (tag) INCLUDE (tag, body)
+
+statement ok
+INSERT INTO notes VALUES ('todo', 'buy milk'), ('todo', 'call bob'), ('done', 'ship it')
+
+query TT rowsort
+SELECT tag, body FROM notes WHERE tag = 'todo'
+----
+todo buy milk
+todo call bob
+
+# Errors: a duplicate INCLUDE column is 1909; an unknown column is invalid.
+statement error
+CREATE INDEX ix_dup ON users (email) INCLUDE (id, id)
+
+statement error
+CREATE INDEX ix_missing ON users (email) INCLUDE (nope)

--- a/crates/truthdb-sql/src/ast.rs
+++ b/crates/truthdb-sql/src/ast.rs
@@ -104,6 +104,9 @@ pub struct CreateIndex {
     pub table: Name,
     pub unique: bool,
     pub columns: Vec<IndexColumn>,
+    /// `INCLUDE (col, ...)`: non-key columns whose values are stored in the
+    /// index leaves so a query over them is answered from the index alone.
+    pub include: Vec<Name>,
     pub span: Span,
 }
 

--- a/crates/truthdb-sql/src/parser.rs
+++ b/crates/truthdb-sql/src/parser.rs
@@ -537,12 +537,26 @@ impl Parser {
                 break;
             }
         }
-        let end = self.expect(&TokenKind::RParen)?;
+        let mut end = self.expect(&TokenKind::RParen)?;
+        // Optional INCLUDE (col [, ...]): non-key columns stored in the leaf.
+        let mut include = Vec::new();
+        if self.peek_keyword().as_deref() == Some("INCLUDE") {
+            self.bump();
+            self.expect(&TokenKind::LParen)?;
+            loop {
+                include.push(self.parse_name()?);
+                if !self.eat(&TokenKind::Comma) {
+                    break;
+                }
+            }
+            end = self.expect(&TokenKind::RParen)?;
+        }
         Ok(Statement::CreateIndex(CreateIndex {
             name,
             table,
             unique,
             columns,
+            include,
             span: start.to(end),
         }))
     }

--- a/crates/truthdb-sql/tests/corpus/ok/create_index.ast
+++ b/crates/truthdb-sql/tests/corpus/ok/create_index.ast
@@ -31,6 +31,7 @@
                     ascending: true,
                 },
             ],
+            include: [],
             span: Span {
                 start: 0,
                 end: 51,
@@ -80,6 +81,7 @@
                     ascending: false,
                 },
             ],
+            include: [],
             span: Span {
                 start: 53,
                 end: 125,
@@ -107,6 +109,110 @@
             span: Span {
                 start: 127,
                 end: 161,
+            },
+        },
+    ),
+    CreateIndex(
+        CreateIndex {
+            name: Name {
+                value: "ix_users_lookup",
+                quoted: false,
+                span: Span {
+                    start: 177,
+                    end: 192,
+                },
+            },
+            table: Name {
+                value: "users",
+                quoted: false,
+                span: Span {
+                    start: 196,
+                    end: 201,
+                },
+            },
+            unique: false,
+            columns: [
+                IndexColumn {
+                    name: Name {
+                        value: "email",
+                        quoted: false,
+                        span: Span {
+                            start: 203,
+                            end: 208,
+                        },
+                    },
+                    ascending: true,
+                },
+            ],
+            include: [
+                Name {
+                    value: "id",
+                    quoted: false,
+                    span: Span {
+                        start: 219,
+                        end: 221,
+                    },
+                },
+                Name {
+                    value: "display_name",
+                    quoted: false,
+                    span: Span {
+                        start: 223,
+                        end: 235,
+                    },
+                },
+            ],
+            span: Span {
+                start: 164,
+                end: 236,
+            },
+        },
+    ),
+    CreateIndex(
+        CreateIndex {
+            name: Name {
+                value: "ix_code",
+                quoted: false,
+                span: Span {
+                    start: 258,
+                    end: 265,
+                },
+            },
+            table: Name {
+                value: "items",
+                quoted: false,
+                span: Span {
+                    start: 269,
+                    end: 274,
+                },
+            },
+            unique: true,
+            columns: [
+                IndexColumn {
+                    name: Name {
+                        value: "code",
+                        quoted: false,
+                        span: Span {
+                            start: 276,
+                            end: 280,
+                        },
+                    },
+                    ascending: false,
+                },
+            ],
+            include: [
+                Name {
+                    value: "price",
+                    quoted: false,
+                    span: Span {
+                        start: 296,
+                        end: 301,
+                    },
+                },
+            ],
+            span: Span {
+                start: 238,
+                end: 302,
             },
         },
     ),

--- a/crates/truthdb-sql/tests/corpus/ok/create_index.sql
+++ b/crates/truthdb-sql/tests/corpus/ok/create_index.sql
@@ -1,3 +1,6 @@
 CREATE UNIQUE INDEX ix_users_email ON users (email);
 CREATE INDEX ix_orders_customer ON orders (customer_id, created_at DESC);
 DROP INDEX ix_users_email ON users
+;
+CREATE INDEX ix_users_lookup ON users (email) INCLUDE (id, display_name);
+CREATE UNIQUE INDEX ix_code ON items (code DESC) INCLUDE (price)


### PR DESCRIPTION
Closes the first of Stage 7's two remaining planner gaps by building the design change the gap note called for: a covering seek cannot read our index keys back (#94 keyed leaves on one-way collation sort keys, and leaves carried no values), so `CREATE [UNIQUE] INDEX ... (cols) INCLUDE (cols)` now stores the included columns' **original** values in the leaf, and a seek whose every read column (projection ∪ WHERE refs — the predicate is re-checked against scanned rows) is INCLUDEd answers from the index alone. SHOWPLAN prints `Index Seek (covering)` with no Key Lookup line.

**Format**: an index without INCLUDE keeps the bare-locator leaf value byte-for-byte (old files and old indexes unchanged; `IndexDef.include` is `serde(default)`); an INCLUDE index length-prefixes the locator — a `Locator::Key` payload would otherwise swallow the include bytes — followed by the included columns through the ordinary row codec (NULLs and var-length for free). The reader picks the format from the catalog, so the two never mix within an index. Include bytes never enter the **key**: uniqueness (2601), seek bounds, and non-unique key-dedup are untouched.

**Divergences, deliberate and documented**: a key column may be INCLUDEd (SQL Server rejects that; its keys are two-way, ours cannot be read back, so covering a query that reads the key column requires storing its value). Unknown CREATE INDEX columns now raise SQL Server's 1911 (was the generic 207); duplicate INCLUDE columns raise 1909.

**Planner**: coverage breaks equality-score ties in `plan::choose` (the add-a-covering-index-to-an-existing-database workflow — found by review, reproduced, fixed); it never outranks a more selective seek or a fully-matched UNIQUE.

**Verification**: adversarial review (4 lenses, own worktrees, every finding refuted independently by 2 agents — 5 findings, 3 refuted with reproductions, 2 survived and are fixed here); slt matrix (covering, original-case under _CI, non-covering fallback through the new format, UPDATE/DELETE maintenance, unique, heap RID locators, errors); storage tests pin the covering path via a test counter, A/B equality against a scan, restart persistence, and the tie-break; every new test proven to fail with its fix removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)