### PR TITLE
Per-table row counts: the statistics facility, as a transactional page op

### DIFF
--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -4721,6 +4721,13 @@ mod tests {
             .execute("CREATE TABLE t (id INT NOT NULL PRIMARY KEY, a INT)")
             .expect("create");
         engine.execute("CREATE INDEX ix_a ON t (a)").expect("index");
+        // Pad past the tiny-table tie-break, or the post-drop "Table Scan"
+        // assertion below would hold with the index still present (vacuous).
+        for i in 0..20 {
+            engine
+                .execute(&format!("INSERT INTO t VALUES ({}, 900)", 100 + i))
+                .expect("pad");
+        }
 
         // sys.indexes lists it.
         let (_, rows) = sql_rows(&engine, "SELECT name FROM sys.indexes");

--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -4471,6 +4471,12 @@ mod tests {
                     "INSERT INTO {t} VALUES (1,10,'a'),(2,20,'b'),(3,20,'c'),(4,30,NULL),(5,10,'e')"
                 ))
                 .expect("insert");
+            // Pad past the tiny-table tie-break (identically on both sides).
+            for i in 0..20 {
+                engine
+                    .execute(&format!("INSERT INTO {t} VALUES ({}, 900, 'p')", 100 + i))
+                    .expect("pad");
+            }
         }
         engine
             .execute("CREATE INDEX ix_a ON idx (a)")
@@ -4590,6 +4596,13 @@ mod tests {
             .execute("CREATE TABLE t (id INT NOT NULL PRIMARY KEY, a INT)")
             .expect("create");
         engine.execute("CREATE INDEX ix_a ON t (a)").expect("index");
+        // Pad past the tiny-table tie-break: a table of <= 16 rows plans as
+        // a scan (the seek ties with it), and this test is about the seek.
+        for i in 0..20 {
+            engine
+                .execute(&format!("INSERT INTO t VALUES ({}, 900)", 100 + i))
+                .expect("pad");
+        }
 
         let seek = plan_lines(&engine, "SELECT id FROM t WHERE a = 7");
         assert_eq!(seek[0], "Index Seek(t.ix_a), SEEK: a = 7");
@@ -4611,6 +4624,12 @@ mod tests {
         engine
             .execute("INSERT INTO t VALUES (1,10),(2,20)")
             .expect("insert");
+        // Pad past the tiny-table tie-break (a <= 16-row table plans as a scan).
+        for i in 0..20 {
+            engine
+                .execute(&format!("INSERT INTO t VALUES ({}, 900)", 100 + i))
+                .expect("pad");
+        }
         engine.execute("CREATE INDEX ix_a ON t (a)").expect("index");
 
         drop(engine);
@@ -4640,6 +4659,12 @@ mod tests {
         engine
             .execute("INSERT INTO t VALUES (1,1,100),(2,1,200),(3,2,100),(4,2,200)")
             .expect("insert");
+        // Pad past the tiny-table tie-break (a <= 16-row table plans as a scan).
+        for i in 0..20 {
+            engine
+                .execute(&format!("INSERT INTO t VALUES ({}, 900, 900)", 100 + i))
+                .expect("pad");
+        }
         engine
             .execute("CREATE INDEX ix_ab ON t (a, b DESC)")
             .expect("create composite index");
@@ -4666,6 +4691,12 @@ mod tests {
         engine
             .execute("INSERT INTO h VALUES (10,'x'),(20,'y'),(10,'z')")
             .expect("insert");
+        // Pad past the tiny-table tie-break (a <= 16-row table plans as a scan).
+        for i in 0..20 {
+            engine
+                .execute(&format!("INSERT INTO h VALUES ({}, 'p')", 900 + i))
+                .expect("pad");
+        }
         engine.execute("CREATE INDEX ix_a ON h (a)").expect("index");
 
         let plan = plan_lines(&engine, "SELECT name FROM h WHERE a = 10");
@@ -4716,6 +4747,13 @@ mod tests {
         engine
             .execute("INSERT INTO t VALUES (1, 'abc'), (2, 'ABC'), (3, 'xyz')")
             .expect("insert");
+        // Pad past the tiny-table tie-break; '0...' sorts below 'a', so the
+        // range assertions below keep their exact row sets.
+        for i in 0..20 {
+            engine
+                .execute(&format!("INSERT INTO t VALUES ({}, '0p{i}')", 100 + i))
+                .expect("pad");
+        }
         engine
             .execute("CREATE INDEX ix_name ON t (name)")
             .expect("index");
@@ -4763,6 +4801,13 @@ mod tests {
         engine
             .execute("INSERT INTO t VALUES (1,'aaa'),(2,'mmm'),(3,'zzz')")
             .expect("insert");
+        // Pad past the tiny-table tie-break; '0...' sorts below 'b', so the
+        // range assertion below keeps its exact row set.
+        for i in 0..20 {
+            engine
+                .execute(&format!("INSERT INTO t VALUES ({}, '0c{i}')", 100 + i))
+                .expect("pad");
+        }
         engine
             .execute("CREATE INDEX ix_code ON t (code)")
             .expect("index");
@@ -4787,6 +4832,12 @@ mod tests {
                     "CREATE TABLE {t} (id INT NOT NULL PRIMARY KEY, a INT)"
                 ))
                 .expect("create");
+            // Pad past the tiny-table tie-break (an empty table plans as a scan).
+            for i in 0..20 {
+                engine
+                    .execute(&format!("INSERT INTO {t} VALUES ({}, 900)", 100 + i))
+                    .expect("pad");
+            }
             engine
                 .execute(&format!("CREATE INDEX ix ON {t} (a)"))
                 .expect("index");
@@ -5477,6 +5528,12 @@ mod tests {
             engine
                 .execute("INSERT INTO t VALUES (1, 'Hello'), (2, 'WORLD')")
                 .expect("insert");
+            // Pad past the tiny-table tie-break (a <= 16-row table scans).
+            for i in 0..20 {
+                engine
+                    .execute(&format!("INSERT INTO t VALUES ({}, '0p{i}')", 100 + i))
+                    .expect("pad");
+            }
             engine
                 .execute("CREATE INDEX ix ON t (name)")
                 .expect("index");

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -1438,13 +1438,20 @@ fn showplan_rows(
                         plan::plan_text(&plan.access, &def.name, plan.covering)
                     } else {
                         let schema = def.schema().map_err(|e| map_storage_err(e, &def.name))?;
+                        // Fetched only when choose() can use it (it returns a
+                        // scan outright without a predicate or indexes).
+                        let row_count = if def.indexes.is_empty() || select.where_clause.is_none() {
+                            None
+                        } else {
+                            storage.rel_row_count(&def.name)
+                        };
                         let path = plan::choose(
                             &def,
                             &schema,
                             &select.where_clause,
                             eval_ctx,
                             None,
-                            storage.rel_row_count(&def.name),
+                            row_count,
                         );
                         plan::plan_text(&path, &def.name, false)
                     }
@@ -5133,8 +5140,9 @@ fn scan_plan(storage: &Storage, select: &Select, eval_ctx: &EvalContext) -> Opti
     // `needed` is known so a covering index can win its tie (see
     // [`plan::choose`]).
     // The row count is a statistic (one buffer-pool-cached page read),
-    // fetched only when there are indexes to choose between.
-    let row_count = if def.indexes.is_empty() {
+    // fetched only when choose() can use it (it returns a scan outright
+    // without a predicate or indexes).
+    let row_count = if def.indexes.is_empty() || select.where_clause.is_none() {
         None
     } else {
         storage.rel_row_count(&def.name)
@@ -6471,14 +6479,14 @@ fn build_table_source(
             let schema = def.schema().map_err(|e| map_storage_err(e, &def.name))?;
             // An index seek narrows the candidate set; the WHERE filter later
             // re-checks, so results match a full scan.
-            let rows = match plan::choose(
-                &def,
-                &schema,
-                where_clause,
-                eval_ctx,
-                None,
-                storage.rel_row_count(&def.name),
-            ) {
+            // Fetched only when choose() can use it (it returns a scan
+            // outright without a predicate or indexes).
+            let row_count = if def.indexes.is_empty() || where_clause.is_none() {
+                None
+            } else {
+                storage.rel_row_count(&def.name)
+            };
+            let rows = match plan::choose(&def, &schema, where_clause, eval_ctx, None, row_count) {
                 // Sliced: a read holds the table's lock, so it need not also
                 // hold the storage lock for the whole table and block every
                 // other session while it walks.

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -1438,8 +1438,14 @@ fn showplan_rows(
                         plan::plan_text(&plan.access, &def.name, plan.covering)
                     } else {
                         let schema = def.schema().map_err(|e| map_storage_err(e, &def.name))?;
-                        let path =
-                            plan::choose(&def, &schema, &select.where_clause, eval_ctx, None);
+                        let path = plan::choose(
+                            &def,
+                            &schema,
+                            &select.where_clause,
+                            eval_ctx,
+                            None,
+                            storage.rel_row_count(&def.name),
+                        );
                         plan::plan_text(&path, &def.name, false)
                     }
                 }
@@ -5126,7 +5132,21 @@ fn scan_plan(storage: &Storage, select: &Select, eval_ctx: &EvalContext) -> Opti
     // `build_table_source` would compute all three again. Chosen after
     // `needed` is known so a covering index can win its tie (see
     // [`plan::choose`]).
-    let access = plan::choose(&def, &schema, &select.where_clause, eval_ctx, Some(&needed));
+    // The row count is a statistic (one buffer-pool-cached page read),
+    // fetched only when there are indexes to choose between.
+    let row_count = if def.indexes.is_empty() {
+        None
+    } else {
+        storage.rel_row_count(&def.name)
+    };
+    let access = plan::choose(
+        &def,
+        &schema,
+        &select.where_clause,
+        eval_ctx,
+        Some(&needed),
+        row_count,
+    );
 
     // Everything downstream now speaks in the scanned row's coordinates.
     let position = |index: usize| {
@@ -6451,7 +6471,14 @@ fn build_table_source(
             let schema = def.schema().map_err(|e| map_storage_err(e, &def.name))?;
             // An index seek narrows the candidate set; the WHERE filter later
             // re-checks, so results match a full scan.
-            let rows = match plan::choose(&def, &schema, where_clause, eval_ctx, None) {
+            let rows = match plan::choose(
+                &def,
+                &schema,
+                where_clause,
+                eval_ctx,
+                None,
+                storage.rel_row_count(&def.name),
+            ) {
                 // Sliced: a read holds the table's lock, so it need not also
                 // hold the storage lock for the whole table and block every
                 // other session while it walks.

--- a/crates/truthdb-core/src/rel/plan.rs
+++ b/crates/truthdb-core/src/rel/plan.rs
@@ -48,13 +48,16 @@ type Bounds = (Option<Vec<u8>>, Option<Vec<u8>>);
 /// the query reads (`needed`, when the caller knows it) wins: it answers
 /// from its leaves with no per-row base-table lookup. Coverage never
 /// outranks a better equality match or a fully-matched UNIQUE seek — a
-/// single-row lookup beats a covering scan of many.
+/// single-row lookup beats a covering scan of many. A `row_count` at or
+/// below [`TINY_TABLE_ROWS`] demotes a non-covering seek to the scan it ties
+/// with (a covering seek still reads less than the table and keeps its win).
 pub fn choose(
     def: &TableDef,
     schema: &Schema,
     where_clause: &Option<Expr>,
     eval_ctx: &EvalContext,
     needed: Option<&[usize]>,
+    row_count: Option<u64>,
 ) -> AccessPath {
     let Some(predicate) = where_clause else {
         return AccessPath::TableScan;
@@ -67,7 +70,7 @@ pub fn choose(
     if sargs.is_empty() {
         return AccessPath::TableScan;
     }
-    let mut best: Option<(u32, AccessPath)> = None;
+    let mut best: Option<(u32, AccessPath, bool)> = None;
     for index in &def.indexes {
         if let Some((mut score, path)) = try_index(index, schema, &sargs) {
             let covers =
@@ -78,13 +81,27 @@ pub fn choose(
                 // narrower range, never a more selective seek.
                 score += 5;
             }
-            if best.as_ref().is_none_or(|(s, _)| score > *s) {
-                best = Some((score, path));
+            if best.as_ref().is_none_or(|(s, _, _)| score > *s) {
+                best = Some((score, path, covers));
             }
         }
     }
-    best.map(|(_, path)| path).unwrap_or(AccessPath::TableScan)
+    match best {
+        // "Row counts as tie-breakers only": on a tiny table the scan reads
+        // about one page, so a seek that would still visit the base table
+        // buys nothing — take the scan. A covering seek keeps its win.
+        Some((_, _, false)) if row_count.is_some_and(|rows| rows <= TINY_TABLE_ROWS) => {
+            AccessPath::TableScan
+        }
+        Some((_, path, _)) => path,
+        None => AccessPath::TableScan,
+    }
 }
+
+/// Rows at or below which a table is "tiny": a full scan touches about one
+/// page, so a non-covering seek — an index descent plus a base-table lookup
+/// per row — ties with it at best, and the tie goes to the scan.
+const TINY_TABLE_ROWS: u64 = 16;
 
 /// Renders the plan as `SHOWPLAN_TEXT` rows. A covering seek (every needed
 /// column INCLUDEd in the leaf) answers from the index alone, so it has no

--- a/crates/truthdb-core/src/relstore/catalog.rs
+++ b/crates/truthdb-core/src/relstore/catalog.rs
@@ -105,6 +105,12 @@ pub struct TableDef {
     /// `FOREIGN KEY` constraints (this table is the referencing child).
     #[serde(default)]
     pub foreign_keys: Vec<ForeignKeyDef>,
+    /// The table's row-counter page (planner statistics), maintained
+    /// transactionally by DML. `None` for views and for tables created before
+    /// counters existed — the planner then has no count and applies no
+    /// tie-break, which is exactly the old behavior.
+    #[serde(default)]
+    pub counter_page: Option<u64>,
     /// For a VIEW: the source text of its `SELECT`, re-parsed and inlined (as a
     /// derived table) wherever the view is referenced. `None` for a base table.
     /// A view carries no data pages, columns, or key.

--- a/crates/truthdb-core/src/relstore/ctx.rs
+++ b/crates/truthdb-core/src/relstore/ctx.rs
@@ -301,6 +301,58 @@ impl RelCtx<'_> {
         Ok(lsn)
     }
 
+    /// Creates a table's row-counter page: allocated, formatted, zero count,
+    /// logged as a system image (like a fresh tree root — a rolled-back
+    /// CREATE TABLE leaves it an unreferenced orphan, which is safe).
+    pub fn counter_create(&mut self, object_id: u32) -> Result<u64, StorageError> {
+        let page_no = self.allocate_page(0)?;
+        let frame = self.format_page(page_no, page::PAGE_TYPE_COUNTER, object_id, 0)?;
+        let at = page::COUNTER_OFFSET;
+        self.pool.page_mut(frame)[at..at + 8].copy_from_slice(&0u64.to_le_bytes());
+        self.pool.unpin(frame);
+        self.log_system_image(page_no)?;
+        Ok(page_no)
+    }
+
+    /// Adds `delta` rows to a table's counter as a transactional page op: the
+    /// undo record carries the inverse delta, so statement savepoints, txn
+    /// rollback and crash recovery keep the count exactly consistent with the
+    /// committed rows.
+    pub fn counter_add(
+        &mut self,
+        txn: &mut TxnLink,
+        page: u64,
+        delta: i64,
+    ) -> Result<(), StorageError> {
+        if delta == 0 {
+            return Ok(());
+        }
+        self.apply_op(
+            LogMode::Txn(
+                txn,
+                PageOpUndo::CounterAdd {
+                    page,
+                    delta: -delta,
+                },
+            ),
+            PageOpRedo::CounterAdd { page, delta },
+        )?;
+        Ok(())
+    }
+
+    /// Reads a counter page's row count.
+    pub fn counter_read(&mut self, page: u64) -> Result<u64, StorageError> {
+        let frame = self.fetch(page)?;
+        let at = page::COUNTER_OFFSET;
+        let count = u64::from_le_bytes(
+            self.pool.page(frame)[at..at + 8]
+                .try_into()
+                .expect("8 bytes"),
+        );
+        self.pool.unpin(frame);
+        Ok(count)
+    }
+
     /// Logs the current full image of a page as a system record (used for
     /// freshly formatted pages whose creation would not be idempotent as
     /// per-op records). On append failure the page stays an orphan (never
@@ -406,6 +458,18 @@ pub(crate) fn apply_redo_to_page(
             .map_err(|_| full("HeapUpdate")),
         PageOpRedo::SetNextPage { next, .. } => {
             page.set_next_page(*next);
+            Ok(())
+        }
+        PageOpRedo::CounterAdd { delta, .. } => {
+            let _ = page;
+            let at = crate::relstore::page::COUNTER_OFFSET;
+            let count = u64::from_le_bytes(page_bytes[at..at + 8].try_into().expect("8 bytes"));
+            // Wrapping, deliberately: a delta the logic never produces (an
+            // undo without its op, an op without its undo) must not turn into
+            // a panic inside redo — the count is a statistic, and the
+            // surrounding ARIES discipline is what keeps it exact.
+            let count = count.wrapping_add_signed(*delta);
+            page_bytes[at..at + 8].copy_from_slice(&count.to_le_bytes());
             Ok(())
         }
     }

--- a/crates/truthdb-core/src/relstore/page.rs
+++ b/crates/truthdb-core/src/relstore/page.rs
@@ -23,6 +23,11 @@ pub const PAGE_TYPE_FREE: u16 = 0;
 /// level field).
 pub const PAGE_TYPE_TREE: u16 = 1;
 pub const PAGE_TYPE_HEAP: u16 = 2;
+/// A table's row-counter page (planner statistics): one u64 count at
+/// [`COUNTER_OFFSET`], maintained transactionally via `CounterAdd` page ops.
+pub const PAGE_TYPE_COUNTER: u16 = 3;
+/// Byte offset of the row count on a counter page (right after the header).
+pub const COUNTER_OFFSET: usize = PAGE_HEADER_SIZE;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct PageHeader {

--- a/crates/truthdb-core/src/relstore/recovery.rs
+++ b/crates/truthdb-core/src/relstore/recovery.rs
@@ -255,6 +255,18 @@ pub(crate) fn undo_one(
                 };
                 apply_tree_undo(ctx, &mut mode, &tree, undo)?;
             }
+            PageOpUndo::CounterAdd { page, delta } => {
+                // The inverse delta was baked in when the undo record was
+                // built; the CLR chain (`undo_next`) guarantees exactly-once
+                // compensation across a crash mid-undo, like every page op.
+                ctx.apply_op(
+                    mode.log_mode(PageOpUndo::None),
+                    PageOpRedo::CounterAdd {
+                        page: *page,
+                        delta: *delta,
+                    },
+                )?;
+            }
             PageOpUndo::HeapDeleteSlot { page, slot } => {
                 if heap_slot_occupied(ctx, *page, *slot)? {
                     ctx.apply_op(

--- a/crates/truthdb-core/src/relstore/recovery.rs
+++ b/crates/truthdb-core/src/relstore/recovery.rs
@@ -235,9 +235,22 @@ pub(crate) fn undo_one(
     tree_roots: &HashMap<u32, u64>,
 ) -> Result<(), StorageError> {
     {
+        // In-group CLRs point AT the record (`record_lsn`): the group re-runs
+        // after a crash, and each op tolerates partial prior application —
+        // heap arms by occupancy guard, tree arms by logical presence check.
+        // A counter compensation is a blind arithmetic delta and CANNOT: a
+        // crash after its CLR but before the sealing no-op would re-undo the
+        // record and apply the delta twice, permanently. Its group is exactly
+        // one op, so its CLR points *past* the compensated record instead
+        // (textbook ARIES): a re-run resumes at `record_prev` and can never
+        // revisit it.
+        let undo_next = match undo {
+            PageOpUndo::CounterAdd { .. } => record_prev,
+            _ => record_lsn,
+        };
         let mut mode = OpMode::Clr {
             txn: link,
-            undo_next: record_lsn,
+            undo_next,
         };
         match undo {
             PageOpUndo::None => {}
@@ -257,8 +270,9 @@ pub(crate) fn undo_one(
             }
             PageOpUndo::CounterAdd { page, delta } => {
                 // The inverse delta was baked in when the undo record was
-                // built; the CLR chain (`undo_next`) guarantees exactly-once
-                // compensation across a crash mid-undo, like every page op.
+                // built. This CLR's `undo_next` is `record_prev` (see above),
+                // which is what makes the compensation exactly-once across a
+                // crash mid-undo.
                 ctx.apply_op(
                     mode.log_mode(PageOpUndo::None),
                     PageOpRedo::CounterAdd {

--- a/crates/truthdb-core/src/relstore/tests.rs
+++ b/crates/truthdb-core/src/relstore/tests.rs
@@ -683,6 +683,136 @@ fn crash_during_recovery_undo_reruns_cleanly() {
     let _ = std::fs::remove_file(path);
 }
 
+/// Review finding: a counter compensation is a blind arithmetic delta, so it
+/// cannot tolerate the CLR-group re-run the other undo arms survive by being
+/// guarded (occupancy checks, logical presence). Its CLR must therefore point
+/// *past* the compensated record — a crash after the CLR but before the
+/// sealing no-op then resumes at the previous record instead of re-applying
+/// the delta. This test pins the mechanism itself, on the WAL bytes: the CLR
+/// compensating a CounterAdd record carries `undo_next == prev_lsn` of that
+/// record, never its own LSN.
+#[test]
+fn counter_compensation_clr_points_past_its_record() {
+    use crate::storage::TxnScope;
+    use crate::wal::records::{PageOpRedo, REL_KIND_CLR, REL_KIND_PAGE_IMAGE, REL_KIND_PAGE_OP};
+
+    let path = unique_temp_path("counter-clr-pointer");
+    let mut storage = create_storage(&path);
+    create_tree_table(&mut storage, "t");
+    storage
+        .rel_insert("t", row(1, "committed"))
+        .expect("insert");
+
+    let mut txn = storage.rel_begin().expect("begin");
+    storage
+        .rel_insert_many(
+            "t",
+            vec![row(2, "rolled back")],
+            &mut TxnScope::Explicit(&mut txn),
+        )
+        .expect("insert under txn");
+    storage.rel_rollback(txn).expect("rollback");
+    assert_eq!(storage.rel_row_count("t"), Some(1), "count restored");
+    // The record scan reads the open-time replay cache, so reopen: the ring
+    // still holds the rollback's records (nothing checkpointed).
+    drop(storage);
+    let mut storage = Storage::open(path.clone()).expect("reopen");
+    assert_eq!(storage.rel_row_count("t"), Some(1));
+
+    let records = storage.rel_wal_records().expect("scan");
+    // The rolled-back statement's forward CounterAdd record. It may have been
+    // logged as a plain page op or — on the counter page's first touch since
+    // a checkpoint — as a full page image; either way its UNDO carries the
+    // inverse CounterAdd.
+    // Both inserts log a +1; the rolled-back transaction's is the LAST one.
+    let (forward_lsn, forward_prev) = records
+        .iter()
+        .filter_map(|(lsn, record)| {
+            if record.txn_id == 0
+                || record.kind != REL_KIND_PAGE_OP && record.kind != REL_KIND_PAGE_IMAGE
+            {
+                return None;
+            }
+            let is_forward_counter = matches!(
+                record.decode_page_op_redo(),
+                Ok(PageOpRedo::CounterAdd { delta, .. }) if delta > 0
+            ) || matches!(
+                record.decode_page_op_undo(),
+                Ok(crate::wal::records::PageOpUndo::CounterAdd { delta, .. }) if delta < 0
+            );
+            if is_forward_counter {
+                Some((*lsn, record.prev_lsn))
+            } else {
+                None
+            }
+        })
+        .last()
+        .expect("the rolled-back insert logged a forward CounterAdd");
+    // The CLR that compensates it.
+    let undo_next = records
+        .iter()
+        .find_map(|(_, record)| {
+            if record.kind != REL_KIND_CLR {
+                return None;
+            }
+            match record.decode_clr() {
+                Ok((undo_next, Some(PageOpRedo::CounterAdd { delta, .. }))) if delta < 0 => {
+                    Some(undo_next)
+                }
+                _ => None,
+            }
+        })
+        .expect("the rollback logged a compensating CounterAdd CLR");
+    assert_eq!(
+        undo_next, forward_prev,
+        "the counter CLR points PAST its record (a crash-resumed undo must \
+         never revisit it: the delta would apply twice)"
+    );
+    assert_ne!(undo_next, forward_lsn, "not the group-re-run pointer");
+
+    drop(storage);
+    let _ = std::fs::remove_file(path);
+}
+
+/// The behavioral face of the same property: a crash mid-recovery-undo whose
+/// re-run walks the loser again must apply the counter compensation exactly
+/// once (the CLR pointer above is what makes the re-run skip the record).
+#[test]
+fn counter_compensation_survives_a_crash_during_recovery_undo() {
+    let path = unique_temp_path("counter-crash-mid-undo");
+    let mut storage = create_storage(&path);
+    create_tree_table(&mut storage, "t");
+    storage
+        .rel_insert("t", row(1, "committed"))
+        .expect("insert");
+    assert_eq!(storage.rel_row_count("t"), Some(1));
+    storage
+        .rel_insert_without_commit("t", row(2, "loser"))
+        .expect("loser");
+    drop(storage); // crash with the loser open
+
+    // Recovery undoes the loser LIFO: the counter compensation lands first,
+    // then the injected fault aborts recovery on the row op behind it.
+    crate::relstore::ctx::FAIL_APPLY_OPS_AFTER.with(|c| c.set(Some(1)));
+    let result = Storage::open(path.clone());
+    crate::relstore::ctx::FAIL_APPLY_OPS_AFTER.with(|c| c.set(None));
+    assert!(
+        result.is_err(),
+        "injected fault must abort recovery mid-undo"
+    );
+    drop(result);
+
+    let mut storage = Storage::open(path.clone()).expect("recovery rerun");
+    assert_eq!(scan_ids(&mut storage, "t"), vec![1], "loser row undone");
+    assert_eq!(
+        storage.rel_row_count("t"),
+        Some(1),
+        "the compensation applied exactly once across the re-run"
+    );
+    drop(storage);
+    let _ = std::fs::remove_file(path);
+}
+
 /// Review finding: a growing update of a tiny row on a page too full to
 /// hold a forwarding stub must fail cleanly (constraint error), not with an
 /// internal logging error or partial application.

--- a/crates/truthdb-core/src/storage.rs
+++ b/crates/truthdb-core/src/storage.rs
@@ -701,6 +701,15 @@ impl Storage {
         self.lock().rel_flush_pool_only()
     }
 
+    /// Test hook: the relational WAL records currently recoverable from the
+    /// ring, exactly as restart's analysis would see them.
+    #[cfg(test)]
+    pub(crate) fn rel_wal_records(
+        &self,
+    ) -> Result<Vec<(u64, crate::wal::records::RelRecord)>, StorageError> {
+        self.lock().rel_records()
+    }
+
     #[cfg(test)]
     pub(crate) fn data_page_offset(&self, page: u64) -> u64 {
         self.lock().data_page_offset(page)
@@ -2059,6 +2068,11 @@ impl StorageFile {
                 first_page: def.root_page,
             };
             heap.insert(&mut ctx, &mut txn, &row)?;
+        }
+        // A real statement's op stream includes the counter op, so the crash
+        // window this hook simulates must too.
+        if let Some(page) = def.counter_page {
+            ctx.counter_add(&mut txn, page, 1)?;
         }
         // Durable ops, no commit record: exactly the crash window.
         ctx.io.wal.sync_all()?;

--- a/crates/truthdb-core/src/storage.rs
+++ b/crates/truthdb-core/src/storage.rs
@@ -448,6 +448,14 @@ impl Storage {
         self.lock().rel_drop_index(table, index_name)
     }
 
+    /// The table's committed row count, when it has a counter page (tables
+    /// created before counters existed do not — the planner then applies no
+    /// tie-break). Errors degrade to `None`: the count is a statistic, never
+    /// load-bearing for results.
+    pub(crate) fn rel_row_count(&self, table: &str) -> Option<u64> {
+        self.lock().rel_row_count(table)
+    }
+
     pub(crate) fn rel_index_scan(
         &self,
         table: &str,
@@ -1006,6 +1014,7 @@ impl StorageFile {
             } else {
                 Heap::create(ctx, object_id)?.first_page
             };
+            let counter_page = ctx.counter_create(object_id)?;
             let def = TableDef {
                 object_id,
                 name: table_name,
@@ -1019,6 +1028,7 @@ impl StorageFile {
                 check_constraints,
                 foreign_keys,
                 view_query: None,
+                counter_page: Some(counter_page),
             };
             catalog::insert_table(ctx, &mut OpMode::Txn(txn), catalog_root, &def)?;
             Ok(def)
@@ -1064,6 +1074,7 @@ impl StorageFile {
                 check_constraints: Vec::new(),
                 foreign_keys: Vec::new(),
                 view_query: Some(query),
+                counter_page: None,
             };
             catalog::insert_table(ctx, &mut OpMode::Txn(txn), catalog_root, &def)?;
             Ok(def)
@@ -1231,6 +1242,14 @@ impl StorageFile {
     /// `[lower, upper]`, then fetches each row by its locator. Returns a
     /// superset the caller re-filters with the full WHERE (so loose bounds are
     /// safe).
+    pub(crate) fn rel_row_count(&mut self, table: &str) -> Option<u64> {
+        if self.ensure_rel_usable().is_err() {
+            return None;
+        }
+        let page = self.rel.tables.get(table)?.counter_page?;
+        self.rel_ctx().counter_read(page).ok()
+    }
+
     pub(crate) fn rel_index_scan(
         &mut self,
         table: &str,
@@ -1352,6 +1371,8 @@ impl StorageFile {
 
         let indexes = def.indexes.clone();
         let collations = def.collations.clone();
+        let counter_page = def.counter_page;
+        let inserted = rows.len() as i64;
         if def.is_tree() {
             let tree = BTree {
                 object_id: def.object_id,
@@ -1379,6 +1400,9 @@ impl StorageFile {
                         &Locator::Key(key.clone()),
                     )?;
                 }
+                if let Some(page) = counter_page {
+                    ctx.counter_add(txn, page, inserted)?;
+                }
                 Ok(())
             })
         } else {
@@ -1399,6 +1423,9 @@ impl StorageFile {
                         values,
                         &Locator::Rid(rid),
                     )?;
+                }
+                if let Some(page) = counter_page {
+                    ctx.counter_add(txn, page, inserted)?;
                 }
                 Ok(())
             })
@@ -1725,12 +1752,17 @@ impl StorageFile {
         }
         let indexes = def.indexes.clone();
         let collations = def.collations.clone();
+        let counter_page = def.counter_page;
+        // The counter follows the rows actually removed inside the statement,
+        // which the arms count as they go (a locator of the wrong kind is
+        // skipped, exactly as the row loop skips it).
         if def.is_tree() {
             let tree = BTree {
                 object_id: def.object_id,
                 root: def.root_page,
             };
             self.rel_statement_scoped(scope, move |ctx, txn| {
+                let mut removed: i64 = 0;
                 for (loc, values) in &targets {
                     if let RowLocator::Key(key) = loc {
                         tree.delete(ctx, &mut OpMode::Txn(txn), key)?;
@@ -1742,7 +1774,11 @@ impl StorageFile {
                             values,
                             &Locator::Key(key.clone()),
                         )?;
+                        removed += 1;
                     }
+                }
+                if let Some(page) = counter_page {
+                    ctx.counter_add(txn, page, -removed)?;
                 }
                 Ok(())
             })?;
@@ -1752,6 +1788,7 @@ impl StorageFile {
                 first_page: def.root_page,
             };
             self.rel_statement_scoped(scope, move |ctx, txn| {
+                let mut removed: i64 = 0;
                 for (loc, values) in &targets {
                     if let RowLocator::Rid(rid) = loc {
                         heap.delete(ctx, txn, *rid)?;
@@ -1763,7 +1800,11 @@ impl StorageFile {
                             values,
                             &Locator::Rid(*rid),
                         )?;
+                        removed += 1;
                     }
+                }
+                if let Some(page) = counter_page {
+                    ctx.counter_add(txn, page, -removed)?;
                 }
                 Ok(())
             })?;
@@ -3300,6 +3341,182 @@ mod tests {
         let _ = std::fs::remove_file(&path);
     }
 
+    /// The row counter tracks every DML shape through the SQL layer — and
+    /// because it is an ordinary transactional page op, statement atomicity,
+    /// savepoints, transaction rollback and crash recovery all keep it exact
+    /// without counter-specific recovery code.
+    #[test]
+    fn row_counts_track_dml_transactions_and_recovery() {
+        use crate::rel::{TxnContext, execute_batch};
+
+        let path = unique_temp_path("row-count");
+        let storage = Storage::create(path.clone(), test_storage_options()).expect("create");
+        let mut ctx = TxnContext::default();
+        let run = |storage: &Storage, ctx: &mut TxnContext, sql: &str| {
+            let outcome = execute_batch(storage, sql, ctx);
+            assert!(outcome.error.is_none(), "{sql}: {:?}", outcome.error);
+        };
+
+        run(
+            &storage,
+            &mut ctx,
+            "CREATE TABLE t (id INT NOT NULL PRIMARY KEY, v INT)",
+        );
+        assert_eq!(storage.rel_row_count("t"), Some(0));
+
+        run(
+            &storage,
+            &mut ctx,
+            "INSERT INTO t VALUES (1, 10), (2, 20), (3, 30)",
+        );
+        assert_eq!(storage.rel_row_count("t"), Some(3));
+
+        run(&storage, &mut ctx, "DELETE FROM t WHERE id = 3");
+        run(&storage, &mut ctx, "UPDATE t SET v = 99 WHERE id = 1");
+        assert_eq!(storage.rel_row_count("t"), Some(2), "delete -1, update 0");
+
+        // A failing multi-row statement (duplicate key on its last row) is
+        // atomic: no rows land, and neither does its count.
+        let dup = execute_batch(&storage, "INSERT INTO t VALUES (5, 1), (1, 1)", &mut ctx);
+        assert!(dup.error.is_some(), "duplicate key must fail");
+        assert_eq!(storage.rel_row_count("t"), Some(2));
+
+        // Transaction rollback restores the count with the rows.
+        run(
+            &storage,
+            &mut ctx,
+            "BEGIN TRANSACTION; INSERT INTO t VALUES (10, 1), (11, 1)",
+        );
+        assert_eq!(storage.rel_row_count("t"), Some(4), "in-flight rows count");
+        run(&storage, &mut ctx, "ROLLBACK");
+        assert_eq!(storage.rel_row_count("t"), Some(2));
+
+        // A savepoint rollback restores exactly the statements behind it.
+        run(
+            &storage,
+            &mut ctx,
+            "BEGIN TRANSACTION; INSERT INTO t VALUES (20, 1); SAVE TRANSACTION sp; \
+             INSERT INTO t VALUES (21, 1); ROLLBACK TRANSACTION sp; COMMIT",
+        );
+        assert_eq!(storage.rel_row_count("t"), Some(3));
+
+        // Crash (no checkpoint, pool never flushed): recovery replays the ops,
+        // counter page included.
+        drop(storage);
+        let storage = Storage::open(path.clone()).expect("reopen");
+        assert_eq!(
+            storage.rel_row_count("t"),
+            Some(3),
+            "count survives recovery"
+        );
+
+        drop(storage);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// Rows of a transaction still open at the crash are undone by recovery —
+    /// and so is their count.
+    #[test]
+    fn an_uncommitted_transactions_rows_are_uncounted_after_crash() {
+        use crate::rel::{TxnContext, execute_batch};
+
+        let path = unique_temp_path("row-count-crash");
+        let storage = Storage::create(path.clone(), test_storage_options()).expect("create");
+        let mut ctx = TxnContext::default();
+        let setup = execute_batch(
+            &storage,
+            "CREATE TABLE t (id INT NOT NULL PRIMARY KEY); INSERT INTO t VALUES (1), (2)",
+            &mut ctx,
+        );
+        assert!(setup.error.is_none(), "{:?}", setup.error);
+
+        let mut open_txn = TxnContext::default();
+        let pending = execute_batch(
+            &storage,
+            "BEGIN TRANSACTION; INSERT INTO t VALUES (10), (11), (12)",
+            &mut open_txn,
+        );
+        assert!(pending.error.is_none(), "{:?}", pending.error);
+        assert_eq!(storage.rel_row_count("t"), Some(5), "in-flight rows count");
+        drop(storage); // crash with the transaction open
+
+        let storage = Storage::open(path.clone()).expect("reopen");
+        assert_eq!(
+            storage.rel_row_count("t"),
+            Some(2),
+            "the loser transaction's rows and count are both undone"
+        );
+
+        drop(storage);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// "Row counts as tie-breakers only": a table at or under the tiny
+    /// threshold plans its seek as the scan it ties with, grows into the seek
+    /// past the threshold — and a covering seek keeps its win at any size,
+    /// since it reads less than the table either way.
+    #[test]
+    fn a_tiny_table_scans_until_it_grows_into_its_seek() {
+        use crate::rel::{StatementResult, TxnContext, execute_batch};
+
+        let path = unique_temp_path("row-count-tiebreak");
+        let storage = Storage::create(path.clone(), test_storage_options()).expect("create");
+        let mut ctx = TxnContext::default();
+        let run = |storage: &Storage, ctx: &mut TxnContext, sql: &str| {
+            let outcome = execute_batch(storage, sql, ctx);
+            assert!(outcome.error.is_none(), "{sql}: {:?}", outcome.error);
+            outcome
+        };
+        let plan_of = |storage: &Storage, ctx: &mut TxnContext, sql: &str| -> String {
+            let outcome = run(storage, ctx, &format!("SET SHOWPLAN_TEXT ON; {sql}"));
+            let mut ctx2 = TxnContext::default();
+            let _ = execute_batch(storage, "SET SHOWPLAN_TEXT OFF", &mut ctx2);
+            match &outcome.results[1] {
+                StatementResult::Rows(rowset) => rowset
+                    .rows
+                    .iter()
+                    .map(|r| format!("{:?}", r[0]))
+                    .collect::<Vec<_>>()
+                    .join("\n"),
+                other => panic!("expected plan rows, got {other:?}"),
+            }
+        };
+
+        run(
+            &storage,
+            &mut ctx,
+            "CREATE TABLE t (id INT NOT NULL PRIMARY KEY, a INT, v INT); \
+             CREATE INDEX ix_a ON t (a); \
+             CREATE INDEX ix_cover ON t (v) INCLUDE (v, id); \
+             INSERT INTO t VALUES (1, 10, 5), (2, 20, 6), (3, 30, 7)",
+        );
+
+        // Tiny: the non-covering seek ties with the scan; the tie goes to the
+        // scan. The covering seek still wins — it reads less than the table.
+        let tiny = plan_of(&storage, &mut ctx, "SELECT id FROM t WHERE a = 20");
+        assert!(tiny.contains("Table Scan"), "tiny table scans: {tiny}");
+        let covering = plan_of(&storage, &mut ctx, "SELECT v, id FROM t WHERE v = 6");
+        assert!(
+            covering.contains("Index Seek (covering)"),
+            "covering exempt from the tie-break: {covering}"
+        );
+
+        // Past the threshold the same query seeks.
+        let mut pad = String::from("INSERT INTO t VALUES (100, 900, 900)");
+        for i in 1..20 {
+            pad.push_str(&format!(", ({}, 900, 900)", 100 + i));
+        }
+        run(&storage, &mut ctx, &pad);
+        let grown = plan_of(&storage, &mut ctx, "SELECT id FROM t WHERE a = 20");
+        assert!(
+            grown.contains("Index Seek") && grown.contains("Key Lookup"),
+            "grown table seeks: {grown}"
+        );
+
+        drop(storage);
+        let _ = std::fs::remove_file(&path);
+    }
+
     /// A covering index wins its tie against an equal-scoring non-INCLUDE
     /// index — the "add a covering index to an existing database" workflow.
     /// Coverage breaks equality ties only: it never outranks a fully-matched
@@ -3443,6 +3660,14 @@ mod tests {
              INSERT INTO t VALUES (1, 'a@x.com', 'Alice')",
             &mut ctx,
         );
+        assert!(setup.error.is_none(), "{:?}", setup.error);
+        // Pad past the tiny-table tie-break: a <= 16-row table plans as a
+        // scan, and this test is about the seek's two plan shapes.
+        let mut pad = String::from("INSERT INTO t VALUES (100, 'z0@x.com', 'p')");
+        for i in 1..20 {
+            pad.push_str(&format!(", ({}, 'z{i}@x.com', 'p')", 100 + i));
+        }
+        let setup = execute_batch(&storage, &pad, &mut ctx);
         assert!(setup.error.is_none(), "{:?}", setup.error);
 
         // `name` is not included: the seek fetches the base row by PK key.

--- a/crates/truthdb-core/src/wal/records.rs
+++ b/crates/truthdb-core/src/wal/records.rs
@@ -85,6 +85,10 @@ pub enum PageOpRedo {
     },
     /// Heap page chain link.
     SetNextPage { page: u64, next: u64 },
+    /// Adds `delta` to a table's row-counter page (planner statistics). The
+    /// same shape serves redo and — with the sign flipped, via a CLR — undo,
+    /// and the page-LSN gate makes replay idempotent like any page op.
+    CounterAdd { page: u64, delta: i64 },
 }
 
 impl PageOpRedo {
@@ -96,7 +100,8 @@ impl PageOpRedo {
             | PageOpRedo::HeapInsert { page, .. }
             | PageOpRedo::HeapDelete { page, .. }
             | PageOpRedo::HeapUpdate { page, .. }
-            | PageOpRedo::SetNextPage { page, .. } => *page,
+            | PageOpRedo::SetNextPage { page, .. }
+            | PageOpRedo::CounterAdd { page, .. } => *page,
         }
     }
 
@@ -141,6 +146,11 @@ impl PageOpRedo {
                 put_u64(out, *page);
                 put_u64(out, *next);
             }
+            PageOpRedo::CounterAdd { page, delta } => {
+                out.push(8);
+                put_u64(out, *page);
+                put_u64(out, *delta as u64);
+            }
         }
     }
 
@@ -177,6 +187,10 @@ impl PageOpRedo {
             7 => PageOpRedo::SetNextPage {
                 page: cursor.u64()?,
                 next: cursor.u64()?,
+            },
+            8 => PageOpRedo::CounterAdd {
+                page: cursor.u64()?,
+                delta: cursor.u64()? as i64,
             },
             other => {
                 return Err(StorageError::InvalidFile(format!(
@@ -227,6 +241,12 @@ pub enum PageOpUndo {
         slot: u16,
         bytes: Vec<u8>,
     },
+    /// Undo of a counter add: apply the inverse delta (already negated when
+    /// the undo record was built).
+    CounterAdd {
+        page: u64,
+        delta: i64,
+    },
 }
 
 impl PageOpUndo {
@@ -275,6 +295,11 @@ impl PageOpUndo {
                 put_u16(out, *slot);
                 put_bytes(out, bytes);
             }
+            PageOpUndo::CounterAdd { page, delta } => {
+                out.push(7);
+                put_u64(out, *page);
+                put_u64(out, *delta as u64);
+            }
         }
     }
 
@@ -308,6 +333,10 @@ impl PageOpUndo {
                 page: cursor.u64()?,
                 slot: cursor.u16()?,
                 bytes: cursor.bytes()?,
+            },
+            7 => PageOpUndo::CounterAdd {
+                page: cursor.u64()?,
+                delta: cursor.u64()? as i64,
             },
             other => {
                 return Err(StorageError::InvalidFile(format!(


### PR DESCRIPTION
Closes Stage 7's last planner gap by building the statistics facility the gap note called for — the counter-page option: a per-table row counter maintained as an ordinary physiological page op (`PageOpRedo::CounterAdd`, undo = inverse delta), so statement atomicity, savepoints, transaction rollback, fuzzy checkpoints and ARIES crash recovery keep the count exactly consistent with committed rows with **no counter-specific recovery code**. The catalog-rewrite option was rejected: an in-transaction rollback would desync the in-memory catalog cache.

`TableDef.counter_page` is `Option<u64>` (`serde(default)`): pre-upgrade tables and views carry `None` and the planner applies no tie-break — exactly the old behavior. CREATE TABLE allocates and zeroes the page; INSERT/DELETE append one ±n op per statement inside the same `rel_statement` as the rows.

**The consumer** ("row counts as tie-breakers only", per the bullet): a non-covering seek on a table at or under 16 rows is demoted to the table scan it ties with — SQL Server makes the same choice — and a covering seek keeps its win at any size. Existing seek tests were padded past the threshold; their subject was seek mechanics, and a tiny table planning as a scan is now the correct plan.

**Review-hardened** (4 lenses, own worktrees, 2 independent refuters per finding; 6 findings, 3 refuted): the HIGH finding — a counter compensation cannot tolerate the recovery module's CLR-group re-run protocol (a blind delta, unlike the guarded heap/tree undo arms), so a crash between the CLR and its sealing no-op double-applied it permanently, reproduced by both refuters via WAL surgery. Fixed the textbook-ARIES way: a single-op group's CLR points *past* the compensated record. Pinned on the WAL record bytes and by a crash-mid-recovery-undo re-run test. Plus: count fetches guarded at all three planner call sites; one vacuous plan assertion re-armed.

Every new test proven to fail with its fix removed; fsync counts and the wire are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)