### PR TITLE
Locale-ordering index tests; NVARCHAR ranges seek over sort keys

### DIFF
--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -4879,6 +4879,172 @@ mod tests {
         let _ = std::fs::remove_file(path);
     }
 
+    /// A/B (seek vs scan) equality for character range seeks
+    /// across collations, with supplementary-plane characters, empty strings
+    /// and NULLs in both the stored data and the bounds.
+    #[test]
+    fn character_range_seeks_match_scans_across_collations() {
+        let values = [
+            "a",
+            "A",
+            "b",
+            "z",
+            "Z",
+            "å",
+            "ä",
+            "ö",
+            "é",
+            "e",
+            "aa",
+            "ab",
+            "",
+            "z\u{1F600}",
+            "a\u{1F600}",
+            "\u{1F600}",
+            "\u{1F600}a",
+            "\u{20000}",
+            "\u{10000}",
+            "\u{E000}",
+            "\u{FFFD}",
+            "\u{10FFFF}",
+        ];
+        let bounds = ["a", "å", "b", "z", "\u{1F600}", "\u{E000}", "\u{20000}", ""];
+        let ops = [">", ">=", "<", "<="];
+        for (label, decl) in [
+            ("nv-default", "NVARCHAR(40)"),
+            ("nv-cs", "NVARCHAR(40) COLLATE Latin1_General_CS_AS"),
+            ("nv-ai", "NVARCHAR(40) COLLATE Latin1_General_CI_AI"),
+            ("nv-bin2", "NVARCHAR(40) COLLATE Latin1_General_BIN2"),
+            ("nv-sv", "NVARCHAR(40) COLLATE Finnish_Swedish_CI_AS"),
+            ("vc-default", "VARCHAR(40)"),
+            ("vc-bin2", "VARCHAR(40) COLLATE Latin1_General_BIN2"),
+        ] {
+            let path = unique_temp_path(&format!("probe-ab-{label}"));
+            let engine = new_engine(&path);
+            engine
+                .execute(&format!(
+                    "CREATE TABLE t (id INT NOT NULL PRIMARY KEY, w {decl})"
+                ))
+                .expect("create");
+            for (i, v) in values.iter().enumerate() {
+                // BIN2/CS keep 'a'/'A' distinct; CI collations make some
+                // values duplicate keys — allowed (non-unique index).
+                engine
+                    .execute(&format!("INSERT INTO t VALUES ({i}, '{v}')"))
+                    .expect("insert");
+            }
+            // NULLs and padding past the tiny-table tie-break.
+            for i in 0..12 {
+                engine
+                    .execute(&format!("INSERT INTO t VALUES ({}, NULL)", 100 + i))
+                    .expect("insert null");
+            }
+            engine.execute("CREATE INDEX ix_w ON t (w)").expect("index");
+            let mut queries = Vec::new();
+            for b in bounds {
+                for op in ops {
+                    queries.push(format!("SELECT id FROM t WHERE w {op} '{b}' ORDER BY id"));
+                }
+            }
+            let mut with_index = Vec::new();
+            for q in &queries {
+                let plan = plan_lines(&engine, q.strip_suffix(" ORDER BY id").unwrap());
+                assert!(
+                    plan.iter().any(|l| l.contains("Index Seek")),
+                    "{label}: expected seek for {q}: {plan:?}"
+                );
+                with_index.push(sql_rows(&engine, q).1);
+            }
+            engine.execute("DROP INDEX ix_w ON t").expect("drop");
+            for (q, seeked) in queries.iter().zip(with_index) {
+                let scanned = sql_rows(&engine, q).1;
+                assert_eq!(scanned, seeked, "{label}: seek != scan for {q}");
+            }
+            let _ = std::fs::remove_file(path);
+        }
+    }
+
+    /// Composite (eq prefix + NVARCHAR range) and DESC-column
+    /// bounds, exercising prefix_upper_bound's carry over inverted bytes.
+    #[test]
+    fn composite_and_desc_index_bounds_match_scans() {
+        let path = unique_temp_path("probe-composite-desc");
+        let engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE t (id INT NOT NULL PRIMARY KEY, k INT, w NVARCHAR(40))")
+            .expect("create");
+        let values = [
+            "a",
+            "b",
+            "z",
+            "å",
+            "ä",
+            "\u{1F600}",
+            "z\u{1F600}",
+            "\u{20000}",
+            "\u{E000}",
+            "aa",
+        ];
+        let mut id = 0;
+        for k in [1, 2, 3] {
+            for v in values {
+                engine
+                    .execute(&format!("INSERT INTO t VALUES ({id}, {k}, '{v}')"))
+                    .expect("insert");
+                id += 1;
+            }
+        }
+        engine
+            .execute("CREATE INDEX ix_kw ON t (k, w)")
+            .expect("index");
+        let mut queries = Vec::new();
+        for b in ["å", "b", "\u{1F600}", "z"] {
+            for op in [">", ">=", "<", "<="] {
+                queries.push(format!(
+                    "SELECT id FROM t WHERE k = 2 AND w {op} '{b}' ORDER BY id"
+                ));
+            }
+        }
+        // Equality-only on k too (prefix_upper_bound over the eq prefix).
+        queries.push("SELECT id FROM t WHERE k = 2 ORDER BY id".to_string());
+        let mut with_index = Vec::new();
+        for q in &queries {
+            let plan = plan_lines(&engine, q.strip_suffix(" ORDER BY id").unwrap());
+            assert!(
+                plan.iter().any(|l| l.contains("Index Seek")),
+                "expected seek for {q}: {plan:?}"
+            );
+            with_index.push(sql_rows(&engine, q).1);
+        }
+        engine.execute("DROP INDEX ix_kw ON t").expect("drop");
+        for (q, seeked) in queries.iter().zip(with_index) {
+            let scanned = sql_rows(&engine, q).1;
+            assert_eq!(scanned, seeked, "composite: seek != scan for {q}");
+        }
+
+        // DESC index: a range must NOT seek (bounds are not inverted), an
+        // equality must seek correctly through inverted-byte bounds
+        // (prefix_upper_bound's 0xFF carry path).
+        engine
+            .execute("CREATE INDEX ix_wd ON t (w DESC)")
+            .expect("desc index");
+        let plan = plan_lines(&engine, "SELECT id FROM t WHERE w < 'b'");
+        assert!(
+            plan.iter().all(|l| !l.contains("Index Seek")),
+            "a DESC column must not back a range seek: {plan:?}"
+        );
+        let q = "SELECT id FROM t WHERE w = 'å' ORDER BY id";
+        let plan = plan_lines(&engine, "SELECT id FROM t WHERE w = 'å'");
+        assert!(
+            plan.iter().any(|l| l.contains("Index Seek")),
+            "DESC equality seeks: {plan:?}"
+        );
+        let seeked = sql_rows(&engine, q).1;
+        engine.execute("DROP INDEX ix_wd ON t").expect("drop");
+        assert_eq!(sql_rows(&engine, q).1, seeked, "desc eq: seek != scan");
+        let _ = std::fs::remove_file(path);
+    }
+
     #[test]
     fn sql_drop_index_is_table_scoped() {
         let path = unique_temp_path("sql-drop-scoped");

--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -4778,11 +4778,15 @@ mod tests {
             "case-insensitive equality matches both 'abc' and 'ABC'"
         );
 
-        // A range on NVARCHAR must NOT seek (UTF-16BE key order can diverge from
-        // the filter's order at astral characters); it scans and stays correct.
-        // Case-insensitive: 'ABC' folds to 'abc' > 'a', so all three match.
+        // An NVARCHAR range SEEKS since the keys became collation sort keys
+        // (#94): sort-key byte order IS the filter's compare order, so the old
+        // UTF-16BE divergence that forced a scan no longer exists.
+        // Case-insensitive: 'ABC' folds with 'abc' > 'a', so all three match.
         let plan = plan_lines(&engine, "SELECT id FROM t WHERE name > 'a'");
-        assert_eq!(plan, vec!["Table Scan(t)".to_string()]);
+        assert!(
+            plan.iter().any(|l| l.contains("Index Seek")),
+            "NVARCHAR ranges seek over sort keys: {plan:?}"
+        );
         let (_, mut rows) = sql_rows(&engine, "SELECT id FROM t WHERE name > 'a'");
         rows.sort();
         assert_eq!(
@@ -4824,6 +4828,54 @@ mod tests {
         let (_, mut rows) = sql_rows(&engine, "SELECT id FROM t WHERE code > 'b'");
         rows.sort();
         assert_eq!(rows, vec![vec![Some("2".into())], vec![Some("3".into())]]);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn sql_range_seek_follows_linguistic_order_not_code_points() {
+        // Under the default collation, accented letters sort next to their
+        // base letter ('å' < 'b') while their UTF-8 bytes sort past 'z'. The
+        // index keys are collation SORT KEYS, so a range seek's bounds agree
+        // with the filter — a code-point-keyed index would exclude 'å'/'ä'
+        // from `w < 'b'` and silently drop matching rows.
+        let path = unique_temp_path("sql-index-locale-range");
+        let engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE t (id INT NOT NULL PRIMARY KEY, w VARCHAR(20))")
+            .expect("create");
+        engine
+            .execute("INSERT INTO t VALUES (1,'a'),(2,'å'),(3,'ä'),(4,'b'),(5,'z')")
+            .expect("insert");
+        // Pad past the tiny-table tie-break; 'z...' sorts above 'b' in every
+        // collation involved, so the range's row set is untouched.
+        for i in 0..20 {
+            engine
+                .execute(&format!("INSERT INTO t VALUES ({}, 'zz{i}')", 100 + i))
+                .expect("pad");
+        }
+        engine.execute("CREATE INDEX ix_w ON t (w)").expect("index");
+
+        let q = "SELECT id FROM t WHERE w < 'b' ORDER BY id";
+        let plan = plan_lines(&engine, "SELECT id FROM t WHERE w < 'b'");
+        assert!(
+            plan.iter().any(|l| l.contains("Index Seek")),
+            "the range seeks: {plan:?}"
+        );
+        let (_, seeked) = sql_rows(&engine, q);
+        assert_eq!(
+            seeked,
+            vec![
+                vec![Some("1".into())],
+                vec![Some("2".into())],
+                vec![Some("3".into())]
+            ],
+            "'å' and 'ä' sort below 'b' linguistically and the seek keeps them"
+        );
+
+        // A/B: the scan agrees.
+        engine.execute("DROP INDEX ix_w ON t").expect("drop");
+        let (_, scanned) = sql_rows(&engine, q);
+        assert_eq!(scanned, seeked, "seek == scan");
         let _ = std::fs::remove_file(path);
     }
 

--- a/crates/truthdb-core/src/rel/plan.rs
+++ b/crates/truthdb-core/src/rel/plan.rs
@@ -9,8 +9,8 @@ use truthdb_sql::eval::{self, EvalContext};
 
 use crate::relstore::catalog::{IndexDef, TableDef};
 use crate::relstore::index;
-use crate::relstore::row::{Column, Schema};
-use crate::relstore::types::{ColumnType, Datum};
+use crate::relstore::row::Schema;
+use crate::relstore::types::Datum;
 
 use super::value::sql_to_datum;
 
@@ -204,24 +204,6 @@ fn as_sarg(
     None
 }
 
-/// Whether a column may back an index *range* seek. A seek is correct only when
-/// the index's key byte order matches the WHERE filter's compare order for that
-/// column. The filter now compares strings by the column's collation (Stage 5)
-/// and the index key is folded the same way (`fold_key_datum`), so VARCHAR keys
-/// (UTF-8 bytes of the folded string) match the filter order — equality seeks
-/// (folded literal vs folded key) and VARCHAR ranges stay correct, including
-/// case-insensitively. NVARCHAR index keys are UTF-16BE, whose byte order
-/// diverges from the filter's order at supplementary-plane characters (surrogate
-/// pairs) regardless of folding — so an NVARCHAR *range* bound could exclude a
-/// matching row the filter keeps, and only NVARCHAR ranges are excluded here.
-/// (Equality seeks stay correct for NVARCHAR: they are exact folded-key matches.)
-///
-/// Locale-specific ordering (Swedish å-after-z) would still need collation sort
-/// keys; case-folding alone gives correct *equality*, not linguistic order.
-fn range_seekable_column(column: &Column) -> bool {
-    !matches!(column.column_type, ColumnType::NVarChar { .. })
-}
-
 /// Evaluates a would-be constant operand. Returns None if it references a
 /// column, is NULL, or does not coerce to the column type (all non-sargable —
 /// execution's own filter handles them).
@@ -276,7 +258,13 @@ fn try_index(index: &IndexDef, schema: &Schema, sargs: &[Sarg]) -> Option<(u32, 
     let mut upper_extra: Option<Datum> = None;
     if i < index.columns.len() {
         let (col, ascending) = index.columns[i];
-        if ascending && range_seekable_column(&schema.columns[col]) {
+        // Character range seeks are correct for VARCHAR and NVARCHAR alike
+        // since #94: both key encodings are the collation's SORT KEY
+        // (`encode_datum_collated`), whose byte order IS the filter's compare
+        // order (`Collation::sort_key` is asserted to agree with `compare`
+        // exhaustively). The old NVARCHAR exclusion guarded UTF-16BE keys,
+        // which no longer exist.
+        if ascending {
             for sarg in sargs.iter().filter(|s| s.column == col) {
                 match sarg.op {
                     BinaryOp::Gt | BinaryOp::Ge => {

--- a/crates/truthdb-core/src/rel/plan.rs
+++ b/crates/truthdb-core/src/rel/plan.rs
@@ -250,20 +250,20 @@ fn try_index(index: &IndexDef, schema: &Schema, sargs: &[Sarg]) -> Option<(u32, 
             break;
         }
     }
-    // Optional single range on the next column. Ascending only (a descending
-    // range would need reversed bounds) and never NVARCHAR (UTF-16BE key order
-    // can diverge from the filter's code-point order); equality prefixes above
-    // are exact matches and stay correct for all types.
+    // Optional single range on the next column. Ascending only: a descending
+    // range would need reversed bounds. Equality prefixes above are exact
+    // matches and stay correct for all types.
     let mut lower_extra: Option<Datum> = None;
     let mut upper_extra: Option<Datum> = None;
     if i < index.columns.len() {
         let (col, ascending) = index.columns[i];
         // Character range seeks are correct for VARCHAR and NVARCHAR alike
         // since #94: both key encodings are the collation's SORT KEY
-        // (`encode_datum_collated`), whose byte order IS the filter's compare
-        // order (`Collation::sort_key` is asserted to agree with `compare`
-        // exhaustively). The old NVARCHAR exclusion guarded UTF-16BE keys,
-        // which no longer exist.
+        // (`encode_datum_collated`), whose byte order is the filter's compare
+        // order — pinned by `truthdb-sql/tests/sortkey_order.rs`, the
+        // tripwire for icu updates (sort keys ride a semver-exempt icu
+        // feature). The old NVARCHAR exclusion guarded UTF-16BE keys, which
+        // no longer exist.
         if ascending {
             for sarg in sargs.iter().filter(|s| s.column == col) {
                 match sarg.op {

--- a/crates/truthdb-core/tests/slt/collation_sort_keys.slt
+++ b/crates/truthdb-core/tests/slt/collation_sort_keys.slt
@@ -132,3 +132,37 @@ query T
 SELECT w FROM bin WHERE w = 'a'
 ----
 a
+
+# --- the index BYTES are in linguistic order, not just ORDER BY's output ---
+# A bare scan of a clustered table returns key order: no executor sort runs,
+# so this pins the on-disk sort-key ordering itself.
+
+query T
+SELECT w FROM sv
+----
+a
+b
+z
+å
+ä
+ö
+
+query T
+SELECT w FROM root
+----
+a
+å
+ä
+b
+ö
+z
+
+# A range through the clustered key follows linguistic order too: under the
+# root collation 'å'/'ä' fall BELOW 'b' even though their code points sort
+# past 'z' — a code-point-ordered key would drop them.
+query T rowsort
+SELECT w FROM root WHERE w < 'b'
+----
+a
+å
+ä

--- a/crates/truthdb-core/tests/slt/collation_sort_keys.slt
+++ b/crates/truthdb-core/tests/slt/collation_sort_keys.slt
@@ -157,9 +157,11 @@ b
 ö
 z
 
-# A range through the clustered key follows linguistic order too: under the
-# root collation 'å'/'ä' fall BELOW 'b' even though their code points sort
-# past 'z' — a code-point-ordered key would drop them.
+# A range filter over the clustered table agrees with linguistic order: under
+# the root collation 'å'/'ä' fall BELOW 'b' even though their code points sort
+# past 'z'. (This runs as a filtered scan — the planner seeks only secondary
+# indexes — so it pins the FILTER's order; the seek-side pin is the engine
+# test sql_range_seek_follows_linguistic_order_not_code_points.)
 query T rowsort
 SELECT w FROM root WHERE w < 'b'
 ----

--- a/crates/truthdb-sql/tests/sortkey_order.rs
+++ b/crates/truthdb-sql/tests/sortkey_order.rs
@@ -1,0 +1,141 @@
+//! Tripwire: memcmp over `Collation::sort_key` must agree with
+//! `Collation::compare` for every pair — the property the NVARCHAR range-seek
+//! gate rests on. `write_sort_key_to` lives behind icu_collator's `unstable`
+//! feature — explicitly semver-exempt — so an icu update may change sort-key
+//! bytes; this test is what turns that into a loud failure instead of range
+//! seeks silently dropping rows. Includes supplementary-plane characters, combining
+//! marks, contractions (Danish 'aa'), and boundary code points.
+
+use truthdb_sql::collation::Collation;
+
+struct Rng(u64);
+impl Rng {
+    fn next(&mut self) -> u64 {
+        let mut x = self.0;
+        x ^= x << 13;
+        x ^= x >> 7;
+        x ^= x << 17;
+        self.0 = x;
+        x
+    }
+}
+
+fn corpus() -> Vec<String> {
+    // Alphabet stressing every divergence channel:
+    // - ASCII upper/lower (case strength)
+    // - Latin accents, precomposed AND decomposed (normalization)
+    // - Nordic letters (locale tailorings), 'aa' contraction fodder
+    // - BMP boundary chars: U+0000-adjacent, U+E000 (private use), U+FFFD,
+    //   U+FFFF-1 region
+    // - Supplementary plane: U+10000, U+1F600, U+20000, U+10FFFF
+    let alphabet: Vec<&str> = vec![
+        "a",
+        "A",
+        "b",
+        "z",
+        "Z",
+        "å",
+        "Å",
+        "ä",
+        "ö",
+        "æ",
+        "ø",
+        "é",
+        "e\u{0301}",
+        "e",
+        "ß",
+        "ss",
+        "aa",
+        "th",
+        "þ",
+        "\u{E000}",
+        "\u{FFFD}",
+        "\u{FFFE}",
+        "\u{10000}",
+        "\u{1F600}",
+        "\u{20000}",
+        "\u{10FFFF}",
+        "0",
+        "9",
+        " ",
+        "-",
+        "'",
+    ];
+    let mut rng = Rng(0x5EEDBEEF_CAFEF00D);
+    let mut out: Vec<String> = Vec::new();
+    // Fixed adversarial strings first.
+    for s in [
+        "",
+        "a",
+        "z",
+        "å",
+        "\u{1F600}",
+        "z\u{1F600}",
+        "a\u{10FFFF}",
+        "\u{E000}",
+        "\u{FFFD}z",
+        "aa",
+        "ab",
+        "b",
+        "resume",
+        "résumé",
+        "Résumé",
+        "e\u{0301}",
+        "é",
+        "\u{10000}",
+        "\u{FFFF}",
+    ] {
+        out.push(s.to_string());
+    }
+    // Random strings of length 0..=6 over the alphabet.
+    for _ in 0..250 {
+        let len = (rng.next() % 7) as usize;
+        let mut s = String::new();
+        for _ in 0..len {
+            s.push_str(alphabet[(rng.next() as usize) % alphabet.len()]);
+        }
+        out.push(s);
+    }
+    out
+}
+
+#[test]
+fn sort_key_memcmp_agrees_with_compare_everywhere() {
+    let names = [
+        "SQL_Latin1_General_CP1_CI_AS",
+        "Latin1_General_CS_AS",
+        "Latin1_General_CI_AI",
+        "Latin1_General_BIN2",
+        "Latin1_General_BIN",
+        "Finnish_Swedish_CI_AS",
+        "Danish_Norwegian_CI_AS",
+        "French_CI_AS",
+        "German_PhoneBook_CI_AS",
+        "Icelandic_CS_AS",
+    ];
+    let strings = corpus();
+    for name in names {
+        let coll = Collation::from_name(name);
+        let keys: Vec<Vec<u8>> = strings.iter().map(|s| coll.sort_key(s)).collect();
+        let mut mismatches = 0;
+        for i in 0..strings.len() {
+            for j in 0..strings.len() {
+                let by_key = keys[i].cmp(&keys[j]);
+                let by_cmp = coll.compare(&strings[i], &strings[j]);
+                if by_key != by_cmp {
+                    mismatches += 1;
+                    if mismatches <= 5 {
+                        eprintln!(
+                            "{name}: {:?} vs {:?}: key {:?} compare {:?}\n  k_i={:02X?}\n  k_j={:02X?}",
+                            strings[i], strings[j], by_key, by_cmp, keys[i], keys[j]
+                        );
+                    }
+                }
+            }
+        }
+        assert_eq!(
+            mismatches, 0,
+            "{name}: sort_key order diverges from compare"
+        );
+    }
+}


### PR DESCRIPTION
Closes Stage 7's exit-bullet gap (locale-ordering index tests) and opens the stale NVARCHAR range-seek gate the tests prove correct.

**The tests pin the index bytes, not just ORDER BY** (which the executor sorts): a bare clustered scan returns key order — Swedish å/ä/ö after z, root-collation accents beside their base letters — and a range seek keeps rows where linguistic order diverges from code-point order ('å' < 'b' linguistically, past 'z' in UTF-8), plan-asserted as a seek, A/B-equal to the scan, teeth-checked with an under-fetching bound (over-fetch is absorbed by the seek-only-narrows invariant; under-fetch is the direction that silently drops rows).

**The gate**: `range_seekable_column` excluded NVARCHAR ranges because UTF-16BE key bytes diverged from the filter's order at supplementary-plane characters. Since #94 both character types key on the collation's sort key through one shared encoder, so the divergence no longer exists and NVARCHAR ranges seek exactly as VARCHAR ranges always did.

**Adversarial review** (own worktree, tasked with breaking the gate): no under-fetching seek found — analytically or empirically — across astral characters, BIN2, \_AI, \_CS, composite prefixes, DESC columns, and prefix_upper_bound's carry. It did catch the claim "asserted exhaustively" being false: the sort-key-order == compare-order invariant had **no in-tree test**, and it rides icu's semver-exempt `unstable` feature. The reviewer's probes are adopted in-tree: a 269-string × 10-collation memcmp-vs-compare tripwire in truthdb-sql, and two engine A/B seek-vs-scan matrices (seven collation combos, astral values, empty strings, NULLs, composite and DESC bounds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)