### PR TITLE
Stage 8 exit: pin all-NULL-group aggregates

### DIFF
--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -5780,6 +5780,53 @@ mod tests {
     // ---- Regression tests for adversarial-review findings on #82 -------------
 
     #[test]
+    fn all_null_groups_aggregate_identically_through_the_spill_path() {
+        // A group whose every value is NULL: SUM/MIN/MAX/AVG NULL, COUNT(col)
+        // 0, COUNT(*) counts rows — and the grace-hash spill path must answer
+        // exactly as the in-memory path does (an all-NULL group must not read
+        // as "no group" after partitioning).
+        let path = unique_temp_path("all-null-spill");
+        let engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE t (id INT NOT NULL PRIMARY KEY, k VARCHAR(10), v INT)")
+            .expect("create");
+        // 100 all-NULL rows in group 'a', 100 mixed rows in group 'b'.
+        for i in 0..100 {
+            engine
+                .execute(&format!("INSERT INTO t VALUES ({i}, 'a', NULL)"))
+                .expect("insert a");
+            let v = if i % 2 == 0 {
+                "NULL".to_string()
+            } else {
+                i.to_string()
+            };
+            engine
+                .execute(&format!("INSERT INTO t VALUES ({}, 'b', {v})", 100 + i))
+                .expect("insert b");
+        }
+        let query = "SELECT k, COUNT(*), COUNT(v), SUM(v), MIN(v), MAX(v), AVG(v)                      FROM t GROUP BY k ORDER BY k";
+        let (_, in_memory) = sql_rows(&engine, query);
+        crate::rel::set_test_sort_budget(Some(400));
+        let (_, spilled) = sql_rows(&engine, query);
+        crate::rel::set_test_sort_budget(None);
+        assert_eq!(spilled, in_memory, "spill path changes all-NULL groups");
+        assert_eq!(
+            in_memory[0],
+            vec![
+                Some("a".into()),
+                Some("100".into()),
+                Some("0".into()),
+                None,
+                None,
+                None,
+                None
+            ],
+            "all-NULL group: COUNT(*) counts, everything else is NULL/0"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
     fn collation_ci_group_by_spill_folds_case() {
         // The grace-hash GROUP BY spill path must partition by the FOLDED key, or
         // case-variant groups split across partitions on large input. 'World'/

--- a/crates/truthdb-core/tests/slt/all_null_groups.slt
+++ b/crates/truthdb-core/tests/slt/all_null_groups.slt
@@ -1,0 +1,60 @@
+# A group whose every aggregated value is NULL (Stage 8 exit matrix): the
+# aggregates must distinguish "no values" from "no rows" — SUM/MIN/MAX/AVG
+# answer NULL, COUNT(col) answers 0, and COUNT(*) still counts the rows.
+
+statement ok
+CREATE TABLE g (id INT NOT NULL PRIMARY KEY, k VARCHAR(10), v INT)
+
+# Group 'a' is all-NULL (three rows), group 'b' mixes NULL and values, and
+# group 'c' has no NULLs at all.
+statement ok
+INSERT INTO g VALUES (1, 'a', NULL), (2, 'a', NULL), (3, 'a', NULL), (4, 'b', NULL), (5, 'b', 10), (6, 'b', 30), (7, 'c', 7)
+
+query TIIIII rowsort
+SELECT k, COUNT(*), COUNT(v), SUM(v), MIN(v), MAX(v) FROM g GROUP BY k
+----
+a 3 0 NULL NULL NULL
+b 3 2 40 10 30
+c 1 1 7 7 7
+
+# AVG over an all-NULL group is NULL too — and never a divide-by-zero.
+query TI rowsort
+SELECT k, AVG(v) FROM g GROUP BY k
+----
+a NULL
+b 20
+c 7
+
+# HAVING sees the same semantics: COUNT(v) = 0 selects exactly the all-NULL
+# group, and a NULL SUM comparison is UNKNOWN, so `SUM(v) > 0` drops it.
+query T
+SELECT k FROM g GROUP BY k HAVING COUNT(v) = 0
+----
+a
+
+query T rowsort
+SELECT k FROM g GROUP BY k HAVING SUM(v) > 0
+----
+b
+c
+
+# COUNT(DISTINCT col) over an all-NULL group is 0 as well.
+query TI rowsort
+SELECT k, COUNT(DISTINCT v) FROM g GROUP BY k
+----
+a 0
+b 2
+c 1
+
+# The ungrouped (single-group) shape over an all-NULL table: SUM/MIN/MAX/AVG
+# NULL, COUNT(col) 0, COUNT(*) counts rows.
+statement ok
+CREATE TABLE n (id INT NOT NULL PRIMARY KEY, v INT)
+
+statement ok
+INSERT INTO n VALUES (1, NULL), (2, NULL)
+
+query IIIIII
+SELECT COUNT(*), COUNT(v), SUM(v), MIN(v), MAX(v), AVG(v) FROM n
+----
+2 0 NULL NULL NULL NULL


### PR DESCRIPTION
Closes the Stage 8 exit bullet's last gap: nothing held `fold()` to the all-NULL-group semantics (SUM/MIN/MAX/AVG → NULL, COUNT(col) → 0, COUNT(*) → n). Now an slt matrix does — grouped, ungrouped, HAVING over `COUNT(col) = 0` and a NULL `SUM` comparison, `COUNT(DISTINCT)` — plus an A/B test that the grace-hash spill path answers identically. Teeth-checked against a weakened `fold()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)