### PR TITLE
Stage 9: the sp_prepare handle family

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,6 +220,9 @@ jobs:
       - name: Conformance — pytds parameterized (sp_executesql RPC)
         run: python3 scripts/tds_conformance_rpc.py 127.0.0.1 1433 sa secret
 
+      - name: Conformance — pytds prepared statements (sp_prepare family)
+        run: python3 scripts/tds_conformance_prepared.py 127.0.0.1 1433 sa secret
+
       - name: Conformance — pytds over TLS (tunneled handshake)
         run: python3 scripts/tds_conformance_tls.py 127.0.0.1 1433 sa secret /etc/truthdb/tls.crt
 

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -158,6 +158,12 @@ impl TxnContext {
         self.txn.is_some()
     }
 
+    /// Whether an explicit transaction is open (`@@TRANCOUNT > 0`) — what a
+    /// reply's DONE stamps as `DONE_INXACT`.
+    pub fn in_transaction(&self) -> bool {
+        self.trancount > 0
+    }
+
     /// The session's current isolation level (drives which locks reads take).
     pub fn isolation(&self) -> Isolation {
         self.isolation

--- a/crates/truthdb-core/src/session.rs
+++ b/crates/truthdb-core/src/session.rs
@@ -114,11 +114,76 @@ pub enum BatchEvent {
     /// A SQL error that stopped the batch. The statements before it kept their
     /// results, which were already sent.
     Error(SqlError),
+    /// The handle `sp_prepare`/`sp_prepexec` allocated, reported to the client
+    /// as a RETURNVALUE token. Sent after every statement's events, just
+    /// before `Complete` — where SQL Server puts return values.
+    PreparedHandle(i32),
     /// Terminal: the batch ended. Carries the batch's *final* transaction
     /// state, which is what the TDS transaction-manager path needs.
     Complete { in_transaction: bool },
     /// Terminal: the engine could not run the batch at all.
     Failed(EngineError),
+}
+
+/// A prepared-statement RPC (the `sp_prepare` handle family). `Prepare` and
+/// `Unprepare` touch only session state; `Execute` and `PrepExec` run the
+/// statement through the ordinary batch path (locks, parking, streaming).
+pub enum PreparedRpc {
+    Prepare {
+        decls: String,
+        stmt: String,
+    },
+    Execute {
+        handle: i32,
+        values: Vec<crate::rel::RpcParam>,
+    },
+    PrepExec {
+        decls: String,
+        stmt: String,
+        values: Vec<crate::rel::RpcParam>,
+    },
+    Unprepare {
+        handle: i32,
+    },
+}
+
+/// A statement a session prepared: its text and parameter declarations, both
+/// verbatim from `sp_prepare`. There is no cached plan to go stale — every
+/// execution re-parses and re-binds against the live catalog, exactly like
+/// `sp_executesql`, so DDL between prepare and execute behaves like SQL
+/// Server's recompile-on-schema-change with no invalidation machinery.
+struct PreparedStatement {
+    decls: String,
+    text: String,
+}
+
+/// The parameter names of a declaration list (`@p1 int, @p2 nvarchar(10)`),
+/// in order: the first token of each top-level comma-separated entry.
+/// `sp_execute` values arrive unnamed on the wire; these names bind them.
+fn decl_names(decls: &str) -> Vec<String> {
+    let mut names = Vec::new();
+    let mut depth = 0usize;
+    let mut entry = String::new();
+    for ch in decls.chars().chain(std::iter::once(',')) {
+        match ch {
+            '(' => {
+                depth += 1;
+                entry.push(ch);
+            }
+            ')' => {
+                depth = depth.saturating_sub(1);
+                entry.push(ch);
+            }
+            ',' if depth == 0 => {
+                if let Some(name) = entry.split_whitespace().next() {
+                    names.push(name.to_string());
+                }
+                entry.clear();
+            }
+            _ => entry.push(ch),
+        }
+    }
+    names
 }
 
 /// The reply channel for one batch.
@@ -141,14 +206,29 @@ pub enum BatchEvent {
 /// any client that keeps up it is bounded by what is in flight.
 pub struct BatchSink {
     tx: mpsc::UnboundedSender<BatchEvent>,
+    /// A handle `sp_prepexec` allocated, reported as a `PreparedHandle` event
+    /// just before `Complete` — return values follow every result set.
+    prepared_handle: Option<i32>,
 }
 
 impl BatchSink {
+    fn new(tx: mpsc::UnboundedSender<BatchEvent>) -> BatchSink {
+        BatchSink {
+            tx,
+            prepared_handle: None,
+        }
+    }
+
     /// Sends one event. Never blocks: `UnboundedSender::send` is a plain
     /// function, which is the point (see the type's docs). `false` once the
     /// receiver is gone — the client disconnected, or its connection task was
     /// dropped — which is the producer's signal to stop.
     fn send(&self, event: BatchEvent) -> bool {
+        if matches!(event, BatchEvent::Complete { .. })
+            && let Some(handle) = self.prepared_handle
+        {
+            let _ = self.tx.send(BatchEvent::PreparedHandle(handle));
+        }
         self.tx.send(event).is_ok()
     }
 
@@ -280,6 +360,9 @@ async fn collect_reply(
             // The aborted statement contributes no result; its partly-streamed
             // rowset is dropped, which is what the buffered path returned too.
             BatchEvent::StatementAborted { .. } => open = None,
+            // A whole-reply caller has nowhere to carry a prepared handle —
+            // only the TDS renderer (RETURNVALUE) consumes it.
+            BatchEvent::PreparedHandle(_) => {}
             BatchEvent::Error(err) => error = Some(err),
             BatchEvent::Complete { in_transaction } => {
                 return Ok(BatchReply {
@@ -315,6 +398,12 @@ struct Session {
     /// [`Scheduler::take_ctx`], so a session mid-batch reports no open
     /// transaction and is never a reap candidate regardless of this stamp.
     last_activity: Instant,
+    /// Statements prepared over the `sp_prepare` family, by handle. Dropped
+    /// with the session (SQL Server scopes prepared handles the same way).
+    prepared: HashMap<i32, PreparedStatement>,
+    /// The next handle to allocate. Handles are opaque to the client and never
+    /// reused within a session.
+    next_prepared_handle: i32,
 }
 
 impl Default for Session {
@@ -322,6 +411,8 @@ impl Default for Session {
         Session {
             txn_ctx: TxnContext::default(),
             last_activity: Instant::now(),
+            prepared: HashMap::new(),
+            next_prepared_handle: 1,
         }
     }
 }
@@ -373,6 +464,39 @@ impl SessionManager {
             state.last_activity = Instant::now();
         }
     }
+
+    /// Stores a prepared statement for the session and returns its handle.
+    fn prepare(&mut self, id: SessionId, decls: String, text: String) -> i32 {
+        let session = self.sessions.entry(id).or_default();
+        let handle = session.next_prepared_handle;
+        session.next_prepared_handle += 1;
+        session.prepared.insert(handle, PreparedStatement { decls, text });
+        handle
+    }
+
+    /// Looks up a session's prepared statement by handle.
+    fn prepared(&self, id: SessionId, handle: i32) -> Option<(String, String)> {
+        self.sessions
+            .get(&id)?
+            .prepared
+            .get(&handle)
+            .map(|p| (p.decls.clone(), p.text.clone()))
+    }
+
+    /// Drops a prepared handle. `false` if the session never prepared it.
+    fn unprepare(&mut self, id: SessionId, handle: i32) -> bool {
+        self.sessions
+            .get_mut(&id)
+            .is_some_and(|s| s.prepared.remove(&handle).is_some())
+    }
+
+    /// Whether the session has an open explicit transaction — the state an
+    /// immediate (no-batch) reply's DONE stamps as `DONE_INXACT`.
+    fn in_transaction(&self, id: SessionId) -> bool {
+        self.sessions
+            .get(&id)
+            .is_some_and(|s| s.txn_ctx.in_transaction())
+    }
 }
 
 /// A message to the engine thread. Each carries a one-shot reply channel the
@@ -391,6 +515,15 @@ enum EngineCall {
         sql: String,
         params: Vec<crate::rel::RpcParam>,
         /// Set by the connection on a TDS Attention to abort the batch mid-flight.
+        cancel: Arc<AtomicBool>,
+        reply: BatchSink,
+    },
+    /// A prepared-statement RPC (`sp_prepare` handle family) on behalf of a
+    /// session. `Execute`/`PrepExec` re-enter the ordinary batch path once the
+    /// handle is resolved; `Prepare`/`Unprepare` answer immediately.
+    RunRpc {
+        session: SessionId,
+        command: PreparedRpc,
         cancel: Arc<AtomicBool>,
         reply: BatchSink,
     },
@@ -625,11 +758,29 @@ impl EngineHandle {
             sql,
             params,
             cancel,
-            reply: BatchSink { tx },
+            reply: BatchSink::new(tx),
         });
         // A closed inbox drops the call, taking the sink with it, so the stream
         // ends with no terminal event — which every reader here turns into the
         // same "the engine is gone" the dead oneshot used to mean.
+        rx
+    }
+
+    /// Runs a prepared-statement RPC (the `sp_prepare` handle family),
+    /// streaming its reply exactly like [`Self::stream_rpc`].
+    pub fn stream_prepared(
+        &self,
+        session: SessionId,
+        command: PreparedRpc,
+        cancel: Arc<AtomicBool>,
+    ) -> mpsc::UnboundedReceiver<BatchEvent> {
+        let (tx, rx) = mpsc::unbounded_channel();
+        self.inbox.send(EngineCall::RunRpc {
+            session,
+            command,
+            cancel,
+            reply: BatchSink::new(tx),
+        });
         rx
     }
 
@@ -896,8 +1047,12 @@ fn worker_loop(shared: &Arc<Shared>) {
             // arbitrary times and would otherwise reap the transaction of a
             // session whose next batch is already in hand.
             let mut sched = shared.scheduler.lock().expect("scheduler poisoned");
-            if let Work::Call(EngineCall::RunBatch { session, .. }) = &work {
-                sched.sessions.touch(*session);
+            match &work {
+                Work::Call(EngineCall::RunBatch { session, .. })
+                | Work::Call(EngineCall::RunRpc { session, .. }) => {
+                    sched.sessions.touch(*session);
+                }
+                _ => {}
             }
         }
         drain_ready(shared);
@@ -923,6 +1078,12 @@ fn worker_loop(shared: &Arc<Shared>) {
                 cancel,
                 reply,
             }) => dispatch_batch(shared, session, sql, params, cancel, reply),
+            Work::Call(EngineCall::RunRpc {
+                session,
+                command,
+                cancel,
+                reply,
+            }) => dispatch_rpc(shared, session, command, cancel, reply),
             Work::Call(EngineCall::RunNative { command, reply }) => {
                 let _ = reply.send(shared.engine.execute(&command));
             }
@@ -936,6 +1097,112 @@ fn worker_loop(shared: &Arc<Shared>) {
             }
         }
     }
+}
+
+/// Resolves a prepared-statement RPC. `Prepare`/`Unprepare` touch only the
+/// session's handle table and answer immediately; `Execute`/`PrepExec`
+/// re-enter [`dispatch_batch`] with the resolved statement text, so locks,
+/// parking and streaming behave exactly as for a plain batch. There is no
+/// cached plan: execution re-parses and re-binds against the live catalog
+/// (like `sp_executesql`), so DDL between prepare and execute needs no
+/// invalidation — the next execute simply sees the new schema.
+fn dispatch_rpc(
+    shared: &Arc<Shared>,
+    session: SessionId,
+    command: PreparedRpc,
+    cancel: Arc<AtomicBool>,
+    mut reply: BatchSink,
+) {
+    // The immediate replies (no batch runs) still stamp DONE_INXACT from the
+    // session's real transaction state.
+    let immediate = |reply: &BatchSink, error: Option<SqlError>| {
+        let in_transaction = {
+            let sched = shared.scheduler.lock().expect("scheduler poisoned");
+            sched.sessions.in_transaction(session)
+        };
+        if let Some(error) = error {
+            reply.send(BatchEvent::Error(error));
+        }
+        reply.send(BatchEvent::Complete { in_transaction });
+    };
+    let missing_handle = |handle: i32| {
+        SqlError::new(
+            8179,
+            16,
+            1,
+            format!("Could not find prepared statement with handle {handle}."),
+        )
+    };
+    match command {
+        PreparedRpc::Prepare { decls, stmt } => {
+            // Parse now so a syntax error surfaces at prepare time, as SQL
+            // Server's compile does. Binding stays at execute (names resolve
+            // against the live catalog there) — a divergence: an unknown
+            // table or column errors at execute, not prepare.
+            if let Err(error) = truthdb_sql::parse(&stmt) {
+                immediate(&reply, Some(error));
+                return;
+            }
+            let handle = {
+                let mut sched = shared.scheduler.lock().expect("scheduler poisoned");
+                sched.sessions.prepare(session, decls, stmt)
+            };
+            reply.send(BatchEvent::PreparedHandle(handle));
+            immediate(&reply, None);
+        }
+        PreparedRpc::Unprepare { handle } => {
+            let dropped = {
+                let mut sched = shared.scheduler.lock().expect("scheduler poisoned");
+                sched.sessions.unprepare(session, handle)
+            };
+            immediate(&reply, (!dropped).then(|| missing_handle(handle)));
+        }
+        PreparedRpc::Execute { handle, values } => {
+            let resolved = {
+                let sched = shared.scheduler.lock().expect("scheduler poisoned");
+                sched.sessions.prepared(session, handle)
+            };
+            let Some((decls, text)) = resolved else {
+                immediate(&reply, Some(missing_handle(handle)));
+                return;
+            };
+            let values = bind_decl_names(&decls, values);
+            dispatch_batch(shared, session, text, values, cancel, reply);
+        }
+        PreparedRpc::PrepExec {
+            decls,
+            stmt,
+            values,
+        } => {
+            if let Err(error) = truthdb_sql::parse(&stmt) {
+                immediate(&reply, Some(error));
+                return;
+            }
+            let handle = {
+                let mut sched = shared.scheduler.lock().expect("scheduler poisoned");
+                sched.sessions.prepare(session, decls.clone(), stmt.clone())
+            };
+            reply.prepared_handle = Some(handle);
+            let values = bind_decl_names(&decls, values);
+            dispatch_batch(shared, session, stmt, values, cancel, reply);
+        }
+    }
+}
+
+/// Names any unnamed value parameters from the declaration list, in order —
+/// `sp_execute` values arrive unnamed on the wire, and seeding a batch
+/// variable needs its name. A value that already has a name keeps it.
+fn bind_decl_names(
+    decls: &str,
+    mut values: Vec<crate::rel::RpcParam>,
+) -> Vec<crate::rel::RpcParam> {
+    let names = decl_names(decls);
+    for (value, name) in values.iter_mut().zip(names) {
+        if value.name.is_empty() {
+            value.name = name;
+        }
+    }
+    values
 }
 
 /// Acquires a batch's locks and runs it, or parks it behind a conflict. Either
@@ -1992,7 +2259,7 @@ mod tests {
                 .expect("begin");
         }
         let (tx, _rx) = mpsc::unbounded_channel();
-        let reply = BatchSink { tx };
+        let reply = BatchSink::new(tx);
         sched.parked.push_back(Parked {
             session: id,
             sql: "SELECT id FROM t".into(),
@@ -2103,7 +2370,7 @@ mod tests {
         let (engine, mut sched, path) = bare("no-spin", Some(Duration::from_millis(50)));
         let id = sched.sessions.open("truthdb".into(), "sa".into());
         let (tx, _rx) = mpsc::unbounded_channel();
-        let reply = BatchSink { tx };
+        let reply = BatchSink::new(tx);
         sched.parked.push_back(Parked {
             session: id,
             sql: "SELECT 1".into(),
@@ -2227,7 +2494,7 @@ mod tests {
         let (engine, mut sched, path) = bare("reap-grantable", None);
         let id = sched.sessions.open("truthdb".into(), "sa".into());
         let (tx, _rx) = mpsc::unbounded_channel();
-        let reply = BatchSink { tx };
+        let reply = BatchSink::new(tx);
         // Parked, deadline long gone, and nothing holds the lock it wants.
         sched.parked.push_back(Parked {
             session: id,

--- a/crates/truthdb-core/src/session.rs
+++ b/crates/truthdb-core/src/session.rs
@@ -163,18 +163,26 @@ struct PreparedStatement {
 fn decl_names(decls: &str) -> Vec<String> {
     let mut names = Vec::new();
     let mut depth = 0usize;
+    let mut in_quote = false;
     let mut entry = String::new();
     for ch in decls.chars().chain(std::iter::once(',')) {
         match ch {
-            '(' => {
+            // A quoted default value (`@p varchar(10) = 'a,b'`) may contain
+            // commas and parens; none of them separate declarations. A
+            // doubled '' escape toggles twice, landing back where it was.
+            '\'' => {
+                in_quote = !in_quote;
+                entry.push(ch);
+            }
+            '(' if !in_quote => {
                 depth += 1;
                 entry.push(ch);
             }
-            ')' => {
+            ')' if !in_quote => {
                 depth = depth.saturating_sub(1);
                 entry.push(ch);
             }
-            ',' if depth == 0 => {
+            ',' if !in_quote && depth == 0 => {
                 if let Some(name) = entry.split_whitespace().next() {
                     names.push(name.to_string());
                 }
@@ -1168,7 +1176,13 @@ fn dispatch_rpc(
                 immediate(&reply, Some(missing_handle(handle)));
                 return;
             };
-            let values = bind_decl_names(&decls, values);
+            let values = match bind_decl_names(&decls, values) {
+                Ok(values) => values,
+                Err(error) => {
+                    immediate(&reply, Some(error));
+                    return;
+                }
+            };
             dispatch_batch(shared, session, text, values, cancel, reply);
         }
         PreparedRpc::PrepExec {
@@ -1185,7 +1199,13 @@ fn dispatch_rpc(
                 sched.sessions.prepare(session, decls.clone(), stmt.clone())
             };
             reply.prepared_handle = Some(handle);
-            let values = bind_decl_names(&decls, values);
+            let values = match bind_decl_names(&decls, values) {
+                Ok(values) => values,
+                Err(error) => {
+                    immediate(&reply, Some(error));
+                    return;
+                }
+            };
             dispatch_batch(shared, session, stmt, values, cancel, reply);
         }
     }
@@ -1197,14 +1217,25 @@ fn dispatch_rpc(
 fn bind_decl_names(
     decls: &str,
     mut values: Vec<crate::rel::RpcParam>,
-) -> Vec<crate::rel::RpcParam> {
+) -> Result<Vec<crate::rel::RpcParam>, SqlError> {
     let names = decl_names(decls);
+    // More values than declarations is SQL Server's 8144. (Fewer is legal —
+    // a declared parameter the statement never reads goes unmissed, and one
+    // it does read errors when the variable lookup fails at execution.)
+    if values.len() > names.len() {
+        return Err(SqlError::new(
+            8144,
+            16,
+            2,
+            "Procedure or function has too many arguments specified.",
+        ));
+    }
     for (value, name) in values.iter_mut().zip(names) {
         if value.name.is_empty() {
             value.name = name;
         }
     }
-    values
+    Ok(values)
 }
 
 /// Acquires a batch's locks and runs it, or parks it behind a conflict. Either
@@ -3665,14 +3696,35 @@ mod tests {
         );
         assert_eq!(decl_names(""), Vec::<String>::new());
         assert_eq!(decl_names("@a int"), ["@a"]);
+        // A quoted default may contain commas and parens; a doubled ''
+        // escape stays inside the string.
+        assert_eq!(
+            decl_names("@p1 varchar(10) = 'a,b', @p2 int, @p3 varchar(5) = 'it''s, ok'"),
+            ["@p1", "@p2", "@p3"]
+        );
     }
 
     #[test]
     fn bind_decl_names_keeps_existing_names() {
         let mut named = int_param(1);
         named.name = "@mine".into();
-        let bound = bind_decl_names("@p1 int, @p2 int", vec![named, int_param(2)]);
+        let bound = bind_decl_names("@p1 int, @p2 int", vec![named, int_param(2)]).expect("bind");
         assert_eq!(bound[0].name, "@mine");
         assert_eq!(bound[1].name, "@p2");
+    }
+
+    #[test]
+    fn more_values_than_declarations_is_8144() {
+        // SQL Server rejects extra arguments rather than silently ignoring
+        // them; without this an unmatched value seeded nothing and vanished.
+        let err = bind_decl_names("@p1 int", vec![int_param(1), int_param(2)])
+            .expect_err("extra value must be rejected");
+        assert_eq!(err.number, 8144);
+        let err = bind_decl_names("", vec![int_param(1)])
+            .expect_err("values against an empty declaration list must be rejected");
+        assert_eq!(err.number, 8144);
+        // Fewer values than declarations stays legal (an unread declared
+        // parameter goes unmissed).
+        assert!(bind_decl_names("@p1 int, @p2 int", vec![int_param(1)]).is_ok());
     }
 }

--- a/crates/truthdb-core/src/session.rs
+++ b/crates/truthdb-core/src/session.rs
@@ -470,7 +470,9 @@ impl SessionManager {
         let session = self.sessions.entry(id).or_default();
         let handle = session.next_prepared_handle;
         session.next_prepared_handle += 1;
-        session.prepared.insert(handle, PreparedStatement { decls, text });
+        session
+            .prepared
+            .insert(handle, PreparedStatement { decls, text });
         handle
     }
 
@@ -3414,5 +3416,263 @@ mod tests {
             Some(1205),
             "the lone waiter should time out as a 1205 victim"
         );
+    }
+
+    // ---- sp_prepare handle family -----------------------------------------
+
+    /// The PreparedHandle event's value, if the stream carried one.
+    fn handle_of(events: &[BatchEvent]) -> Option<i32> {
+        events.iter().find_map(|event| match event {
+            BatchEvent::PreparedHandle(h) => Some(*h),
+            _ => None,
+        })
+    }
+
+    /// The first Error event's number, if any.
+    fn event_error(events: &[BatchEvent]) -> Option<i32> {
+        events.iter().find_map(|event| match event {
+            BatchEvent::Error(e) => Some(e.number),
+            _ => None,
+        })
+    }
+
+    fn int_param(value: i32) -> crate::rel::RpcParam {
+        crate::rel::RpcParam {
+            name: String::new(),
+            column_type: crate::relstore::types::ColumnType::Int,
+            value: Datum::Int(value),
+        }
+    }
+
+    /// All streamed rows, flattened.
+    fn rows_of(events: &[BatchEvent]) -> Vec<Vec<Datum>> {
+        events
+            .iter()
+            .filter_map(|event| match event {
+                BatchEvent::Rows(rows) => Some(rows.clone()),
+                _ => None,
+            })
+            .flatten()
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn prepare_execute_unprepare_roundtrip() {
+        let h = start(LOCK_WAIT_TIMEOUT);
+        let s = h.handle.open_session("truthdb".into(), "sa".into()).await;
+        fill(&h, s, 5).await;
+
+        let events = drain_events(h.handle.stream_prepared(
+            s,
+            PreparedRpc::Prepare {
+                decls: "@p1 int".into(),
+                stmt: "SELECT id FROM t WHERE id = @p1".into(),
+            },
+            no_cancel(),
+        ))
+        .await;
+        assert_eq!(event_error(&events), None, "{events:?}");
+        let handle = handle_of(&events).expect("prepare returns a handle");
+
+        // Execute twice with different values: the same handle re-binds each
+        // time, and the unnamed wire value takes the declaration's name.
+        for wanted in [3, 5] {
+            let events = drain_events(h.handle.stream_prepared(
+                s,
+                PreparedRpc::Execute {
+                    handle,
+                    values: vec![int_param(wanted)],
+                },
+                no_cancel(),
+            ))
+            .await;
+            assert_eq!(event_error(&events), None, "{events:?}");
+            assert_eq!(rows_of(&events), vec![vec![Datum::Int(wanted)]]);
+        }
+
+        let events = drain_events(h.handle.stream_prepared(
+            s,
+            PreparedRpc::Unprepare { handle },
+            no_cancel(),
+        ))
+        .await;
+        assert_eq!(event_error(&events), None, "{events:?}");
+
+        // The dropped handle is gone: 8179, SQL Server's number for it.
+        let events = drain_events(h.handle.stream_prepared(
+            s,
+            PreparedRpc::Execute {
+                handle,
+                values: vec![int_param(1)],
+            },
+            no_cancel(),
+        ))
+        .await;
+        assert_eq!(event_error(&events), Some(8179), "{events:?}");
+    }
+
+    #[tokio::test]
+    async fn an_unknown_handle_answers_8179() {
+        let h = start(LOCK_WAIT_TIMEOUT);
+        let s = h.handle.open_session("truthdb".into(), "sa".into()).await;
+        let events = drain_events(h.handle.stream_prepared(
+            s,
+            PreparedRpc::Execute {
+                handle: 42,
+                values: Vec::new(),
+            },
+            no_cancel(),
+        ))
+        .await;
+        assert_eq!(event_error(&events), Some(8179));
+        let events = drain_events(h.handle.stream_prepared(
+            s,
+            PreparedRpc::Unprepare { handle: 42 },
+            no_cancel(),
+        ))
+        .await;
+        assert_eq!(event_error(&events), Some(8179));
+    }
+
+    #[tokio::test]
+    async fn a_parse_error_at_prepare_allocates_no_handle() {
+        let h = start(LOCK_WAIT_TIMEOUT);
+        let s = h.handle.open_session("truthdb".into(), "sa".into()).await;
+        let events = drain_events(h.handle.stream_prepared(
+            s,
+            PreparedRpc::Prepare {
+                decls: String::new(),
+                stmt: "SELEC oops".into(),
+            },
+            no_cancel(),
+        ))
+        .await;
+        assert!(event_error(&events).is_some(), "{events:?}");
+        assert_eq!(handle_of(&events), None, "no handle on a failed prepare");
+
+        // The failed prepare consumed nothing: the next handle is still 1.
+        let events = drain_events(h.handle.stream_prepared(
+            s,
+            PreparedRpc::Prepare {
+                decls: String::new(),
+                stmt: "SELECT 1 AS one".into(),
+            },
+            no_cancel(),
+        ))
+        .await;
+        assert_eq!(handle_of(&events), Some(1));
+    }
+
+    #[tokio::test]
+    async fn ddl_between_prepare_and_execute_sees_the_new_schema() {
+        // There is no cached plan: every execute re-binds against the live
+        // catalog, so DDL between prepare and execute needs no invalidation —
+        // the same handle simply sees the new schema (the plan's
+        // catalog_version/rebind machinery is moot by design).
+        let h = start(LOCK_WAIT_TIMEOUT);
+        let s = h.handle.open_session("truthdb".into(), "sa".into()).await;
+        fill(&h, s, 3).await;
+        let events = drain_events(h.handle.stream_prepared(
+            s,
+            PreparedRpc::Prepare {
+                decls: String::new(),
+                stmt: "SELECT * FROM t ORDER BY id".into(),
+            },
+            no_cancel(),
+        ))
+        .await;
+        let handle = handle_of(&events).expect("prepare returns a handle");
+
+        h.handle
+            .run_batch(
+                s,
+                "DROP TABLE t; CREATE TABLE t (id INT NOT NULL PRIMARY KEY, v INT NOT NULL); INSERT INTO t VALUES (7, 70)".into(),
+            )
+            .await
+            .unwrap();
+
+        let events = drain_events(h.handle.stream_prepared(
+            s,
+            PreparedRpc::Execute {
+                handle,
+                values: Vec::new(),
+            },
+            no_cancel(),
+        ))
+        .await;
+        assert_eq!(event_error(&events), None, "{events:?}");
+        // The wildcard expands against the NEW table: two columns, new row.
+        assert_eq!(rows_of(&events), vec![vec![Datum::Int(7), Datum::Int(70)]]);
+    }
+
+    #[tokio::test]
+    async fn prepexec_reports_the_handle_after_the_results() {
+        let h = start(LOCK_WAIT_TIMEOUT);
+        let s = h.handle.open_session("truthdb".into(), "sa".into()).await;
+        fill(&h, s, 4).await;
+        let events = drain_events(h.handle.stream_prepared(
+            s,
+            PreparedRpc::PrepExec {
+                decls: "@p1 int".into(),
+                stmt: "SELECT id FROM t WHERE id > @p1 ORDER BY id".into(),
+                values: vec![int_param(2)],
+            },
+            no_cancel(),
+        ))
+        .await;
+        assert_eq!(event_error(&events), None, "{events:?}");
+        assert_eq!(
+            rows_of(&events),
+            vec![vec![Datum::Int(3)], vec![Datum::Int(4)]]
+        );
+        // Return values follow every result set: the handle event comes after
+        // the statement's DONE, immediately before Complete.
+        let positions: Vec<&str> = events
+            .iter()
+            .map(|e| match e {
+                BatchEvent::Columns(_) => "columns",
+                BatchEvent::Rows(_) => "rows",
+                BatchEvent::StatementDone { .. } => "done",
+                BatchEvent::PreparedHandle(_) => "handle",
+                BatchEvent::Complete { .. } => "complete",
+                _ => "other",
+            })
+            .collect();
+        assert_eq!(
+            positions.iter().rev().take(2).copied().collect::<Vec<_>>(),
+            ["complete", "handle"],
+            "{positions:?}"
+        );
+        // And the stored handle is executable afterwards.
+        let handle = handle_of(&events).expect("prepexec returns a handle");
+        let events = drain_events(h.handle.stream_prepared(
+            s,
+            PreparedRpc::Execute {
+                handle,
+                values: vec![int_param(3)],
+            },
+            no_cancel(),
+        ))
+        .await;
+        assert_eq!(rows_of(&events), vec![vec![Datum::Int(4)]]);
+    }
+
+    #[test]
+    fn decl_names_splits_top_level_commas_only() {
+        assert_eq!(
+            decl_names("@p1 int, @p2 nvarchar(10), @p3 decimal(10,2)"),
+            ["@p1", "@p2", "@p3"]
+        );
+        assert_eq!(decl_names(""), Vec::<String>::new());
+        assert_eq!(decl_names("@a int"), ["@a"]);
+    }
+
+    #[test]
+    fn bind_decl_names_keeps_existing_names() {
+        let mut named = int_param(1);
+        named.name = "@mine".into();
+        let bound = bind_decl_names("@p1 int, @p2 int", vec![named, int_param(2)]);
+        assert_eq!(bound[0].name, "@mine");
+        assert_eq!(bound[1].name, "@p2");
     }
 }

--- a/crates/truthdb-tds/src/rpc.rs
+++ b/crates/truthdb-tds/src/rpc.rs
@@ -7,8 +7,9 @@
 //! as batch variables. Parameters are decoded as typed values, never spliced
 //! back into SQL text, so a parameter can never change the statement's shape.
 //!
-//! `sp_prepare`/`sp_execute`/`sp_prepexec`/`sp_unprepare` (handle-based prepared
-//! statements) are a later increment; they surface here as [`RpcProc::Other`].
+//! `sp_prepare`/`sp_execute`/`sp_prepexec`/`sp_unprepare` (handle-based
+//! prepared statements) dispatch by well-known ProcID or by name; `sp_cursor*`
+//! is recognized so the server can reject server-side cursors distinctly.
 
 use std::io;
 
@@ -172,8 +173,9 @@ fn int_param(param: &RpcParam, what: &str) -> io::Result<i32> {
         Datum::Int(v) => Ok(v),
         Datum::SmallInt(v) => Ok(v as i32),
         Datum::TinyInt(v) => Ok(v as i32),
-        Datum::BigInt(v) => i32::try_from(v)
-            .map_err(|_| protocol_err(&format!("{what} out of range: {v}"))),
+        Datum::BigInt(v) => {
+            i32::try_from(v).map_err(|_| protocol_err(&format!("{what} out of range: {v}")))
+        }
         _ => Err(protocol_err(&format!("{what} is not an integer"))),
     }
 }
@@ -680,10 +682,40 @@ mod tests {
     fn unknown_proc_reports_other() {
         let mut b = Vec::new();
         b.extend_from_slice(&PROCID_SENTINEL.to_le_bytes());
-        b.extend_from_slice(&11u16.to_le_bytes()); // sp_prepare
+        b.extend_from_slice(&200u16.to_le_bytes()); // no such well-known ProcID
         b.extend_from_slice(&0u16.to_le_bytes());
         let req = parse_rpc_request(&b).expect("parse");
         assert!(matches!(req.proc, RpcProc::Other(_)));
+    }
+
+    #[test]
+    fn the_handle_family_and_cursors_dispatch_by_procid_and_name() {
+        let by_procid = |procid: u16| {
+            let mut b = Vec::new();
+            b.extend_from_slice(&PROCID_SENTINEL.to_le_bytes());
+            b.extend_from_slice(&procid.to_le_bytes());
+            b.extend_from_slice(&0u16.to_le_bytes());
+            parse_rpc_request(&b).expect("parse").proc
+        };
+        assert!(matches!(by_procid(11), RpcProc::SpPrepare));
+        assert!(matches!(by_procid(12), RpcProc::SpExecute));
+        assert!(matches!(by_procid(13), RpcProc::SpPrepExec));
+        assert!(matches!(by_procid(15), RpcProc::SpUnprepare));
+        assert!(matches!(by_procid(2), RpcProc::SpCursor(_))); // sp_cursoropen
+
+        let by_name = |name: &str| {
+            let mut b = Vec::new();
+            b.extend_from_slice(&(name.len() as u16).to_le_bytes());
+            for unit in name.encode_utf16() {
+                b.extend_from_slice(&unit.to_le_bytes());
+            }
+            b.extend_from_slice(&0u16.to_le_bytes());
+            parse_rpc_request(&b).expect("parse").proc
+        };
+        assert!(matches!(by_name("sp_prepare"), RpcProc::SpPrepare));
+        assert!(matches!(by_name("SP_EXECUTE"), RpcProc::SpExecute));
+        assert!(matches!(by_name("sp_unprepare"), RpcProc::SpUnprepare));
+        assert!(matches!(by_name("sp_cursorfetch"), RpcProc::SpCursor(_)));
     }
 
     #[test]

--- a/crates/truthdb-tds/src/rpc.rs
+++ b/crates/truthdb-tds/src/rpc.rs
@@ -44,6 +44,15 @@ const PLP_NULL: u64 = 0xffff_ffff_ffff_ffff;
 
 /// The well-known `ProcID` for `sp_executesql` (MS-TDS 2.2.6.6).
 const SP_EXECUTESQL_PROCID: u16 = 10;
+/// Well-known `ProcID`s for the prepared-statement handle family.
+const SP_PREPARE_PROCID: u16 = 11;
+const SP_EXECUTE_PROCID: u16 = 12;
+const SP_PREPEXEC_PROCID: u16 = 13;
+const SP_UNPREPARE_PROCID: u16 = 15;
+/// The `sp_cursor*` family occupies ProcIDs 1–9 (sp_cursor through
+/// sp_cursorunprepare) — recognized so they can be rejected politely.
+const SP_CURSOR_FIRST_PROCID: u16 = 1;
+const SP_CURSOR_LAST_PROCID: u16 = 9;
 /// Sentinel `NameLenProcID` length selecting a well-known `ProcID` instead of a
 /// procedure name.
 const PROCID_SENTINEL: u16 = 0xffff;
@@ -52,6 +61,17 @@ const PROCID_SENTINEL: u16 = 0xffff;
 pub enum RpcProc {
     /// `sp_executesql` (by ProcID 10 or by name).
     SpExecuteSql,
+    /// `sp_prepare` (ProcID 11): store a statement, return a handle.
+    SpPrepare,
+    /// `sp_execute` (ProcID 12): run a prepared handle with values.
+    SpExecute,
+    /// `sp_prepexec` (ProcID 13): prepare and run in one round trip.
+    SpPrepExec,
+    /// `sp_unprepare` (ProcID 15): drop a prepared handle.
+    SpUnprepare,
+    /// An `sp_cursor*` procedure — server-side cursors are not supported, and
+    /// say so distinctly rather than "not found".
+    SpCursor(String),
     /// Any other procedure — reported back to the client as unsupported.
     Other(String),
 }
@@ -69,15 +89,31 @@ pub fn parse_rpc_request(body: &[u8]) -> io::Result<RpcRequest> {
     let name_len = c.u16()?;
     let proc = if name_len == PROCID_SENTINEL {
         let procid = c.u16()?;
-        if procid == SP_EXECUTESQL_PROCID {
-            RpcProc::SpExecuteSql
-        } else {
-            RpcProc::Other(format!("ProcID #{procid}"))
+        match procid {
+            SP_EXECUTESQL_PROCID => RpcProc::SpExecuteSql,
+            SP_PREPARE_PROCID => RpcProc::SpPrepare,
+            SP_EXECUTE_PROCID => RpcProc::SpExecute,
+            SP_PREPEXEC_PROCID => RpcProc::SpPrepExec,
+            SP_UNPREPARE_PROCID => RpcProc::SpUnprepare,
+            SP_CURSOR_FIRST_PROCID..=SP_CURSOR_LAST_PROCID => {
+                RpcProc::SpCursor(format!("ProcID #{procid}"))
+            }
+            _ => RpcProc::Other(format!("ProcID #{procid}")),
         }
     } else {
         let name = c.utf16(name_len as usize * 2)?;
         if name.eq_ignore_ascii_case("sp_executesql") {
             RpcProc::SpExecuteSql
+        } else if name.eq_ignore_ascii_case("sp_prepare") {
+            RpcProc::SpPrepare
+        } else if name.eq_ignore_ascii_case("sp_execute") {
+            RpcProc::SpExecute
+        } else if name.eq_ignore_ascii_case("sp_prepexec") {
+            RpcProc::SpPrepExec
+        } else if name.eq_ignore_ascii_case("sp_unprepare") {
+            RpcProc::SpUnprepare
+        } else if name.to_ascii_lowercase().starts_with("sp_cursor") {
+            RpcProc::SpCursor(name)
         } else {
             RpcProc::Other(name)
         }
@@ -119,6 +155,79 @@ pub fn split_sp_executesql(mut params: Vec<RpcParam>) -> io::Result<(String, Vec
         _ => return Err(protocol_err("sp_executesql: statement is not a string")),
     };
     Ok((stmt, values))
+}
+
+/// Reads a string parameter that may be NULL (an empty declaration list).
+fn opt_string(param: &RpcParam, what: &str) -> io::Result<String> {
+    match &param.value {
+        Datum::NVarChar(s) | Datum::VarChar(s) => Ok(s.clone()),
+        Datum::Null => Ok(String::new()),
+        _ => Err(protocol_err(&format!("{what} is not a string"))),
+    }
+}
+
+/// Reads a required integer parameter (a prepared-statement handle).
+fn int_param(param: &RpcParam, what: &str) -> io::Result<i32> {
+    match param.value {
+        Datum::Int(v) => Ok(v),
+        Datum::SmallInt(v) => Ok(v as i32),
+        Datum::TinyInt(v) => Ok(v as i32),
+        Datum::BigInt(v) => i32::try_from(v)
+            .map_err(|_| protocol_err(&format!("{what} out of range: {v}"))),
+        _ => Err(protocol_err(&format!("{what} is not an integer"))),
+    }
+}
+
+/// Splits an `sp_prepare` parameter list — `@handle` OUTPUT (ignored on input),
+/// `@params` declarations, `@stmt`, optional `@options` — into (declarations,
+/// statement text).
+pub fn split_sp_prepare(params: Vec<RpcParam>) -> io::Result<(String, String)> {
+    if params.len() < 3 {
+        return Err(protocol_err("sp_prepare: expected @handle, @params, @stmt"));
+    }
+    let decls = opt_string(&params[1], "sp_prepare: @params")?;
+    let stmt = match opt_string(&params[2], "sp_prepare: @stmt")? {
+        s if s.is_empty() => return Err(protocol_err("sp_prepare: NULL statement")),
+        s => s,
+    };
+    Ok((decls, stmt))
+}
+
+/// Splits an `sp_execute` parameter list — `@handle`, then the value
+/// parameters — into (handle, values).
+pub fn split_sp_execute(mut params: Vec<RpcParam>) -> io::Result<(i32, Vec<RpcParam>)> {
+    if params.is_empty() {
+        return Err(protocol_err("sp_execute: missing @handle"));
+    }
+    let values = params.split_off(1);
+    let handle = int_param(&params[0], "sp_execute: @handle")?;
+    Ok((handle, values))
+}
+
+/// Splits an `sp_prepexec` parameter list — `@handle` OUTPUT (ignored on
+/// input), `@params` declarations, `@stmt`, then the value parameters — into
+/// (declarations, statement text, values).
+pub fn split_sp_prepexec(mut params: Vec<RpcParam>) -> io::Result<(String, String, Vec<RpcParam>)> {
+    if params.len() < 3 {
+        return Err(protocol_err(
+            "sp_prepexec: expected @handle, @params, @stmt",
+        ));
+    }
+    let values = params.split_off(3);
+    let decls = opt_string(&params[1], "sp_prepexec: @params")?;
+    let stmt = match opt_string(&params[2], "sp_prepexec: @stmt")? {
+        s if s.is_empty() => return Err(protocol_err("sp_prepexec: NULL statement")),
+        s => s,
+    };
+    Ok((decls, stmt, values))
+}
+
+/// Splits an `sp_unprepare` parameter list into its handle.
+pub fn split_sp_unprepare(params: Vec<RpcParam>) -> io::Result<i32> {
+    if params.is_empty() {
+        return Err(protocol_err("sp_unprepare: missing @handle"));
+    }
+    int_param(&params[0], "sp_unprepare: @handle")
 }
 
 /// Decodes one parameter's TYPE_INFO and value into a column type + datum.

--- a/crates/truthdb-tds/src/server.rs
+++ b/crates/truthdb-tds/src/server.rs
@@ -8,7 +8,7 @@ use tokio::io::{self, AsyncRead, AsyncReadExt, AsyncWrite};
 use tokio::sync::mpsc;
 use truthdb_core::engine::EngineError;
 use truthdb_core::rel::ResultColumn;
-use truthdb_core::session::{BatchEvent, EngineHandle, SessionId};
+use truthdb_core::session::{BatchEvent, EngineHandle, PreparedRpc, SessionId};
 
 use crate::login::{self, parse_login7};
 use crate::packet::{
@@ -583,6 +583,40 @@ fn start_rpc(
                 .map_err(|err| rpc_error(&err.to_string()))?;
             Ok(engine.stream_rpc(session, sql, params, cancel))
         }
+        RpcProc::SpPrepare => {
+            let (decls, stmt) = rpc::split_sp_prepare(request.params)
+                .map_err(|err| rpc_error(&err.to_string()))?;
+            Ok(engine.stream_prepared(session, PreparedRpc::Prepare { decls, stmt }, cancel))
+        }
+        RpcProc::SpExecute => {
+            let (handle, values) = rpc::split_sp_execute(request.params)
+                .map_err(|err| rpc_error(&err.to_string()))?;
+            Ok(engine.stream_prepared(session, PreparedRpc::Execute { handle, values }, cancel))
+        }
+        RpcProc::SpPrepExec => {
+            let (decls, stmt, values) = rpc::split_sp_prepexec(request.params)
+                .map_err(|err| rpc_error(&err.to_string()))?;
+            Ok(engine.stream_prepared(
+                session,
+                PreparedRpc::PrepExec {
+                    decls,
+                    stmt,
+                    values,
+                },
+                cancel,
+            ))
+        }
+        RpcProc::SpUnprepare => {
+            let handle = rpc::split_sp_unprepare(request.params)
+                .map_err(|err| rpc_error(&err.to_string()))?;
+            Ok(engine.stream_prepared(session, PreparedRpc::Unprepare { handle }, cancel))
+        }
+        // Server-side cursors are not implemented; say so rather than "not
+        // found" so a driver's fallback logic gets an honest signal.
+        RpcProc::SpCursor(name) => Err(rpc_error_num(
+            40510,
+            &format!("The stored procedure '{name}' is not supported (server-side cursors are not implemented)."),
+        )),
         // Error 2812 is SQL Server's "Could not find stored procedure".
         RpcProc::Other(name) => Err(rpc_error_num(
             2812,
@@ -672,6 +706,14 @@ impl BatchRender {
                     count: None,
                     in_transaction,
                 });
+            }
+            BatchEvent::PreparedHandle(handle) => {
+                // The handle rides a RETURNVALUE token, after every result
+                // set (return values follow results in an RPC response).
+                self.flush_pending(out, true).await?;
+                self.buf.clear();
+                token::return_value_int(&mut self.buf, "handle", handle);
+                out.write(&self.buf).await?;
             }
             BatchEvent::Error(error) => {
                 self.flush_pending(out, true).await?;

--- a/crates/truthdb-tds/src/server.rs
+++ b/crates/truthdb-tds/src/server.rs
@@ -584,13 +584,13 @@ fn start_rpc(
             Ok(engine.stream_rpc(session, sql, params, cancel))
         }
         RpcProc::SpPrepare => {
-            let (decls, stmt) = rpc::split_sp_prepare(request.params)
-                .map_err(|err| rpc_error(&err.to_string()))?;
+            let (decls, stmt) =
+                rpc::split_sp_prepare(request.params).map_err(|err| rpc_error(&err.to_string()))?;
             Ok(engine.stream_prepared(session, PreparedRpc::Prepare { decls, stmt }, cancel))
         }
         RpcProc::SpExecute => {
-            let (handle, values) = rpc::split_sp_execute(request.params)
-                .map_err(|err| rpc_error(&err.to_string()))?;
+            let (handle, values) =
+                rpc::split_sp_execute(request.params).map_err(|err| rpc_error(&err.to_string()))?;
             Ok(engine.stream_prepared(session, PreparedRpc::Execute { handle, values }, cancel))
         }
         RpcProc::SpPrepExec => {
@@ -615,7 +615,9 @@ fn start_rpc(
         // found" so a driver's fallback logic gets an honest signal.
         RpcProc::SpCursor(name) => Err(rpc_error_num(
             40510,
-            &format!("The stored procedure '{name}' is not supported (server-side cursors are not implemented)."),
+            &format!(
+                "The stored procedure '{name}' is not supported (server-side cursors are not implemented)."
+            ),
         )),
         // Error 2812 is SQL Server's "Could not find stored procedure".
         RpcProc::Other(name) => Err(rpc_error_num(
@@ -1050,6 +1052,48 @@ mod render_tests {
         })
         .unwrap();
         rx
+    }
+
+    /// A prepared handle renders as a RETURNVALUE token after the statement's
+    /// DONE (return values follow results), with the exact bytes MS-TDS
+    /// 2.2.7.19 prescribes for an INT output parameter.
+    #[tokio::test]
+    async fn a_prepared_handle_renders_as_a_returnvalue_token() {
+        let (tx, rx) = mpsc::unbounded_channel();
+        tx.send(BatchEvent::StatementDone {
+            count: Some(1),
+            in_transaction: false,
+        })
+        .unwrap();
+        tx.send(BatchEvent::PreparedHandle(7)).unwrap();
+        tx.send(BatchEvent::Complete {
+            in_transaction: false,
+        })
+        .unwrap();
+        drop(tx);
+
+        let mut expected = Vec::new();
+        token::done(&mut expected, true, false, false, Some(1));
+        token::return_value_int(&mut expected, "handle", 7);
+        token::done(&mut expected, false, false, false, None);
+        assert_eq!(rendered_events(rx, 4096).await, expected);
+
+        // The token's own bytes, pinned: 0xAC, ordinal 0, B_VARCHAR name,
+        // status 0x01 (output param), UserType 0, Flags 0, INTN(4), value.
+        let mut token_bytes = Vec::new();
+        token::return_value_int(&mut token_bytes, "h", 7);
+        assert_eq!(
+            token_bytes,
+            [
+                0xac, 0x00, 0x00, // token, ParamOrdinal
+                0x01, b'h' as u8, 0x00, // B_VARCHAR "h"
+                0x01, // Status: output parameter
+                0x00, 0x00, 0x00, 0x00, // UserType
+                0x00, 0x00, // Flags
+                0x26, 0x04, // TYPE_INFO: INTN, max 4
+                0x04, 0x07, 0x00, 0x00, 0x00, // 4-byte value 7
+            ]
+        );
     }
 
     /// Each DONE carries the transaction state of *its own* statement on the

--- a/crates/truthdb-tds/src/token.rs
+++ b/crates/truthdb-tds/src/token.rs
@@ -167,6 +167,25 @@ fn message_token(out: &mut Vec<u8>, token: u8, number: i32, state: u8, class: u8
     out.extend_from_slice(&body);
 }
 
+const TOKEN_RETURNVALUE: u8 = 0xac;
+
+/// RETURNVALUE carrying an INT output parameter — the prepared-statement
+/// handle `sp_prepare`/`sp_prepexec` reports. Layout (MS-TDS 2.2.7.19):
+/// ParamOrdinal, ParamName, Status (0x01 = output parameter), UserType,
+/// Flags, TYPE_INFO (INTN, 4), value.
+pub fn return_value_int(out: &mut Vec<u8>, name: &str, value: i32) {
+    out.push(TOKEN_RETURNVALUE);
+    out.extend_from_slice(&0u16.to_le_bytes()); // ParamOrdinal
+    push_b_varchar(out, name);
+    out.push(0x01); // Status: output parameter
+    out.extend_from_slice(&0u32.to_le_bytes()); // UserType
+    out.extend_from_slice(&0u16.to_le_bytes()); // Flags
+    out.push(0x26); // INTN
+    out.push(4);
+    out.push(4); // value length
+    out.extend_from_slice(&value.to_le_bytes());
+}
+
 /// COLMETADATA for a result set's columns.
 pub fn colmetadata(out: &mut Vec<u8>, columns: &[ResultColumn]) {
     out.push(TOKEN_COLMETADATA);

--- a/scripts/tds_conformance_prepared.py
+++ b/scripts/tds_conformance_prepared.py
@@ -96,7 +96,7 @@ def main() -> int:
         fail(f"sp_prepexec rowset: got {rows!r}")
     handle2 = cur.get_proc_outputs()[0]
     if not isinstance(handle2, int):
-        fail(f"sp_prepexec returned no integer handle: {result!r}")
+        fail(f"sp_prepexec returned no integer handle: {handle2!r}")
     cur.callproc("sp_execute", (handle2, 3))
     rows = cur.fetchall()
     if rows != [(4,)]:

--- a/scripts/tds_conformance_prepared.py
+++ b/scripts/tds_conformance_prepared.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""TDS conformance: the sp_prepare handle family over real RPC.
+
+pytds's `callproc` sends an RPC by procedure name with typed parameters and
+fills `pytds.output(...)` arguments from the response's RETURNVALUE tokens —
+so this adjudicates the whole family against an independent client: the
+handle comes back through RETURNVALUE, sp_execute binds unnamed wire values
+to the prepared declaration list, sp_unprepare drops the handle, and a
+dropped/unknown handle answers 8179. (go-mssqldb cannot cover this:
+database/sql's Prepare is client-side text caching — it re-sends
+sp_executesql per execution and never speaks the handle family, verified by
+running it against a server without the family.)
+
+Usage: tds_conformance_prepared.py <host> <port> <user> <password>
+Exits non-zero on any mismatch.
+"""
+
+import sys
+
+import pytds
+
+
+def fail(msg: str) -> None:
+    print(f"FAIL: {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+def main() -> int:
+    host, port, user, password = sys.argv[1], int(sys.argv[2]), sys.argv[3], sys.argv[4]
+    conn = pytds.connect(
+        host, "truthdb", user, password, port=port, login_timeout=10, autocommit=True
+    )
+    cur = conn.cursor()
+
+    cur.execute(
+        "CREATE TABLE prep_py (id INT NOT NULL PRIMARY KEY, name NVARCHAR(40))"
+    )
+    cur.execute("INSERT INTO prep_py VALUES (1, 'one'), (2, 'two'), (3, 'three')")
+
+    # sp_prepare: the handle arrives as a RETURNVALUE-filled output parameter.
+    result = cur.callproc(
+        "sp_prepare",
+        (
+            pytds.output(param_type=int),
+            "@p1 int",
+            "SELECT name FROM prep_py WHERE id = @p1",
+            1,
+        ),
+    )
+    handle = result[0]
+    if not isinstance(handle, int):
+        fail(f"sp_prepare returned no integer handle: {result!r}")
+
+    # sp_execute re-uses the handle; the value parameter is unnamed on the
+    # wire and binds to the declaration's @p1.
+    for wanted_id, wanted_name in ((2, "two"), (3, "three")):
+        cur.callproc("sp_execute", (handle, wanted_id))
+        rows = cur.fetchall()
+        if rows != [(wanted_name,)]:
+            fail(f"sp_execute id={wanted_id}: got {rows!r} want [({wanted_name!r},)]")
+
+    # A write between executions is visible to the next execute: there is no
+    # cached plan or snapshot behind the handle.
+    cur.execute("INSERT INTO prep_py VALUES (4, 'four')")
+    cur.callproc("sp_execute", (handle, 4))
+    rows = cur.fetchall()
+    if rows != [("four",)]:
+        fail(f"sp_execute after insert: got {rows!r}")
+
+    # sp_unprepare drops the handle; executing it afterwards answers 8179
+    # (SQL Server's "Could not find prepared statement with handle %d").
+    cur.callproc("sp_unprepare", (handle,))
+    try:
+        cur.callproc("sp_execute", (handle, 1))
+        cur.fetchall()
+        fail("sp_execute on a dropped handle did not raise")
+    except pytds.Error as err:
+        number = getattr(err, "number", None)
+        if number != 8179:
+            fail(f"dropped handle: expected 8179, got {number} ({err})")
+
+    # sp_prepexec: prepare + execute in one round trip. Its RETURNVALUE
+    # follows the result set, so the output param is readable only after the
+    # rows are drained (get_proc_outputs), unlike sp_prepare's.
+    cur.callproc(
+        "sp_prepexec",
+        (
+            pytds.output(param_type=int),
+            "@p1 int",
+            "SELECT id FROM prep_py WHERE id > @p1 ORDER BY id",
+            2,
+        ),
+    )
+    rows = cur.fetchall()
+    if rows != [(3,), (4,)]:
+        fail(f"sp_prepexec rowset: got {rows!r}")
+    handle2 = cur.get_proc_outputs()[0]
+    if not isinstance(handle2, int):
+        fail(f"sp_prepexec returned no integer handle: {result!r}")
+    cur.callproc("sp_execute", (handle2, 3))
+    rows = cur.fetchall()
+    if rows != [(4,)]:
+        fail(f"sp_execute on prepexec handle: got {rows!r}")
+    cur.callproc("sp_unprepare", (handle2,))
+
+    # A syntax error surfaces at prepare time, and allocates nothing.
+    try:
+        cur.callproc(
+            "sp_prepare", (pytds.output(param_type=int), "", "SELEC oops", 1)
+        )
+        fail("sp_prepare of invalid SQL did not raise")
+    except pytds.Error:
+        pass
+
+    conn.close()
+    print("tds conformance (sp_prepare family, pytds): OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

`sp_prepare`/`sp_execute`/`sp_prepexec`/`sp_unprepare` work end to end — by well-known ProcID (11/12/13/15) and by name — with the handle returned as a RETURNVALUE token. `sp_cursor*` (ProcIDs 1–9, name prefix) is rejected distinctly (40510) rather than "not found". This closes the machinery half of Stage 9's prepared-statement bullet.

## Design finding (recorded for the plan)

The bullet prescribes `PreparedStatement{text, param_decls, bound plan, catalog_version}` with lazy rebind after DDL. That design fails the code audit: this engine has no bound-plan artifact — every execution re-parses and re-binds against the live catalog, which the plan's own Stage 3 note concedes ("a cached plan can never go stale"). So a prepared statement is `{decls, text}` per session, and DDL between prepare and execute behaves as SQL Server's recompile-on-schema-change with zero invalidation machinery. The catalog_version/rebind piece is moot by design — same class as the bounded-sinks refutation. Pinned by a test that drops and recreates the target table between prepare and execute.

## How

- `sp_prepare` parses at prepare time (syntax errors surface there, as SQL Server's compile does); binding errors surface at execute — a documented divergence.
- `sp_execute` resolves the handle (unknown → 8179) and re-enters the ordinary batch path, so locks, parking, and streaming are exactly a plain batch's. Unnamed wire values bind to the declaration list's names (quote- and paren-aware splitting; extra values answer 8144).
- `sp_prepexec` stores, then runs; its handle event is injected just before the terminal event, so the RETURNVALUE follows every result set.
- Handles are session-scoped and dropped with the session; the idle-transaction reaper does not touch them.

## Real-driver adjudication

- **pytds drives the whole family live** (`scripts/tds_conformance_prepared.py`, wired into CI): handle read back from RETURNVALUE, sp_execute re-use with rebinding, write-visibility between executions, 8179 on a dropped handle, sp_prepexec's post-rowset RETURNVALUE via `get_proc_outputs`, syntax-error-at-prepare. Verified green against this branch and **red against main** (2812 at sp_prepare) — the script has teeth.
- **go-mssqldb cannot adjudicate this**: `database/sql`'s Prepare is client-side text caching that re-sends sp_executesql per execution — proven by running a prepared-statement section against the family-less main server (it passed; the section was dropped as toothless).
- pytds accepts plain-DONE finals for the family, so the DONEPROC/DONEINPROC/RETURNSTATUS conversion is deferred to the exit-matrix bullet where the drivers that may require it (ODBC/JDBC) get real coverage.

## Adversarial review

Run in a detached worktree. Findings and outcomes: quoted-default comma splitting in `decl_names` (fixed + teeth-checked), silent extra arguments (fixed: 8144), a wrong-variable diagnostic in the conformance script (fixed). Noted, deliberately not fixed here: multi-RPC requests still run only the first RPC — pre-existing, but now the top follow-up since mssql-jdbc's default flow (batched sp_unprepare + sp_prepexec) can reach it; it is a named prerequisite of the exit-matrix bullet, where a JDBC harness can actually verify the fix. A cancelled/failed sp_prepexec's handle stays allocated without the client learning it — session-scoped state, same class as any per-session cache, dropped at session close. Clean checks included the two-lock Execute window (unreachable: one in-flight request per connection is enforced by the connection layer), the parked-1205-victim event order (ERROR, RETURNVALUE, DONE — legal for both drivers), RETURNVALUE byte layout for TDS 7.4, and the DONE_INXACT stamp on immediate replies.

## Tests

Engine: roundtrip, unknown-handle 8179, parse-error-at-prepare allocates nothing, DDL-between-prepare-and-execute, prepexec handle-after-results ordering, decl-name splitting (quotes, nested parens, `decimal(10,2)`), 8144. Renderer: RETURNVALUE byte pin. RPC: ProcID/name/cursor dispatch. All teeth-checked (binding no-op, inject-on-Columns, allocate-before-parse, quote-toggle removal — each fails its test). Full workspace: 472 passed, 0 failed; fmt and clippy (-D warnings) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)