### PR TITLE
Stage 9: sp_describe_first_result_set for statically-derivable shapes

### DIFF
--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -189,6 +189,16 @@ impl Engine {
     /// leaves through `emitter` as it is produced (see
     /// [`crate::rel::execute_batch_streamed`]). Returns the batch's terminal
     /// error, which the caller reports after the statement events.
+    /// `sp_describe_first_result_set`: statically-derivable column metadata
+    /// for `tsql`'s first statement, without executing it.
+    pub fn describe_first_result_set(
+        &self,
+        tsql: &str,
+    ) -> Result<crate::rel::RowSet, truthdb_sql::error::SqlError> {
+        let _meta = self.meta.read().expect("engine meta poisoned");
+        crate::rel::describe_first_result_set(&self.storage, tsql)
+    }
+
     pub fn sql_batch_streamed(
         &self,
         input: &str,

--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -185,12 +185,8 @@ impl Engine {
         Ok(collector.into_outcome(error))
     }
 
-    /// Like [`Self::sql_batch_with_params`], but each statement's result
-    /// leaves through `emitter` as it is produced (see
-    /// [`crate::rel::execute_batch_streamed`]). Returns the batch's terminal
-    /// error, which the caller reports after the statement events.
     /// `sp_describe_first_result_set`: statically-derivable column metadata
-    /// for `tsql`'s first statement, without executing it.
+    /// for `tsql`'s first result set, without executing anything.
     pub fn describe_first_result_set(
         &self,
         tsql: &str,
@@ -199,6 +195,10 @@ impl Engine {
         crate::rel::describe_first_result_set(&self.storage, tsql)
     }
 
+    /// Like [`Self::sql_batch_with_params`], but each statement's result
+    /// leaves through `emitter` as it is produced (see
+    /// [`crate::rel::execute_batch_streamed`]). Returns the batch's terminal
+    /// error, which the caller reports after the statement events.
     pub fn sql_batch_streamed(
         &self,
         input: &str,

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -666,6 +666,110 @@ fn run_block(
     Ok(())
 }
 
+/// `sp_describe_first_result_set`: the column metadata of `tsql`'s first
+/// statement's result set, without executing it. Covers exactly the shapes
+/// whose output columns are statically derivable — the single-table SELECTs
+/// [`scan_plan`] recognises (their COLMETADATA is derived before the first
+/// row at execution too). A statement producing no result set describes as
+/// zero rows, matching SQL Server. Everything else — joins, aggregates,
+/// computed columns — has result types this engine only learns by executing
+/// (`infer_type` over the values), so it answers 11514: honest, and the same
+/// static-type-derivation gap Stage 8's output streaming tracks.
+///
+/// `@tsql`'s declared parameters need no binding here: the planner treats an
+/// unresolvable variable as a non-seekable predicate and falls back to the
+/// scan, and output columns come from the table schema either way — pinned by
+/// the parameterized-describe test.
+pub fn describe_first_result_set(storage: &Storage, tsql: &str) -> Result<RowSet, SqlError> {
+    let undeterminable = || {
+        SqlError::new(
+            11514,
+            16,
+            1,
+            "The metadata could not be determined because the statement's result-set \
+             types are not statically derivable by this server (single-table SELECTs \
+             are; joins, aggregates and computed columns are typed at execution).",
+        )
+    };
+    let statements = truthdb_sql::parse(tsql)?;
+    let columns = match statements.first() {
+        None => Vec::new(),
+        Some(statement) if !produces_rowset(statement) => Vec::new(),
+        Some(Statement::Select(select)) => {
+            let ctx = TxnContext::default();
+            match scan_plan(storage, select, &ctx.eval_context()) {
+                Some(plan) => plan.columns,
+                None => return Err(undeterminable()),
+            }
+        }
+        Some(_) => return Err(undeterminable()),
+    };
+
+    let mut rows = Vec::new();
+    for (ordinal, column) in columns.iter().enumerate() {
+        let (type_id, type_name) = describe_type(&column.column_type);
+        rows.push(vec![
+            Datum::Bit(false),                    // is_hidden
+            Datum::Int(ordinal as i32 + 1),       // column_ordinal
+            Datum::NVarChar(column.name.clone()), // name
+            Datum::Bit(true), // is_nullable (result metadata is nullable, as at execution)
+            Datum::Int(type_id), // system_type_id
+            Datum::NVarChar(type_name), // system_type_name
+        ]);
+    }
+    Ok(RowSet {
+        columns: vec![
+            ResultColumn {
+                name: "is_hidden".into(),
+                column_type: ColumnType::Bit,
+            },
+            ResultColumn {
+                name: "column_ordinal".into(),
+                column_type: ColumnType::Int,
+            },
+            ResultColumn {
+                name: "name".into(),
+                column_type: ColumnType::NVarChar { max_len: 128 },
+            },
+            ResultColumn {
+                name: "is_nullable".into(),
+                column_type: ColumnType::Bit,
+            },
+            ResultColumn {
+                name: "system_type_id".into(),
+                column_type: ColumnType::Int,
+            },
+            ResultColumn {
+                name: "system_type_name".into(),
+                column_type: ColumnType::NVarChar { max_len: 256 },
+            },
+        ],
+        rows,
+    })
+}
+
+/// A column type's `sys.types` id and its `system_type_name` spelling, as
+/// `sp_describe_first_result_set` reports them.
+fn describe_type(column_type: &ColumnType) -> (i32, String) {
+    match column_type {
+        ColumnType::TinyInt => (48, "tinyint".into()),
+        ColumnType::SmallInt => (52, "smallint".into()),
+        ColumnType::Int => (56, "int".into()),
+        ColumnType::BigInt => (127, "bigint".into()),
+        ColumnType::Bit => (104, "bit".into()),
+        ColumnType::Real => (59, "real".into()),
+        ColumnType::Float => (62, "float".into()),
+        ColumnType::Decimal { precision, scale } => (106, format!("decimal({precision},{scale})")),
+        ColumnType::Date => (40, "date".into()),
+        ColumnType::Time => (41, "time".into()),
+        ColumnType::DateTime2 => (42, "datetime2".into()),
+        ColumnType::UniqueIdentifier => (36, "uniqueidentifier".into()),
+        ColumnType::VarChar { max_len } => (167, format!("varchar({max_len})")),
+        ColumnType::NVarChar { max_len } => (231, format!("nvarchar({max_len})")),
+        ColumnType::VarBinary { max_len } => (165, format!("varbinary({max_len})")),
+    }
+}
+
 /// Whether a statement can open a result set on the stream: a `SELECT` that
 /// returns rows (an assignment `SELECT @v = ...` returns none). `SET
 /// SHOWPLAN_TEXT`'s plan rows ride the same `SELECT` arm.

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -692,12 +692,19 @@ pub fn describe_first_result_set(storage: &Storage, tsql: &str) -> Result<RowSet
         )
     };
     let statements = truthdb_sql::parse(tsql)?;
-    let columns = match statements.first() {
+    // The contract is the batch's first RESULT SET, not its first statement:
+    // `INSERT ...; SELECT ...` describes the SELECT. TRY blocks are entered
+    // (their statements run unless an error preempts them); a rowset only a
+    // CATCH can produce stays undescribed — that path is conditional.
+    let columns = match first_rowset_statement(&statements) {
         None => Vec::new(),
-        Some(statement) if !produces_rowset(statement) => Vec::new(),
         Some(Statement::Select(select)) => {
+            // TOP never changes the columns, and `scan_plan` rejects `TOP 0`
+            // for an execution-path reason describe does not share.
+            let mut select = select.clone();
+            select.top = None;
             let ctx = TxnContext::default();
-            match scan_plan(storage, select, &ctx.eval_context()) {
+            match scan_plan(storage, &select, &ctx.eval_context()) {
                 Some(plan) => plan.columns,
                 None => return Err(undeterminable()),
             }
@@ -745,6 +752,17 @@ pub fn describe_first_result_set(storage: &Storage, tsql: &str) -> Result<RowSet
             },
         ],
         rows,
+    })
+}
+
+/// The first statement in `statements` that opens a result set, descending
+/// into TRY blocks (entered unless an error preempts them) but not CATCH
+/// blocks (conditional).
+fn first_rowset_statement(statements: &[Statement]) -> Option<&Statement> {
+    statements.iter().find_map(|statement| match statement {
+        Statement::TryCatch { try_block, .. } => first_rowset_statement(try_block),
+        s if produces_rowset(s) => Some(s),
+        _ => None,
     })
 }
 

--- a/crates/truthdb-core/src/session.rs
+++ b/crates/truthdb-core/src/session.rs
@@ -3721,8 +3721,10 @@ mod tests {
             .await
             .unwrap();
 
-        // A parameterized single-table SELECT describes without executing:
-        // the declared @p1 resolves (as NULL) during planning.
+        // A parameterized single-table SELECT describes without executing.
+        // The @p1 is unresolvable in describe's default context — the planner
+        // swallows that and falls back to a scan (non-sargable predicate);
+        // the columns come from the table schema either way.
         let events = drain_events(h.handle.stream_prepared(
             s,
             PreparedRpc::Describe {
@@ -3740,7 +3742,8 @@ mod tests {
         assert_eq!(rows[1][2], Datum::NVarChar("name".into()));
         assert_eq!(rows[1][5], Datum::NVarChar("nvarchar(40)".into()));
 
-        // A statement producing no result set describes as zero rows.
+        // A statement producing no result set describes as zero rows — and
+        // describing it executes nothing: the table stays empty.
         let events = drain_events(h.handle.stream_prepared(
             s,
             PreparedRpc::Describe {
@@ -3751,6 +3754,40 @@ mod tests {
         .await;
         assert_eq!(event_error(&events), None, "{events:?}");
         assert_eq!(rows_of(&events), Vec::<Vec<Datum>>::new());
+        let reply = h
+            .handle
+            .run_batch(s, "SELECT COUNT(*) FROM d".into())
+            .await
+            .unwrap();
+        match &reply.outcome.results[0] {
+            StatementResult::Rows(rowset) => assert_eq!(
+                rowset.rows[0][0],
+                Datum::BigInt(0),
+                "describe must not execute the INSERT"
+            ),
+            other => panic!("expected rows, got {other:?}"),
+        }
+
+        // The contract is the first RESULT SET, not the first statement:
+        // `INSERT; SELECT` (and a SELECT inside a TRY block) describe the
+        // SELECT, and `TOP 0` — the standard metadata-discovery idiom —
+        // describes like any other TOP.
+        for tsql in [
+            "INSERT INTO d VALUES (9, 'y'); SELECT id FROM d",
+            "BEGIN TRY SELECT id FROM d END TRY BEGIN CATCH END CATCH",
+            "SELECT TOP 0 id FROM d",
+        ] {
+            let events = drain_events(h.handle.stream_prepared(
+                s,
+                PreparedRpc::Describe { tsql: tsql.into() },
+                no_cancel(),
+            ))
+            .await;
+            assert_eq!(event_error(&events), None, "{tsql}: {events:?}");
+            let rows = rows_of(&events);
+            assert_eq!(rows.len(), 1, "{tsql}");
+            assert_eq!(rows[0][2], Datum::NVarChar("id".into()), "{tsql}");
+        }
 
         // A shape whose types are only known by executing answers 11514.
         let events = drain_events(h.handle.stream_prepared(

--- a/crates/truthdb-core/src/session.rs
+++ b/crates/truthdb-core/src/session.rs
@@ -145,6 +145,10 @@ pub enum PreparedRpc {
     Unprepare {
         handle: i32,
     },
+    /// `sp_describe_first_result_set`: metadata discovery, no execution.
+    Describe {
+        tsql: String,
+    },
 }
 
 /// A statement a session prepared: its text and parameter declarations, both
@@ -1167,6 +1171,23 @@ fn dispatch_rpc(
             };
             immediate(&reply, (!dropped).then(|| missing_handle(handle)));
         }
+        PreparedRpc::Describe { tsql } => match shared.engine.describe_first_result_set(&tsql) {
+            Ok(rowset) => {
+                let count = rowset.rows.len() as u64;
+                let in_transaction = {
+                    let sched = shared.scheduler.lock().expect("scheduler poisoned");
+                    sched.sessions.in_transaction(session)
+                };
+                reply.send(BatchEvent::Columns(rowset.columns));
+                reply.send(BatchEvent::Rows(rowset.rows));
+                reply.send(BatchEvent::StatementDone {
+                    count: Some(count),
+                    in_transaction,
+                });
+                reply.send(BatchEvent::Complete { in_transaction });
+            }
+            Err(error) => immediate(&reply, Some(error)),
+        },
         PreparedRpc::Execute { handle, values } => {
             let resolved = {
                 let sched = shared.scheduler.lock().expect("scheduler poisoned");
@@ -3686,6 +3707,61 @@ mod tests {
         ))
         .await;
         assert_eq!(rows_of(&events), vec![vec![Datum::Int(4)]]);
+    }
+
+    #[tokio::test]
+    async fn describe_first_result_set_covers_static_shapes_only() {
+        let h = start(LOCK_WAIT_TIMEOUT);
+        let s = h.handle.open_session("truthdb".into(), "sa".into()).await;
+        h.handle
+            .run_batch(
+                s,
+                "CREATE TABLE d (id INT NOT NULL PRIMARY KEY, name NVARCHAR(40))".into(),
+            )
+            .await
+            .unwrap();
+
+        // A parameterized single-table SELECT describes without executing:
+        // the declared @p1 resolves (as NULL) during planning.
+        let events = drain_events(h.handle.stream_prepared(
+            s,
+            PreparedRpc::Describe {
+                tsql: "SELECT id, name FROM d WHERE id = @p1".into(),
+            },
+            no_cancel(),
+        ))
+        .await;
+        assert_eq!(event_error(&events), None, "{events:?}");
+        let rows = rows_of(&events);
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0][1], Datum::Int(1)); // column_ordinal
+        assert_eq!(rows[0][2], Datum::NVarChar("id".into()));
+        assert_eq!(rows[0][4], Datum::Int(56)); // system_type_id: int
+        assert_eq!(rows[1][2], Datum::NVarChar("name".into()));
+        assert_eq!(rows[1][5], Datum::NVarChar("nvarchar(40)".into()));
+
+        // A statement producing no result set describes as zero rows.
+        let events = drain_events(h.handle.stream_prepared(
+            s,
+            PreparedRpc::Describe {
+                tsql: "INSERT INTO d VALUES (1, 'x')".into(),
+            },
+            no_cancel(),
+        ))
+        .await;
+        assert_eq!(event_error(&events), None, "{events:?}");
+        assert_eq!(rows_of(&events), Vec::<Vec<Datum>>::new());
+
+        // A shape whose types are only known by executing answers 11514.
+        let events = drain_events(h.handle.stream_prepared(
+            s,
+            PreparedRpc::Describe {
+                tsql: "SELECT a.id FROM d a JOIN d b ON a.id = b.id".into(),
+            },
+            no_cancel(),
+        ))
+        .await;
+        assert_eq!(event_error(&events), Some(11514), "{events:?}");
     }
 
     #[test]

--- a/crates/truthdb-tds/src/rpc.rs
+++ b/crates/truthdb-tds/src/rpc.rs
@@ -70,6 +70,8 @@ pub enum RpcProc {
     SpPrepExec,
     /// `sp_unprepare` (ProcID 15): drop a prepared handle.
     SpUnprepare,
+    /// `sp_describe_first_result_set` (by name): metadata discovery.
+    SpDescribeFirstResultSet,
     /// An `sp_cursor*` procedure — server-side cursors are not supported, and
     /// say so distinctly rather than "not found".
     SpCursor(String),
@@ -113,6 +115,8 @@ pub fn parse_rpc_request(body: &[u8]) -> io::Result<RpcRequest> {
             RpcProc::SpPrepExec
         } else if name.eq_ignore_ascii_case("sp_unprepare") {
             RpcProc::SpUnprepare
+        } else if name.eq_ignore_ascii_case("sp_describe_first_result_set") {
+            RpcProc::SpDescribeFirstResultSet
         } else if name.to_ascii_lowercase().starts_with("sp_cursor") {
             RpcProc::SpCursor(name)
         } else {
@@ -222,6 +226,19 @@ pub fn split_sp_prepexec(mut params: Vec<RpcParam>) -> io::Result<(String, Strin
         s => s,
     };
     Ok((decls, stmt, values))
+}
+
+/// Splits an `sp_describe_first_result_set` parameter list — `@tsql`, then
+/// optional `@params`/`@browse_information_mode` (both ignored: declared
+/// parameters need no binding to derive columns) — into the statement text.
+pub fn split_sp_describe(params: Vec<RpcParam>) -> io::Result<String> {
+    if params.is_empty() {
+        return Err(protocol_err("sp_describe_first_result_set: missing @tsql"));
+    }
+    match opt_string(&params[0], "sp_describe_first_result_set: @tsql")? {
+        s if s.is_empty() => Err(protocol_err("sp_describe_first_result_set: NULL @tsql")),
+        s => Ok(s),
+    }
 }
 
 /// Splits an `sp_unprepare` parameter list into its handle.

--- a/crates/truthdb-tds/src/rpc.rs
+++ b/crates/truthdb-tds/src/rpc.rs
@@ -231,13 +231,18 @@ pub fn split_sp_prepexec(mut params: Vec<RpcParam>) -> io::Result<(String, Strin
 /// Splits an `sp_describe_first_result_set` parameter list — `@tsql`, then
 /// optional `@params`/`@browse_information_mode` (both ignored: declared
 /// parameters need no binding to derive columns) — into the statement text.
+/// An empty `@tsql` is a valid empty batch (describes as zero rows); only a
+/// NULL one is rejected.
 pub fn split_sp_describe(params: Vec<RpcParam>) -> io::Result<String> {
     if params.is_empty() {
         return Err(protocol_err("sp_describe_first_result_set: missing @tsql"));
     }
-    match opt_string(&params[0], "sp_describe_first_result_set: @tsql")? {
-        s if s.is_empty() => Err(protocol_err("sp_describe_first_result_set: NULL @tsql")),
-        s => Ok(s),
+    match &params[0].value {
+        Datum::NVarChar(s) | Datum::VarChar(s) => Ok(s.clone()),
+        Datum::Null => Err(protocol_err("sp_describe_first_result_set: NULL @tsql")),
+        _ => Err(protocol_err(
+            "sp_describe_first_result_set: @tsql is not a string",
+        )),
     }
 }
 

--- a/crates/truthdb-tds/src/server.rs
+++ b/crates/truthdb-tds/src/server.rs
@@ -611,6 +611,11 @@ fn start_rpc(
                 .map_err(|err| rpc_error(&err.to_string()))?;
             Ok(engine.stream_prepared(session, PreparedRpc::Unprepare { handle }, cancel))
         }
+        RpcProc::SpDescribeFirstResultSet => {
+            let tsql = rpc::split_sp_describe(request.params)
+                .map_err(|err| rpc_error(&err.to_string()))?;
+            Ok(engine.stream_prepared(session, PreparedRpc::Describe { tsql }, cancel))
+        }
         // Server-side cursors are not implemented; say so rather than "not
         // found" so a driver's fallback logic gets an honest signal.
         RpcProc::SpCursor(name) => Err(rpc_error_num(

--- a/scripts/tds_conformance_prepared.py
+++ b/scripts/tds_conformance_prepared.py
@@ -112,6 +112,27 @@ def main() -> int:
     except pytds.Error:
         pass
 
+    # sp_describe_first_result_set: metadata without execution, over real RPC.
+    cur.callproc(
+        "sp_describe_first_result_set",
+        ("SELECT id, name FROM prep_py WHERE id = @p1", "@p1 int", 0),
+    )
+    described = [(row[1], row[2], row[5]) for row in cur.fetchall()]
+    want = [(1, "id", "int"), (2, "name", "nvarchar(40)")]
+    if described != want:
+        fail(f"describe: got {described!r} want {want!r}")
+    # An execution-typed shape (join) answers 11514 rather than guessing.
+    try:
+        cur.callproc(
+            "sp_describe_first_result_set",
+            ("SELECT a.id FROM prep_py a JOIN prep_py b ON a.id = b.id", None, 0),
+        )
+        cur.fetchall()
+        fail("describe of a join did not raise")
+    except pytds.Error as err:
+        if getattr(err, "number", None) != 11514:
+            fail(f"describe join: expected 11514, got {err}")
+
     conn.close()
     print("tds conformance (sp_prepare family, pytds): OK")
     return 0


### PR DESCRIPTION
## What

`sp_describe_first_result_set` works over RPC (by name): it returns the first result set's column metadata — is_hidden, column_ordinal, name, is_nullable, system_type_id, system_type_name — without executing the statement. This closes the Stage 9 shims bullet's remaining gap.

## Scope and the honest boundary

Coverage is exactly the shapes whose output columns this engine derives statically: the single-table SELECTs `scan_plan` recognises (their COLMETADATA is emitted before the first row at execution too). A statement producing no result set describes as zero rows, as SQL Server does. Joins, aggregates, and computed columns have result types the engine only learns by executing (`infer_type` over the values), so describe answers 11514 ("the metadata could not be determined...") rather than guessing — the same static-type-derivation gap Stage 8's output-streaming item tracks; it now has two consumers.

A teeth-check found the planned parameter seeding was dead code: the planner treats an unresolvable `@p` as a non-seekable predicate and falls back to the scan, so declared parameters need no binding to derive columns. The seeding and its plumbing were removed; the parameterized-describe test pins the behavior.

## Verification

pytds adjudicates it live in `scripts/tds_conformance_prepared.py` (already in CI): the described metadata for a parameterized single-table SELECT (`[(1,'id','int'),(2,'name','nvarchar(40)')]`) and 11514 for a join — run green against this branch's server in a container. Engine test covers the parameterized describe, the zero-row INSERT case, and the 11514 join case. Full workspace: 473 passed, 0 failed; fmt and clippy (-D warnings) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)