### PR TITLE
Stage 9 exit matrix: RPC framing, multi-RPC requests, and a three-driver harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,6 +236,31 @@ jobs:
           go get github.com/microsoft/go-mssqldb@v1.8.0
           go run . 127.0.0.1 1433 sa secret
 
+      - name: Conformance — mssql-jdbc (Java, prepared-statement flow)
+        run: |
+          apt-get install -y --no-install-recommends openjdk-17-jdk-headless
+          curl -sfLo /tmp/mssql-jdbc.jar https://repo1.maven.org/maven2/com/microsoft/sqlserver/mssql-jdbc/12.8.1.jre11/mssql-jdbc-12.8.1.jre11.jar
+          java -cp /tmp/mssql-jdbc.jar scripts/TdsConformance.java 127.0.0.1 1433 sa secret
+
+      - name: Conformance — ODBC sqlcmd (mssql-tools18, scripted with output diff)
+        run: |
+          curl -s https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /usr/share/keyrings/ms.gpg
+          echo 'deb [signed-by=/usr/share/keyrings/ms.gpg] https://packages.microsoft.com/debian/12/prod bookworm main' > /etc/apt/sources.list.d/mssql.list
+          apt-get update
+          ACCEPT_EULA=Y apt-get install -y --no-install-recommends msodbcsql18 mssql-tools18
+          /opt/mssql-tools18/bin/sqlcmd -S 127.0.0.1,1433 -U sa -P secret -d truthdb -N o -I \
+            -v TABLE=conf_odbc -i scripts/tds_conformance_sqlcmd.sql > /tmp/odbc.out 2>&1
+          diff -u scripts/tds_conformance_sqlcmd.expected /tmp/odbc.out
+          echo "tds conformance (ODBC sqlcmd): OK"
+
+      - name: Conformance — go-sqlcmd (scripted with output diff)
+        run: |
+          curl -sfL https://github.com/microsoft/go-sqlcmd/releases/download/v1.8.2/sqlcmd-linux-amd64.tar.bz2 | tar xj -C /usr/local/bin sqlcmd
+          sqlcmd -S 127.0.0.1,1433 -U sa -P secret -d truthdb -N disable -I \
+            -v TABLE=conf_go -i scripts/tds_conformance_sqlcmd.sql > /tmp/gosqlcmd.out 2>&1
+          diff -u scripts/tds_conformance_gosqlcmd.expected /tmp/gosqlcmd.out
+          echo "tds conformance (go-sqlcmd): OK"
+
       - name: Stop server
         if: always()
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,7 +249,7 @@ jobs:
           apt-get update
           ACCEPT_EULA=Y apt-get install -y --no-install-recommends msodbcsql18 mssql-tools18
           /opt/mssql-tools18/bin/sqlcmd -S 127.0.0.1,1433 -U sa -P secret -d truthdb -N o -I \
-            -v TABLE=conf_odbc -i scripts/tds_conformance_sqlcmd.sql > /tmp/odbc.out 2>&1
+            -v TABLE=conf_odbc -i scripts/tds_conformance_sqlcmd.sql > /tmp/odbc.out
           diff -u scripts/tds_conformance_sqlcmd.expected /tmp/odbc.out
           echo "tds conformance (ODBC sqlcmd): OK"
 
@@ -257,7 +257,7 @@ jobs:
         run: |
           curl -sfL https://github.com/microsoft/go-sqlcmd/releases/download/v1.8.2/sqlcmd-linux-amd64.tar.bz2 | tar xj -C /usr/local/bin sqlcmd
           sqlcmd -S 127.0.0.1,1433 -U sa -P secret -d truthdb -N disable -I \
-            -v TABLE=conf_go -i scripts/tds_conformance_sqlcmd.sql > /tmp/gosqlcmd.out 2>&1
+            -v TABLE=conf_go -i scripts/tds_conformance_sqlcmd.sql > /tmp/gosqlcmd.out
           diff -u scripts/tds_conformance_gosqlcmd.expected /tmp/gosqlcmd.out
           echo "tds conformance (go-sqlcmd): OK"
 

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -352,9 +352,10 @@ pub trait BatchEmitter {
     fn columns(&mut self, columns: Vec<ResultColumn>);
     /// A chunk of rows for the open result set.
     fn rows(&mut self, rows: Vec<Vec<Datum>>);
-    /// Ends one statement: its row count / rows-affected (`None` for DDL), and
-    /// the transaction state after it ran.
-    fn statement_done(&mut self, count: Option<u64>, in_transaction: bool);
+    /// Ends one statement: its row count / rows-affected (`None` for DDL),
+    /// the transaction state after it ran, and its command class (the DONE's
+    /// `CurCmd` on the wire).
+    fn statement_done(&mut self, count: Option<u64>, in_transaction: bool, command: DoneCommand);
     /// Ends a statement that failed after its result set had begun streaming:
     /// the set is closed so the stream stays framed for the statements that
     /// follow. The error itself is reported separately — at the end of the
@@ -397,7 +398,7 @@ impl BatchEmitter for Collector {
         }
     }
 
-    fn statement_done(&mut self, count: Option<u64>, _in_transaction: bool) {
+    fn statement_done(&mut self, count: Option<u64>, _in_transaction: bool, _command: DoneCommand) {
         self.results.push(match self.open.take() {
             Some(rowset) => StatementResult::Rows(rowset),
             None => match count {
@@ -441,6 +442,32 @@ struct BatchRun<'a> {
 struct DeferredDone {
     count: Option<u64>,
     in_transaction: bool,
+    command: DoneCommand,
+}
+
+/// The command class a statement's DONE reports in its `CurCmd` field.
+/// mssql-jdbc discards a DONE's row count unless `CurCmd` names a DML
+/// command, so `executeUpdate` returns -1 against a server that leaves it
+/// zero (pytds and go-mssqldb ignore the field).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum DoneCommand {
+    Select,
+    Insert,
+    Update,
+    Delete,
+    /// DDL, SET, transaction control — anything whose count nobody reads.
+    Other,
+}
+
+/// The `CurCmd` class of a statement.
+fn done_command(statement: &Statement) -> DoneCommand {
+    match statement {
+        Statement::Select(_) => DoneCommand::Select,
+        Statement::Insert(_) => DoneCommand::Insert,
+        Statement::Update(_) => DoneCommand::Update,
+        Statement::Delete(_) => DoneCommand::Delete,
+        _ => DoneCommand::Other,
+    }
 }
 
 impl BatchRun<'_> {
@@ -463,11 +490,12 @@ impl BatchRun<'_> {
     }
 
     /// Ends a statement. Its DONE is deferred to the next durability point.
-    fn done(&mut self, count: Option<u64>, in_transaction: bool) {
+    fn done(&mut self, count: Option<u64>, in_transaction: bool, command: DoneCommand) {
         self.rowset_open = false;
         self.deferred.push(DeferredDone {
             count,
             in_transaction,
+            command,
         });
     }
 
@@ -502,7 +530,8 @@ impl BatchRun<'_> {
             }
         }
         for done in self.deferred.drain(..) {
-            self.emitter.statement_done(done.count, done.in_transaction);
+            self.emitter
+                .statement_done(done.count, done.in_transaction, done.command);
         }
         Ok(())
     }
@@ -520,7 +549,8 @@ impl BatchRun<'_> {
             }
         }
         for done in self.deferred.drain(..) {
-            self.emitter.statement_done(done.count, done.in_transaction);
+            self.emitter
+                .statement_done(done.count, done.in_transaction, done.command);
         }
         None
     }
@@ -611,21 +641,22 @@ fn run_block(
         match exec_statement_streamed(storage, statement, txn_ctx, run) {
             Ok(outcome) => {
                 let in_transaction = txn_ctx.in_txn();
+                let command = done_command(statement);
                 match outcome {
                     StatementOutcome::Streamed { rows } => {
-                        run.done(Some(rows), in_transaction);
+                        run.done(Some(rows), in_transaction, command);
                     }
                     StatementOutcome::Result(StatementResult::Rows(rowset)) => {
                         let count = rowset.rows.len() as u64;
                         run.open_rowset(rowset.columns);
                         run.rows(rowset.rows);
-                        run.done(Some(count), in_transaction);
+                        run.done(Some(count), in_transaction, command);
                     }
                     StatementOutcome::Result(StatementResult::RowsAffected(n)) => {
-                        run.done(Some(n), in_transaction);
+                        run.done(Some(n), in_transaction, command);
                     }
                     StatementOutcome::Result(StatementResult::Done) => {
-                        run.done(None, in_transaction);
+                        run.done(None, in_transaction, command);
                     }
                 }
             }

--- a/crates/truthdb-core/src/session.rs
+++ b/crates/truthdb-core/src/session.rs
@@ -103,6 +103,8 @@ pub enum BatchEvent {
         /// The transaction state to stamp on this statement's DONE
         /// (`DONE_INXACT`).
         in_transaction: bool,
+        /// The DONE's `CurCmd` class — mssql-jdbc drops the count without it.
+        command: crate::rel::DoneCommand,
     },
     /// Ends a statement that failed after its result set had begun streaming:
     /// closes the set (with a clean DONE — an error-flagged DONE without an
@@ -256,10 +258,12 @@ impl BatchSink {
                 StatementResult::RowsAffected(n) => self.send(BatchEvent::StatementDone {
                     count: Some(n),
                     in_transaction,
+                    command: crate::rel::DoneCommand::Other,
                 }),
                 StatementResult::Done => self.send(BatchEvent::StatementDone {
                     count: None,
                     in_transaction,
+                    command: crate::rel::DoneCommand::Other,
                 }),
             };
             if !sent {
@@ -296,6 +300,7 @@ impl BatchSink {
         self.send(BatchEvent::StatementDone {
             count: Some(count),
             in_transaction,
+            command: crate::rel::DoneCommand::Select,
         })
     }
 
@@ -326,10 +331,16 @@ impl crate::rel::BatchEmitter for BatchSink {
         self.send(BatchEvent::Rows(rows));
     }
 
-    fn statement_done(&mut self, count: Option<u64>, in_transaction: bool) {
+    fn statement_done(
+        &mut self,
+        count: Option<u64>,
+        in_transaction: bool,
+        command: crate::rel::DoneCommand,
+    ) {
         self.send(BatchEvent::StatementDone {
             count,
             in_transaction,
+            command,
         });
     }
 
@@ -734,7 +745,7 @@ impl EngineHandle {
         params: Vec<crate::rel::RpcParam>,
         cancel: Arc<AtomicBool>,
     ) -> Result<BatchReply, EngineError> {
-        let mut events = self.stream_rpc(session, sql, params, cancel);
+        let mut events = self.stream_rpc(session, sql, String::new(), params, cancel);
         collect_reply(&mut events).await
     }
 
@@ -746,7 +757,7 @@ impl EngineHandle {
         sql: String,
         cancel: Arc<AtomicBool>,
     ) -> mpsc::UnboundedReceiver<BatchEvent> {
-        self.stream_rpc(session, sql, Vec::new(), cancel)
+        self.stream_rpc(session, sql, String::new(), Vec::new(), cancel)
     }
 
     /// Runs a batch and returns its reply as a stream of [`BatchEvent`]s, so a
@@ -763,10 +774,24 @@ impl EngineHandle {
         &self,
         session: SessionId,
         sql: String,
+        decls: String,
         params: Vec<crate::rel::RpcParam>,
         cancel: Arc<AtomicBool>,
     ) -> mpsc::UnboundedReceiver<BatchEvent> {
         let (tx, rx) = mpsc::unbounded_channel();
+        // Unnamed values take the declaration list's names (mssql-jdbc sends
+        // them unnamed), exactly as sp_execute binds them.
+        let params = match bind_decl_names(&decls, params) {
+            Ok(params) => params,
+            Err(error) => {
+                let sink = BatchSink::new(tx);
+                sink.send(BatchEvent::Error(error));
+                sink.send(BatchEvent::Complete {
+                    in_transaction: false,
+                });
+                return rx;
+            }
+        };
         self.inbox.send(EngineCall::RunBatch {
             session,
             sql,
@@ -1183,6 +1208,7 @@ fn dispatch_rpc(
                 reply.send(BatchEvent::StatementDone {
                     count: Some(count),
                     in_transaction,
+                    command: crate::rel::DoneCommand::Select,
                 });
                 reply.send(BatchEvent::Complete { in_transaction });
             }

--- a/crates/truthdb-core/src/session.rs
+++ b/crates/truthdb-core/src/session.rs
@@ -1266,10 +1266,17 @@ fn bind_decl_names(
     mut values: Vec<crate::rel::RpcParam>,
 ) -> Result<Vec<crate::rel::RpcParam>, SqlError> {
     let names = decl_names(decls);
-    // More values than declarations is SQL Server's 8144. (Fewer is legal —
-    // a declared parameter the statement never reads goes unmissed, and one
-    // it does read errors when the variable lookup fails at execution.)
-    if values.len() > names.len() {
+    // An unnamed value with no declaration to name it is SQL Server's 8144.
+    // (Fewer values than declarations is legal — a declared parameter the
+    // statement never reads goes unmissed, and one it does read errors when
+    // the variable lookup fails at execution. Extra NAMED values pass
+    // through: they seed variables by their own names, which keeps the
+    // `run_rpc` wrappers' seed-named-params contract intact.)
+    if values
+        .iter()
+        .skip(names.len())
+        .any(|value| value.name.is_empty())
+    {
         return Err(SqlError::new(
             8144,
             16,
@@ -3865,5 +3872,10 @@ mod tests {
         // Fewer values than declarations stays legal (an unread declared
         // parameter goes unmissed).
         assert!(bind_decl_names("@p1 int, @p2 int", vec![int_param(1)]).is_ok());
+        // Extra NAMED values pass through — they seed variables by their own
+        // names (the run_rpc wrappers' contract).
+        let mut named = int_param(9);
+        named.name = "@extra".into();
+        assert!(bind_decl_names("", vec![named]).is_ok());
     }
 }

--- a/crates/truthdb-core/src/storage.rs
+++ b/crates/truthdb-core/src/storage.rs
@@ -3937,7 +3937,12 @@ mod tests {
             fn rows(&mut self, _rows: Vec<Vec<Datum>>) {
                 self.note("rows");
             }
-            fn statement_done(&mut self, _count: Option<u64>, _in_transaction: bool) {
+            fn statement_done(
+                &mut self,
+                _count: Option<u64>,
+                _in_transaction: bool,
+                _command: crate::rel::DoneCommand,
+            ) {
                 self.note("done");
             }
             fn statement_aborted(&mut self, _in_transaction: bool) {
@@ -4016,7 +4021,12 @@ mod tests {
             fn rows(&mut self, _rows: Vec<Vec<Datum>>) {
                 self.note("rows");
             }
-            fn statement_done(&mut self, _count: Option<u64>, _in_transaction: bool) {
+            fn statement_done(
+                &mut self,
+                _count: Option<u64>,
+                _in_transaction: bool,
+                _command: crate::rel::DoneCommand,
+            ) {
                 self.note("done");
             }
             fn statement_aborted(&mut self, _in_transaction: bool) {

--- a/crates/truthdb-tds/Cargo.toml
+++ b/crates/truthdb-tds/Cargo.toml
@@ -9,11 +9,10 @@ license = "MIT"
 tokio = { workspace = true }
 tracing = { workspace = true }
 truthdb-core = { path = "../truthdb-core", version = "0.1.0" }
+# The SqlError a decode failure renders in-frame (and tests model with).
+truthdb-sql = { path = "../truthdb-sql", version = "0.1.0" }
 rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12", "logging"] }
 tokio-rustls = { version = "0.26", default-features = false, features = ["ring", "tls12"] }
 rustls-pemfile = "2"
 
 [dev-dependencies]
-# Only to build the SqlError an engine reply carries, so a test can model what
-# the executor really sends on cancellation.
-truthdb-sql = { path = "../truthdb-sql", version = "0.1.0" }

--- a/crates/truthdb-tds/src/rpc.rs
+++ b/crates/truthdb-tds/src/rpc.rs
@@ -174,10 +174,14 @@ pub fn parse_rpc_request(body: &[u8]) -> io::Result<RpcRequest> {
     Ok(requests.remove(0))
 }
 
-/// Splits an `sp_executesql` parameter list into (statement text, value
-/// parameters). Layout: `@stmt`, optional `@params` declaration, then the
-/// value parameters — which are the only ones seeded as batch variables.
-pub fn split_sp_executesql(mut params: Vec<RpcParam>) -> io::Result<(String, Vec<RpcParam>)> {
+/// Splits an `sp_executesql` parameter list into (statement text, parameter
+/// declarations, value parameters). Layout: `@stmt`, optional `@params`
+/// declaration, then the values — which seed batch variables, named from the
+/// declaration list when the driver sends them unnamed (mssql-jdbc does;
+/// pytds and go-mssqldb name theirs).
+pub fn split_sp_executesql(
+    mut params: Vec<RpcParam>,
+) -> io::Result<(String, String, Vec<RpcParam>)> {
     if params.is_empty() {
         return Err(protocol_err("sp_executesql: missing statement parameter"));
     }
@@ -187,7 +191,11 @@ pub fn split_sp_executesql(mut params: Vec<RpcParam>) -> io::Result<(String, Vec
         Datum::Null => return Err(protocol_err("sp_executesql: NULL statement")),
         _ => return Err(protocol_err("sp_executesql: statement is not a string")),
     };
-    Ok((stmt, values))
+    let decls = match params.get(1) {
+        Some(p) => opt_string(p, "sp_executesql: @params")?,
+        None => String::new(),
+    };
+    Ok((stmt, decls, values))
 }
 
 /// Reads a string parameter that may be NULL (an empty declaration list).
@@ -671,7 +679,7 @@ mod tests {
         assert_eq!(requests.len(), 2);
         for (request, want) in requests.into_iter().zip(["SELECT 1 AS a", "SELECT 2 AS b"]) {
             assert!(matches!(request.proc, RpcProc::SpExecuteSql));
-            let (sql, values) = split_sp_executesql(request.params).expect("split");
+            let (sql, _decls, values) = split_sp_executesql(request.params).expect("split");
             assert_eq!(sql, want);
             assert!(values.is_empty());
         }
@@ -683,7 +691,7 @@ mod tests {
         assert!(matches!(req.proc, RpcProc::SpExecuteSql));
         assert_eq!(req.params.len(), 3);
 
-        let (sql, values) = split_sp_executesql(req.params).expect("split");
+        let (sql, _decls, values) = split_sp_executesql(req.params).expect("split");
         assert_eq!(sql, "SELECT @p1");
         assert_eq!(values.len(), 1);
         assert_eq!(values[0].name, "@p1");
@@ -716,7 +724,7 @@ mod tests {
         b.push(0); // NULL
 
         let req = parse_rpc_request(&b).expect("parse");
-        let (_sql, values) = split_sp_executesql(req.params).expect("split");
+        let (_sql, _decls, values) = split_sp_executesql(req.params).expect("split");
         assert_eq!(values.len(), 3);
         assert!(matches!(&values[0].value, Datum::NVarChar(s) if s == "café"));
         assert!(matches!(values[1].value, Datum::BigInt(5_000_000_000)));
@@ -745,7 +753,7 @@ mod tests {
         b.extend_from_slice(&7i32.to_le_bytes());
 
         let req = parse_rpc_request(&b).expect("parse");
-        let (_sql, values) = split_sp_executesql(req.params).expect("split");
+        let (_sql, _decls, values) = split_sp_executesql(req.params).expect("split");
         assert_eq!(values.len(), 2);
         assert!(matches!(values[0].value, Datum::Null));
         assert!(matches!(values[1].value, Datum::Int(7)));

--- a/crates/truthdb-tds/src/rpc.rs
+++ b/crates/truthdb-tds/src/rpc.rs
@@ -86,8 +86,29 @@ pub struct RpcRequest {
 }
 
 /// Decodes an RPC request body (the bytes *after* the ALL_HEADERS block).
-pub fn parse_rpc_request(body: &[u8]) -> io::Result<RpcRequest> {
+/// A request may carry several RPCs separated by batch flags (0xFF, or 0x80
+/// from older TDS versions) — mssql-jdbc batches sp_unprepare calls with the
+/// next execution's sp_prepexec this way. Each runs in order and answers its
+/// own DONEPROC-framed reply within the one response.
+pub fn parse_rpc_requests(body: &[u8]) -> io::Result<Vec<RpcRequest>> {
     let mut c = Cursor::new(body);
+    let mut requests = Vec::new();
+    loop {
+        requests.push(parse_one_rpc(&mut c)?);
+        if c.remaining() == 0 {
+            return Ok(requests);
+        }
+        // The separator byte; the next RPC's NameLenProcID follows.
+        let _flag = c.u8()?;
+        if c.remaining() == 0 {
+            // A trailing separator with nothing after it.
+            return Ok(requests);
+        }
+    }
+}
+
+/// Decodes one RPC from the cursor, stopping at a batch separator.
+fn parse_one_rpc(c: &mut Cursor) -> io::Result<RpcRequest> {
     // NameLenProcID: a US_VARCHAR proc name, or 0xFFFF + a well-known ProcID.
     let name_len = c.u16()?;
     let proc = if name_len == PROCID_SENTINEL {
@@ -127,8 +148,8 @@ pub fn parse_rpc_request(body: &[u8]) -> io::Result<RpcRequest> {
 
     let mut params = Vec::new();
     while c.remaining() > 0 {
-        // A batch flag (0x80 = fWithRecompile / 0xFF = separator) begins the
-        // next RPC in a multi-RPC request; we run the first and stop there.
+        // A batch flag (0x80 = old-style / 0xFF = separator) begins the next
+        // RPC in a multi-RPC request; the caller consumes it and loops.
         let lead = c.peek_u8();
         if lead == 0xff || lead == 0x80 {
             break;
@@ -136,7 +157,7 @@ pub fn parse_rpc_request(body: &[u8]) -> io::Result<RpcRequest> {
         let name_len = c.u8()? as usize;
         let name = c.utf16(name_len * 2)?;
         let _status = c.u8()?; // StatusFlags: fByRefValue / fDefaultValue.
-        let (column_type, value) = decode_param(&mut c)?;
+        let (column_type, value) = decode_param(c)?;
         params.push(RpcParam {
             name,
             column_type,
@@ -144,6 +165,13 @@ pub fn parse_rpc_request(body: &[u8]) -> io::Result<RpcRequest> {
         });
     }
     Ok(RpcRequest { proc, params })
+}
+
+/// Decodes a body expected to hold exactly one RPC (tests' shorthand).
+#[cfg(test)]
+pub fn parse_rpc_request(body: &[u8]) -> io::Result<RpcRequest> {
+    let mut requests = parse_rpc_requests(body)?;
+    Ok(requests.remove(0))
 }
 
 /// Splits an `sp_executesql` parameter list into (statement text, value
@@ -624,6 +652,29 @@ mod tests {
         let bytes: Vec<u8> = value.encode_utf16().flat_map(|u| u.to_le_bytes()).collect();
         b.extend_from_slice(&(bytes.len() as u16).to_le_bytes());
         b.extend_from_slice(&bytes);
+    }
+
+    #[test]
+    fn a_multi_rpc_body_parses_each_rpc() {
+        let mut b = Vec::new();
+        b.extend_from_slice(&PROCID_SENTINEL.to_le_bytes());
+        b.extend_from_slice(&SP_EXECUTESQL_PROCID.to_le_bytes());
+        b.extend_from_slice(&0u16.to_le_bytes());
+        push_nvarchar_param(&mut b, "", "SELECT 1 AS a");
+        b.push(0xff); // batch separator
+        b.extend_from_slice(&PROCID_SENTINEL.to_le_bytes());
+        b.extend_from_slice(&SP_EXECUTESQL_PROCID.to_le_bytes());
+        b.extend_from_slice(&0u16.to_le_bytes());
+        push_nvarchar_param(&mut b, "", "SELECT 2 AS b");
+
+        let requests = parse_rpc_requests(&b).expect("parse");
+        assert_eq!(requests.len(), 2);
+        for (request, want) in requests.into_iter().zip(["SELECT 1 AS a", "SELECT 2 AS b"]) {
+            assert!(matches!(request.proc, RpcProc::SpExecuteSql));
+            let (sql, values) = split_sp_executesql(request.params).expect("split");
+            assert_eq!(sql, want);
+            assert!(values.is_empty());
+        }
     }
 
     #[test]

--- a/crates/truthdb-tds/src/server.rs
+++ b/crates/truthdb-tds/src/server.rs
@@ -133,7 +133,7 @@ where
             14,
             &format!("Login failed for user '{}'.", login.username),
         );
-        token::done(&mut out, false, true, false, None);
+        token::done(&mut out, false, true, false, None, 0);
         write_message(&mut stream, PKT_TABULAR_RESULT, &out, packet_size).await?;
         return Ok(());
     }
@@ -153,6 +153,7 @@ where
     let mut out = Vec::new();
     token::loginack(&mut out);
     token::envchange_database(&mut out, &database);
+    token::envchange_sql_collation(&mut out);
     token::envchange_packet_size(&mut out, packet_size, DEFAULT_PACKET_SIZE);
     token::info(
         &mut out,
@@ -161,7 +162,7 @@ where
         10,
         &format!("Changed database context to '{database}'."),
     );
-    token::done(&mut out, false, false, false, None);
+    token::done(&mut out, false, false, false, None, 0);
     write_message(&mut stream, PKT_TABULAR_RESULT, &out, packet_size).await?;
 
     // Each connection gets an engine-side session; it is closed (rolling back
@@ -298,7 +299,7 @@ async fn handle_tm_request(
         Err(err) => {
             let mut out = Vec::new();
             token::error(&mut out, 50000, 1, 16, &err.to_string());
-            token::done(&mut out, false, true, false, None);
+            token::done(&mut out, false, true, false, None, 0);
             return Ok(out);
         }
     };
@@ -314,7 +315,7 @@ async fn handle_tm_request(
             error.level,
             &error.message,
         );
-        token::done(&mut out, false, true, reply.in_transaction, None);
+        token::done(&mut out, false, true, reply.in_transaction, None, 0);
         return Ok(out);
     }
 
@@ -344,7 +345,7 @@ async fn handle_tm_request(
         }
         _ => unreachable!("request type validated above"),
     }
-    token::done(&mut out, false, false, reply.in_transaction, None);
+    token::done(&mut out, false, false, reply.in_transaction, None, 0);
     Ok(out)
 }
 
@@ -680,9 +681,9 @@ fn start_rpc(
     let rpc_error = |message: String| (50000, message);
     match request.proc {
         RpcProc::SpExecuteSql => {
-            let (sql, params) = rpc::split_sp_executesql(request.params)
+            let (sql, decls, params) = rpc::split_sp_executesql(request.params)
                 .map_err(|err| rpc_error(err.to_string()))?;
-            Ok(engine.stream_rpc(session, sql, params, cancel))
+            Ok(engine.stream_rpc(session, sql, decls, params, cancel))
         }
         RpcProc::SpPrepare => {
             let (decls, stmt) =
@@ -766,6 +767,19 @@ struct BatchRender {
 struct PendingDone {
     count: Option<u64>,
     in_transaction: bool,
+    curcmd: u16,
+}
+
+/// The DONE `CurCmd` value for a statement's command class.
+fn curcmd_of(command: truthdb_core::rel::DoneCommand) -> u16 {
+    use truthdb_core::rel::DoneCommand;
+    match command {
+        DoneCommand::Select => token::CMD_SELECT,
+        DoneCommand::Insert => token::CMD_INSERT,
+        DoneCommand::Update => token::CMD_UPDATE,
+        DoneCommand::Delete => token::CMD_DELETE,
+        DoneCommand::Other => 0,
+    }
 }
 
 impl BatchRender {
@@ -797,11 +811,13 @@ impl BatchRender {
             BatchEvent::StatementDone {
                 count,
                 in_transaction,
+                command,
             } => {
                 self.flush_pending(out, true).await?;
                 self.pending = Some(PendingDone {
                     count,
                     in_transaction,
+                    curcmd: curcmd_of(command),
                 });
             }
             BatchEvent::StatementAborted { in_transaction } => {
@@ -821,6 +837,7 @@ impl BatchRender {
                 self.pending = Some(PendingDone {
                     count: None,
                     in_transaction,
+                    curcmd: 0,
                 });
             }
             BatchEvent::PreparedHandle(handle) => {
@@ -889,8 +906,15 @@ impl BatchRender {
         more: bool,
     ) -> io::Result<()> {
         if let Some(done) = self.pending.take() {
-            self.done(out, more, false, done.in_transaction, done.count)
-                .await?;
+            self.done(
+                out,
+                more,
+                false,
+                done.in_transaction,
+                done.count,
+                done.curcmd,
+            )
+            .await?;
         }
         Ok(())
     }
@@ -904,12 +928,13 @@ impl BatchRender {
         error: bool,
         in_transaction: bool,
         count: Option<u64>,
+        curcmd: u16,
     ) -> io::Result<()> {
         self.buf.clear();
         if self.rpc {
-            token::done_in_proc(&mut self.buf, more, error, in_transaction, count);
+            token::done_in_proc(&mut self.buf, more, error, in_transaction, count, curcmd);
         } else {
-            token::done(&mut self.buf, more, error, in_transaction, count);
+            token::done(&mut self.buf, more, error, in_transaction, count, curcmd);
         }
         out.write(&self.buf).await
     }
@@ -932,7 +957,7 @@ impl BatchRender {
                 None,
             );
         } else {
-            token::done(&mut self.buf, false, error, in_transaction, None);
+            token::done(&mut self.buf, false, error, in_transaction, None, 0);
         }
         out.write(&self.buf).await
     }
@@ -941,7 +966,7 @@ impl BatchRender {
 fn rpc_error(message: &str) -> Vec<u8> {
     let mut out = Vec::new();
     token::error(&mut out, 50000, 1, 16, message);
-    token::done(&mut out, false, true, false, None);
+    token::done(&mut out, false, true, false, None, 0);
     out
 }
 
@@ -1102,13 +1127,14 @@ mod render_tests {
                         false,
                         in_transaction,
                         Some(rowset.rows.len() as u64),
+                        token::CMD_SELECT,
                     );
                 }
                 StatementResult::RowsAffected(n) => {
-                    token::done(&mut out, more, false, in_transaction, Some(*n));
+                    token::done(&mut out, more, false, in_transaction, Some(*n), 0);
                 }
                 StatementResult::Done => {
-                    token::done(&mut out, more, false, in_transaction, None);
+                    token::done(&mut out, more, false, in_transaction, None, 0);
                 }
             }
         }
@@ -1120,9 +1146,9 @@ mod render_tests {
                 error.level,
                 &error.message,
             );
-            token::done(&mut out, false, true, in_transaction, None);
+            token::done(&mut out, false, true, in_transaction, None, 0);
         } else if outcome.results.is_empty() {
-            token::done(&mut out, false, false, in_transaction, None);
+            token::done(&mut out, false, false, in_transaction, None, 0);
         }
         out
     }
@@ -1188,6 +1214,7 @@ mod render_tests {
                     tx.send(BatchEvent::StatementDone {
                         count: Some(rowset.rows.len() as u64),
                         in_transaction: in_xact,
+                        command: truthdb_core::rel::DoneCommand::Select,
                     })
                     .unwrap();
                 }
@@ -1195,12 +1222,14 @@ mod render_tests {
                     .send(BatchEvent::StatementDone {
                         count: Some(*n),
                         in_transaction: in_xact,
+                        command: truthdb_core::rel::DoneCommand::Other,
                     })
                     .unwrap(),
                 StatementResult::Done => tx
                     .send(BatchEvent::StatementDone {
                         count: None,
                         in_transaction: in_xact,
+                        command: truthdb_core::rel::DoneCommand::Other,
                     })
                     .unwrap(),
             }
@@ -1225,6 +1254,7 @@ mod render_tests {
         tx.send(BatchEvent::StatementDone {
             count: Some(1),
             in_transaction: false,
+            command: truthdb_core::rel::DoneCommand::Other,
         })
         .unwrap();
         tx.send(BatchEvent::PreparedHandle(7)).unwrap();
@@ -1235,7 +1265,7 @@ mod render_tests {
         drop(tx);
 
         let mut expected = Vec::new();
-        token::done_in_proc(&mut expected, true, false, false, Some(1));
+        token::done_in_proc(&mut expected, true, false, false, Some(1), 0);
         token::return_status(&mut expected, 0);
         token::return_value_int(&mut expected, "handle", 7);
         token::done_proc(&mut expected, false, false, false, None);
@@ -1247,6 +1277,7 @@ mod render_tests {
         tx.send(BatchEvent::StatementDone {
             count: Some(3),
             in_transaction: false,
+            command: truthdb_core::rel::DoneCommand::Other,
         })
         .unwrap();
         tx.send(BatchEvent::Complete {
@@ -1255,7 +1286,7 @@ mod render_tests {
         .unwrap();
         drop(tx);
         let mut expected = Vec::new();
-        token::done_in_proc(&mut expected, true, false, false, Some(3));
+        token::done_in_proc(&mut expected, true, false, false, Some(3), 0);
         token::return_status(&mut expected, 0);
         token::done_proc(&mut expected, false, false, false, None);
         assert_eq!(rendered_events_framed(rx, 4096, true).await, expected);
@@ -1314,6 +1345,7 @@ mod render_tests {
             tx.send(BatchEvent::StatementDone {
                 count,
                 in_transaction,
+                command: truthdb_core::rel::DoneCommand::Other,
             })
             .unwrap();
         }
@@ -1324,9 +1356,9 @@ mod render_tests {
         drop(tx);
 
         let mut expected = Vec::new();
-        token::done(&mut expected, true, false, true, None);
-        token::done(&mut expected, true, false, true, Some(1));
-        token::done(&mut expected, false, false, false, None);
+        token::done(&mut expected, true, false, true, None, 0);
+        token::done(&mut expected, true, false, true, Some(1), 0);
+        token::done(&mut expected, false, false, false, None, 0);
         assert_eq!(rendered_events(rx, 4096).await, expected);
     }
 
@@ -1351,6 +1383,7 @@ mod render_tests {
         tx.send(BatchEvent::StatementDone {
             count: Some(1),
             in_transaction: false,
+            command: truthdb_core::rel::DoneCommand::Other,
         })
         .unwrap();
         tx.send(BatchEvent::Complete {
@@ -1362,10 +1395,10 @@ mod render_tests {
         let mut expected = Vec::new();
         token::colmetadata(&mut expected, &columns());
         token::row(&mut expected, &[Datum::Int(1)], &columns());
-        token::done(&mut expected, true, false, false, None);
+        token::done(&mut expected, true, false, false, None, 0);
         token::colmetadata(&mut expected, &columns());
         token::row(&mut expected, &[Datum::Int(9)], &columns());
-        token::done(&mut expected, false, false, false, Some(1));
+        token::done(&mut expected, false, false, false, Some(1), 0);
         assert_eq!(rendered_events(rx, 4096).await, expected);
     }
 
@@ -1393,7 +1426,7 @@ mod render_tests {
         let mut expected = Vec::new();
         token::colmetadata(&mut expected, &columns());
         token::row(&mut expected, &[Datum::Int(1)], &columns());
-        token::done(&mut expected, false, false, false, None);
+        token::done(&mut expected, false, false, false, None, 0);
         assert_eq!(rendered_events(rx, 4096).await, expected);
     }
 
@@ -1747,6 +1780,7 @@ mod attention_tests {
         tx.send(BatchEvent::StatementDone {
             count: Some(1),
             in_transaction: false,
+            command: truthdb_core::rel::DoneCommand::Other,
         })
         .unwrap();
         tx.send(BatchEvent::Complete {
@@ -1777,7 +1811,7 @@ mod attention_tests {
         let mut expected = Vec::new();
         token::colmetadata(&mut expected, &columns());
         token::row(&mut expected, &[Datum::Int(1)], &columns());
-        token::done(&mut expected, false, false, false, Some(1));
+        token::done(&mut expected, false, false, false, Some(1), 0);
         assert_eq!(payload, expected);
     }
 
@@ -1797,6 +1831,7 @@ mod attention_tests {
         tx.send(BatchEvent::StatementDone {
             count: Some(1),
             in_transaction: false,
+            command: truthdb_core::rel::DoneCommand::Other,
         })
         .unwrap();
         drop(tx);
@@ -1824,7 +1859,7 @@ mod attention_tests {
         let mut expected = Vec::new();
         token::colmetadata(&mut expected, &columns());
         token::row(&mut expected, &[Datum::Int(1)], &columns());
-        token::done(&mut expected, true, false, false, Some(1));
+        token::done(&mut expected, true, false, false, Some(1), 0);
         token::error(
             &mut expected,
             50000,
@@ -1832,7 +1867,7 @@ mod attention_tests {
             16,
             &EngineError::Unavailable.to_string(),
         );
-        token::done(&mut expected, false, true, false, None);
+        token::done(&mut expected, false, true, false, None, 0);
         assert_eq!(payload, expected);
     }
 

--- a/crates/truthdb-tds/src/server.rs
+++ b/crates/truthdb-tds/src/server.rs
@@ -202,7 +202,11 @@ where
                 let sql = batch_sql(headers.body)?;
                 let cancel = Arc::new(AtomicBool::new(false));
                 let events = engine.stream_batch(session, sql, cancel.clone());
-                if !stream_reply(stream, events, cancel, packet_size, false).await? {
+                let source = ReplySource::Single {
+                    events: Some(events),
+                    rpc: false,
+                };
+                if !stream_reply(stream, source, cancel, packet_size).await? {
                     return Ok(());
                 }
             }
@@ -210,15 +214,21 @@ where
                 let headers = parse_all_headers(&message.payload)?;
                 check_transaction_descriptor(headers.transaction_descriptor, tran_descriptor)?;
                 let cancel = Arc::new(AtomicBool::new(false));
-                match start_rpc(engine, session, headers.body, cancel.clone()) {
-                    Ok(events) => {
-                        if !stream_reply(stream, events, cancel, packet_size, true).await? {
+                match rpc::parse_rpc_requests(headers.body) {
+                    Ok(requests) => {
+                        let source = ReplySource::Rpcs {
+                            engine,
+                            session,
+                            requests: requests.into_iter(),
+                        };
+                        if !stream_reply(stream, source, cancel, packet_size).await? {
                             return Ok(());
                         }
                     }
-                    // A malformed or unsupported request never reached the
-                    // engine, so there is no stream — just the error tokens.
-                    Err(tokens) => {
+                    // An undecodable body never identified an RPC to run —
+                    // just the error tokens.
+                    Err(err) => {
+                        let tokens = rpc_error(&format!("malformed RPC request: {err}"));
                         write_message(stream, PKT_TABULAR_RESULT, &tokens, packet_size).await?
                     }
                 }
@@ -421,111 +431,200 @@ async fn write_attention_ack<S: AsyncWrite + Unpin>(
 /// `AsyncReadExt::read` is cancellation-safe, so bytes read into `hdr` survive a
 /// `select!` iteration that resolves to an event instead; any partial header
 /// left when the batch ends is completed afterwards so packet framing is intact.
+/// What a response renders: one already-started reply stream (a SQL batch, or
+/// the render tests' RPC framing), or an RPC request's one-or-more RPCs — each
+/// issued only after the previous one's terminal event, since a session runs
+/// one call at a time.
+enum ReplySource<'a> {
+    Single {
+        events: Option<mpsc::UnboundedReceiver<BatchEvent>>,
+        rpc: bool,
+    },
+    Rpcs {
+        engine: &'a EngineHandle,
+        session: SessionId,
+        requests: std::vec::IntoIter<rpc::RpcRequest>,
+    },
+}
+
+impl ReplySource<'_> {
+    fn is_rpc(&self) -> bool {
+        match self {
+            ReplySource::Single { rpc, .. } => *rpc,
+            ReplySource::Rpcs { .. } => true,
+        }
+    }
+
+    /// Whether more replies follow the one about to render — what sets
+    /// `DONE_MORE` on a non-last RPC's DONEPROC.
+    fn has_more(&self) -> bool {
+        match self {
+            ReplySource::Single { .. } => false,
+            ReplySource::Rpcs { requests, .. } => requests.len() > 0,
+        }
+    }
+
+    /// Starts the next reply, or `None` when the response is complete. `Err`
+    /// is a decode error to render in-frame (no engine call was made).
+    fn next(
+        &mut self,
+        cancel: &Arc<AtomicBool>,
+    ) -> Option<Result<mpsc::UnboundedReceiver<BatchEvent>, (i32, String)>> {
+        match self {
+            ReplySource::Single { events, .. } => events.take().map(Ok),
+            ReplySource::Rpcs {
+                engine,
+                session,
+                requests,
+            } => {
+                let request = requests.next()?;
+                Some(start_rpc(engine, *session, request, cancel.clone()))
+            }
+        }
+    }
+}
+
 async fn stream_reply<S>(
     stream: &mut S,
-    mut events: mpsc::UnboundedReceiver<BatchEvent>,
+    mut source: ReplySource<'_>,
     cancel: Arc<AtomicBool>,
     packet_size: usize,
-    rpc: bool,
 ) -> io::Result<bool>
 where
     S: AsyncRead + AsyncWrite + Unpin,
 {
     let (mut rd, mut wr) = tokio::io::split(stream);
     let mut out = MessageWriter::new(&mut wr, PKT_TABULAR_RESULT, packet_size);
-    let mut render = BatchRender {
-        rpc,
-        ..BatchRender::default()
-    };
+    let rpc = source.is_rpc();
     let mut hdr = [0u8; HEADER_LEN];
     let mut got = 0usize;
     let mut attention = false;
-    loop {
-        tokio::select! {
-            event = events.recv() => match event {
-                // Render until the terminal event. After an Attention the
-                // remaining events are drained without rendering: they would
-                // otherwise put the executor's internal "query was canceled"
-                // error on the wire, which the buffered path never showed.
-                Some(event) => {
-                    if attention {
-                        continue;
-                    }
-                    match render.event(&mut out, event).await {
-                        Ok(terminal) => {
-                            if terminal {
-                                break;
+    'replies: while let Some(start) = source.next(&cancel) {
+        let mut render = BatchRender {
+            rpc,
+            more_responses: source.has_more(),
+            ..BatchRender::default()
+        };
+        let mut events = match start {
+            Ok(events) => events,
+            // A decode error: render it in-frame so the multi-RPC response
+            // stays token-legal, and keep going — each RPC in a request
+            // answers independently, like statements in a batch.
+            Err((number, message)) => {
+                if attention {
+                    continue;
+                }
+                render
+                    .event(
+                        &mut out,
+                        BatchEvent::Error(truthdb_sql::error::SqlError::new(
+                            number, 16, 1, message,
+                        )),
+                    )
+                    .await?;
+                render
+                    .event(
+                        &mut out,
+                        BatchEvent::Complete {
+                            in_transaction: false,
+                        },
+                    )
+                    .await?;
+                continue;
+            }
+        };
+        loop {
+            tokio::select! {
+                event = events.recv() => match event {
+                    // Render until the terminal event. After an Attention the
+                    // remaining events are drained without rendering: they would
+                    // otherwise put the executor's internal "query was canceled"
+                    // error on the wire, which the buffered path never showed.
+                    Some(event) => {
+                        if attention {
+                            continue;
+                        }
+                        match render.event(&mut out, event).await {
+                            Ok(terminal) => {
+                                if terminal {
+                                    break;
+                                }
+                            }
+                            // A socket write failed mid-batch — the ordinary way a
+                            // client dies while a result streams. The batch is
+                            // still RUNNING and holds its locks, and the caller
+                            // will close the session the moment this returns —
+                            // which releases those locks out from under it. Same
+                            // contract as every other early exit: cancel the
+                            // batch, wait for it to actually end, then leave.
+                            Err(err) => {
+                                cancel.store(true, Ordering::Relaxed);
+                                drain_to_end(&mut events).await;
+                                return Err(err);
                             }
                         }
-                        // A socket write failed mid-batch — the ordinary way a
-                        // client dies while a result streams. The batch is
-                        // still RUNNING and holds its locks, and the caller
-                        // will close the session the moment this returns —
-                        // which releases those locks out from under it. Same
-                        // contract as every other early exit: cancel the
-                        // batch, wait for it to actually end, then leave.
-                        Err(err) => {
-                            cancel.store(true, Ordering::Relaxed);
-                            drain_to_end(&mut events).await;
-                            return Err(err);
+                    }
+                    // The stream ended without a terminal event: the worker panicked,
+                    // or the pool dropped the call at shutdown. Falling through here
+                    // would emit a message with no DONE at all — an empty EOM packet
+                    // that leaves the client waiting for a result that never
+                    // terminates. The buffered path turned a dead reply channel into
+                    // a clean 50000, so render exactly that, flushing any DONE still
+                    // held back on the way (a stream that died between
+                    // `StatementDone` and `Complete` would otherwise leave its result
+                    // set unterminated).
+                    None => {
+                        if !attention {
+                            render
+                                .event(&mut out, BatchEvent::Failed(EngineError::Unavailable))
+                                .await?;
+                        }
+                        break;
+                    }
+                },
+                read = rd.read(&mut hdr[got..]) => match read {
+                    // A read error is a disconnect with an errno: same treatment
+                    // as the clean EOF below, or the still-running batch would
+                    // have its locks released by the caller's close_session.
+                    Err(err) => {
+                        cancel.store(true, Ordering::Relaxed);
+                        drain_to_end(&mut events).await;
+                        return Err(err);
+                    }
+                    Ok(0) => {
+                        // Client disconnected mid-batch.
+                        cancel.store(true, Ordering::Relaxed);
+                        drain_to_end(&mut events).await;
+                        return Ok(false);
+                    }
+                    Ok(n) => {
+                        got += n;
+                        if got == HEADER_LEN {
+                            // Only an Attention (a header-only packet) is legal during
+                            // a running batch — TDS is request/response with no MARS.
+                            if hdr[0] == PKT_ATTENTION {
+                                attention = true;
+                                cancel.store(true, Ordering::Relaxed);
+                                got = 0;
+                            } else {
+                                // A pipelined non-Attention packet: fail loud rather
+                                // than silently ignore its (undrained) body and misframe
+                                // the next read. Abort the batch, then error out.
+                                cancel.store(true, Ordering::Relaxed);
+                                drain_to_end(&mut events).await;
+                                return Err(protocol_err(
+                                    "unexpected TDS packet during a running batch",
+                                ));
+                            }
                         }
                     }
-                }
-                // The stream ended without a terminal event: the worker panicked,
-                // or the pool dropped the call at shutdown. Falling through here
-                // would emit a message with no DONE at all — an empty EOM packet
-                // that leaves the client waiting for a result that never
-                // terminates. The buffered path turned a dead reply channel into
-                // a clean 50000, so render exactly that, flushing any DONE still
-                // held back on the way (a stream that died between
-                // `StatementDone` and `Complete` would otherwise leave its result
-                // set unterminated).
-                None => {
-                    if !attention {
-                        render
-                            .event(&mut out, BatchEvent::Failed(EngineError::Unavailable))
-                            .await?;
-                    }
-                    break;
-                }
-            },
-            read = rd.read(&mut hdr[got..]) => match read {
-                // A read error is a disconnect with an errno: same treatment
-                // as the clean EOF below, or the still-running batch would
-                // have its locks released by the caller's close_session.
-                Err(err) => {
-                    cancel.store(true, Ordering::Relaxed);
-                    drain_to_end(&mut events).await;
-                    return Err(err);
-                }
-                Ok(0) => {
-                    // Client disconnected mid-batch.
-                    cancel.store(true, Ordering::Relaxed);
-                    drain_to_end(&mut events).await;
-                    return Ok(false);
-                }
-                Ok(n) => {
-                    got += n;
-                    if got == HEADER_LEN {
-                        // Only an Attention (a header-only packet) is legal during
-                        // a running batch — TDS is request/response with no MARS.
-                        if hdr[0] == PKT_ATTENTION {
-                            attention = true;
-                            cancel.store(true, Ordering::Relaxed);
-                            got = 0;
-                        } else {
-                            // A pipelined non-Attention packet: fail loud rather
-                            // than silently ignore its (undrained) body and misframe
-                            // the next read. Abort the batch, then error out.
-                            cancel.store(true, Ordering::Relaxed);
-                            drain_to_end(&mut events).await;
-                            return Err(protocol_err(
-                                "unexpected TDS packet during a running batch",
-                            ));
-                        }
-                    }
-                }
-            },
+                },
+            }
+        }
+        if attention {
+            // Everything after the Attention is discarded; the RPCs not yet
+            // issued never run.
+            break 'replies;
         }
     }
     // The batch finished before a header fully arrived: complete it so the next
@@ -567,39 +666,37 @@ where
     Ok(true)
 }
 
-/// Starts an RPC request on the engine, returning its reply stream.
+/// Starts one RPC on the engine, returning its reply stream.
 ///
-/// Supports `sp_executesql` — decode its statement and typed parameters and run
-/// them, streaming exactly what a batch would. Any other procedure, or a
-/// malformed request, never reaches the engine and comes back as ready-made
-/// error tokens (`Err`) plus a final DONE, so the connection stays usable.
+/// A malformed or unsupported procedure never reaches the engine and comes
+/// back as an error `(number, message)` the caller renders in-frame, so the
+/// connection stays usable and a multi-RPC response stays token-legal.
 fn start_rpc(
     engine: &EngineHandle,
     session: SessionId,
-    body: &[u8],
+    request: rpc::RpcRequest,
     cancel: Arc<AtomicBool>,
-) -> Result<mpsc::UnboundedReceiver<BatchEvent>, Vec<u8>> {
-    let request = rpc::parse_rpc_request(body)
-        .map_err(|err| rpc_error(&format!("malformed RPC request: {err}")))?;
+) -> Result<mpsc::UnboundedReceiver<BatchEvent>, (i32, String)> {
+    let rpc_error = |message: String| (50000, message);
     match request.proc {
         RpcProc::SpExecuteSql => {
             let (sql, params) = rpc::split_sp_executesql(request.params)
-                .map_err(|err| rpc_error(&err.to_string()))?;
+                .map_err(|err| rpc_error(err.to_string()))?;
             Ok(engine.stream_rpc(session, sql, params, cancel))
         }
         RpcProc::SpPrepare => {
             let (decls, stmt) =
-                rpc::split_sp_prepare(request.params).map_err(|err| rpc_error(&err.to_string()))?;
+                rpc::split_sp_prepare(request.params).map_err(|err| rpc_error(err.to_string()))?;
             Ok(engine.stream_prepared(session, PreparedRpc::Prepare { decls, stmt }, cancel))
         }
         RpcProc::SpExecute => {
             let (handle, values) =
-                rpc::split_sp_execute(request.params).map_err(|err| rpc_error(&err.to_string()))?;
+                rpc::split_sp_execute(request.params).map_err(|err| rpc_error(err.to_string()))?;
             Ok(engine.stream_prepared(session, PreparedRpc::Execute { handle, values }, cancel))
         }
         RpcProc::SpPrepExec => {
-            let (decls, stmt, values) = rpc::split_sp_prepexec(request.params)
-                .map_err(|err| rpc_error(&err.to_string()))?;
+            let (decls, stmt, values) =
+                rpc::split_sp_prepexec(request.params).map_err(|err| rpc_error(err.to_string()))?;
             Ok(engine.stream_prepared(
                 session,
                 PreparedRpc::PrepExec {
@@ -612,27 +709,24 @@ fn start_rpc(
         }
         RpcProc::SpUnprepare => {
             let handle = rpc::split_sp_unprepare(request.params)
-                .map_err(|err| rpc_error(&err.to_string()))?;
+                .map_err(|err| rpc_error(err.to_string()))?;
             Ok(engine.stream_prepared(session, PreparedRpc::Unprepare { handle }, cancel))
         }
         RpcProc::SpDescribeFirstResultSet => {
-            let tsql = rpc::split_sp_describe(request.params)
-                .map_err(|err| rpc_error(&err.to_string()))?;
+            let tsql =
+                rpc::split_sp_describe(request.params).map_err(|err| rpc_error(err.to_string()))?;
             Ok(engine.stream_prepared(session, PreparedRpc::Describe { tsql }, cancel))
         }
         // Server-side cursors are not implemented; say so rather than "not
         // found" so a driver's fallback logic gets an honest signal.
-        RpcProc::SpCursor(name) => Err(rpc_error_num(
+        RpcProc::SpCursor(name) => Err((
             40510,
-            &format!(
+            format!(
                 "The stored procedure '{name}' is not supported (server-side cursors are not implemented)."
             ),
         )),
         // Error 2812 is SQL Server's "Could not find stored procedure".
-        RpcProc::Other(name) => Err(rpc_error_num(
-            2812,
-            &format!("Could not find stored procedure '{name}'."),
-        )),
+        RpcProc::Other(name) => Err((2812, format!("Could not find stored procedure '{name}'."))),
     }
 }
 
@@ -661,6 +755,9 @@ struct BatchRender {
     /// A prepared handle to report as a RETURNVALUE just before the final
     /// DONEPROC — held so RETURNSTATUS precedes it, SQL Server's order.
     pending_handle: Option<i32>,
+    /// More replies follow this one in the same response (a multi-RPC
+    /// request): the final DONEPROC keeps `DONE_MORE` instead of `DONE_FINAL`.
+    more_responses: bool,
     /// Scratch for encoding tokens, reused so a row costs no allocation here.
     buf: Vec<u8>,
 }
@@ -758,18 +855,17 @@ impl BatchRender {
                         token::return_value_int(&mut self.buf, "handle", handle);
                     }
                     out.write(&self.buf).await?;
-                    self.done(out, false, self.errored, in_transaction, None)
-                        .await?;
+                    self.final_done(out, self.errored, in_transaction).await?;
                 } else if self.errored {
                     // The error's own final DONE, after the last statement's.
                     self.flush_pending(out, true).await?;
-                    self.done(out, false, true, in_transaction, None).await?;
+                    self.final_done(out, true, in_transaction).await?;
                 } else if self.pending.is_some() {
                     self.flush_pending(out, false).await?;
                 } else {
                     // A batch with no statements at all (e.g. only comments):
                     // one final DONE.
-                    self.done(out, false, false, in_transaction, None).await?;
+                    self.final_done(out, false, in_transaction).await?;
                 }
                 return Ok(true);
             }
@@ -779,7 +875,7 @@ impl BatchRender {
                 self.buf.clear();
                 token::error(&mut self.buf, 50000, 1, 16, &err.to_string());
                 out.write(&self.buf).await?;
-                self.done(out, false, true, false, None).await?;
+                self.final_done(out, true, false).await?;
                 return Ok(true);
             }
         }
@@ -799,6 +895,8 @@ impl BatchRender {
         Ok(())
     }
 
+    /// A statement's DONE: DONEINPROC inside an RPC response, plain DONE in a
+    /// batch (where `more = false` makes it the batch's final).
     async fn done<W: AsyncWrite + Unpin>(
         &mut self,
         out: &mut MessageWriter<'_, W>,
@@ -808,24 +906,41 @@ impl BatchRender {
         count: Option<u64>,
     ) -> io::Result<()> {
         self.buf.clear();
-        if !self.rpc {
-            token::done(&mut self.buf, more, error, in_transaction, count);
-        } else if more {
+        if self.rpc {
             token::done_in_proc(&mut self.buf, more, error, in_transaction, count);
         } else {
-            token::done_proc(&mut self.buf, more, error, in_transaction, count);
+            token::done(&mut self.buf, more, error, in_transaction, count);
+        }
+        out.write(&self.buf).await
+    }
+
+    /// The reply's final DONE: DONEPROC for an RPC (keeping `DONE_MORE` when
+    /// more RPCs follow in the same response), plain final DONE for a batch.
+    async fn final_done<W: AsyncWrite + Unpin>(
+        &mut self,
+        out: &mut MessageWriter<'_, W>,
+        error: bool,
+        in_transaction: bool,
+    ) -> io::Result<()> {
+        self.buf.clear();
+        if self.rpc {
+            token::done_proc(
+                &mut self.buf,
+                self.more_responses,
+                error,
+                in_transaction,
+                None,
+            );
+        } else {
+            token::done(&mut self.buf, false, error, in_transaction, None);
         }
         out.write(&self.buf).await
     }
 }
 
 fn rpc_error(message: &str) -> Vec<u8> {
-    rpc_error_num(50000, message)
-}
-
-fn rpc_error_num(number: i32, message: &str) -> Vec<u8> {
     let mut out = Vec::new();
-    token::error(&mut out, number, 1, 16, message);
+    token::error(&mut out, 50000, 1, 16, message);
     token::done(&mut out, false, true, false, None);
     out
 }
@@ -1042,10 +1157,12 @@ mod render_tests {
         };
         let kept = stream_reply(
             &mut wire,
-            events,
+            ReplySource::Single {
+                events: Some(events),
+                rpc,
+            },
             Arc::new(AtomicBool::new(false)),
             packet_size,
-            rpc,
         )
         .await
         .expect("stream");
@@ -1348,7 +1465,16 @@ mod render_tests {
         });
 
         let mut wire = FailingWrite;
-        let result = stream_reply(&mut wire, rx, cancel.clone(), MIN_PACKET_SIZE, false).await;
+        let result = stream_reply(
+            &mut wire,
+            ReplySource::Single {
+                events: Some(rx),
+                rpc: false,
+            },
+            cancel.clone(),
+            MIN_PACKET_SIZE,
+        )
+        .await;
         assert!(result.is_err(), "the write error surfaces");
         assert!(
             cancel.load(Ordering::Relaxed),
@@ -1496,10 +1622,12 @@ mod render_tests {
         };
         stream_reply(
             &mut duplex,
-            events,
+            ReplySource::Single {
+                events: Some(events),
+                rpc: false,
+            },
             Arc::new(AtomicBool::new(false)),
             MIN_PACKET_SIZE,
-            false,
         )
         .await
         .expect("stream");
@@ -1577,9 +1705,17 @@ mod attention_tests {
         let events = cancellable_batch(cancel.clone());
         // The client sends an Attention (header-only packet) during the batch.
         client.write_all(&ATTN).await.expect("send attention");
-        let kept = stream_reply(&mut server, events, cancel.clone(), 4096, false)
-            .await
-            .expect("io ok");
+        let kept = stream_reply(
+            &mut server,
+            ReplySource::Single {
+                events: Some(events),
+                rpc: false,
+            },
+            cancel.clone(),
+            4096,
+        )
+        .await
+        .expect("io ok");
         assert!(kept, "the client is still connected");
         assert!(
             cancel.load(Ordering::Relaxed),
@@ -1619,9 +1755,17 @@ mod attention_tests {
         .unwrap();
         drop(tx);
 
-        let kept = stream_reply(&mut server, rx, cancel.clone(), 4096, false)
-            .await
-            .expect("io ok");
+        let kept = stream_reply(
+            &mut server,
+            ReplySource::Single {
+                events: Some(rx),
+                rpc: false,
+            },
+            cancel.clone(),
+            4096,
+        )
+        .await
+        .expect("io ok");
         assert!(kept);
         assert!(!cancel.load(Ordering::Relaxed));
         let mut cursor = std::io::Cursor::new(read_client_bytes(&mut client).await);
@@ -1659,10 +1803,12 @@ mod attention_tests {
 
         let kept = stream_reply(
             &mut server,
-            rx,
+            ReplySource::Single {
+                events: Some(rx),
+                rpc: false,
+            },
             Arc::new(AtomicBool::new(false)),
             4096,
-            false,
         )
         .await
         .expect("io ok");
@@ -1724,9 +1870,17 @@ mod attention_tests {
             // `tx` drops here: the sink dying is what says the batch is over.
         });
 
-        let kept = stream_reply(&mut server, rx, cancel.clone(), 4096, false)
-            .await
-            .expect("io ok");
+        let kept = stream_reply(
+            &mut server,
+            ReplySource::Single {
+                events: Some(rx),
+                rpc: false,
+            },
+            cancel.clone(),
+            4096,
+        )
+        .await
+        .expect("io ok");
         assert!(!kept, "the client disconnected");
         assert!(
             cancel.load(Ordering::Relaxed),
@@ -1746,9 +1900,17 @@ mod attention_tests {
         drop(client);
         let cancel = Arc::new(AtomicBool::new(false));
         let events = cancellable_batch(cancel.clone());
-        let kept = stream_reply(&mut server, events, cancel.clone(), 4096, false)
-            .await
-            .expect("io ok");
+        let kept = stream_reply(
+            &mut server,
+            ReplySource::Single {
+                events: Some(events),
+                rpc: false,
+            },
+            cancel.clone(),
+            4096,
+        )
+        .await
+        .expect("io ok");
         assert!(!kept, "the client disconnected");
         assert!(
             cancel.load(Ordering::Relaxed),

--- a/crates/truthdb-tds/src/server.rs
+++ b/crates/truthdb-tds/src/server.rs
@@ -202,7 +202,7 @@ where
                 let sql = batch_sql(headers.body)?;
                 let cancel = Arc::new(AtomicBool::new(false));
                 let events = engine.stream_batch(session, sql, cancel.clone());
-                if !stream_reply(stream, events, cancel, packet_size).await? {
+                if !stream_reply(stream, events, cancel, packet_size, false).await? {
                     return Ok(());
                 }
             }
@@ -212,7 +212,7 @@ where
                 let cancel = Arc::new(AtomicBool::new(false));
                 match start_rpc(engine, session, headers.body, cancel.clone()) {
                     Ok(events) => {
-                        if !stream_reply(stream, events, cancel, packet_size).await? {
+                        if !stream_reply(stream, events, cancel, packet_size, true).await? {
                             return Ok(());
                         }
                     }
@@ -426,13 +426,17 @@ async fn stream_reply<S>(
     mut events: mpsc::UnboundedReceiver<BatchEvent>,
     cancel: Arc<AtomicBool>,
     packet_size: usize,
+    rpc: bool,
 ) -> io::Result<bool>
 where
     S: AsyncRead + AsyncWrite + Unpin,
 {
     let (mut rd, mut wr) = tokio::io::split(stream);
     let mut out = MessageWriter::new(&mut wr, PKT_TABULAR_RESULT, packet_size);
-    let mut render = BatchRender::default();
+    let mut render = BatchRender {
+        rpc,
+        ..BatchRender::default()
+    };
     let mut hdr = [0u8; HEADER_LEN];
     let mut got = 0usize;
     let mut attention = false;
@@ -649,6 +653,14 @@ struct BatchRender {
     /// Set once a batch-stopping ERROR has been written, so the final DONE
     /// carries `DONE_ERROR`.
     errored: bool,
+    /// RPC response framing: per-statement DONEs render as DONEINPROC, and the
+    /// response ends RETURNSTATUS → RETURNVALUE(s) → DONEPROC, as SQL Server
+    /// frames a procedure's reply. A SQL batch keeps plain DONEs (the #97
+    /// oracle pins those bytes).
+    rpc: bool,
+    /// A prepared handle to report as a RETURNVALUE just before the final
+    /// DONEPROC — held so RETURNSTATUS precedes it, SQL Server's order.
+    pending_handle: Option<i32>,
     /// Scratch for encoding tokens, reused so a row costs no allocation here.
     buf: Vec<u8>,
 }
@@ -715,12 +727,9 @@ impl BatchRender {
                 });
             }
             BatchEvent::PreparedHandle(handle) => {
-                // The handle rides a RETURNVALUE token, after every result
-                // set (return values follow results in an RPC response).
-                self.flush_pending(out, true).await?;
-                self.buf.clear();
-                token::return_value_int(&mut self.buf, "handle", handle);
-                out.write(&self.buf).await?;
+                // Held for the response tail: RETURNSTATUS precedes the
+                // RETURNVALUE, which precedes the final DONEPROC.
+                self.pending_handle = Some(handle);
             }
             BatchEvent::Error(error) => {
                 self.flush_pending(out, true).await?;
@@ -736,7 +745,22 @@ impl BatchRender {
                 self.errored = true;
             }
             BatchEvent::Complete { in_transaction } => {
-                if self.errored {
+                if self.rpc {
+                    // The last statement's DONEINPROC keeps DONE_MORE — the
+                    // RETURNSTATUS/RETURNVALUE/DONEPROC tail always follows.
+                    self.flush_pending(out, true).await?;
+                    self.buf.clear();
+                    if !self.errored {
+                        // A failed procedure returns no status.
+                        token::return_status(&mut self.buf, 0);
+                    }
+                    if let Some(handle) = self.pending_handle.take() {
+                        token::return_value_int(&mut self.buf, "handle", handle);
+                    }
+                    out.write(&self.buf).await?;
+                    self.done(out, false, self.errored, in_transaction, None)
+                        .await?;
+                } else if self.errored {
                     // The error's own final DONE, after the last statement's.
                     self.flush_pending(out, true).await?;
                     self.done(out, false, true, in_transaction, None).await?;
@@ -784,7 +808,13 @@ impl BatchRender {
         count: Option<u64>,
     ) -> io::Result<()> {
         self.buf.clear();
-        token::done(&mut self.buf, more, error, in_transaction, count);
+        if !self.rpc {
+            token::done(&mut self.buf, more, error, in_transaction, count);
+        } else if more {
+            token::done_in_proc(&mut self.buf, more, error, in_transaction, count);
+        } else {
+            token::done_proc(&mut self.buf, more, error, in_transaction, count);
+        }
         out.write(&self.buf).await
     }
 }
@@ -998,6 +1028,14 @@ mod render_tests {
         events: mpsc::UnboundedReceiver<BatchEvent>,
         packet_size: usize,
     ) -> Vec<u8> {
+        rendered_events_framed(events, packet_size, false).await
+    }
+
+    async fn rendered_events_framed(
+        events: mpsc::UnboundedReceiver<BatchEvent>,
+        packet_size: usize,
+        rpc: bool,
+    ) -> Vec<u8> {
         let mut wire = Duplex {
             read: std::io::Cursor::new(Vec::new()),
             written: Vec::new(),
@@ -1007,6 +1045,7 @@ mod render_tests {
             events,
             Arc::new(AtomicBool::new(false)),
             packet_size,
+            rpc,
         )
         .await
         .expect("stream");
@@ -1059,9 +1098,10 @@ mod render_tests {
         rx
     }
 
-    /// A prepared handle renders as a RETURNVALUE token after the statement's
-    /// DONE (return values follow results), with the exact bytes MS-TDS
-    /// 2.2.7.19 prescribes for an INT output parameter.
+    /// An RPC response frames as SQL Server does: per-statement DONEINPROC
+    /// (DONE_MORE kept on the last), then RETURNSTATUS, then RETURNVALUE (the
+    /// prepared handle, when there is one), then a final DONEPROC. A SQL
+    /// batch's plain-DONE framing is untouched — the oracle pins those bytes.
     #[tokio::test]
     async fn a_prepared_handle_renders_as_a_returnvalue_token() {
         let (tx, rx) = mpsc::unbounded_channel();
@@ -1078,10 +1118,56 @@ mod render_tests {
         drop(tx);
 
         let mut expected = Vec::new();
-        token::done(&mut expected, true, false, false, Some(1));
+        token::done_in_proc(&mut expected, true, false, false, Some(1));
+        token::return_status(&mut expected, 0);
         token::return_value_int(&mut expected, "handle", 7);
-        token::done(&mut expected, false, false, false, None);
-        assert_eq!(rendered_events(rx, 4096).await, expected);
+        token::done_proc(&mut expected, false, false, false, None);
+        assert_eq!(rendered_events_framed(rx, 4096, true).await, expected);
+
+        // Without a handle (sp_executesql, sp_execute): DONEINPROC,
+        // RETURNSTATUS, DONEPROC.
+        let (tx, rx) = mpsc::unbounded_channel();
+        tx.send(BatchEvent::StatementDone {
+            count: Some(3),
+            in_transaction: false,
+        })
+        .unwrap();
+        tx.send(BatchEvent::Complete {
+            in_transaction: false,
+        })
+        .unwrap();
+        drop(tx);
+        let mut expected = Vec::new();
+        token::done_in_proc(&mut expected, true, false, false, Some(3));
+        token::return_status(&mut expected, 0);
+        token::done_proc(&mut expected, false, false, false, None);
+        assert_eq!(rendered_events_framed(rx, 4096, true).await, expected);
+
+        // A failed RPC returns no status: ERROR, DONEINPROC for what ran,
+        // then DONEPROC with DONE_ERROR.
+        let (tx, rx) = mpsc::unbounded_channel();
+        tx.send(BatchEvent::Error(truthdb_sql::error::SqlError::new(
+            8179,
+            16,
+            1,
+            "Could not find prepared statement with handle 42.",
+        )))
+        .unwrap();
+        tx.send(BatchEvent::Complete {
+            in_transaction: false,
+        })
+        .unwrap();
+        drop(tx);
+        let mut expected = Vec::new();
+        token::error(
+            &mut expected,
+            8179,
+            1,
+            16,
+            "Could not find prepared statement with handle 42.",
+        );
+        token::done_proc(&mut expected, false, true, false, None);
+        assert_eq!(rendered_events_framed(rx, 4096, true).await, expected);
 
         // The token's own bytes, pinned: 0xAC, ordinal 0, B_VARCHAR name,
         // status 0x01 (output param), UserType 0, Flags 0, INTN(4), value.
@@ -1262,7 +1348,7 @@ mod render_tests {
         });
 
         let mut wire = FailingWrite;
-        let result = stream_reply(&mut wire, rx, cancel.clone(), MIN_PACKET_SIZE).await;
+        let result = stream_reply(&mut wire, rx, cancel.clone(), MIN_PACKET_SIZE, false).await;
         assert!(result.is_err(), "the write error surfaces");
         assert!(
             cancel.load(Ordering::Relaxed),
@@ -1413,6 +1499,7 @@ mod render_tests {
             events,
             Arc::new(AtomicBool::new(false)),
             MIN_PACKET_SIZE,
+            false,
         )
         .await
         .expect("stream");
@@ -1490,7 +1577,7 @@ mod attention_tests {
         let events = cancellable_batch(cancel.clone());
         // The client sends an Attention (header-only packet) during the batch.
         client.write_all(&ATTN).await.expect("send attention");
-        let kept = stream_reply(&mut server, events, cancel.clone(), 4096)
+        let kept = stream_reply(&mut server, events, cancel.clone(), 4096, false)
             .await
             .expect("io ok");
         assert!(kept, "the client is still connected");
@@ -1532,7 +1619,7 @@ mod attention_tests {
         .unwrap();
         drop(tx);
 
-        let kept = stream_reply(&mut server, rx, cancel.clone(), 4096)
+        let kept = stream_reply(&mut server, rx, cancel.clone(), 4096, false)
             .await
             .expect("io ok");
         assert!(kept);
@@ -1570,9 +1657,15 @@ mod attention_tests {
         .unwrap();
         drop(tx);
 
-        let kept = stream_reply(&mut server, rx, Arc::new(AtomicBool::new(false)), 4096)
-            .await
-            .expect("io ok");
+        let kept = stream_reply(
+            &mut server,
+            rx,
+            Arc::new(AtomicBool::new(false)),
+            4096,
+            false,
+        )
+        .await
+        .expect("io ok");
         assert!(kept);
         let mut cursor = std::io::Cursor::new(read_client_bytes(&mut client).await);
         let payload = crate::packet::read_message(&mut cursor)
@@ -1631,7 +1724,7 @@ mod attention_tests {
             // `tx` drops here: the sink dying is what says the batch is over.
         });
 
-        let kept = stream_reply(&mut server, rx, cancel.clone(), 4096)
+        let kept = stream_reply(&mut server, rx, cancel.clone(), 4096, false)
             .await
             .expect("io ok");
         assert!(!kept, "the client disconnected");
@@ -1653,7 +1746,7 @@ mod attention_tests {
         drop(client);
         let cancel = Arc::new(AtomicBool::new(false));
         let events = cancellable_batch(cancel.clone());
-        let kept = stream_reply(&mut server, events, cancel.clone(), 4096)
+        let kept = stream_reply(&mut server, events, cancel.clone(), 4096, false)
             .await
             .expect("io ok");
         assert!(!kept, "the client disconnected");

--- a/crates/truthdb-tds/src/token.rs
+++ b/crates/truthdb-tds/src/token.rs
@@ -90,12 +90,15 @@ pub fn envchange_database(out: &mut Vec<u8>, database: &str) {
 /// ENVCHANGE for the connection's default SQL collation (login response).
 /// mssql-jdbc dereferences this collation when encoding every NVARCHAR RPC
 /// parameter — a login without it NPEs the driver client-side. The bytes are
-/// the LCID+flags+sort form COLMETADATA already uses for character columns.
+/// [`crate::typeinfo::COLLATION`], the same value COLMETADATA stamps on every
+/// character column, so login and metadata can never diverge. (A configured
+/// non-default `default_collation` is still not advertised — pre-existing,
+/// recorded in the plan.)
 pub fn envchange_sql_collation(out: &mut Vec<u8>) {
     let mut body = Vec::new();
     body.push(ENV_SQL_COLLATION);
     body.push(5); // B_VARBYTE new value: the collation
-    body.extend_from_slice(&[0x09, 0x04, 0xd0, 0x00, 0x34]);
+    body.extend_from_slice(&crate::typeinfo::COLLATION);
     body.push(0); // B_VARBYTE old value: none
     out.push(TOKEN_ENVCHANGE);
     out.extend_from_slice(&(body.len() as u16).to_le_bytes());

--- a/crates/truthdb-tds/src/token.rs
+++ b/crates/truthdb-tds/src/token.rs
@@ -13,6 +13,9 @@ const TOKEN_LOGINACK: u8 = 0xad;
 const TOKEN_ROW: u8 = 0xd1;
 const TOKEN_ENVCHANGE: u8 = 0xe3;
 const TOKEN_DONE: u8 = 0xfd;
+const TOKEN_DONEPROC: u8 = 0xfe;
+const TOKEN_DONEINPROC: u8 = 0xff;
+const TOKEN_RETURNSTATUS: u8 = 0x79;
 
 // DONE status bits.
 const DONE_FINAL: u16 = 0x0000;
@@ -210,6 +213,28 @@ pub fn row(out: &mut Vec<u8>, values: &[Datum], columns: &[ResultColumn]) {
 /// carries a row count (DONE_COUNT); `error` sets DONE_ERROR; `in_xact` sets
 /// DONE_INXACT (a transaction is still active for the connection).
 pub fn done(out: &mut Vec<u8>, more: bool, error: bool, in_xact: bool, count: Option<u64>) {
+    done_kind(out, TOKEN_DONE, more, error, in_xact, count);
+}
+
+/// DONEINPROC (0xFF): a statement's DONE inside an RPC response. Same body as
+/// DONE; only the token byte differs.
+pub fn done_in_proc(out: &mut Vec<u8>, more: bool, error: bool, in_xact: bool, count: Option<u64>) {
+    done_kind(out, TOKEN_DONEINPROC, more, error, in_xact, count);
+}
+
+/// DONEPROC (0xFE): the final DONE of an RPC response.
+pub fn done_proc(out: &mut Vec<u8>, more: bool, error: bool, in_xact: bool, count: Option<u64>) {
+    done_kind(out, TOKEN_DONEPROC, more, error, in_xact, count);
+}
+
+fn done_kind(
+    out: &mut Vec<u8>,
+    token: u8,
+    more: bool,
+    error: bool,
+    in_xact: bool,
+    count: Option<u64>,
+) {
     let mut status = if more { DONE_MORE } else { DONE_FINAL };
     if error {
         status |= DONE_ERROR;
@@ -220,10 +245,17 @@ pub fn done(out: &mut Vec<u8>, more: bool, error: bool, in_xact: bool, count: Op
     if count.is_some() {
         status |= DONE_COUNT;
     }
-    out.push(TOKEN_DONE);
+    out.push(token);
     out.extend_from_slice(&status.to_le_bytes());
     out.extend_from_slice(&0u16.to_le_bytes()); // CurCmd
     out.extend_from_slice(&count.unwrap_or(0).to_le_bytes());
+}
+
+/// RETURNSTATUS (0x79): the RETURN value of the procedure an RPC invoked.
+/// The sp_* procedures here return 0 (success); a failed one sends none.
+pub fn return_status(out: &mut Vec<u8>, value: i32) {
+    out.push(TOKEN_RETURNSTATUS);
+    out.extend_from_slice(&value.to_le_bytes());
 }
 
 /// DONE acknowledging an Attention (cancel) request.

--- a/crates/truthdb-tds/src/token.rs
+++ b/crates/truthdb-tds/src/token.rs
@@ -28,6 +28,7 @@ const DONE_ATTN: u16 = 0x0020;
 // ENVCHANGE types.
 const ENV_DATABASE: u8 = 1;
 const ENV_PACKET_SIZE: u8 = 4;
+const ENV_SQL_COLLATION: u8 = 7;
 const ENV_BEGIN_TRAN: u8 = 8;
 const ENV_COMMIT_TRAN: u8 = 9;
 const ENV_ROLLBACK_TRAN: u8 = 10;
@@ -81,6 +82,21 @@ pub fn envchange_database(out: &mut Vec<u8>, database: &str) {
     body.push(ENV_DATABASE);
     push_b_varchar(&mut body, database);
     push_b_varchar(&mut body, database);
+    out.push(TOKEN_ENVCHANGE);
+    out.extend_from_slice(&(body.len() as u16).to_le_bytes());
+    out.extend_from_slice(&body);
+}
+
+/// ENVCHANGE for the connection's default SQL collation (login response).
+/// mssql-jdbc dereferences this collation when encoding every NVARCHAR RPC
+/// parameter — a login without it NPEs the driver client-side. The bytes are
+/// the LCID+flags+sort form COLMETADATA already uses for character columns.
+pub fn envchange_sql_collation(out: &mut Vec<u8>) {
+    let mut body = Vec::new();
+    body.push(ENV_SQL_COLLATION);
+    body.push(5); // B_VARBYTE new value: the collation
+    body.extend_from_slice(&[0x09, 0x04, 0xd0, 0x00, 0x34]);
+    body.push(0); // B_VARBYTE old value: none
     out.push(TOKEN_ENVCHANGE);
     out.extend_from_slice(&(body.len() as u16).to_le_bytes());
     out.extend_from_slice(&body);
@@ -212,20 +228,51 @@ pub fn row(out: &mut Vec<u8>, values: &[Datum], columns: &[ResultColumn]) {
 /// DONE token. `more` sets DONE_MORE (another result follows); `count`
 /// carries a row count (DONE_COUNT); `error` sets DONE_ERROR; `in_xact` sets
 /// DONE_INXACT (a transaction is still active for the connection).
-pub fn done(out: &mut Vec<u8>, more: bool, error: bool, in_xact: bool, count: Option<u64>) {
-    done_kind(out, TOKEN_DONE, more, error, in_xact, count);
+pub fn done(
+    out: &mut Vec<u8>,
+    more: bool,
+    error: bool,
+    in_xact: bool,
+    count: Option<u64>,
+    curcmd: u16,
+) {
+    done_kind(out, TOKEN_DONE, more, error, in_xact, count, curcmd);
 }
 
 /// DONEINPROC (0xFF): a statement's DONE inside an RPC response. Same body as
 /// DONE; only the token byte differs.
-pub fn done_in_proc(out: &mut Vec<u8>, more: bool, error: bool, in_xact: bool, count: Option<u64>) {
-    done_kind(out, TOKEN_DONEINPROC, more, error, in_xact, count);
+pub fn done_in_proc(
+    out: &mut Vec<u8>,
+    more: bool,
+    error: bool,
+    in_xact: bool,
+    count: Option<u64>,
+    curcmd: u16,
+) {
+    done_kind(out, TOKEN_DONEINPROC, more, error, in_xact, count, curcmd);
 }
 
-/// DONEPROC (0xFE): the final DONE of an RPC response.
+/// DONEPROC (0xFE): the final DONE of an RPC response. `CurCmd` is EXECUTE
+/// (0xE0), as SQL Server stamps a procedure's final DONE.
 pub fn done_proc(out: &mut Vec<u8>, more: bool, error: bool, in_xact: bool, count: Option<u64>) {
-    done_kind(out, TOKEN_DONEPROC, more, error, in_xact, count);
+    done_kind(
+        out,
+        TOKEN_DONEPROC,
+        more,
+        error,
+        in_xact,
+        count,
+        CMD_EXECUTE,
+    );
 }
+
+/// `CurCmd` command classes (StreamDone in every driver that reads them —
+/// mssql-jdbc requires a DML value here to accept a DONE's row count).
+pub const CMD_SELECT: u16 = 0xc1;
+pub const CMD_INSERT: u16 = 0xc3;
+pub const CMD_DELETE: u16 = 0xc4;
+pub const CMD_UPDATE: u16 = 0xc5;
+pub const CMD_EXECUTE: u16 = 0xe0;
 
 fn done_kind(
     out: &mut Vec<u8>,
@@ -234,6 +281,7 @@ fn done_kind(
     error: bool,
     in_xact: bool,
     count: Option<u64>,
+    curcmd: u16,
 ) {
     let mut status = if more { DONE_MORE } else { DONE_FINAL };
     if error {
@@ -247,7 +295,7 @@ fn done_kind(
     }
     out.push(token);
     out.extend_from_slice(&status.to_le_bytes());
-    out.extend_from_slice(&0u16.to_le_bytes()); // CurCmd
+    out.extend_from_slice(&curcmd.to_le_bytes());
     out.extend_from_slice(&count.unwrap_or(0).to_le_bytes());
 }
 
@@ -314,7 +362,7 @@ mod tests {
     #[test]
     fn done_status_bits() {
         let mut out = Vec::new();
-        done(&mut out, false, false, false, Some(3));
+        done(&mut out, false, false, false, Some(3), 0);
         assert_eq!(out[0], TOKEN_DONE);
         let status = u16::from_le_bytes([out[1], out[2]]);
         assert_eq!(status, DONE_COUNT);
@@ -325,7 +373,7 @@ mod tests {
     #[test]
     fn done_sets_inxact_flag() {
         let mut out = Vec::new();
-        done(&mut out, false, false, true, None);
+        done(&mut out, false, false, true, None, 0);
         let status = u16::from_le_bytes([out[1], out[2]]);
         assert_eq!(status & DONE_INXACT, DONE_INXACT);
     }

--- a/crates/truthdb-tds/src/typeinfo.rs
+++ b/crates/truthdb-tds/src/typeinfo.rs
@@ -20,7 +20,7 @@ const BIGVARBINARY: u8 = 0xa5;
 /// A 5-byte collation for a Latin1-general, case-insensitive, accent-
 /// sensitive locale (LCID 0x0409, SortId 0x34 = code page 1252). Character
 /// columns carry it; clients use it to pick a decoder for BIGVARCHR bytes.
-const COLLATION: [u8; 5] = [0x09, 0x04, 0xd0, 0x00, 0x34];
+pub const COLLATION: [u8; 5] = [0x09, 0x04, 0xd0, 0x00, 0x34];
 
 /// Max UCS-2 code units in a non-MAX NVARCHAR row value: 32767 units = 65534
 /// bytes, the largest even byte count a u16 value-length prefix can hold.

--- a/crates/truthdb-tds/tests/tds_client.rs
+++ b/crates/truthdb-tds/tests/tds_client.rs
@@ -299,11 +299,27 @@ enum Token {
     LoginAck,
     ColMetadata(Vec<ColType>),
     Row(Vec<Cell>),
-    Error { number: i32 },
-    EnvChange { kind: u8, descriptor: u64 },
-    Done { count: Option<u64>, in_xact: bool },
-    DoneInProc { count: Option<u64> },
-    DoneProc { more: bool, error: bool },
+    Error {
+        number: i32,
+    },
+    EnvChange {
+        kind: u8,
+        descriptor: u64,
+    },
+    Done {
+        count: Option<u64>,
+        in_xact: bool,
+        cmd: u16,
+    },
+    DoneInProc {
+        count: Option<u64>,
+        cmd: u16,
+    },
+    DoneProc {
+        more: bool,
+        error: bool,
+        cmd: u16,
+    },
     ReturnStatus(i32),
     ReturnValue,
     Other(u8),
@@ -375,6 +391,7 @@ fn parse_tokens(payload: &[u8]) -> Vec<Token> {
             0xfd..=0xff => {
                 // DONE / DONEPROC / DONEINPROC: status u16, curcmd u16, count u64.
                 let status = u16::from_le_bytes([payload[i], payload[i + 1]]);
+                let cmd = u16::from_le_bytes([payload[i + 2], payload[i + 3]]);
                 let count = u64::from_le_bytes(payload[i + 4..i + 12].try_into().unwrap());
                 let has_count = status & 0x0010 != 0;
                 let in_xact = status & 0x0004 != 0;
@@ -383,13 +400,16 @@ fn parse_tokens(payload: &[u8]) -> Vec<Token> {
                     0xfd => Token::Done {
                         count: has_count.then_some(count),
                         in_xact,
+                        cmd,
                     },
                     0xfe => Token::DoneProc {
                         more: status & 0x0001 != 0,
                         error: status & 0x0002 != 0,
+                        cmd,
                     },
                     _ => Token::DoneInProc {
                         count: has_count.then_some(count),
+                        cmd,
                     },
                 });
             }
@@ -788,7 +808,7 @@ async fn a_multi_rpc_request_answers_each_rpc_in_one_response() {
     let procs: Vec<(bool, bool)> = tokens
         .iter()
         .filter_map(|t| match t {
-            Token::DoneProc { more, error } => Some((*more, *error)),
+            Token::DoneProc { more, error, .. } => Some((*more, *error)),
             _ => None,
         })
         .collect();
@@ -828,11 +848,93 @@ async fn a_multi_rpc_request_answers_each_rpc_in_one_response() {
     let procs: Vec<(bool, bool)> = tokens
         .iter()
         .filter_map(|t| match t {
-            Token::DoneProc { more, error } => Some((*more, *error)),
+            Token::DoneProc { more, error, .. } => Some((*more, *error)),
             _ => None,
         })
         .collect();
     assert_eq!(procs, [(true, true), (false, false)], "tokens: {tokens:?}");
+
+    // A decode-level error mid-request (an unknown procedure never reaches
+    // the engine) renders in-frame and the RPCs after it still run.
+    let mut body = Vec::new();
+    body.extend_from_slice(&5u16.to_le_bytes()); // name length in chars
+    body.extend(ucs2le("sp_no"));
+    body.extend_from_slice(&0u16.to_le_bytes()); // option flags
+    body.push(0xff);
+    body.extend(sp_executesql_rpc("SELECT 4 AS d"));
+    let tokens = client.rpc(&body).await;
+    assert!(
+        tokens
+            .iter()
+            .any(|t| matches!(t, Token::Error { number: 2812 })),
+        "tokens: {tokens:?}"
+    );
+    assert_eq!(row_ints(&tokens), [4], "tokens: {tokens:?}");
+
+    let _ = std::fs::remove_file(&path);
+}
+
+/// The login response advertises the connection's default SQL collation
+/// (ENVCHANGE 7) — mssql-jdbc dereferences it to encode every NVARCHAR RPC
+/// parameter and NPEs client-side without it — and every DONE stamps its
+/// statement's command class in CurCmd, which the same driver requires
+/// before it accepts a DONE's row count (executeUpdate returns -1 without
+/// it). Both regressions previously survived every in-repo test.
+#[tokio::test]
+async fn login_advertises_collation_and_dones_carry_their_command_class() {
+    let path = temp_path("curcmd");
+    let engine = engine(&path);
+    let mut client = connect(engine.clone()).await;
+    client.prelogin().await;
+    let login = client.login("sa", "secret").await;
+    assert!(
+        has_envchange(&login, 7),
+        "login must carry ENVCHANGE 7 (SQL collation): {login:?}"
+    );
+
+    client
+        .batch("CREATE TABLE cc (id INT NOT NULL PRIMARY KEY)")
+        .await;
+    // The REAL engine's statement→command mapping, batch path: INSERT 0xC3,
+    // UPDATE 0xC5, SELECT 0xC1, DELETE 0xC4 on the statement's own DONE.
+    for (sql, want) in [
+        ("INSERT INTO cc VALUES (1), (2)", 0xc3u16),
+        ("UPDATE cc SET id = 3 WHERE id = 1", 0xc5),
+        ("SELECT id FROM cc ORDER BY id", 0xc1),
+        ("DELETE FROM cc WHERE id = 3", 0xc4),
+    ] {
+        let tokens = client.batch(sql).await;
+        let cmds: Vec<u16> = tokens
+            .iter()
+            .filter_map(|t| match t {
+                Token::Done { cmd, .. } => Some(*cmd),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(cmds, [want], "{sql}: {tokens:?}");
+    }
+
+    // The RPC path: the DONEINPROC carries the statement's class, the final
+    // DONEPROC carries EXECUTE (0xE0).
+    let tokens = client
+        .rpc(&sp_executesql_rpc("INSERT INTO cc VALUES (9)"))
+        .await;
+    let inproc: Vec<u16> = tokens
+        .iter()
+        .filter_map(|t| match t {
+            Token::DoneInProc { cmd, .. } => Some(*cmd),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(inproc, [0xc3], "tokens: {tokens:?}");
+    let procs: Vec<u16> = tokens
+        .iter()
+        .filter_map(|t| match t {
+            Token::DoneProc { cmd, .. } => Some(*cmd),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(procs, [0xe0], "tokens: {tokens:?}");
 
     let _ = std::fs::remove_file(&path);
 }

--- a/crates/truthdb-tds/tests/tds_client.rs
+++ b/crates/truthdb-tds/tests/tds_client.rs
@@ -163,6 +163,20 @@ impl Client {
         parse_tokens(&payload)
     }
 
+    /// Sends a PKT_RPC message with the given (post-headers) body and
+    /// returns the response tokens.
+    async fn rpc(&mut self, body: &[u8]) -> Vec<Token> {
+        let mut payload = Vec::new();
+        let headers = all_headers(self.tran_descriptor);
+        let total = 4 + headers.len();
+        payload.extend_from_slice(&(total as u32).to_le_bytes());
+        payload.extend_from_slice(&headers);
+        payload.extend_from_slice(body);
+        self.write_packet(0x03, &payload).await;
+        let (_, response) = self.read_message().await;
+        parse_tokens(&response)
+    }
+
     async fn batch(&mut self, sql: &str) -> Vec<Token> {
         let mut payload = Vec::new();
         // ALL_HEADERS: TotalLength includes itself (the 4-byte field) plus
@@ -288,6 +302,10 @@ enum Token {
     Error { number: i32 },
     EnvChange { kind: u8, descriptor: u64 },
     Done { count: Option<u64>, in_xact: bool },
+    DoneInProc { count: Option<u64> },
+    DoneProc { more: bool, error: bool },
+    ReturnStatus(i32),
+    ReturnValue,
     Other(u8),
 }
 
@@ -361,10 +379,36 @@ fn parse_tokens(payload: &[u8]) -> Vec<Token> {
                 let has_count = status & 0x0010 != 0;
                 let in_xact = status & 0x0004 != 0;
                 i += 12;
-                tokens.push(Token::Done {
-                    count: has_count.then_some(count),
-                    in_xact,
+                tokens.push(match token {
+                    0xfd => Token::Done {
+                        count: has_count.then_some(count),
+                        in_xact,
+                    },
+                    0xfe => Token::DoneProc {
+                        more: status & 0x0001 != 0,
+                        error: status & 0x0002 != 0,
+                    },
+                    _ => Token::DoneInProc {
+                        count: has_count.then_some(count),
+                    },
                 });
+            }
+            0x79 => {
+                let value = i32::from_le_bytes(payload[i..i + 4].try_into().unwrap());
+                i += 4;
+                tokens.push(Token::ReturnStatus(value));
+            }
+            0xac => {
+                // RETURNVALUE: ordinal u16, B_VARCHAR name, status u8,
+                // usertype u32, flags u16, TYPE_INFO(INTN,4), value.
+                i += 2;
+                let name_chars = payload[i] as usize;
+                i += 1 + name_chars * 2;
+                i += 1 + 4 + 2; // status, usertype, flags
+                i += 2; // INTN + max len
+                let len = payload[i] as usize;
+                i += 1 + len;
+                tokens.push(Token::ReturnValue);
             }
             other => {
                 tokens.push(Token::Other(other));
@@ -705,6 +749,101 @@ async fn computed_columns_and_constant_select() {
 const TM_BEGIN_XACT: u16 = 5;
 const TM_COMMIT_XACT: u16 = 7;
 const TM_ROLLBACK_XACT: u16 = 8;
+
+/// One sp_executesql RPC (by ProcID) with a single unnamed @stmt param.
+fn sp_executesql_rpc(sql: &str) -> Vec<u8> {
+    let mut b = Vec::new();
+    b.extend_from_slice(&0xffffu16.to_le_bytes()); // ProcID sentinel
+    b.extend_from_slice(&10u16.to_le_bytes()); // sp_executesql
+    b.extend_from_slice(&0u16.to_le_bytes()); // option flags
+    b.push(0); // empty param name
+    b.push(0); // status
+    b.push(0xe7); // NVARCHAR
+    b.extend_from_slice(&8000u16.to_le_bytes());
+    b.extend_from_slice(&[0x09, 0x04, 0xd0, 0x00, 0x34]); // collation
+    let bytes = ucs2le(sql);
+    b.extend_from_slice(&(bytes.len() as u16).to_le_bytes());
+    b.extend_from_slice(&bytes);
+    b
+}
+
+/// A multi-RPC request (mssql-jdbc's default flow batches sp_unprepare with
+/// the next sp_prepexec this way): each RPC answers its own DONEPROC-framed
+/// reply — DONE_MORE on every DONEPROC but the last — inside one response.
+#[tokio::test]
+async fn a_multi_rpc_request_answers_each_rpc_in_one_response() {
+    let path = temp_path("multirpc");
+    let engine = engine(&path);
+    let mut client = connect(engine.clone()).await;
+    client.prelogin().await;
+    client.login("sa", "secret").await;
+
+    let mut body = sp_executesql_rpc("SELECT 1 AS a");
+    body.push(0xff); // batch separator
+    body.extend(sp_executesql_rpc("SELECT 2 AS b"));
+    let tokens = client.rpc(&body).await;
+
+    let ints: Vec<i64> = row_ints(&tokens);
+    assert_eq!(ints, [1, 2], "tokens: {tokens:?}");
+    let procs: Vec<(bool, bool)> = tokens
+        .iter()
+        .filter_map(|t| match t {
+            Token::DoneProc { more, error } => Some((*more, *error)),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        procs,
+        [(true, false), (false, false)],
+        "every DONEPROC but the last carries DONE_MORE: {tokens:?}"
+    );
+    assert_eq!(
+        tokens
+            .iter()
+            .filter(|t| matches!(t, Token::ReturnStatus(0)))
+            .count(),
+        2,
+        "one RETURNSTATUS per RPC: {tokens:?}"
+    );
+
+    // An erroring RPC does not take the rest of the request with it: the
+    // second RPC still runs and the response stays framed.
+    let mut body = Vec::new();
+    body.extend_from_slice(&0xffffu16.to_le_bytes());
+    body.extend_from_slice(&15u16.to_le_bytes()); // sp_unprepare
+    body.extend_from_slice(&0u16.to_le_bytes());
+    body.push(0); // empty param name
+    body.push(0); // status
+    b_int(&mut body, 42); // a handle that was never prepared
+    body.push(0xff);
+    body.extend(sp_executesql_rpc("SELECT 3 AS c"));
+    let tokens = client.rpc(&body).await;
+    assert!(
+        tokens
+            .iter()
+            .any(|t| matches!(t, Token::Error { number: 8179 })),
+        "tokens: {tokens:?}"
+    );
+    assert_eq!(row_ints(&tokens), [3], "tokens: {tokens:?}");
+    let procs: Vec<(bool, bool)> = tokens
+        .iter()
+        .filter_map(|t| match t {
+            Token::DoneProc { more, error } => Some((*more, *error)),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(procs, [(true, true), (false, false)], "tokens: {tokens:?}");
+
+    let _ = std::fs::remove_file(&path);
+}
+
+/// An INTN(4) parameter value.
+fn b_int(b: &mut Vec<u8>, value: i32) {
+    b.push(0x26); // INTN
+    b.push(4);
+    b.push(4);
+    b.extend_from_slice(&value.to_le_bytes());
+}
 
 fn has_envchange(tokens: &[Token], kind: u8) -> bool {
     tokens

--- a/scripts/TdsConformance.java
+++ b/scripts/TdsConformance.java
@@ -1,0 +1,91 @@
+// TDS conformance: mssql-jdbc, the third independent driver — and the one
+// whose default prepared-statement flow exercises what pytds and go-mssqldb
+// cannot: sp_prepexec on first execution, sp_execute on re-use, and
+// discarded-handle sp_unprepare calls BATCHED into the next execution's
+// request (a multi-RPC request), all under DONEPROC/RETURNSTATUS framing.
+//
+// Usage: java -cp mssql-jdbc.jar TdsConformance.java <host> <port> <user> <password>
+// Exits non-zero on any mismatch.
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+public class TdsConformance {
+    static void fail(String message) {
+        System.err.println("FAIL: " + message);
+        System.exit(1);
+    }
+
+    public static void main(String[] args) throws Exception {
+        String url = String.format(
+                "jdbc:sqlserver://%s:%s;databaseName=truthdb;encrypt=false;user=%s;password=%s;loginTimeout=10",
+                args[0], args[1], args[2], args[3]);
+        try (Connection conn = DriverManager.getConnection(url)) {
+            try (Statement st = conn.createStatement()) {
+                st.executeUpdate("CREATE TABLE prep_jdbc (id INT NOT NULL PRIMARY KEY, name NVARCHAR(40))");
+            }
+
+            // A prepared INSERT executed repeatedly: sp_prepexec on the first
+            // execution, sp_execute after — and each execution past the
+            // driver's discard threshold batches sp_unprepare RPCs in front.
+            try (PreparedStatement ins = conn.prepareStatement("INSERT INTO prep_jdbc VALUES (?, ?)")) {
+                for (int i = 1; i <= 5; i++) {
+                    ins.setInt(1, i);
+                    ins.setString(2, "row" + i);
+                    if (ins.executeUpdate() != 1) {
+                        fail("insert " + i + ": rows affected != 1");
+                    }
+                }
+            }
+
+            // A prepared SELECT re-used with different parameters.
+            try (PreparedStatement sel = conn.prepareStatement("SELECT name FROM prep_jdbc WHERE id = ?")) {
+                for (int i = 1; i <= 5; i++) {
+                    sel.setInt(1, i);
+                    try (ResultSet rs = sel.executeQuery()) {
+                        if (!rs.next() || !rs.getString(1).equals("row" + i)) {
+                            fail("select id=" + i + " mismatch");
+                        }
+                    }
+                }
+
+                // DDL between executions: there is no cached plan to go
+                // stale — the same handle sees the new row.
+                try (Statement st = conn.createStatement()) {
+                    st.executeUpdate("INSERT INTO prep_jdbc VALUES (6, 'row6')");
+                }
+                sel.setInt(1, 6);
+                try (ResultSet rs = sel.executeQuery()) {
+                    if (!rs.next() || !rs.getString(1).equals("row6")) {
+                        fail("select after insert mismatch");
+                    }
+                }
+            }
+
+            // An error inside a prepared execution surfaces as a SQLException
+            // with the server's number, and the connection stays usable.
+            try (PreparedStatement dup = conn.prepareStatement("INSERT INTO prep_jdbc VALUES (?, ?)")) {
+                dup.setInt(1, 1);
+                dup.setString(2, "dup");
+                dup.executeUpdate();
+                fail("duplicate PK did not raise");
+            } catch (SQLException e) {
+                if (e.getErrorCode() != 2627) {
+                    fail("expected 2627, got " + e.getErrorCode() + ": " + e.getMessage());
+                }
+            }
+            try (Statement st = conn.createStatement();
+                    ResultSet rs = st.executeQuery("SELECT COUNT(*) FROM prep_jdbc")) {
+                rs.next();
+                if (rs.getInt(1) != 6) {
+                    fail("count: got " + rs.getInt(1) + " want 6");
+                }
+            }
+        }
+        System.out.println("tds conformance (mssql-jdbc): OK");
+    }
+}

--- a/scripts/tds_conformance_gosqlcmd.expected
+++ b/scripts/tds_conformance_gosqlcmd.expected
@@ -1,0 +1,19 @@
+(3 rows affected)
+id          name                
+----------- --------------------
+          1 one                 
+          2 two                 
+          3 NULL                
+
+(3 rows affected)
+n                    
+---------------------
+                    2
+
+(1 row affected)
+(1 row affected)
+name                
+--------------------
+one                 
+
+(1 row affected)

--- a/scripts/tds_conformance_sqlcmd.expected
+++ b/scripts/tds_conformance_sqlcmd.expected
@@ -1,0 +1,21 @@
+
+(3 rows affected)
+id          name                
+----------- --------------------
+          1 one                 
+          2 two                 
+          3 NULL                
+
+(3 rows affected)
+n                   
+--------------------
+                   2
+
+(1 rows affected)
+
+(1 rows affected)
+name                
+--------------------
+one                 
+
+(1 rows affected)

--- a/scripts/tds_conformance_sqlcmd.sql
+++ b/scripts/tds_conformance_sqlcmd.sql
@@ -1,15 +1,15 @@
 :setvar SQLCMDMAXVARTYPEWIDTH 20
-CREATE TABLE sqlcmd_conf (id INT NOT NULL PRIMARY KEY, name NVARCHAR(20));
+CREATE TABLE $(TABLE) (id INT NOT NULL PRIMARY KEY, name NVARCHAR(20));
 GO
-INSERT INTO sqlcmd_conf VALUES (1, 'one'), (2, 'two'), (3, NULL);
+INSERT INTO $(TABLE) VALUES (1, 'one'), (2, 'two'), (3, NULL);
 GO
-SELECT id, name FROM sqlcmd_conf ORDER BY id;
+SELECT id, name FROM $(TABLE) ORDER BY id;
 GO
-SELECT COUNT(*) AS n FROM sqlcmd_conf WHERE name IS NOT NULL;
+SELECT COUNT(*) AS n FROM $(TABLE) WHERE name IS NOT NULL;
 GO
 BEGIN TRANSACTION;
-UPDATE sqlcmd_conf SET name = 'uno' WHERE id = 1;
+UPDATE $(TABLE) SET name = 'uno' WHERE id = 1;
 ROLLBACK;
 GO
-SELECT name FROM sqlcmd_conf WHERE id = 1;
+SELECT name FROM $(TABLE) WHERE id = 1;
 GO

--- a/scripts/tds_conformance_sqlcmd.sql
+++ b/scripts/tds_conformance_sqlcmd.sql
@@ -1,0 +1,15 @@
+:setvar SQLCMDMAXVARTYPEWIDTH 20
+CREATE TABLE sqlcmd_conf (id INT NOT NULL PRIMARY KEY, name NVARCHAR(20));
+GO
+INSERT INTO sqlcmd_conf VALUES (1, 'one'), (2, 'two'), (3, NULL);
+GO
+SELECT id, name FROM sqlcmd_conf ORDER BY id;
+GO
+SELECT COUNT(*) AS n FROM sqlcmd_conf WHERE name IS NOT NULL;
+GO
+BEGIN TRANSACTION;
+UPDATE sqlcmd_conf SET name = 'uno' WHERE id = 1;
+ROLLBACK;
+GO
+SELECT name FROM sqlcmd_conf WHERE id = 1;
+GO


### PR DESCRIPTION
## What

Closes Stage 9's exit bullet — the last Stage 9 yellow. Five commits:

1. **RPC responses frame as procedure replies** (DONEINPROC per statement, RETURNSTATUS, RETURNVALUE, DONEPROC), with batch framing pinned byte-identical by the #97 oracle.
2. **Multi-RPC requests run every RPC in one response** — issued sequentially (a session runs one call at a time), DONE_MORE chained across DONEPROCs, each RPC answering independently, Attention discarding the unissued tail. This is mssql-jdbc's default flow (batched sp_unprepare + sp_prepexec).
3. **Three server gaps mssql-jdbc exposed**, each verified against the driver's v12.8.1 source: the login lacked ENVCHANGE 7 (SQL collation — the driver NPEs without it); parameter values arrive unnamed relying on the @params declaration string, which the sp_executesql path dropped; and DONE tokens carried CurCmd=0, which makes the driver discard every row count (`StreamDone.cmdIsDMLOrDDL`) so executeUpdate returned -1. Statements now stamp their command class into every DONE (INSERT 0xC3, UPDATE 0xC5, DELETE 0xC4, SELECT 0xC1; DONEPROC finals 0xE0).
4. **The CI harness**: mssql-jdbc prepared-statement CRUD (TdsConformance.java), ODBC sqlcmd (mssql-tools18, `-N o -I`), and go-sqlcmd v1.8.2 — the last two running a shared scripted .sql with byte-exact output diffs. All verified live in containers before wiring.
5. **Review fixes**: in-repo teeth for CurCmd and ENVCHANGE 7 (the review proved both regressions survived every suite — a new e2e test pins them through the real engine, teeth-checked); 8144 refined to fire only for unnamed values with no declaration (restoring the run_rpc wrappers' named-params contract); the login collation shares typeinfo's constant; sqlcmd CI diffs no longer capture stderr.

## Adjudication

Every wire change was accepted live by all five clients against the final build: pytds (three scripts), go-mssqldb (full suite), mssql-jdbc (prepared CRUD, handle reuse across DDL, 2627 recovery), ODBC sqlcmd, and go-sqlcmd. The exit bullet's "rebind test" already exists in its honest form (#112's DDL-between-prepare-and-execute — there is no plan to rebind).

## Review

Adversarial review of the four feature commits in a detached worktree: one medium finding (the missing in-repo teeth — fixed above, empirically demonstrated by neutering `curcmd_of` with every suite staying green) and five lows (fixed: run_rpc contract flip, duplicated collation bytes, stderr in CI diffs, untested decode-error-mid-request; accepted and documented: the 8144 early reply's DONE_INXACT fidelity, attention-during-multi-RPC having only refutation-level coverage, mssql-tools18 being apt-unpinned). Clean checks included the attention-hang refutation (every BatchSink holder drops promptly, so the None arm always breaks), DONE_MORE chaining on decode-error renders, and the oracle's non-self-referential structure.

## Tests

476 workspace tests green; fmt and clippy (-D warnings) clean. New coverage: multi-RPC end-to-end (framing, independent errors, decode-error mid-request), CurCmd/ENVCHANGE 7 through the real engine, RPC framing render pins, multi-RPC body parsing — all teeth-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)