### PR TITLE
Stage 10: ALTER TABLE ADD column as a transactional row rewrite

### DIFF
--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -2992,6 +2992,7 @@ fn exec_alter_table(
         .ok_or_else(|| SqlError::invalid_object(&alter.table.value).at(alter.table.span))?;
     reject_view_as_table(&def)?;
     match &alter.action {
+        AlterAction::AddColumn(column) => alter_add_column(storage, &def, column, eval_ctx),
         AlterAction::AddCheck(check) => alter_add_check(storage, &def, check, eval_ctx),
         AlterAction::AddForeignKey(fk) => alter_add_foreign_key(storage, &def, fk),
         AlterAction::DropConstraint(name) => alter_drop_constraint(storage, &def, name),
@@ -3078,6 +3079,84 @@ fn alter_add_foreign_key(
 /// `ALTER TABLE ... ADD [CONSTRAINT name] CHECK (expr)`. Validates the new
 /// constraint against every existing row (SQL Server's default WITH CHECK); a
 /// violating row is error 547 and the constraint is not added.
+/// `ALTER TABLE ADD <column>`: appends the column to the catalog and
+/// rewrites every existing row under the new schema. The row codec is
+/// positional (every offset derives from the schema, with no per-row version
+/// stamp), so a metadata-only ADD cannot exist — the rewrite is the honest
+/// implementation, one transactional statement under the ALTER's exclusive
+/// lock. Existing rows take a FROZEN fill: NULL, or the DEFAULT evaluated
+/// once now (SQL Server freezes it the same way); later INSERTs evaluate the
+/// live default text per row like any other column.
+fn alter_add_column(
+    storage: &Storage,
+    def: &catalog::TableDef,
+    column: &ColumnDef,
+    eval_ctx: &EvalContext,
+) -> Result<StatementResult, SqlError> {
+    if def
+        .columns
+        .iter()
+        .any(|(name, _, _)| name.eq_ignore_ascii_case(&column.name.value))
+    {
+        return Err(SqlError::new(
+            2705,
+            16,
+            4,
+            format!(
+                "Column names in each table must be unique. Column name '{}' is specified more than once.",
+                column.name.value
+            ),
+        )
+        .at(column.name.span));
+    }
+    // The plan's scope: a plain column with nullability, DEFAULT and COLLATE.
+    // Constraint-carrying additions are their own statements in T-SQL anyway.
+    if column.primary_key
+        || column.unique
+        || column.identity.is_some()
+        || !column.checks.is_empty()
+        || !column.foreign_keys.is_empty()
+    {
+        return Err(SqlError::new(
+            40510,
+            16,
+            1,
+            "ALTER TABLE ADD supports a plain column (with NULL/NOT NULL, DEFAULT and COLLATE); add constraints with their own ALTER TABLE ADD CONSTRAINT statements.",
+        )
+        .at(column.span));
+    }
+    let bound = bind_column(column)?;
+    // No counter (a pre-upgrade table) means "assume rows exist".
+    let has_rows = storage
+        .rel_row_count(&def.name)
+        .map(|n| n > 0)
+        .unwrap_or(true);
+    // The frozen fill existing rows take.
+    let fill = match &column.default {
+        Some(text) => {
+            let sql_value = eval_default(text, eval_ctx)?;
+            value::sql_to_datum(&sql_value, &bound.column_type, &bound.name)?
+        }
+        None => Datum::Null,
+    };
+    if !bound.nullable && fill.is_null() && has_rows {
+        return Err(SqlError::new(
+            4901,
+            16,
+            1,
+            format!(
+                "ALTER TABLE only allows columns to be added that can contain nulls, or have a DEFAULT definition specified, or the column being added is an identity or timestamp column, or alternatively if none of the previous conditions are satisfied the table must be empty to allow addition of this column. Column '{}' cannot be added to non-empty table '{}' because it does not satisfy these conditions.",
+                bound.name, def.name
+            ),
+        )
+        .at(column.span));
+    }
+    storage
+        .rel_alter_add_column(&def.name, bound, column.default.clone(), fill)
+        .map_err(|err| map_storage_err(err, &def.name))?;
+    Ok(StatementResult::Done)
+}
+
 fn alter_add_check(
     storage: &Storage,
     def: &TableDef,

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -3076,9 +3076,6 @@ fn alter_add_foreign_key(
     Ok(StatementResult::Done)
 }
 
-/// `ALTER TABLE ... ADD [CONSTRAINT name] CHECK (expr)`. Validates the new
-/// constraint against every existing row (SQL Server's default WITH CHECK); a
-/// violating row is error 547 and the constraint is not added.
 /// `ALTER TABLE ADD <column>`: appends the column to the catalog and
 /// rewrites every existing row under the new schema. The row codec is
 /// positional (every offset derives from the schema, with no per-row version
@@ -3126,11 +3123,18 @@ fn alter_add_column(
         .at(column.span));
     }
     let bound = bind_column(column)?;
-    // No counter (a pre-upgrade table) means "assume rows exist".
-    let has_rows = storage
-        .rel_row_count(&def.name)
-        .map(|n| n > 0)
-        .unwrap_or(true);
+    // An authoritative emptiness probe (one-row scan under the ALTER's
+    // exclusive lock) — the row counter is a statistic and must not become
+    // load-bearing here: an under-count would let NULL fills into a NOT NULL
+    // column, and a pre-upgrade table without a counter would 4901 even when
+    // empty.
+    let has_rows = {
+        let mut probe = Vec::new();
+        storage
+            .rel_scan_slice(&def.name, ScanCursor::start(), 1, None, &mut probe)
+            .map_err(|err| map_storage_err(err, &def.name))?;
+        !probe.is_empty()
+    };
     // The frozen fill existing rows take.
     let fill = match &column.default {
         Some(text) => {
@@ -3157,6 +3161,9 @@ fn alter_add_column(
     Ok(StatementResult::Done)
 }
 
+/// `ALTER TABLE ... ADD [CONSTRAINT name] CHECK (expr)`. Validates the new
+/// constraint against every existing row (SQL Server's default WITH CHECK); a
+/// violating row is error 547 and the constraint is not added.
 fn alter_add_check(
     storage: &Storage,
     def: &TableDef,

--- a/crates/truthdb-core/src/storage.rs
+++ b/crates/truthdb-core/src/storage.rs
@@ -468,6 +468,17 @@ impl Storage {
         self.lock().rel_drop_index(table, index_name)
     }
 
+    pub(crate) fn rel_alter_add_column(
+        &self,
+        table: &str,
+        column: Column,
+        default_text: Option<String>,
+        fill: Datum,
+    ) -> Result<(), StorageError> {
+        self.lock()
+            .rel_alter_add_column(table, column, default_text, fill)
+    }
+
     /// The table's committed row count, when it has a counter page (tables
     /// created before counters existed do not — the planner then applies no
     /// tie-break). Errors degrade to `None`: the count is a statistic, never
@@ -1224,6 +1235,100 @@ impl StorageFile {
             Ok(def)
         })?;
         self.rel.next_object_id += 1;
+        self.rel.tables.insert(table.to_string(), updated);
+        Ok(())
+    }
+
+    /// `ALTER TABLE ADD <column>`: appends the column to the table's catalog
+    /// entry and rewrites every existing row under the widened schema, all in
+    /// one transactional statement — the row codec is positional, so an old
+    /// row cannot be read under the new schema without re-encoding. Keys and
+    /// index entries are untouched: appending a column shifts no schema index
+    /// the key or any secondary index refers to, tree rewrites are in-place
+    /// by key, and heap RIDs are stable across an update.
+    pub(crate) fn rel_alter_add_column(
+        &mut self,
+        table: &str,
+        column: Column,
+        default_text: Option<String>,
+        fill: Datum,
+    ) -> Result<(), StorageError> {
+        self.ensure_rel_usable()?;
+        let mut column = column;
+        // A character column without an explicit COLLATE inherits the database
+        // default by name, exactly as CREATE TABLE records it.
+        if column.collation.is_none()
+            && matches!(
+                column.column_type,
+                crate::relstore::types::ColumnType::VarChar { .. }
+                    | crate::relstore::types::ColumnType::NVarChar { .. }
+            )
+        {
+            column.collation = self.default_collation.clone();
+        }
+        let mut def = self
+            .rel
+            .tables
+            .get(table)
+            .cloned()
+            .ok_or_else(|| StorageError::InvalidConfig(format!("unknown table '{table}'")))?;
+        let catalog_root = self
+            .rel
+            .catalog_root
+            .ok_or_else(|| StorageError::InvalidFile("catalog root missing".to_string()))?;
+        // Snapshot every row under the OLD schema (with its locator), before
+        // the definition widens.
+        let located = self.rel_scan_located(table)?;
+
+        // Parallel catalog arrays: `defaults`/`collations` may be shorter than
+        // `columns` (serde(default) on pre-upgrade tables) — pad before push.
+        def.defaults.resize(def.columns.len(), None);
+        def.collations.resize(def.columns.len(), None);
+        def.columns.push((
+            column.name.clone(),
+            column.column_type.name(),
+            column.nullable,
+        ));
+        def.defaults.push(default_text);
+        def.collations.push(column.collation.clone());
+        let new_schema = def.schema()?;
+
+        // Re-encode every row with the frozen fill appended.
+        let mut tree_rows: Vec<(Vec<u8>, Vec<u8>)> = Vec::new();
+        let mut heap_rows: Vec<(Rid, Vec<u8>)> = Vec::new();
+        for (loc, mut values) in located {
+            values.push(fill.clone());
+            let row = encode_row(&new_schema, &values)?;
+            match loc {
+                RowLocator::Key(key) => tree_rows.push((key, row)),
+                RowLocator::Rid(rid) => heap_rows.push((rid, row)),
+            }
+        }
+
+        let is_tree = def.is_tree();
+        let object_id = def.object_id;
+        let root_page = def.root_page;
+        let updated = self.rel_statement(move |ctx, txn| {
+            if is_tree {
+                let tree = BTree {
+                    object_id,
+                    root: root_page,
+                };
+                for (key, row) in &tree_rows {
+                    tree.update(ctx, &mut OpMode::Txn(txn), key, row)?;
+                }
+            } else {
+                let heap = Heap {
+                    object_id,
+                    first_page: root_page,
+                };
+                for (rid, row) in &heap_rows {
+                    heap.update(ctx, txn, *rid, row)?;
+                }
+            }
+            catalog::update_table(ctx, &mut OpMode::Txn(txn), catalog_root, &def)?;
+            Ok(def)
+        })?;
         self.rel.tables.insert(table.to_string(), updated);
         Ok(())
     }
@@ -3299,6 +3404,67 @@ mod tests {
             reserved_ratio: 0.17,
             default_collation: None,
         }
+    }
+
+    /// ALTER TABLE ADD survives a restart — the widened schema and the frozen
+    /// fills are one durable statement — and a failure mid-rewrite rolls the
+    /// whole ALTER back: old schema, old rows, fully readable.
+    #[test]
+    fn alter_add_column_is_durable_and_atomic() {
+        use crate::rel::{StatementResult, TxnContext, execute_batch};
+
+        let path = unique_temp_path("alter-add");
+        let storage = Storage::create(path.clone(), test_storage_options()).expect("create");
+        let mut ctx = TxnContext::default();
+        for sql in [
+            "CREATE TABLE t (id INT NOT NULL PRIMARY KEY, name NVARCHAR(20))",
+            "INSERT INTO t VALUES (1, 'one'), (2, 'two')",
+            "ALTER TABLE t ADD score INT DEFAULT 7",
+        ] {
+            let outcome = execute_batch(&storage, sql, &mut ctx);
+            assert!(outcome.error.is_none(), "{sql}: {:?}", outcome.error);
+        }
+        drop(storage);
+
+        // Reopen: the widened schema and the frozen fill survived.
+        let storage = Storage::open(path.clone()).expect("reopen");
+        let mut ctx = TxnContext::default();
+        let outcome = execute_batch(&storage, "SELECT id, score FROM t ORDER BY id", &mut ctx);
+        assert!(outcome.error.is_none(), "{:?}", outcome.error);
+        match &outcome.results[0] {
+            StatementResult::Rows(rowset) => assert_eq!(
+                rowset.rows,
+                vec![
+                    vec![Datum::Int(1), Datum::Int(7)],
+                    vec![Datum::Int(2), Datum::Int(7)],
+                ]
+            ),
+            other => panic!("expected rows, got {other:?}"),
+        }
+
+        // A failure mid-rewrite (fault injection inside the ALTER's statement)
+        // rolls the whole thing back: the new column does not exist and the
+        // old rows are intact.
+        crate::relstore::ctx::FAIL_APPLY_OPS_AFTER.with(|c| c.set(Some(1)));
+        let outcome = execute_batch(&storage, "ALTER TABLE t ADD flag BIT DEFAULT 1", &mut ctx);
+        crate::relstore::ctx::FAIL_APPLY_OPS_AFTER.with(|c| c.set(None));
+        assert!(outcome.error.is_some(), "the injected failure must surface");
+
+        let outcome = execute_batch(&storage, "SELECT flag FROM t", &mut ctx);
+        assert!(
+            outcome.error.is_some(),
+            "the rolled-back column must not exist: {:?}",
+            outcome.results
+        );
+        let outcome = execute_batch(&storage, "SELECT id, score FROM t ORDER BY id", &mut ctx);
+        assert!(outcome.error.is_none(), "{:?}", outcome.error);
+        match &outcome.results[0] {
+            StatementResult::Rows(rowset) => assert_eq!(rowset.rows.len(), 2),
+            other => panic!("expected rows, got {other:?}"),
+        }
+
+        drop(storage);
+        let _ = std::fs::remove_file(&path);
     }
 
     fn unique_temp_path(label: &str) -> PathBuf {

--- a/crates/truthdb-core/tests/slt/alter_add_column.slt
+++ b/crates/truthdb-core/tests/slt/alter_add_column.slt
@@ -113,6 +113,31 @@ SELECT id, extra FROM b WHERE tag = 'x'
 1 5
 3 5
 
+# Adding the 9th column crosses the null bitmap's byte boundary (8 → 9
+# columns grows the bitmap), with NULLs present on both sides of the ALTER.
+statement ok
+CREATE TABLE wide (c1 INT NOT NULL PRIMARY KEY, c2 INT, c3 INT, c4 INT, c5 INT, c6 INT, c7 INT, c8 INT)
+
+statement ok
+INSERT INTO wide VALUES (1, NULL, 3, NULL, 5, NULL, 7, NULL)
+
+statement ok
+ALTER TABLE wide ADD c9 INT
+
+query IIIIIIIII
+SELECT c1, c2, c3, c4, c5, c6, c7, c8, c9 FROM wide
+----
+1 NULL 3 NULL 5 NULL 7 NULL NULL
+
+statement ok
+INSERT INTO wide VALUES (2, 2, NULL, 4, NULL, 6, NULL, 8, 9)
+
+query II rowsort
+SELECT c1, c9 FROM wide
+----
+1 NULL
+2 9
+
 # A heap table (no PRIMARY KEY) rewrites the same way.
 statement ok
 CREATE TABLE h (v INT)

--- a/crates/truthdb-core/tests/slt/alter_add_column.slt
+++ b/crates/truthdb-core/tests/slt/alter_add_column.slt
@@ -1,0 +1,130 @@
+# ALTER TABLE ADD <column> (Stage 10): the catalog widens and every existing
+# row is rewritten under the new schema in one transactional statement. Old
+# rows take a FROZEN fill — NULL, or the DEFAULT evaluated at ALTER time —
+# while later INSERTs evaluate the live default per row.
+
+statement ok
+CREATE TABLE a (id INT NOT NULL PRIMARY KEY, name NVARCHAR(20))
+
+statement ok
+INSERT INTO a VALUES (1, 'one'), (2, 'two')
+
+# A nullable column: old rows read NULL.
+statement ok
+ALTER TABLE a ADD note NVARCHAR(30)
+
+query ITT rowsort
+SELECT id, name, note FROM a
+----
+1 one NULL
+2 two NULL
+
+# New inserts carry values for it; the wildcard sees the new column.
+statement ok
+INSERT INTO a VALUES (3, 'three', 'noted')
+
+query ITT rowsort
+SELECT * FROM a
+----
+1 one NULL
+2 two NULL
+3 three noted
+
+# A DEFAULT column: old rows take the frozen default, an INSERT that omits it
+# takes the live default.
+statement ok
+ALTER TABLE a ADD score INT DEFAULT 7
+
+query II rowsort
+SELECT id, score FROM a
+----
+1 7
+2 7
+3 7
+
+statement ok
+INSERT INTO a (id, name) VALUES (4, 'four')
+
+query I
+SELECT score FROM a WHERE id = 4
+----
+7
+
+# NOT NULL with DEFAULT works on a non-empty table.
+statement ok
+ALTER TABLE a ADD flag BIT NOT NULL DEFAULT 1
+
+query I
+SELECT COUNT(*) FROM a WHERE flag = 1
+----
+4
+
+# NOT NULL without DEFAULT on a non-empty table is SQL Server's 4901.
+statement error
+ALTER TABLE a ADD strict INT NOT NULL
+
+# ...but legal on an empty table.
+statement ok
+CREATE TABLE empty_t (id INT NOT NULL PRIMARY KEY)
+
+statement ok
+ALTER TABLE empty_t ADD strict INT NOT NULL
+
+# A duplicate column name is 2705.
+statement error
+ALTER TABLE a ADD name INT
+
+# Constraint-carrying additions are their own statements.
+statement error
+ALTER TABLE a ADD extra INT UNIQUE
+
+# Old rows remain updatable and deletable after the rewrite, and a UPDATE can
+# set the added column.
+statement ok
+UPDATE a SET note = 'filled' WHERE id = 1
+
+statement ok
+DELETE FROM a WHERE id = 2
+
+query ITT rowsort
+SELECT id, name, note FROM a
+----
+1 one filled
+3 three noted
+4 four NULL
+
+# An index created before the ADD still seeks correctly afterwards (index
+# entries reference schema positions the append never shifts).
+statement ok
+CREATE TABLE b (id INT NOT NULL PRIMARY KEY, tag NVARCHAR(10))
+
+statement ok
+CREATE INDEX ix_b_tag ON b (tag)
+
+statement ok
+INSERT INTO b VALUES (1, 'x'), (2, 'y'), (3, 'x')
+
+statement ok
+ALTER TABLE b ADD extra INT DEFAULT 5
+
+query II rowsort
+SELECT id, extra FROM b WHERE tag = 'x'
+----
+1 5
+3 5
+
+# A heap table (no PRIMARY KEY) rewrites the same way.
+statement ok
+CREATE TABLE h (v INT)
+
+statement ok
+INSERT INTO h VALUES (10), (20)
+
+statement ok
+ALTER TABLE h ADD label NVARCHAR(10) DEFAULT 'pad'
+
+query IT rowsort
+SELECT v, label FROM h
+----
+10 pad
+20 pad

--- a/crates/truthdb-sql/src/ast.rs
+++ b/crates/truthdb-sql/src/ast.rs
@@ -71,6 +71,8 @@ pub struct AlterTable {
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum AlterAction {
+    /// `ADD <column> <type> [NULL|NOT NULL] [DEFAULT expr] [COLLATE name]`.
+    AddColumn(ColumnDef),
     /// `ADD [CONSTRAINT name] CHECK (expr)`.
     AddCheck(CheckConstraint),
     /// `ADD [CONSTRAINT name] FOREIGN KEY (...) REFERENCES ...`.

--- a/crates/truthdb-sql/src/parser.rs
+++ b/crates/truthdb-sql/src/parser.rs
@@ -959,17 +959,27 @@ impl Parser {
         let (action, end) = match self.peek_keyword().as_deref() {
             Some("ADD") => {
                 self.bump();
-                // `ADD [CONSTRAINT name] (CHECK | FOREIGN KEY ...)`. ADD column
-                // arrives in a later part.
-                let name = self.parse_optional_constraint_name()?;
-                if self.peek_keyword().as_deref() == Some("FOREIGN") {
-                    let fk = self.parse_foreign_key(name)?;
-                    let end = fk.span;
-                    (AlterAction::AddForeignKey(fk), end)
-                } else {
-                    let check = self.parse_check_constraint(name)?;
-                    let end = check.span;
-                    (AlterAction::AddCheck(check), end)
+                // `ADD [CONSTRAINT name] (CHECK | FOREIGN KEY ...)`, or
+                // `ADD <column> <type> ...` — T-SQL has no COLUMN keyword
+                // here, so anything but a constraint introducer is a column.
+                match self.peek_keyword().as_deref() {
+                    Some("CONSTRAINT") | Some("FOREIGN") | Some("CHECK") => {
+                        let name = self.parse_optional_constraint_name()?;
+                        if self.peek_keyword().as_deref() == Some("FOREIGN") {
+                            let fk = self.parse_foreign_key(name)?;
+                            let end = fk.span;
+                            (AlterAction::AddForeignKey(fk), end)
+                        } else {
+                            let check = self.parse_check_constraint(name)?;
+                            let end = check.span;
+                            (AlterAction::AddCheck(check), end)
+                        }
+                    }
+                    _ => {
+                        let column = self.parse_column_def()?;
+                        let end = column.span;
+                        (AlterAction::AddColumn(column), end)
+                    }
                 }
             }
             Some("DROP") => {


### PR DESCRIPTION
## What

`ALTER TABLE ADD <column>` works: nullable, `NOT NULL`, `DEFAULT`, and `COLLATE` forms, on clustered and heap tables, with old rows readable afterwards. This closes Stage 10's ADD-column gap and the exit bullet's uncovered old-row-read case.

## Design finding (recorded for the plan)

The bullet prescribed "metadata-only when nullable/defaulted". That fails the code audit: the row codec is positional — the null bitmap, fixed section, and var offsets all derive their lengths from the schema, and rows carry no version stamp — so an old row decoded under a widened schema misreads from the bitmap on. The honest implementation rewrites the table in one transactional statement under the ALTER's exclusive lock: decode each row under the old schema, append the frozen fill (NULL, or the DEFAULT evaluated once at ALTER time, as SQL Server freezes it), re-encode, update the catalog. Keys and index entries are untouched — appending shifts no schema index, tree rewrites are in-place by key, heap RIDs are stable. Later INSERTs evaluate the live default text per row.

## Semantics

NOT NULL without DEFAULT on a non-empty table answers 4901 (gated by an authoritative one-row probe under the held lock, not the statistics counter — an under-count would otherwise admit NULL fills into a NOT NULL column); duplicate names answer 2705; constraint-carrying additions are directed to their own ALTER TABLE ADD CONSTRAINT statements; character columns inherit the database default collation by name, exactly as CREATE TABLE records it.

## Review

Adversarial review in a detached worktree: no correctness, atomicity, or crash-safety defect. The highest-risk item — `ColumnType::name()` round-tripping through the spec parser, where a failure would corrupt the table permanently — was verified variant-by-variant, and is structurally closed anyway (`def.schema()?` runs on the exact def before it persists). Row growth was probed live at both caps (clean SqlError past MAX_ROW_BYTES; a mid-statement tree-cell failure rolls the whole ALTER back with the table readable). Fixed from the findings: the counter-based 4901 gate (now a real probe), a doc-comment splice, and a missing 8→9-column null-bitmap-growth case in the slt matrix. Noted: the rewrite materializes the table in memory like the index-build precedent, and READ UNCOMMITTED scans racing DDL are a pre-existing class.

## Tests

slt matrix: old-row reads across nullable/DEFAULT/NOT NULL DEFAULT, frozen-vs-live defaults, 4901, empty-table NOT NULL, duplicate/constraint errors, index seeks after ADD, heap tables, UPDATE/DELETE of rewritten rows, and the null-bitmap byte-boundary crossing. Rust test pins durability across a real WAL-recovery reopen and atomicity under fault injection landing mid-rewrite. Teeth-checked: a catalog-only ALTER fails the old-row reads with error 1701. Full workspace: 477 passed, 0 failed; fmt and clippy (-D warnings) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)