### PR TITLE
Stage 11: correlated subqueries in the SELECT list, HAVING, and derived tables

### DIFF
--- a/crates/truthdb-core/src/rel/aggregate.rs
+++ b/crates/truthdb-core/src/rel/aggregate.rs
@@ -86,6 +86,26 @@ impl truthdb_sql::eval::ColumnResolver for SynthScope {
     }
 }
 
+/// Resolves an outer reference from a correlated HAVING/projection subquery
+/// to a group-key position — binding ONLY when the reference and a bare-
+/// column group key name the SAME source column of this query's FROM. A
+/// qualified reference to a different table that merely shares the bare name
+/// stays unresolved (and errors inside the subquery, as SQL Server rejects
+/// non-grouped outer references).
+fn group_key_resolver<'a>(
+    select: &'a Select,
+    resolver: &'a JoinScope,
+) -> impl Fn(&str) -> Option<usize> + 'a {
+    use truthdb_sql::eval::ColumnResolver;
+    move |name: &str| {
+        let source = resolver.resolve(name)?;
+        select.group_by.iter().position(|key| match &key.kind {
+            truthdb_sql::ast::ExprKind::Column(n) => resolver.resolve(&n.value) == Some(source),
+            _ => false,
+        })
+    }
+}
+
 /// One aggregate to compute over each group.
 struct AggSpec {
     func: AggFunc,
@@ -213,26 +233,12 @@ fn aggregate_partition(
             // inside the subquery, as SQL Server rejects it too.
             let bound;
             let having = if crate::rel::expr_has_subquery(having) {
-                // The synth scope's names are synthetic ($gk0, $agg0) — an
-                // outer reference binds against the ORIGINAL group-by
-                // expressions instead: a bare-column key at position i is
-                // group_row[i]. Qualified and bare spellings match either way
-                // (the qualifier can only name this query's own FROM, which
-                // is where the grouping column came from).
-                let resolve = |name: &str| -> Option<usize> {
-                    let bare = name.rsplit_once('.').map(|(_, b)| b).unwrap_or(name);
-                    select.group_by.iter().position(|key| match &key.kind {
-                        truthdb_sql::ast::ExprKind::Column(n) => {
-                            let key_bare =
-                                n.value.rsplit_once('.').map(|(_, b)| b).unwrap_or(&n.value);
-                            n.value.eq_ignore_ascii_case(name)
-                                || key_bare.eq_ignore_ascii_case(bare)
-                        }
-                        _ => false,
-                    })
-                };
                 bound = crate::rel::substitute_correlated_in_expr(
-                    storage, having, &resolve, &group_row, eval_ctx,
+                    storage,
+                    having,
+                    &group_key_resolver(select, resolver),
+                    &group_row,
+                    eval_ctx,
                 )?;
                 &bound
             } else {
@@ -253,6 +259,21 @@ fn aggregate_partition(
         }
         let mut row = Vec::with_capacity(out_exprs.len());
         for expr in out_exprs {
+            // A subquery here is correlated to a grouping column (the
+            // rewrite left it): bind the group row, exactly as HAVING does.
+            let bound;
+            let expr = if crate::rel::expr_has_subquery(expr) {
+                bound = crate::rel::substitute_correlated_in_expr(
+                    storage,
+                    expr,
+                    &group_key_resolver(select, resolver),
+                    &group_row,
+                    eval_ctx,
+                )?;
+                &bound
+            } else {
+                expr
+            };
             row.push(eval::eval(expr, &group_row, synth, eval_ctx)?);
         }
         out_rows.push(row);
@@ -555,8 +576,8 @@ fn rewrite(expr: &Expr, group_by: &[Expr], aggs: &mut Vec<AggSpec>) -> Result<Ex
         | ExprKind::Literal(_)
         | ExprKind::GlobalVar(_)
         | ExprKind::LocalVar(_) => expr.kind.clone(),
-        // Subqueries are rewritten to literals before aggregation runs; clone
-        // defensively (evaluation would reject any that slipped through).
+        // A subquery surviving to here is correlated to a grouping column;
+        // the per-group loops bind and evaluate it (HAVING and projection).
         ExprKind::Subquery(_) | ExprKind::Exists(_) | ExprKind::InSubquery { .. } => {
             expr.kind.clone()
         }

--- a/crates/truthdb-core/src/rel/aggregate.rs
+++ b/crates/truthdb-core/src/rel/aggregate.rs
@@ -158,7 +158,7 @@ pub fn execute(
     let input_bytes: usize = rows.iter().map(|r| super::approx_row_bytes(r)).sum();
     let out_rows = if select.group_by.is_empty() || input_bytes <= budget {
         aggregate_partition(
-            select, rows, types, resolver, eval_ctx, &aggs, &having, &out_exprs, &synth,
+            storage, select, rows, types, resolver, eval_ctx, &aggs, &having, &out_exprs, &synth,
         )?
     } else {
         grace_hash_aggregate(
@@ -185,6 +185,7 @@ pub fn execute(
 /// grace-hash partition.
 #[allow(clippy::too_many_arguments)]
 fn aggregate_partition(
+    storage: &crate::storage::Storage,
     select: &Select,
     rows: &[Vec<Datum>],
     types: &[ColumnType],
@@ -205,6 +206,38 @@ fn aggregate_partition(
             )?);
         }
         if let Some(having) = having {
+            // A subquery still present in HAVING is correlated to this
+            // query's grouping columns (the rewrite pass left it): bind the
+            // group row's values in, making it uncorrelated for this group.
+            // A reference to a non-grouped column stays unresolved and errors
+            // inside the subquery, as SQL Server rejects it too.
+            let bound;
+            let having = if crate::rel::expr_has_subquery(having) {
+                // The synth scope's names are synthetic ($gk0, $agg0) — an
+                // outer reference binds against the ORIGINAL group-by
+                // expressions instead: a bare-column key at position i is
+                // group_row[i]. Qualified and bare spellings match either way
+                // (the qualifier can only name this query's own FROM, which
+                // is where the grouping column came from).
+                let resolve = |name: &str| -> Option<usize> {
+                    let bare = name.rsplit_once('.').map(|(_, b)| b).unwrap_or(name);
+                    select.group_by.iter().position(|key| match &key.kind {
+                        truthdb_sql::ast::ExprKind::Column(n) => {
+                            let key_bare =
+                                n.value.rsplit_once('.').map(|(_, b)| b).unwrap_or(&n.value);
+                            n.value.eq_ignore_ascii_case(name)
+                                || key_bare.eq_ignore_ascii_case(bare)
+                        }
+                        _ => false,
+                    })
+                };
+                bound = crate::rel::substitute_correlated_in_expr(
+                    storage, having, &resolve, &group_row, eval_ctx,
+                )?;
+                &bound
+            } else {
+                having
+            };
             match eval::eval(having, &group_row, synth, eval_ctx)? {
                 SqlValue::Bool(true) => {}
                 SqlValue::Bool(false) | SqlValue::Null => continue,
@@ -273,7 +306,7 @@ fn grace_hash_aggregate(
             part_rows.push(row);
         }
         out_rows.extend(aggregate_partition(
-            select, &part_rows, types, resolver, eval_ctx, aggs, having, out_exprs, synth,
+            storage, select, &part_rows, types, resolver, eval_ctx, aggs, having, out_exprs, synth,
         )?);
     }
     Ok(out_rows)

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -4609,6 +4609,70 @@ fn is_correlated(storage: &Storage, subquery: &Select, outer: &JoinScope) -> boo
     correlated || from_has_correlated_derived(storage, subquery.from.as_ref(), outer)
 }
 
+/// Calls `f` on every column reference inside an AGGREGATE argument anywhere
+/// in the select's own clauses (not descending into nested subqueries).
+fn select_aggregate_arg_refs(select: &Select, f: &mut impl FnMut(&Name)) {
+    fn walk(expr: &Expr, f: &mut impl FnMut(&Name)) {
+        match &expr.kind {
+            ExprKind::Aggregate { arg: Some(a), .. } => expr_column_refs(a, f),
+            ExprKind::Aggregate { arg: None, .. } => {}
+            ExprKind::Unary { expr: e, .. }
+            | ExprKind::IsNull { expr: e, .. }
+            | ExprKind::Cast { expr: e, .. } => walk(e, f),
+            ExprKind::Binary { left, right, .. } => {
+                walk(left, f);
+                walk(right, f);
+            }
+            ExprKind::Like {
+                expr: e, pattern, ..
+            } => {
+                walk(e, f);
+                walk(pattern, f);
+            }
+            ExprKind::InList { expr: e, list, .. } => {
+                walk(e, f);
+                list.iter().for_each(|x| walk(x, f));
+            }
+            ExprKind::Between {
+                expr: e, low, high, ..
+            } => {
+                walk(e, f);
+                walk(low, f);
+                walk(high, f);
+            }
+            ExprKind::Function { args, .. } => args.iter().for_each(|x| walk(x, f)),
+            ExprKind::Case {
+                operand,
+                branches,
+                else_result,
+            } => {
+                if let Some(o) = operand {
+                    walk(o, f);
+                }
+                for (w, r) in branches {
+                    walk(w, f);
+                    walk(r, f);
+                }
+                if let Some(e) = else_result {
+                    walk(e, f);
+                }
+            }
+            _ => {}
+        }
+    }
+    if let Some(w) = &select.where_clause {
+        walk(w, f);
+    }
+    for item in &select.items {
+        if let SelectItem::Expr { expr, .. } = item {
+            walk(expr, f);
+        }
+    }
+    if let Some(h) = &select.having {
+        walk(h, f);
+    }
+}
+
 /// Whether any derived-table body in a FROM tree is correlated to `outer`.
 fn from_has_correlated_derived(
     storage: &Storage,
@@ -4955,6 +5019,19 @@ fn substitute_subquery_outer_refs(
             span: name.span,
         })
     };
+    // An outer reference INSIDE an aggregate argument has outer-aggregate
+    // semantics in SQL Server (the aggregate computes over the OUTER group);
+    // substituting a per-row literal would silently compute something else.
+    // Bail — the subquery runs unchanged and errors cleanly.
+    let mut outer_in_agg = false;
+    select_aggregate_arg_refs(subquery, &mut |name| {
+        if !inner.matches_any(&name.value) && outer(&name.value).is_some() {
+            outer_in_agg = true;
+        }
+    });
+    if outer_in_agg {
+        return None;
+    }
     let mut out = subquery.clone();
     out.where_clause = out
         .where_clause

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -4233,10 +4233,11 @@ fn rewrite_select_subqueries(
     select: &Select,
     eval_ctx: &EvalContext,
 ) -> Result<Select, SqlError> {
-    // The columns this query exposes to a correlated subquery in its WHERE. A
-    // correlated WHERE subquery is left un-evaluated here (the per-row loop runs
-    // it with the outer row bound); other positions (SELECT list, HAVING, GROUP
-    // BY, ORDER BY) do not support correlation and evaluate as before.
+    // The columns this query exposes to a correlated subquery. A correlated
+    // subquery in the WHERE or the SELECT list is left un-evaluated here (the
+    // per-row loops bind the outer row), and one in HAVING likewise (the
+    // per-group loop binds the group row). GROUP BY and ORDER BY do not
+    // support correlation and evaluate as before.
     let self_scope = select
         .from
         .as_ref()
@@ -4250,7 +4251,7 @@ fn rewrite_select_subqueries(
         .iter()
         .map(|item| match item {
             SelectItem::Expr { expr, alias } => Ok(SelectItem::Expr {
-                expr: rewrite_subqueries(storage, expr, eval_ctx, None)?,
+                expr: rewrite_subqueries(storage, expr, eval_ctx, self_scope.as_ref())?,
                 alias: alias.clone(),
             }),
             other => Ok(other.clone()),
@@ -4264,7 +4265,7 @@ fn rewrite_select_subqueries(
     let having = select
         .having
         .as_ref()
-        .map(|e| rewrite_subqueries(storage, e, eval_ctx, None))
+        .map(|e| rewrite_subqueries(storage, e, eval_ctx, self_scope.as_ref()))
         .transpose()?;
     let group_by = select
         .group_by
@@ -4537,7 +4538,42 @@ fn from_column_names(storage: &Storage, from: &TableRef) -> Option<Vec<(Option<S
             cols.extend(from_column_names(storage, right)?);
             Some(cols)
         }
-        TableRef::Derived { .. } => None,
+        TableRef::Derived { subquery, alias } => {
+            let mut cols = Vec::new();
+            for item in &subquery.items {
+                match item {
+                    SelectItem::Expr { expr, alias: a } => {
+                        let name = a
+                            .as_ref()
+                            .map(|n| n.value.clone())
+                            .or_else(|| bare_column_name(expr))?;
+                        cols.push((Some(alias.value.clone()), name));
+                    }
+                    SelectItem::Wildcard => {
+                        let inner = from_column_names(storage, subquery.from.as_ref()?)?;
+                        cols.extend(
+                            inner
+                                .into_iter()
+                                .map(|(_, n)| (Some(alias.value.clone()), n)),
+                        );
+                    }
+                    SelectItem::QualifiedWildcard(q) => {
+                        let inner = from_column_names(storage, subquery.from.as_ref()?)?;
+                        cols.extend(
+                            inner
+                                .into_iter()
+                                .filter(|(qu, _)| {
+                                    qu.as_deref()
+                                        .is_some_and(|x| x.eq_ignore_ascii_case(&q.value))
+                                })
+                                .map(|(_, n)| (Some(alias.value.clone()), n)),
+                        );
+                    }
+                    SelectItem::Assign { .. } => return None,
+                }
+            }
+            Some(cols)
+        }
     }
 }
 
@@ -4568,7 +4604,25 @@ fn is_correlated(storage: &Storage, subquery: &Select, outer: &JoinScope) -> boo
             correlated = true;
         }
     });
-    correlated
+    // A correlated reference may live inside a derived table's body — its own
+    // clauses resolve in the derived scope, so the walk above never sees it.
+    correlated || from_has_correlated_derived(storage, subquery.from.as_ref(), outer)
+}
+
+/// Whether any derived-table body in a FROM tree is correlated to `outer`.
+fn from_has_correlated_derived(
+    storage: &Storage,
+    from: Option<&TableRef>,
+    outer: &JoinScope,
+) -> bool {
+    match from {
+        None | Some(TableRef::Table { .. }) => false,
+        Some(TableRef::Join { left, right, .. }) => {
+            from_has_correlated_derived(storage, Some(left), outer)
+                || from_has_correlated_derived(storage, Some(right), outer)
+        }
+        Some(TableRef::Derived { subquery, .. }) => is_correlated(storage, subquery, outer),
+    }
 }
 
 /// Calls `f` on every column reference in a select's own clauses (WHERE, SELECT
@@ -4887,7 +4941,7 @@ fn map_expr_columns(expr: &Expr, f: &impl Fn(&Name) -> Option<Expr>) -> Expr {
 fn substitute_subquery_outer_refs(
     storage: &Storage,
     subquery: &Select,
-    outer: &JoinScope,
+    outer: &dyn Fn(&str) -> Option<usize>,
     outer_row: &[SqlValue],
 ) -> Option<Select> {
     let inner = subquery_inner_scope(storage, subquery)?;
@@ -4895,7 +4949,7 @@ fn substitute_subquery_outer_refs(
         if inner.matches_any(&name.value) {
             return None; // the subquery's own column wins (even if ambiguous)
         }
-        let index = outer.resolve(&name.value)?;
+        let index = outer(&name.value)?;
         Some(Expr {
             kind: ExprKind::Literal(outer_row.get(index)?.clone()),
             span: name.span,
@@ -4934,7 +4988,34 @@ fn substitute_subquery_outer_refs(
             descending: o.descending,
         })
         .collect();
+    // A correlated reference INSIDE a derived table's body lives in `from`,
+    // not in any expression above — descend and substitute there too. The
+    // recursive call's own inner-scope check handles shadowing.
+    if let Some(from) = out.from.as_mut() {
+        substitute_from_outer_refs(storage, from, outer, outer_row)?;
+    }
     Some(out)
+}
+
+/// Substitutes outer references inside every derived-table body of a FROM
+/// tree. `None` when any derived body's scope cannot be determined.
+fn substitute_from_outer_refs(
+    storage: &Storage,
+    from: &mut TableRef,
+    outer: &dyn Fn(&str) -> Option<usize>,
+    outer_row: &[SqlValue],
+) -> Option<()> {
+    match from {
+        TableRef::Table { .. } => Some(()),
+        TableRef::Join { left, right, .. } => {
+            substitute_from_outer_refs(storage, left, outer, outer_row)?;
+            substitute_from_outer_refs(storage, right, outer, outer_row)
+        }
+        TableRef::Derived { subquery, .. } => {
+            **subquery = substitute_subquery_outer_refs(storage, subquery, outer, outer_row)?;
+            Some(())
+        }
+    }
 }
 
 /// Evaluates each correlated subquery in `expr` against `outer_row` (binding the
@@ -4943,7 +5024,7 @@ fn substitute_subquery_outer_refs(
 fn substitute_correlated_in_expr(
     storage: &Storage,
     expr: &Expr,
-    outer: &JoinScope,
+    outer: &dyn Fn(&str) -> Option<usize>,
     outer_row: &[SqlValue],
     eval_ctx: &EvalContext,
 ) -> Result<Expr, SqlError> {
@@ -5163,7 +5244,11 @@ fn exec_select(
                 let bound;
                 let predicate = if where_correlated {
                     bound = substitute_correlated_in_expr(
-                        storage, predicate, &resolver, &sql_row, eval_ctx,
+                        storage,
+                        predicate,
+                        &|name| resolver.resolve(name),
+                        &sql_row,
+                        eval_ctx,
                     )?;
                     &bound
                 } else {
@@ -5204,6 +5289,7 @@ fn exec_select(
             aggregate::execute(storage, select, &rows, &types, &resolver, eval_ctx)?
         } else {
             project(
+                storage,
                 &select.items,
                 &source.columns,
                 &rows,
@@ -5257,6 +5343,7 @@ fn exec_select(
     }
 
     project(
+        storage,
         &select.items,
         &source.columns,
         &rows,
@@ -6350,6 +6437,7 @@ fn read_head(
 }
 
 fn project(
+    storage: &Storage,
     items: &[SelectItem],
     source_columns: &[ResultColumn],
     rows: &[Vec<Datum>],
@@ -6432,9 +6520,26 @@ fn project(
                 }
             }
             Proj::Expr { name, expr } => {
-                // Evaluate the column for every row, then infer one type.
+                // Evaluate the column for every row, then infer one type. A
+                // subquery still present here is correlated (the rewrite pass
+                // left it for the per-row bind): substitute the outer row's
+                // values in, making it uncorrelated for that row.
+                let correlated = expr_has_subquery(expr);
                 let mut values = Vec::with_capacity(rows.len());
                 for row in &row_sql {
+                    let bound;
+                    let expr = if correlated {
+                        bound = substitute_correlated_in_expr(
+                            storage,
+                            expr,
+                            &|name| resolver.resolve(name),
+                            row,
+                            eval_ctx,
+                        )?;
+                        &bound
+                    } else {
+                        expr
+                    };
                     values.push(eval::eval(expr, row, resolver, eval_ctx)?);
                 }
                 let column_type = value::infer_type(&values);

--- a/crates/truthdb-core/tests/slt/correlated_subqueries.slt
+++ b/crates/truthdb-core/tests/slt/correlated_subqueries.slt
@@ -87,3 +87,69 @@ SELECT name FROM cust WHERE EXISTS (SELECT 1 FROM ord WHERE ord.cust_id = cust.i
 ----
 alice
 bob
+
+# ---- Correlation beyond the WHERE clause (Stage 11) ---------------------
+# State here: cust = (1,alice)(2,bob)(3,carol)(4,dave);
+# ord = (10,1,100)(11,1,250)(12,2,50)(13,NULL,5).
+
+# A correlated scalar subquery in the SELECT list — the most common
+# real-world form. dave (no orders) reads NULL; the NULL-cust_id order
+# matches nobody.
+query TI rowsort
+SELECT name, (SELECT SUM(amount) FROM ord WHERE ord.cust_id = cust.id) AS total FROM cust
+----
+alice 350
+bob 50
+carol NULL
+dave NULL
+
+# Correlated EXISTS inside a CASE in the SELECT list.
+query TT rowsort
+SELECT name, CASE WHEN EXISTS (SELECT 1 FROM ord WHERE ord.cust_id = cust.id) THEN 'yes' ELSE 'no' END AS has_orders FROM cust
+----
+alice yes
+bob yes
+carol no
+dave no
+
+# Inner-shadows-outer holds in the SELECT list too: the subquery's own `id`
+# wins, so this counts orders whose id equals their own cust_id (none).
+query TI rowsort
+SELECT name, (SELECT COUNT(*) FROM ord WHERE cust_id = id) AS n FROM cust
+----
+alice 0
+bob 0
+carol 0
+dave 0
+
+# A correlated subquery in HAVING, referencing a grouping column.
+query II rowsort
+SELECT cust_id, COUNT(*) FROM ord WHERE cust_id IS NOT NULL GROUP BY cust_id
+HAVING EXISTS (SELECT 1 FROM cust WHERE cust.id = ord.cust_id AND cust.name = 'alice')
+----
+1 2
+
+# A correlated scalar in HAVING compared against an aggregate.
+query I
+SELECT cust_id FROM ord WHERE cust_id IS NOT NULL GROUP BY cust_id
+HAVING COUNT(*) > (SELECT COUNT(*) FROM cust WHERE cust.id = ord.cust_id)
+----
+1
+
+# A correlated reference inside a DERIVED TABLE's body, within a WHERE
+# subquery: the derived table's inner query reads the outer cust.id.
+query T rowsort
+SELECT name FROM cust
+WHERE EXISTS (SELECT 1 FROM (SELECT amount FROM ord WHERE ord.cust_id = cust.id) d WHERE d.amount > 200)
+----
+alice
+
+# The derived table's own columns shadow the outer scope inside its body's
+# consumers: d.amount belongs to d, not to any outer table.
+query TI rowsort
+SELECT name, (SELECT MAX(d.amount) FROM (SELECT amount FROM ord WHERE ord.cust_id = cust.id) d) AS top_amount FROM cust
+----
+alice 250
+bob 50
+carol NULL
+dave NULL

--- a/crates/truthdb-core/tests/slt/correlated_subqueries.slt
+++ b/crates/truthdb-core/tests/slt/correlated_subqueries.slt
@@ -153,3 +153,45 @@ alice 250
 bob 50
 carol NULL
 dave NULL
+
+# ---- Review-pinned cases -------------------------------------------------
+
+# A correlated scalar in the SELECT list of an AGGREGATED query: correlation
+# on the grouping column (SQL Server accepts this).
+query IT rowsort
+SELECT cust_id, (SELECT name FROM cust WHERE cust.id = ord.cust_id) AS who
+FROM ord WHERE cust_id IS NOT NULL GROUP BY cust_id
+----
+1 alice
+2 bob
+
+# A qualified reference to a NON-GROUPED sibling column that merely shares
+# the bare name with a group key must NOT silently bind — it errors, as SQL
+# Server rejects non-grouped outer references.
+statement ok
+CREATE TABLE gt (id INT NOT NULL PRIMARY KEY, x INT)
+
+statement ok
+CREATE TABLE gs (id INT NOT NULL PRIMARY KEY, x INT)
+
+statement ok
+CREATE TABLE gu (y INT)
+
+statement ok
+INSERT INTO gt VALUES (1,10),(2,20),(3,20)
+
+statement ok
+INSERT INTO gs VALUES (1,99),(2,77),(3,66)
+
+statement ok
+INSERT INTO gu VALUES (30),(10)
+
+statement error
+SELECT gt.x, COUNT(*) FROM gt JOIN gs ON gs.id = gt.id GROUP BY gt.x
+HAVING EXISTS (SELECT 1 FROM gu WHERE gu.y = gs.x)
+
+# An outer reference INSIDE an aggregate argument has outer-aggregate
+# semantics in SQL Server; substituting a literal would silently compute
+# something else — it errors instead.
+statement error
+SELECT gt.x FROM gt GROUP BY gt.x HAVING (SELECT SUM(gt.x) FROM gu) = 20


### PR DESCRIPTION
## What

Correlation was wired only into the WHERE loop (#73); the most common real-world form — a correlated scalar in the SELECT list — errored 207, as did HAVING correlation and correlated references inside derived-table bodies. All three now bind through the same per-row/per-group literal-substitution machinery, including the grouped-projection case (`SELECT k, (SELECT ... WHERE x = t.k) FROM t GROUP BY k`).

## How

The rewrite pass leaves correlated subqueries in SELECT items and HAVING (as it already did for WHERE); `project()` substitutes the outer row per row, and the aggregate path substitutes the group row per group for both HAVING and the projection. Group-key references bind by **source identity** — the reference and a bare-column group key must resolve to the same source column of the query's FROM — so a qualified reference to a non-grouped sibling column sharing a bare name stays unresolved and errors, as SQL Server rejects it. An outer reference inside an aggregate argument (outer-aggregate semantics in SQL Server) makes the substitution bail to a clean error rather than silently computing over literals. `from_column_names` now derives derived-table columns from the body's projection; the substitution descends into derived bodies in the FROM tree; and `is_correlated` checks derived bodies too — previously such subqueries were judged uncorrelated and eagerly executed into 207.

## Review

Adversarial review in a detached worktree found two error-to-silent-wrong-result regressions in the first cut (the bare-name HAVING binding and the aggregate-argument substitution — both constructed and run against SQL Server semantics) plus the uncovered grouped-projection case; all three are fixed and pinned in the slt matrix with the review's own scenarios. Clean checks included hot-path cost (one boolean per expression, nothing per row when uncorrelated), no regression for ORDER BY/GROUP BY positions, nested skip-level correlation (pre-existing limitation, unchanged), view-FROM cases, and assignment SELECTs (which now work through the Expr-item conversion).

## Tests

slt: correlated scalar and EXISTS-in-CASE in the SELECT list, NULL correlation, inner-shadows-outer in the new positions, HAVING via EXISTS and scalar-vs-aggregate with qualified references, grouped projection, correlation inside derived bodies, derived-alias shadowing, and the two must-error regression cases. Teeth-checked leg by leg (dropping the item scope, the derived-body check, or the HAVING substitution each fails its cases). Full workspace: 477 passed, 0 failed; fmt and clippy (-D warnings) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)