### PR TITLE
Stage 11: EXEC sp_executesql as T-SQL text

### DIFF
--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -15,9 +15,9 @@ mod value;
 
 use truthdb_sql::ast::{
     AlterAction, AlterTable, CheckConstraint, ColumnDef, CreateIndex, CreateTable, CreateView,
-    DataType, Declaration, Delete, DropIndex, DropTable, DropView, Expr, ExprKind, ForeignKey,
-    Insert, InsertSource, IsolationLevel, JoinKind, Name, OrderItem, Select, SelectItem,
-    SetStatement, Statement, TableRef, Update,
+    DataType, Declaration, Delete, DropIndex, DropTable, DropView, ExecStatement, Expr, ExprKind,
+    ForeignKey, Insert, InsertSource, IsolationLevel, JoinKind, Name, OrderItem, Select,
+    SelectItem, SetStatement, Statement, TableRef, Update,
 };
 use truthdb_sql::collation::CollationSensitivity;
 use truthdb_sql::error::SqlError;
@@ -579,6 +579,155 @@ impl BatchRun<'_> {
 /// batch policy. Returns `Err` when the enclosing context must stop: a cancel,
 /// an error that propagates to a `CATCH`, or a dooming/terminating error at the
 /// top level.
+/// The inner SQL text of an `EXEC sp_executesql N'...'` whose statement
+/// argument is a string LITERAL — the analyzable case. `None` for any other
+/// procedure or a non-literal statement argument.
+fn exec_literal_sql(exec: &ExecStatement) -> Option<String> {
+    if !strip_schema(&exec.proc.value).eq_ignore_ascii_case("sp_executesql") {
+        return None;
+    }
+    let stmt = exec
+        .args
+        .iter()
+        .find(|a| {
+            a.name.as_ref().is_some_and(|n| {
+                n.value.eq_ignore_ascii_case("stmt") || n.value.eq_ignore_ascii_case("statement")
+            })
+        })
+        .or_else(|| exec.args.first().filter(|a| a.name.is_none()))?;
+    match &stmt.value.kind {
+        ExprKind::Str(text) => Some(text.clone()),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+thread_local! {
+    /// Test hook mirroring EXEC_DEPTH assertions.
+    static EXEC_DEPTH_SEEN: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
+}
+
+thread_local! {
+    /// Nesting depth of EXEC inner batches on this worker (SQL Server caps
+    /// procedure nesting at 32, error 217).
+    static EXEC_DEPTH: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
+}
+
+/// Runs `EXEC sp_executesql @stmt [, @params, values...]`: evaluates the
+/// arguments against the CURRENT variables, then runs the inner text as its
+/// own batch scope — fresh variables seeded from the declared parameters
+/// (inner DECLAREs do not leak out; outer variables are not visible inside),
+/// sharing the transaction context. Each inner statement emits its own
+/// events, exactly like a top-level statement. Any other procedure answers
+/// 2812, the same as the RPC path.
+fn run_exec(
+    storage: &Storage,
+    exec: &ExecStatement,
+    txn_ctx: &mut TxnContext,
+    run: &mut BatchRun<'_>,
+    in_try: bool,
+) -> Result<(), SqlError> {
+    if !strip_schema(&exec.proc.value).eq_ignore_ascii_case("sp_executesql") {
+        return Err(SqlError::new(
+            2812,
+            16,
+            62,
+            format!("Could not find stored procedure '{}'.", exec.proc.value),
+        )
+        .at(exec.proc.span));
+    }
+    let eval_ctx = txn_ctx.eval_context();
+    let mut positional = Vec::new();
+    let mut named: Vec<(String, SqlValue)> = Vec::new();
+    for arg in &exec.args {
+        let value = eval_constant(&arg.value, &eval_ctx)?;
+        match &arg.name {
+            Some(n) => named.push((n.value.clone(), value)),
+            None => positional.push(value),
+        }
+    }
+    let take_named = |named: &mut Vec<(String, SqlValue)>, keys: &[&str]| -> Option<SqlValue> {
+        let index = named
+            .iter()
+            .position(|(n, _)| keys.iter().any(|k| n.eq_ignore_ascii_case(k)))?;
+        Some(named.remove(index).1)
+    };
+    let mut positional = positional.into_iter();
+    let stmt = take_named(&mut named, &["stmt", "statement"])
+        .or_else(|| positional.next())
+        .ok_or_else(|| {
+            SqlError::new(
+                214,
+                16,
+                2,
+                "Procedure expects parameter '@statement' of type 'ntext/nchar/nvarchar'.",
+            )
+        })?;
+    let SqlValue::Str(sql) = stmt else {
+        return Err(SqlError::new(
+            214,
+            16,
+            2,
+            "Procedure expects parameter '@statement' of type 'ntext/nchar/nvarchar'.",
+        ));
+    };
+    let decls =
+        match take_named(&mut named, &["params", "parameters"]).or_else(|| positional.next()) {
+            Some(SqlValue::Str(d)) => d,
+            Some(SqlValue::Null) | None => String::new(),
+            Some(_) => {
+                return Err(SqlError::new(
+                    214,
+                    16,
+                    3,
+                    "Procedure expects parameter '@params' of type 'ntext/nchar/nvarchar'.",
+                ));
+            }
+        };
+    // Bind values: named ones by their own names, positional ones from the
+    // declaration list, exactly as the RPC path binds unnamed wire values.
+    let names = decl_names(&decls);
+    let mut seeded: Vec<(String, SqlValue)> = named;
+    for (i, value) in positional.enumerate() {
+        let Some(name) = names.get(i) else {
+            return Err(SqlError::new(
+                8144,
+                16,
+                2,
+                "Procedure or function has too many arguments specified.",
+            ));
+        };
+        seeded.push((name.clone(), value));
+    }
+    let statements = truthdb_sql::parse(&sql)?;
+
+    // The inner batch is its own variable scope, on the shared transaction.
+    let outer_vars = std::mem::take(&mut txn_ctx.variables);
+    for (name, value) in seeded {
+        let key = name.trim_start_matches('@').to_ascii_lowercase();
+        let column_type = value::infer_type(std::slice::from_ref(&value));
+        txn_ctx.variables.insert(key, (column_type, value));
+    }
+    let depth = EXEC_DEPTH.with(|d| {
+        let v = d.get() + 1;
+        d.set(v);
+        v
+    });
+    let result = if depth > 32 {
+        Err(SqlError::new(
+            217,
+            16,
+            1,
+            "Maximum stored procedure, function, trigger, or view nesting level exceeded (limit 32).",
+        ))
+    } else {
+        run_block(storage, &statements, txn_ctx, run, in_try)
+    };
+    EXEC_DEPTH.with(|d| d.set(d.get() - 1));
+    txn_ctx.variables = outer_vars;
+    result
+}
+
 fn run_block(
     storage: &Storage,
     statements: &[Statement],
@@ -590,6 +739,35 @@ fn run_block(
         // A TDS Attention (cancel) aborts the batch before the next statement.
         // It is never catchable — it propagates straight out, past any TRY.
         check_cancelled()?;
+        if let Statement::Exec(exec) = statement {
+            // The inner statements flow through `run_block` recursion, whose
+            // own loop applies the per-statement flush and commit flag — the
+            // same shape as TRY/CATCH dispatch. Errors take the ordinary
+            // statement path: cancels and durability failures propagate, a
+            // TRY transfers to CATCH, XACT_ABORT OFF continues the batch.
+            match run_exec(storage, exec, txn_ctx, run, in_try) {
+                Ok(()) => {}
+                Err(error) if error.number == CANCEL_ERROR => return Err(error),
+                Err(error) if run.durability_failed => return Err(error),
+                Err(error) if in_try => {
+                    run.abort_open_rowset(txn_ctx.in_txn());
+                    return Err(error);
+                }
+                Err(error) => {
+                    let dooms = txn_ctx.xact_abort || error.level >= XACT_ABORT_SEVERITY;
+                    if txn_ctx.in_txn() && !dooms {
+                        run.abort_open_rowset(txn_ctx.in_txn());
+                        run.last_error = Some(error);
+                        continue;
+                    }
+                    if txn_ctx.in_txn() {
+                        txn_ctx.doomed = true;
+                    }
+                    return Err(error);
+                }
+            }
+            continue;
+        }
         if let Statement::TryCatch {
             try_block,
             catch_block,
@@ -828,6 +1006,8 @@ fn produces_rowset(statement: &Statement) -> bool {
             .items
             .iter()
             .any(|i| matches!(i, SelectItem::Assign { .. })),
+        // EXEC's inner batch may open result sets; conservative.
+        Statement::Exec(_) => true,
         _ => false,
     }
 }
@@ -890,6 +1070,7 @@ fn statement_may_commit(statement: &Statement) -> bool {
             | Statement::CreateIndex(_)
             | Statement::DropIndex(_)
             | Statement::AlterTable(_)
+            | Statement::Exec(_)
             | Statement::Commit { .. }
     )
 }
@@ -1356,6 +1537,19 @@ pub fn analyze_locks(
             | Statement::AlterTable(_) => {
                 add(Resource::Database, LockMode::Exclusive);
             }
+            // EXEC sp_executesql with a LITERAL statement is analyzable up
+            // front: recurse into the inner text. Anything else (a variable
+            // statement, an unknown procedure) cannot be analyzed before it
+            // runs — lock the database exclusively rather than under-lock
+            // (2PL acquires the full set up front).
+            Statement::Exec(exec) => match exec_literal_sql(exec) {
+                Some(inner) => {
+                    for (resource, mode) in analyze_locks(storage, &inner, isolation) {
+                        add(resource, mode);
+                    }
+                }
+                None => add(Resource::Database, LockMode::Exclusive),
+            },
             // Transaction control, SET, and DECLARE take no data locks.
             // TRY/CATCH was flattened away by `flatten_statements`, so its
             // contained statements appear here directly.
@@ -1538,6 +1732,11 @@ fn exec_statement(
         Statement::TryCatch { .. } => Err(SqlError::message_only(
             0,
             "internal error: TRY/CATCH must be executed by run_block",
+        )),
+        // EXEC recurses into its inner batch, handled by `run_block` too.
+        Statement::Exec(_) => Err(SqlError::message_only(
+            0,
+            "internal error: EXEC must be executed by run_block",
         )),
     }
 }
@@ -5490,6 +5689,43 @@ struct ScanPlan {
     /// index alone — no per-row base-table lookup. Never true for a table
     /// scan.
     covering: bool,
+}
+
+/// The parameter names of a declaration list (`@p1 int, @p2 nvarchar(10)`),
+/// in order: the first token of each top-level comma-separated entry.
+/// `sp_execute` values arrive unnamed on the wire; these names bind them.
+pub(crate) fn decl_names(decls: &str) -> Vec<String> {
+    let mut names = Vec::new();
+    let mut depth = 0usize;
+    let mut in_quote = false;
+    let mut entry = String::new();
+    for ch in decls.chars().chain(std::iter::once(',')) {
+        match ch {
+            // A quoted default value (`@p varchar(10) = 'a,b'`) may contain
+            // commas and parens; none of them separate declarations. A
+            // doubled '' escape toggles twice, landing back where it was.
+            '\'' => {
+                in_quote = !in_quote;
+                entry.push(ch);
+            }
+            '(' if !in_quote => {
+                depth += 1;
+                entry.push(ch);
+            }
+            ')' if !in_quote => {
+                depth = depth.saturating_sub(1);
+                entry.push(ch);
+            }
+            ',' if !in_quote && depth == 0 => {
+                if let Some(name) = entry.split_whitespace().next() {
+                    names.push(name.to_string());
+                }
+                entry.clear();
+            }
+            _ => entry.push(ch),
+        }
+    }
+    names
 }
 
 /// Recognises the shape [`scan_select`] can run, or `None` for everything else

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -601,12 +601,6 @@ fn exec_literal_sql(exec: &ExecStatement) -> Option<String> {
     }
 }
 
-#[cfg(test)]
-thread_local! {
-    /// Test hook mirroring EXEC_DEPTH assertions.
-    static EXEC_DEPTH_SEEN: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
-}
-
 thread_local! {
     /// Nesting depth of EXEC inner batches on this worker (SQL Server caps
     /// procedure nesting at 32, error 217).
@@ -701,8 +695,15 @@ fn run_exec(
     }
     let statements = truthdb_sql::parse(&sql)?;
 
-    // The inner batch is its own variable scope, on the shared transaction.
+    // The inner batch is its own variable scope, on the shared transaction —
+    // and SET options revert at scope exit, as SQL Server reverts them: an
+    // inner SET (XACT_ABORT, ISOLATION LEVEL, SHOWPLAN) must not outlive the
+    // EXEC, or a post-EXEC statement would run under an isolation the up-front
+    // lock analysis never saw.
     let outer_vars = std::mem::take(&mut txn_ctx.variables);
+    let outer_xact_abort = txn_ctx.xact_abort;
+    let outer_isolation = txn_ctx.isolation;
+    let outer_showplan = txn_ctx.showplan_text;
     for (name, value) in seeded {
         let key = name.trim_start_matches('@').to_ascii_lowercase();
         let column_type = value::infer_type(std::slice::from_ref(&value));
@@ -725,6 +726,9 @@ fn run_exec(
     };
     EXEC_DEPTH.with(|d| d.set(d.get() - 1));
     txn_ctx.variables = outer_vars;
+    txn_ctx.xact_abort = outer_xact_abort;
+    txn_ctx.isolation = outer_isolation;
+    txn_ctx.showplan_text = outer_showplan;
     result
 }
 
@@ -1544,7 +1548,19 @@ pub fn analyze_locks(
             // (2PL acquires the full set up front).
             Statement::Exec(exec) => match exec_literal_sql(exec) {
                 Some(inner) => {
-                    for (resource, mode) in analyze_locks(storage, &inner, isolation) {
+                    // The inner text runs under the batch's EFFECTIVE
+                    // isolation: a `SET ... SERIALIZABLE` before the EXEC
+                    // must lock the inner reads too, so the recursion gets a
+                    // read-locking level whenever this batch locks reads.
+                    // (An inner SET raising isolation is seen by the
+                    // recursion's own scan; it cannot outlive the EXEC — SET
+                    // options revert at scope exit.)
+                    let inner_isolation = if reads_lock {
+                        Isolation::ReadCommitted
+                    } else {
+                        isolation
+                    };
+                    for (resource, mode) in analyze_locks(storage, &inner, inner_isolation) {
                         add(resource, mode);
                     }
                 }

--- a/crates/truthdb-core/src/session.rs
+++ b/crates/truthdb-core/src/session.rs
@@ -163,43 +163,6 @@ struct PreparedStatement {
     text: String,
 }
 
-/// The parameter names of a declaration list (`@p1 int, @p2 nvarchar(10)`),
-/// in order: the first token of each top-level comma-separated entry.
-/// `sp_execute` values arrive unnamed on the wire; these names bind them.
-fn decl_names(decls: &str) -> Vec<String> {
-    let mut names = Vec::new();
-    let mut depth = 0usize;
-    let mut in_quote = false;
-    let mut entry = String::new();
-    for ch in decls.chars().chain(std::iter::once(',')) {
-        match ch {
-            // A quoted default value (`@p varchar(10) = 'a,b'`) may contain
-            // commas and parens; none of them separate declarations. A
-            // doubled '' escape toggles twice, landing back where it was.
-            '\'' => {
-                in_quote = !in_quote;
-                entry.push(ch);
-            }
-            '(' if !in_quote => {
-                depth += 1;
-                entry.push(ch);
-            }
-            ')' if !in_quote => {
-                depth = depth.saturating_sub(1);
-                entry.push(ch);
-            }
-            ',' if !in_quote && depth == 0 => {
-                if let Some(name) = entry.split_whitespace().next() {
-                    names.push(name.to_string());
-                }
-                entry.clear();
-            }
-            _ => entry.push(ch),
-        }
-    }
-    names
-}
-
 /// The reply channel for one batch.
 ///
 /// **Unbounded, deliberately.** A bounded queue would make the worker block
@@ -1265,7 +1228,7 @@ fn bind_decl_names(
     decls: &str,
     mut values: Vec<crate::rel::RpcParam>,
 ) -> Result<Vec<crate::rel::RpcParam>, SqlError> {
-    let names = decl_names(decls);
+    let names = crate::rel::decl_names(decls);
     // An unnamed value with no declaration to name it is SQL Server's 8144.
     // (Fewer values than declarations is legal — a declared parameter the
     // statement never reads goes unmissed, and one it does read errors when
@@ -3837,15 +3800,17 @@ mod tests {
     #[test]
     fn decl_names_splits_top_level_commas_only() {
         assert_eq!(
-            decl_names("@p1 int, @p2 nvarchar(10), @p3 decimal(10,2)"),
+            crate::rel::decl_names("@p1 int, @p2 nvarchar(10), @p3 decimal(10,2)"),
             ["@p1", "@p2", "@p3"]
         );
-        assert_eq!(decl_names(""), Vec::<String>::new());
-        assert_eq!(decl_names("@a int"), ["@a"]);
+        assert_eq!(crate::rel::decl_names(""), Vec::<String>::new());
+        assert_eq!(crate::rel::decl_names("@a int"), ["@a"]);
         // A quoted default may contain commas and parens; a doubled ''
         // escape stays inside the string.
         assert_eq!(
-            decl_names("@p1 varchar(10) = 'a,b', @p2 int, @p3 varchar(5) = 'it''s, ok'"),
+            crate::rel::decl_names(
+                "@p1 varchar(10) = 'a,b', @p2 int, @p3 varchar(5) = 'it''s, ok'"
+            ),
             ["@p1", "@p2", "@p3"]
         );
     }

--- a/crates/truthdb-core/src/storage.rs
+++ b/crates/truthdb-core/src/storage.rs
@@ -3467,6 +3467,131 @@ mod tests {
         let _ = std::fs::remove_file(&path);
     }
 
+    /// The EXEC text path's two load-bearing lock properties, pinned: a
+    /// variable @stmt cannot be analyzed up front and takes the conservative
+    /// database-exclusive lock, and isolation escalation crosses the EXEC
+    /// boundary in both directions (mutating either previously went green).
+    #[test]
+    fn exec_lock_analysis_never_under_locks() {
+        use crate::lock::{LockMode, Resource};
+        use crate::rel::{Isolation, TxnContext, execute_batch};
+
+        let path = unique_temp_path("exec-locks");
+        let storage = Storage::create(path.clone(), test_storage_options()).expect("create");
+        let mut ctx = TxnContext::default();
+        let outcome = execute_batch(
+            &storage,
+            "CREATE TABLE t (id INT NOT NULL PRIMARY KEY, v INT)",
+            &mut ctx,
+        );
+        assert!(outcome.error.is_none(), "{:?}", outcome.error);
+
+        // A variable statement text is unknowable before it runs: the batch
+        // locks the database exclusively rather than ever under-locking.
+        let needs = crate::rel::analyze_locks(
+            &storage,
+            "DECLARE @s NVARCHAR(50) = N'SELECT v FROM t'; EXEC sp_executesql @s",
+            Isolation::ReadCommitted,
+        );
+        assert!(
+            needs.contains(&(Resource::Database, LockMode::Exclusive)),
+            "variable @stmt must take Database X: {needs:?}"
+        );
+
+        // Direction 1: a SET raise BEFORE the EXEC locks the inner reads.
+        let needs = crate::rel::analyze_locks(
+            &storage,
+            "SET TRANSACTION ISOLATION LEVEL SERIALIZABLE; EXEC sp_executesql N'SELECT v FROM t'",
+            Isolation::ReadUncommitted,
+        );
+        assert!(
+            needs
+                .iter()
+                .any(|(r, m)| matches!(r, Resource::Table(_)) && *m == LockMode::Shared),
+            "escalated isolation must lock the inner SELECT: {needs:?}"
+        );
+
+        // Direction 2 (intra-EXEC): a SET raise INSIDE the literal locks the
+        // statements after it inside the same literal.
+        let needs = crate::rel::analyze_locks(
+            &storage,
+            "EXEC sp_executesql N'SET TRANSACTION ISOLATION LEVEL SERIALIZABLE; SELECT v FROM t'",
+            Isolation::ReadUncommitted,
+        );
+        assert!(
+            needs
+                .iter()
+                .any(|(r, m)| matches!(r, Resource::Table(_)) && *m == LockMode::Shared),
+            "an inner SET raise must lock the inner reads: {needs:?}"
+        );
+
+        drop(storage);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// EXEC scope semantics, pinned: outer variables are restored after the
+    /// inner batch (a regression previously went green), and SET options
+    /// revert at scope exit as SQL Server reverts them — an inner
+    /// `SET XACT_ABORT ON` must not doom the outer batch's transaction.
+    #[test]
+    fn exec_scope_restores_variables_and_set_options() {
+        use crate::rel::{StatementResult, TxnContext, execute_batch};
+
+        let path = unique_temp_path("exec-scope");
+        let storage = Storage::create(path.clone(), test_storage_options()).expect("create");
+        let mut ctx = TxnContext::default();
+        let outcome = execute_batch(
+            &storage,
+            "CREATE TABLE t (id INT NOT NULL PRIMARY KEY)",
+            &mut ctx,
+        );
+        assert!(outcome.error.is_none(), "{:?}", outcome.error);
+
+        // Inner @o shadows; the outer @o is intact after the EXEC returns.
+        let outcome = execute_batch(
+            &storage,
+            "DECLARE @o INT = 1; EXEC sp_executesql N'DECLARE @o INT = 99; SELECT @o AS inner_o'; SELECT @o AS outer_o",
+            &mut ctx,
+        );
+        assert!(outcome.error.is_none(), "{:?}", outcome.error);
+        let values: Vec<i64> = outcome
+            .results
+            .iter()
+            .filter_map(|r| match r {
+                StatementResult::Rows(rs) => match rs.rows[0][0] {
+                    Datum::Int(v) => Some(v as i64),
+                    Datum::BigInt(v) => Some(v),
+                    _ => None,
+                },
+                _ => None,
+            })
+            .collect();
+        assert_eq!(values, [99, 1], "{:?}", outcome.results);
+
+        // An inner SET XACT_ABORT ON reverts at EXEC exit: the later duplicate
+        // key fails its own statement but the batch continues and commits.
+        let outcome = execute_batch(
+            &storage,
+            "BEGIN TRANSACTION; INSERT INTO t VALUES (1); \
+             EXEC sp_executesql N'SET XACT_ABORT ON'; \
+             INSERT INTO t VALUES (1); INSERT INTO t VALUES (2); COMMIT",
+            &mut ctx,
+        );
+        assert!(outcome.error.is_some(), "the dup insert reports its error");
+        let outcome = execute_batch(&storage, "SELECT COUNT(*) FROM t", &mut ctx);
+        match &outcome.results[0] {
+            StatementResult::Rows(rs) => assert_eq!(
+                rs.rows[0][0],
+                Datum::BigInt(2),
+                "XACT_ABORT must revert at scope exit; the transaction commits"
+            ),
+            other => panic!("expected rows, got {other:?}"),
+        }
+
+        drop(storage);
+        let _ = std::fs::remove_file(&path);
+    }
+
     fn unique_temp_path(label: &str) -> PathBuf {
         let mut path = std::env::temp_dir();
         let nanos = std::time::SystemTime::now()

--- a/crates/truthdb-core/tests/slt/exec_text.slt
+++ b/crates/truthdb-core/tests/slt/exec_text.slt
@@ -1,0 +1,86 @@
+# EXEC sp_executesql as T-SQL text (Stage 11): the same machinery as the RPC
+# path — the inner text runs as its own batch scope (fresh variables seeded
+# from the declared parameters; inner DECLAREs do not leak; outer variables
+# are not visible inside) on the shared transaction.
+
+statement ok
+CREATE TABLE ex (id INT NOT NULL PRIMARY KEY, v INT)
+
+statement ok
+EXEC sp_executesql N'INSERT INTO ex VALUES (1, 10), (2, 20)'
+
+query II rowsort
+SELECT id, v FROM ex
+----
+1 10
+2 20
+
+# Parameterized, positional values bound from the declaration list.
+statement ok
+EXEC sp_executesql N'INSERT INTO ex VALUES (@a, @b)', N'@a int, @b int', 3, 30
+
+# Named argument form, in any order.
+statement ok
+EXEC sp_executesql @params = N'@a int, @b int', @stmt = N'INSERT INTO ex VALUES (@a, @b)', @a = 4, @b = 40
+
+query I
+SELECT COUNT(*) FROM ex
+----
+4
+
+# The inner text may SELECT — its rowset streams like a top-level statement.
+query I
+EXEC sp_executesql N'SELECT v FROM ex WHERE id = @p', N'@p int', 3
+----
+30
+
+# EXECUTE spelling; a variable carrying the statement text (dynamic SQL —
+# lock analysis falls back to a conservative exclusive lock, but it runs).
+statement ok
+DECLARE @sql NVARCHAR(100) = N'SELECT COUNT(*) FROM ex'; EXECUTE sp_executesql @sql
+
+# The inner batch is its own variable scope: an outer variable is not
+# visible inside.
+statement error
+DECLARE @outer INT = 7; EXEC sp_executesql N'SELECT @outer'
+
+# An unknown procedure answers 2812 like the RPC path.
+statement error
+EXEC sp_no_such_thing
+
+# Too many positional values for the declaration list is 8144.
+statement error
+EXEC sp_executesql N'SELECT 1', N'@a int', 1, 2
+
+# Errors inside the inner batch surface like ordinary statement errors: under
+# XACT_ABORT OFF outside a transaction the batch stops with the error.
+statement error
+EXEC sp_executesql N'INSERT INTO ex VALUES (1, 99)'
+
+# The failed duplicate insert left the table unchanged.
+query I
+SELECT COUNT(*) FROM ex
+----
+4
+
+# EXEC participates in an open transaction (shared context): a rollback
+# undoes the inner batch's writes.
+statement ok
+BEGIN TRANSACTION
+
+statement ok
+EXEC sp_executesql N'INSERT INTO ex VALUES (9, 90)'
+
+statement ok
+ROLLBACK
+
+query I
+SELECT COUNT(*) FROM ex
+----
+4
+
+# Nested EXEC works (depth-capped at 32 like SQL Server's 217).
+query I
+EXEC sp_executesql N'EXEC sp_executesql N''SELECT 5 AS five'''
+----
+5

--- a/crates/truthdb-sql/src/ast.rs
+++ b/crates/truthdb-sql/src/ast.rs
@@ -42,6 +42,9 @@ pub enum Statement {
     AlterTable(AlterTable),
     /// `DECLARE @a TYPE [= expr], ...` — batch variable declarations.
     Declare(Vec<Declaration>),
+    /// `EXEC[UTE] <proc> [args...]` — the T-SQL text path to the system
+    /// procedures (`sp_executesql` is the supported one).
+    Exec(ExecStatement),
     /// `BEGIN TRY <try_block> END TRY BEGIN CATCH <catch_block> END CATCH`. An
     /// error in the try block transfers control to the catch block.
     TryCatch {
@@ -59,6 +62,21 @@ pub struct Declaration {
     pub data_type: DataType,
     pub initializer: Option<Expr>,
     pub span: Span,
+}
+
+/// `EXEC[UTE] <proc> [@name =] <expr> [, ...]`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ExecStatement {
+    pub proc: Name,
+    pub args: Vec<ExecArg>,
+    pub span: Span,
+}
+
+/// One argument of an `EXEC`: optionally named (`@p = expr`).
+#[derive(Debug, Clone, PartialEq)]
+pub struct ExecArg {
+    pub name: Option<Name>,
+    pub value: Expr,
 }
 
 /// `ALTER TABLE <table> <action>`.

--- a/crates/truthdb-sql/src/lexer.rs
+++ b/crates/truthdb-sql/src/lexer.rs
@@ -255,6 +255,12 @@ impl<'a> Lexer<'a> {
                 Ok(single(TokenKind::Ne, 2))
             }
             b'\'' => self.lex_string(start),
+            // A Unicode string literal: `N'...'`. Everything here is Unicode
+            // already, so the prefix only selects string lexing.
+            b'N' | b'n' if self.peek2() == Some(b'\'') => {
+                self.pos += 1;
+                self.lex_string(start)
+            }
             b'[' => self.lex_bracket_ident(start),
             b'"' => self.lex_quoted_ident(start),
             b'@' if self.peek2() == Some(b'@') => {

--- a/crates/truthdb-sql/src/parser.rs
+++ b/crates/truthdb-sql/src/parser.rs
@@ -118,11 +118,57 @@ impl Parser {
             Some("SAVE") => self.parse_save(),
             Some("SET") => self.parse_set(),
             Some("DECLARE") => self.parse_declare(),
+            Some("EXEC") | Some("EXECUTE") => self.parse_exec(),
             _ => {
                 let token = self.peek().clone();
                 Err(SqlError::syntax(self.token_text(&token), token.span))
             }
         }
+    }
+
+    /// `EXEC[UTE] <proc> [[@name =] <expr> [, ...]]` — the T-SQL text path to
+    /// the system procedures. Arguments end at the statement boundary.
+    fn parse_exec(&mut self) -> SqlResult<Statement> {
+        let start = self.bump().span; // EXEC or EXECUTE
+        let proc = self.parse_name()?;
+        let mut args = Vec::new();
+        let mut end = proc.span;
+        if !self.at_eof() && !self.check(&TokenKind::Semicolon) {
+            loop {
+                // `@name = expr` names the argument (the `=` after a local
+                // variable disambiguates from a positional `@var` argument);
+                // a bare expr is positional.
+                let next = &self.tokens[(self.pos + 1).min(self.tokens.len() - 1)];
+                let name = if matches!(self.peek().kind, TokenKind::LocalVar(_))
+                    && next.kind == TokenKind::Eq
+                {
+                    let token = self.bump();
+                    let TokenKind::LocalVar(var) = &token.kind else {
+                        unreachable!("matched above");
+                    };
+                    let named = Name {
+                        value: var.clone(),
+                        quoted: false,
+                        span: token.span,
+                    };
+                    self.bump(); // `=`
+                    Some(named)
+                } else {
+                    None
+                };
+                let value = self.parse_expr()?;
+                end = value.span;
+                args.push(ExecArg { name, value });
+                if !self.eat(&TokenKind::Comma) {
+                    break;
+                }
+            }
+        }
+        Ok(Statement::Exec(ExecStatement {
+            proc,
+            args,
+            span: start.to(end),
+        }))
     }
 
     // ---- transaction control --------------------------------------------

--- a/scripts/tds_conformance_gosqlcmd.expected
+++ b/scripts/tds_conformance_gosqlcmd.expected
@@ -17,3 +17,8 @@ name
 one                 
 
 (1 row affected)
+via_exec             
+---------------------
+                    3
+
+(1 row affected)

--- a/scripts/tds_conformance_sqlcmd.expected
+++ b/scripts/tds_conformance_sqlcmd.expected
@@ -19,3 +19,8 @@ name
 one                 
 
 (1 rows affected)
+via_exec            
+--------------------
+                   3
+
+(1 rows affected)

--- a/scripts/tds_conformance_sqlcmd.sql
+++ b/scripts/tds_conformance_sqlcmd.sql
@@ -13,3 +13,5 @@ ROLLBACK;
 GO
 SELECT name FROM $(TABLE) WHERE id = 1;
 GO
+EXEC sp_executesql N'SELECT COUNT(*) AS via_exec FROM $(TABLE) WHERE id > @min', N'@min int', 0;
+GO


### PR DESCRIPTION
## What

`EXEC [sp_executesql]` works as T-SQL text — the last piece of Stage 11. The parser gains `EXEC[UTE]` with named (`@p = value`) and positional arguments, and the lexer gains `N'...'` Unicode literals (the text path hits them where RPC never did). The inner text runs as its own batch scope through `run_block` recursion: fresh variables seeded from the declared parameters, inner DECLAREs don't leak, outer variables invisible inside, transaction context shared, inner statements emitting their own events and DONEs, errors taking the ordinary statement ladder, nesting capped at 32 (217). Other procedures answer 2812, matching RPC.

## The 2PL answer for dynamic SQL

Up-front lock acquisition meets runtime-determined text: a **literal** statement argument is parsed and lock-analyzed recursively under the batch's **effective** isolation; a **variable** one takes a conservative database-exclusive lock — the engine never under-locks, and the exclusive hold is batch-scoped so nothing can race the unknown text. SET options (XACT_ABORT, ISOLATION LEVEL, SHOWPLAN) revert at EXEC scope exit as SQL Server reverts them, so no inner SET can outlive the EXEC and invalidate the lock set acquired up front.

## Review

The adversarial review found a HIGH under-lock in the first cut — isolation escalation didn't cross the EXEC boundary in either direction (probed live: an RU session with `SET SERIALIZABLE; EXEC N'SELECT...'` acquired nothing) — fixed at the root by the effective-isolation recursion plus the scope-exit revert, and pinned by a lock-analysis test covering both directions. Mutation testing proved the two load-bearing properties (the conservative fallback, the variable-scope restore) were unpinned; both now have direct tests. The extraction paths for the statement argument were verified byte-identical between analysis and execution — every constructible disagreement collapses to an over-lock, never an under-lock. Recorded divergences: parameter types infer from values (as the RPC path yields to wire TYPE_INFO), inner DONEs are plain per-statement DONEs rather than DONEINPROC nesting, SCOPE_IDENTITY crosses the scope boundary (pre-existing on RPC), and positional-after-named is accepted where SQL Server errors.

## Tests

slt: literal/parameterized/named-argument forms, rowsets streaming from inner text, dynamic `@sql` via variable, scope isolation, 2812/8144, error-stops-batch, rollback across EXEC, nested EXEC. Rust: the lock-analysis pin (Database X for variable text; table Shared across both escalation directions) and the scope pin (variable restore; XACT_ABORT revert — an inner SET must not doom the outer transaction). Conformance: both real sqlcmds run a parameterized EXEC live (expected files regenerated from container runs). Teeth-checked: disabling the dispatch fails the slt file. Full workspace: 479 passed, 0 failed; fmt and clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)