### PR TITLE
TCP_NODELAY on every socket: the wire had a 90ms Nagle floor

### DIFF
--- a/crates/truthdb-bench/src/main.rs
+++ b/crates/truthdb-bench/src/main.rs
@@ -304,6 +304,7 @@ fn format_latency(us: f64) -> String {
 
 async fn connect(addr: &str) -> Result<TcpStream> {
     let mut stream = TcpStream::connect(addr).await?;
+    stream.set_nodelay(true)?;
 
     let req = HelloReq {
         protocol_version: PROTOCOL_VERSION,

--- a/crates/truthdb-core/src/client_listener.rs
+++ b/crates/truthdb-core/src/client_listener.rs
@@ -43,6 +43,10 @@ impl ClientListener {
                 }
                 res = listener.accept() => {
                     let (stream, _) = res?;
+                    // The protocol is write-write-read per request; Nagle +
+                    // delayed ACK turns that into a ~40-200ms stall per
+                    // round trip (measured ~90ms on WSL2 loopback).
+                    let _ = stream.set_nodelay(true);
                     let mut conn_shutdown = shutdown.clone();
                     let engine = self.engine.clone();
                     tokio::spawn(async move {

--- a/crates/truthdb-tds/src/lib.rs
+++ b/crates/truthdb-tds/src/lib.rs
@@ -57,6 +57,9 @@ impl TdsListener {
             tokio::select! {
                 accepted = self.listener.accept() => {
                     let (stream, peer) = accepted?;
+                    // TDS is request/response with multi-write framing; Nagle
+                    // + delayed ACK stalls each round trip without this.
+                    let _ = stream.set_nodelay(true);
                     debug!(%peer, "TDS connection accepted");
                     let engine = self.engine.clone();
                     let config = Arc::clone(&self.config);


### PR DESCRIPTION
## What

Both listeners (native and TDS) and the bench client set TCP_NODELAY on their sockets. Neither did before, and the protocols' write-header-write-body-read shape is exactly what Nagle plus delayed ACK stalls: a flat ~90ms per-operation floor on WSL2 loopback, swamping every real cost.

## Measured

| | before | after |
|---|---|---|
| write ops/sec, 1 conn | 11 | 647 |
| write p50 | 91.9ms | 1.23ms |
| read ops/sec, 1 conn | ~11 | 2072 |
| read p50 | 88ms | 640µs |

Found while auditing Stage 12's scale-out bullet. The corrected numbers give that work its honest baseline — and confirm its premise for reads: read throughput drops from 2072/sec at one connection to 966/sec at eight (p50 640µs → 8ms), negative scaling under the coarse storage mutex, while writes hold flat because group commit already shares the fsyncs. The latch-sharding work starts from these numbers.

No behavioral change; 479 tests green, fmt and clippy clean. The effect is bench-verified rather than unit-tested — a socket option with a timing-dependent effect has no honest in-repo assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)