### PR TITLE
Stage 12: read-gate scaling, heartbeat exit test, 1222 vs 1205, reachable escalation

### DIFF
--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -30,10 +30,11 @@ struct EngineMeta {
 /// **execution gate** decoupling the two execution paths, which do not share a
 /// lock manager: a relational batch ([`Self::sql_batch_with_params`]) holds
 /// `meta.read()` for its whole run (many run concurrently), while a native
-/// command ([`Self::execute`], which bypasses table locks) takes `meta.write()`
-/// and so runs exclusively. Without this, a concurrent native batch could read
-/// a relational batch's half-applied writes — which the old single-threaded
-/// actor prevented for free.
+/// WRITE ([`Self::execute`] on a mutating command) takes `meta.write()` and so
+/// runs exclusively; a native SEARCH takes `meta.read()` like the batches (it
+/// is `&self` throughout, and readers must scale). Without the write gate, a
+/// concurrent native batch could read a relational batch's half-applied
+/// writes — which the old single-threaded actor prevented for free.
 pub struct Engine {
     storage: Storage,
     meta: RwLock<EngineMeta>,

--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -83,15 +83,48 @@ impl Engine {
     }
 
     pub fn execute(&self, input: &str) -> Result<String, EngineError> {
-        // Native path: exclusive on the execution gate (see [`Engine`]), which
-        // also gives the search state the `&mut` it needs.
-        let mut meta = self.meta.write().expect("engine meta poisoned");
         // Routing: the legacy ES commands all carry a `{` JSON body; that
         // shape routes to the frozen search path. Everything else is SQL.
         match parse_command(input)? {
-            Some(command) => self.execute_es(&mut meta, command),
-            None => self.execute_sql(&mut meta, input),
+            // A search only reads: it takes the gate SHARED, alongside other
+            // searches and SQL batches (which already read-lock it), so
+            // concurrent readers scale instead of serializing on the write
+            // gate. Measured: 8-connection search throughput went from HALF
+            // of 1-connection (2072 -> 966 ops/sec) to scaling with readers.
+            Some(Command::Search { index, query }) => {
+                let meta = self.meta.read().expect("engine meta poisoned");
+                Self::render_search(&meta, &index, &query)
+            }
+            // Every other ES command writes; exclusive as before.
+            Some(command) => {
+                let mut meta = self.meta.write().expect("engine meta poisoned");
+                self.execute_es(&mut meta, command)
+            }
+            None => {
+                let mut meta = self.meta.write().expect("engine meta poisoned");
+                self.execute_sql(&mut meta, input)
+            }
         }
+    }
+
+    /// Runs a search against an index and renders the hits.
+    fn render_search(
+        meta: &EngineMeta,
+        index: &str,
+        query: &SearchQuery,
+    ) -> Result<String, EngineError> {
+        let index_state =
+            meta.state.indices.get(index).ok_or_else(|| {
+                EngineError::Command(CommandError::UnknownIndex(index.to_string()))
+            })?;
+        let hits = index_state.search(query)?;
+        let total = hits.len();
+        render_json(&json!({
+            "hits": {
+                "total": total,
+                "hits": hits,
+            }
+        }))
     }
 
     fn execute_es(&self, meta: &mut EngineMeta, command: Command) -> Result<String, EngineError> {
@@ -127,19 +160,7 @@ impl Engine {
                     "result": "created",
                 }))
             }
-            Command::Search { index, query } => {
-                let index_state = meta.state.indices.get(&index).ok_or_else(|| {
-                    EngineError::Command(CommandError::UnknownIndex(index.clone()))
-                })?;
-                let hits = index_state.search(&query)?;
-                let total = hits.len();
-                render_json(&json!({
-                    "hits": {
-                        "total": total,
-                        "hits": hits,
-                    }
-                }))
-            }
+            Command::Search { index, query } => Self::render_search(meta, &index, &query),
         }
     }
 

--- a/crates/truthdb-core/src/session.rs
+++ b/crates/truthdb-core/src/session.rs
@@ -2029,8 +2029,9 @@ mod tests {
             .run_batch(s, "CREATE TABLE t (id INT NOT NULL PRIMARY KEY)".into())
             .await
             .unwrap();
-        // Batched into 500-tuple inserts: one giant tuple list hits the
-        // parser's nesting guard (error 191).
+        // Batched into 500-tuple inserts: the per-expression node budget
+        // keeps giant single statements bounded, and chunks stay far from
+        // every limit.
         let ids: Vec<usize> = (1..=n).collect();
         for chunk in ids.chunks(500) {
             let values: Vec<String> = chunk.iter().map(|i| format!("({i})")).collect();
@@ -2876,8 +2877,12 @@ mod tests {
 
     #[tokio::test]
     async fn deadlock_is_broken_by_timeout_with_1205() {
-        // Short timeout so the reaper fires quickly.
-        let h = start(Duration::from_millis(300));
+        // Wide enough that BOTH conflicting batches park (forming the cycle)
+        // before any deadline expires: since the 1222 split, an expired
+        // waiter with no cycle is reaped as a lock timeout, and a loaded
+        // runner delaying the second park past the deadline would otherwise
+        // turn this test's deadlock into a 1222.
+        let h = start(Duration::from_secs(2));
         let a = h.handle.open_session(String::new(), String::new()).await;
         let b = h.handle.open_session(String::new(), String::new()).await;
 

--- a/crates/truthdb-core/src/session.rs
+++ b/crates/truthdb-core/src/session.rs
@@ -1590,7 +1590,11 @@ impl Scheduler {
             .min_by_key(|(_, p)| p.deadline)
             .map(|(i, _)| i);
         if let Some(idx) = victim_idx {
-            self.abort_parked_victim(engine, idx);
+            // An expired wait behind a LIVE holder is not a deadlock: SQL
+            // Server raises 1205 only for real cycles and 1222 for a lock
+            // wait that timed out. Reporting a false deadlock sends drivers
+            // into retry loops for a condition retrying cannot fix.
+            self.abort_parked_victim(engine, idx, lock_timeout_error());
         }
     }
 
@@ -1641,13 +1645,19 @@ impl Scheduler {
     /// Aborts the parked batch at `idx` as a deadlock victim: rolls back its
     /// transaction, releases its locks, and replies with error 1205. The caller
     /// drains any batches the released locks unblock.
-    fn abort_parked_victim(&mut self, engine: &Engine, idx: usize) {
+    fn abort_parked_victim(&mut self, engine: &Engine, idx: usize, error: SqlError) {
         let victim = self.parked.remove(idx).expect("index in bounds");
         if let Some(state) = self.sessions.get_mut(victim.session) {
             engine.abort_session_txn(&mut state.txn_ctx);
         }
         self.locks.release_all(victim.session.raw());
-        victim.reply.send_outcome(deadlock_victim_reply(), false);
+        victim.reply.send_outcome(
+            BatchOutcome {
+                results: Vec::new(),
+                error: Some(error),
+            },
+            false,
+        );
     }
 
     /// Detects lock-wait *cycles* among the parked batches — a waits-for graph
@@ -1657,7 +1667,7 @@ impl Scheduler {
     /// wait-timeout backstop. Aborts victims until the graph is acyclic.
     fn detect_deadlock(&mut self, engine: &Engine) {
         while let Some(idx) = self.find_deadlock_victim() {
-            self.abort_parked_victim(engine, idx);
+            self.abort_parked_victim(engine, idx, deadlock_victim_error());
         }
     }
 
@@ -1773,16 +1783,19 @@ fn find_cycle(
     None
 }
 
-fn deadlock_victim_reply() -> BatchOutcome {
-    BatchOutcome {
-        results: Vec::new(),
-        error: Some(SqlError::new(
-            1205,
-            13,
-            51,
-            "Transaction was deadlocked on lock resources with another process and has been chosen as the deadlock victim. Rerun the transaction.",
-        )),
-    }
+fn deadlock_victim_error() -> SqlError {
+    SqlError::new(
+        1205,
+        13,
+        51,
+        "Transaction was deadlocked on lock resources with another process and has been chosen as the deadlock victim. Rerun the transaction.",
+    )
+}
+
+/// A lock wait that outlived the timeout behind a LIVE holder — no cycle.
+/// SQL Server's number for an expired lock wait is 1222.
+fn lock_timeout_error() -> SqlError {
+    SqlError::new(1222, 16, 56, "Lock request time out period exceeded.")
 }
 
 #[cfg(test)]
@@ -3467,8 +3480,9 @@ mod tests {
         .unwrap();
         assert_eq!(
             error_number(&out),
-            Some(1205),
-            "the lone waiter should time out as a 1205 victim"
+            Some(1222),
+            "a lone waiter behind a live holder times out as 1222 — there is \
+             no cycle, so 1205 would report a deadlock that never happened"
         );
     }
 

--- a/crates/truthdb-core/src/session.rs
+++ b/crates/truthdb-core/src/session.rs
@@ -2016,12 +2016,18 @@ mod tests {
             .run_batch(s, "CREATE TABLE t (id INT NOT NULL PRIMARY KEY)".into())
             .await
             .unwrap();
-        let mut insert = String::from("INSERT INTO t VALUES (1)");
-        for i in 2..=n {
-            insert.push_str(&format!(", ({i})"));
+        // Batched into 500-tuple inserts: one giant tuple list hits the
+        // parser's nesting guard (error 191).
+        let ids: Vec<usize> = (1..=n).collect();
+        for chunk in ids.chunks(500) {
+            let values: Vec<String> = chunk.iter().map(|i| format!("({i})")).collect();
+            let reply = h
+                .handle
+                .run_batch(s, format!("INSERT INTO t VALUES {}", values.join(", ")))
+                .await
+                .unwrap();
+            assert!(reply.outcome.error.is_none(), "{:?}", reply.outcome.error);
         }
-        let reply = h.handle.run_batch(s, insert).await.unwrap();
-        assert!(reply.outcome.error.is_none(), "{:?}", reply.outcome.error);
     }
 
     #[tokio::test]
@@ -3464,6 +3470,68 @@ mod tests {
             Some(1205),
             "the lone waiter should time out as a 1205 victim"
         );
+    }
+
+    /// Stage 12's exit case: the engine stays responsive during a large
+    /// scan. A protocol heartbeat never touches the engine (the dispatcher
+    /// answers it), so the meaningful half is a native search completing
+    /// WHILE a worker is mid-scan holding the batch-long read gate — pinned
+    /// by synchronizing on the scan's first Columns event (the worker is
+    /// provably inside the batch) and asserting the search returns before
+    /// the scan finishes. A regression to an exclusive gate blocks the
+    /// search behind the whole scan.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn a_search_is_answered_while_a_large_scan_runs() {
+        let h = start(LOCK_WAIT_TIMEOUT);
+        let s = h.handle.open_session("truthdb".into(), "sa".into()).await;
+        fill(&h, s, 60_000).await;
+        h.handle
+            .run_native(
+                r#"create index bench { "mappings": { "properties": { "title": { "type": "text" } } } }"#
+                    .to_string(),
+            )
+            .await
+            .expect("create index");
+        h.handle
+            .run_native(r#"insert document bench { "title": "hello world" }"#.to_string())
+            .await
+            .expect("insert doc");
+
+        let mut events = h
+            .handle
+            .stream_batch(s, "SELECT id FROM t".into(), no_cancel());
+        // The first Columns event: the worker is inside the batch, gate held.
+        loop {
+            match events.recv().await.expect("stream lives") {
+                BatchEvent::Columns(_) => break,
+                BatchEvent::Failed(err) => panic!("scan failed to start: {err}"),
+                _ => {}
+            }
+        }
+
+        let search = h
+            .handle
+            .run_native(r#"search bench {"query": {"match": {"title": "hello"}}}"#.to_string())
+            .await
+            .expect("search");
+        assert!(search.contains("hello world"), "search answered: {search}");
+        // The scan must have STILL BEEN RUNNING when the search returned.
+        // The channel is unbounded, so "the next event" proves nothing —
+        // instead drain everything already buffered at this instant without
+        // blocking: if the batch's terminal event is among it, the batch
+        // finished before the search did (an exclusive gate makes the search
+        // wait out the whole scan, and this assertion catches exactly that).
+        let mut already_finished = false;
+        while let Ok(event) = events.try_recv() {
+            if matches!(event, BatchEvent::Complete { .. } | BatchEvent::Failed(_)) {
+                already_finished = true;
+            }
+        }
+        assert!(
+            !already_finished,
+            "the search must complete while the scan is mid-stream, not after it"
+        );
+        drain_events(events).await;
     }
 
     // ---- sp_prepare handle family -----------------------------------------

--- a/crates/truthdb-core/src/storage.rs
+++ b/crates/truthdb-core/src/storage.rs
@@ -3529,6 +3529,80 @@ mod tests {
         let _ = std::fs::remove_file(&path);
     }
 
+    /// Row-lock escalation (Stage 12), pinned at its actual threshold: a
+    /// statement naming more than 1000 row keys takes ONE table lock instead
+    /// of flooding the lock table; at or below the threshold it takes row
+    /// locks. (The plan sketched ~5000; 1000 is the shipped value — this
+    /// test is the record of that divergence.)
+    #[test]
+    fn row_locks_escalate_past_the_threshold() {
+        use crate::lock::{LockMode, Resource};
+        use crate::rel::{Isolation, TxnContext, execute_batch};
+
+        let path = unique_temp_path("escalation");
+        let storage = Storage::create(path.clone(), test_storage_options()).expect("create");
+        let mut ctx = TxnContext::default();
+        let outcome = execute_batch(
+            &storage,
+            "CREATE TABLE t (id INT NOT NULL PRIMARY KEY, v INT)",
+            &mut ctx,
+        );
+        assert!(outcome.error.is_none(), "{:?}", outcome.error);
+
+        let insert = |n: usize| {
+            let tuples: Vec<String> = (0..n).map(|i| format!("({i}, 0)")).collect();
+            format!("INSERT INTO t VALUES {}", tuples.join(", "))
+        };
+
+        // At the threshold: per-row locks (plus the table intent).
+        let needs = crate::rel::analyze_locks(&storage, &insert(1000), Isolation::ReadCommitted);
+        let rows = needs
+            .iter()
+            .filter(|(r, _)| matches!(r, Resource::Row(_, _)))
+            .count();
+        assert_eq!(rows, 1000, "at the threshold every key gets a row lock");
+        assert!(
+            !needs
+                .iter()
+                .any(|(r, m)| matches!(r, Resource::Table(_)) && *m == LockMode::Exclusive),
+            "no table X below escalation: {:?}",
+            needs.len()
+        );
+
+        // Past it — summed across the whole batch: 1001 point DELETEs each
+        // want one Row X, and the batch-level pass replaces them with one
+        // table-exclusive lock. (A single statement cannot textually exceed
+        // the threshold: a 1001-tuple INSERT hits the parser's depth guard
+        // before the lock analysis ever sees it.)
+        // Past it — summed across the whole batch: a 1000-tuple INSERT plus
+        // 20 point DELETEs wants 1020 row locks on one table, and the
+        // batch-level pass replaces them all with one table-exclusive lock.
+        // (No single statement can exceed the threshold alone: a 1001-tuple
+        // INSERT hits the parser's guards before lock analysis sees it.)
+        let deletes: Vec<String> = (2000..2020)
+            .map(|i| format!("DELETE FROM t WHERE id = {i}"))
+            .collect();
+        let over = format!("{}; {}", insert(1000), deletes.join("; "));
+        let needs = crate::rel::analyze_locks(&storage, &over, Isolation::ReadCommitted);
+        assert!(
+            needs
+                .iter()
+                .any(|(r, m)| matches!(r, Resource::Table(_)) && *m == LockMode::Exclusive),
+            "past the threshold the statement takes table X: {needs:?}"
+        );
+        assert_eq!(
+            needs
+                .iter()
+                .filter(|(r, _)| matches!(r, Resource::Row(_, _)))
+                .count(),
+            0,
+            "row locks are replaced, not added to"
+        );
+
+        drop(storage);
+        let _ = std::fs::remove_file(&path);
+    }
+
     /// EXEC scope semantics, pinned: outer variables are restored after the
     /// inner batch (a regression previously went green), and SET options
     /// revert at scope exit as SQL Server reverts them — an inner

--- a/crates/truthdb-core/src/storage.rs
+++ b/crates/truthdb-core/src/storage.rs
@@ -3569,16 +3569,30 @@ mod tests {
             needs.len()
         );
 
-        // Past it — summed across the whole batch: 1001 point DELETEs each
-        // want one Row X, and the batch-level pass replaces them with one
-        // table-exclusive lock. (A single statement cannot textually exceed
-        // the threshold: a 1001-tuple INSERT hits the parser's depth guard
-        // before the lock analysis ever sees it.)
-        // Past it — summed across the whole batch: a 1000-tuple INSERT plus
-        // 20 point DELETEs wants 1020 row locks on one table, and the
-        // batch-level pass replaces them all with one table-exclusive lock.
-        // (No single statement can exceed the threshold alone: a 1001-tuple
-        // INSERT hits the parser's guards before lock analysis sees it.)
+        // A single statement past the threshold: the per-statement cap
+        // declines to enumerate 1001 row hashes and the INSERT falls back to
+        // one table-exclusive lock. (Reachable since the node budget became
+        // per-expression — a 1001-tuple INSERT parses now.)
+        let needs = crate::rel::analyze_locks(&storage, &insert(1001), Isolation::ReadCommitted);
+        assert!(
+            needs
+                .iter()
+                .any(|(r, m)| matches!(r, Resource::Table(_)) && *m == LockMode::Exclusive),
+            "a single over-threshold statement takes table X: {needs:?}"
+        );
+        assert_eq!(
+            needs
+                .iter()
+                .filter(|(r, _)| matches!(r, Resource::Row(_, _)))
+                .count(),
+            0
+        );
+
+        // Past it — summed across the WHOLE BATCH: a 1000-tuple INSERT plus
+        // 20 point DELETEs on DISTINCT keys wants 1020 row locks on one
+        // table (the needs map dedups by key hash, so overlapping keys would
+        // not count twice), and the batch-level pass replaces them all with
+        // one table-exclusive lock.
         let deletes: Vec<String> = (2000..2020)
             .map(|i| format!("DELETE FROM t WHERE id = {i}"))
             .collect();

--- a/crates/truthdb-sql/src/parser.rs
+++ b/crates/truthdb-sql/src/parser.rs
@@ -97,6 +97,11 @@ impl Parser {
             if self.at_eof() {
                 break;
             }
+            // The expression-node budget also resets per statement: CTE and
+            // derived-table bodies parse under depth >= 1, so their
+            // expressions never reach parse_expr's depth-0 reset and would
+            // otherwise inherit the previous statement's count.
+            self.nodes = 0;
             statements.push(self.parse_statement()?);
             if !self.at_eof() && !self.check(&TokenKind::Semicolon) {
                 let token = self.peek().clone();
@@ -2405,6 +2410,17 @@ mod tests {
         // otherwise-light batch (1001 ORs ≈ 2003 nodes).
         let over = format!("SELECT 1; SELECT 1{}", " OR 1".repeat(1001));
         assert_eq!(Parser::parse_str(&over).unwrap_err().number, 191);
+        // CTE and derived-table bodies parse under depth >= 1 (no depth-0
+        // reset for their expressions): the per-statement reset must cover
+        // them, or a big-but-legal statement poisons the next one's budget.
+        let big = format!("SELECT 1{}", " OR 1".repeat(900));
+        let derived = format!("{big}; SELECT * FROM (SELECT 1{}) d", " OR 1".repeat(200));
+        assert!(Parser::parse_str(&derived).is_ok(), "derived after big");
+        let cte = format!(
+            "{big}; WITH c AS (SELECT 1{} AS x) SELECT x FROM c",
+            " OR 1".repeat(200)
+        );
+        assert!(Parser::parse_str(&cte).is_ok(), "cte after big");
     }
 
     #[test]

--- a/crates/truthdb-sql/src/parser.rs
+++ b/crates/truthdb-sql/src/parser.rs
@@ -13,10 +13,13 @@ use crate::lexer::{Span, Token, TokenKind};
 /// even a 2 MiB thread stack. Real SQL never nests remotely this deep.
 const MAX_EXPR_DEPTH: usize = 64;
 
-/// Maximum number of expression nodes per batch. Bounds the AST size so a
-/// long operator chain (`1 OR 1 OR 1 ...`), which parses iteratively but
-/// evaluates recursively down its spine, cannot overflow the stack during
-/// evaluation.
+/// Maximum number of expression nodes per TOP-LEVEL expression. Bounds each
+/// expression's size so a long operator chain (`1 OR 1 OR 1 ...`), which
+/// parses iteratively but evaluates recursively down its spine, cannot
+/// overflow the stack during evaluation. Per expression, not per batch: a
+/// 1000-tuple `INSERT ... VALUES` is thousands of tiny FLAT expressions —
+/// none deepens any evaluation spine — and a per-batch count made row-lock
+/// escalation unreachable (its threshold sat above the whole-batch budget).
 const MAX_EXPR_NODES: usize = 2000;
 
 pub struct Parser {
@@ -1608,6 +1611,13 @@ impl Parser {
     /// Expression entry point with a recursion-depth guard (parens, the only
     /// unbounded nesting other than NOT/unary, re-enter here).
     fn parse_expr(&mut self) -> SqlResult<Expr> {
+        if self.depth == 0 {
+            // The node budget is per top-level expression (see
+            // MAX_EXPR_NODES): reset it here rather than accumulating across
+            // the batch, or flat many-expression statements (a 1000-tuple
+            // INSERT) exhaust a budget meant for one deep spine.
+            self.nodes = 0;
+        }
         self.depth += 1;
         if self.depth > MAX_EXPR_DEPTH {
             return Err(Self::too_deep());
@@ -2374,6 +2384,27 @@ mod tests {
         // Parses iteratively but would overflow eval; the node budget caps it.
         let sql = format!("SELECT 1{}", " OR 1".repeat(20_000));
         assert_eq!(Parser::parse_str(&sql).unwrap_err().number, 191);
+    }
+
+    #[test]
+    fn the_node_budget_is_per_expression_not_per_batch() {
+        // Thousands of tiny FLAT expressions are fine — none deepens an
+        // evaluation spine. A per-batch count once made a 1001-tuple INSERT
+        // unparseable, which put row-lock escalation above the reachable
+        // ceiling.
+        let tuples: Vec<String> = (0..3000).map(|i| format!("({i}, {i})")).collect();
+        let sql = format!("INSERT INTO t VALUES {}", tuples.join(", "));
+        assert!(Parser::parse_str(&sql).is_ok());
+        // Two statements each near the budget: legal — the budget resets.
+        // Each `OR` costs ~2 nodes (the operator and its literal): 900 ORs
+        // ≈ 1801 nodes, inside the 2000 budget — twice over in one batch.
+        let chain = format!("SELECT 1{}", " OR 1".repeat(900));
+        let batch = format!("{chain}; {chain}");
+        assert!(Parser::parse_str(&batch).is_ok());
+        // One expression over the budget still errors, even at the end of an
+        // otherwise-light batch (1001 ORs ≈ 2003 nodes).
+        let over = format!("SELECT 1; SELECT 1{}", " OR 1".repeat(1001));
+        assert_eq!(Parser::parse_str(&over).unwrap_err().number, 191);
     }
 
     #[test]


### PR DESCRIPTION
## What

Four Stage 12 pieces, each preceded by measurement or audit:

1. **Searches take the read gate.** `Engine::execute` took the meta RwLock's write side for every native command; readers halved under contention (2072 → 966 ops/sec from 1 to 8 connections on the post-nodelay baseline). The search path is `&self` throughout — verified before routing — and now scales: 2032/3575/3349 at 1/4/8 connections.
2. **The heartbeats-during-scan exit test.** The protocol heartbeat never touches the engine (the dispatcher answers it), so the meaningful half is a native search answered while a worker is mid-scan holding the batch-long read gate. Event-synchronized (the scan's first Columns event), asserted by a non-blocking drain — the first assertion was vacuous against the unbounded channel, caught by its own teeth-check.
3. **1222 for lock timeouts, 1205 only for cycles.** The 5s backstop reported every expired wait as a deadlock victim; a wait behind a live holder is not a deadlock, and a false 1205 sends drivers into retry loops for a condition retrying cannot fix. Cycles still break instantly at park time. Both numbers pinned by their own tests. The bullet's "200ms waits-for poll" is moot on audit: cycles can only form when a batch parks, and detection runs synchronously at exactly that moment — strictly better than polling.
4. **Escalation made reachable.** The 1000-key threshold sat above the parser's whole-batch node budget, so no parseable batch could ever trigger it — dead code. The budget is now per top-level expression (its purpose is bounding one evaluation spine; flat INSERT tuples never deepen one), the OR-chain guard is re-pinned per scope with an over-budget-at-batch-end case, and the escalation test pins both sides of the threshold.

## Tests

482 passed, 0 failed; fmt and clippy clean. New: the exit test (teeth-checked against an exclusive-gate regression), the 1222 pin (updated from the false-1205 pin), the two-sided escalation test, and the per-expression budget scope test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)