### PR TITLE
Stage 13: READ_COMMITTED_SNAPSHOT — version store, snapshot reads, ALTER DATABASE options

### DIFF
--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -289,6 +289,13 @@ impl Engine {
         self.storage.version_prune();
     }
 
+    /// The lock-analysis epoch (bumped by `ALTER DATABASE` option flips): the
+    /// scheduler re-analyzes parked batches whose epoch is stale before
+    /// granting them.
+    pub(crate) fn lock_analysis_epoch(&self) -> u64 {
+        self.storage.lock_analysis_epoch()
+    }
+
     fn maybe_checkpoint(&self, meta: &EngineMeta) -> Result<(), EngineError> {
         // A (fuzzy) checkpoint flushes dirty pages and truncates the WAL head to
         // the oldest open transaction's begin LSN, so it may run with open

--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -283,6 +283,12 @@ impl Engine {
         self.storage.wal_usage_ratio()
     }
 
+    /// Drops version-store history no live snapshot can need (called by the
+    /// session pool's maintenance thread; cheap when nothing is versioned).
+    pub(crate) fn version_prune(&self) {
+        self.storage.version_prune();
+    }
+
     fn maybe_checkpoint(&self, meta: &EngineMeta) -> Result<(), EngineError> {
         // A (fuzzy) checkpoint flushes dirty pages and truncates the WAL head to
         // the oldest open transaction's begin LSN, so it may run with open

--- a/crates/truthdb-core/src/group_commit.rs
+++ b/crates/truthdb-core/src/group_commit.rs
@@ -106,6 +106,16 @@ impl GroupCommit {
         self.flushed_cv.notify_all();
     }
 
+    /// The durable watermark: the highest WAL tail known fsync-durable. The
+    /// version store's snapshot capture reads this to bound visibility to the
+    /// durable commit prefix.
+    pub(crate) fn flushed(&self) -> u64 {
+        self.state
+            .lock()
+            .expect("group-commit state poisoned")
+            .flushed
+    }
+
     /// The number of fsyncs the log-writer has issued so far.
     #[cfg(test)]
     pub(crate) fn fsync_count(&self) -> u64 {

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -1637,8 +1637,21 @@ pub fn analyze_locks(
                     // (An inner SET raising isolation is seen by the
                     // recursion's own scan; it cannot outlive the EXEC — SET
                     // options revert at scope exit.)
+                    //
+                    // That level must be one the versioned-read path can
+                    // never claim: under RCSI the recursion's own
+                    // `versioned_reads` would drop Table S for a plain
+                    // READ COMMITTED, while at runtime the inner statement
+                    // executes under the OUTER effective level and reads
+                    // lock-based — a reachable dirty read at SERIALIZABLE
+                    // (caught by the adversarial review). READ COMMITTED is
+                    // passed only when it truly is the effective level.
                     let inner_isolation = if reads_lock {
-                        Isolation::ReadCommitted
+                        if matches!(isolation, Isolation::ReadCommitted) && !escalates_reads {
+                            Isolation::ReadCommitted
+                        } else {
+                            Isolation::RepeatableRead
+                        }
                     } else {
                         isolation
                     };

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -14,10 +14,10 @@ mod plan;
 mod value;
 
 use truthdb_sql::ast::{
-    AlterAction, AlterTable, CheckConstraint, ColumnDef, CreateIndex, CreateTable, CreateView,
-    DataType, Declaration, Delete, DropIndex, DropTable, DropView, ExecStatement, Expr, ExprKind,
-    ForeignKey, Insert, InsertSource, IsolationLevel, JoinKind, Name, OrderItem, Select,
-    SelectItem, SetStatement, Statement, TableRef, Update,
+    AlterAction, AlterDatabase, AlterTable, CheckConstraint, ColumnDef, CreateIndex, CreateTable,
+    CreateView, DataType, DatabaseOption, Declaration, Delete, DropIndex, DropTable, DropView,
+    ExecStatement, Expr, ExprKind, ForeignKey, Insert, InsertSource, IsolationLevel, JoinKind,
+    Name, OrderItem, Select, SelectItem, SetStatement, Statement, TableRef, Update,
 };
 use truthdb_sql::collation::CollationSensitivity;
 use truthdb_sql::error::SqlError;
@@ -33,6 +33,7 @@ use crate::relstore::btree::ScanCursor;
 use crate::relstore::catalog::{self, TableDef};
 use crate::relstore::row::{Column, Schema};
 use crate::relstore::types::{ColumnType, Datum};
+use crate::relstore::version::ReadSnapshot;
 use crate::storage::{Storage, StorageError, StorageTxn, TxnScope};
 
 /// Per-session transaction state carried across statements/batches. Lives in
@@ -1025,12 +1026,80 @@ enum StatementOutcome {
     Streamed { rows: u64 },
 }
 
+thread_local! {
+    /// The running statement's read snapshot (Stage 13), when its isolation
+    /// is versioned — RCSI's per-statement view. Thread-local rather than
+    /// threaded through every read path: a batch executes synchronously on
+    /// one worker thread, and every nested read of the statement (subqueries,
+    /// views, derived tables, correlated re-evaluation) shares the statement
+    /// snapshot by construction.
+    static CURRENT_SNAPSHOT: std::cell::Cell<Option<ReadSnapshot>> =
+        const { std::cell::Cell::new(None) };
+}
+
+/// The running statement's read snapshot, if it reads versioned.
+fn current_snapshot() -> Option<ReadSnapshot> {
+    CURRENT_SNAPSHOT.get()
+}
+
+/// Statement-scoped snapshot registration: capture on entry, and release —
+/// pruning must not wait on a statement that errored — on every exit path.
+struct SnapshotScope<'a> {
+    storage: &'a Storage,
+    seq: u64,
+}
+
+impl<'a> SnapshotScope<'a> {
+    fn enter(storage: &'a Storage, own_txn: Option<u64>) -> Self {
+        let snap = storage.capture_read_snapshot(own_txn);
+        CURRENT_SNAPSHOT.set(Some(snap));
+        SnapshotScope {
+            storage,
+            seq: snap.seq,
+        }
+    }
+}
+
+impl Drop for SnapshotScope<'_> {
+    fn drop(&mut self) {
+        CURRENT_SNAPSHOT.set(None);
+        self.storage.release_read_snapshot(self.seq);
+    }
+}
+
 /// Runs one statement. A plain `SELECT` the scan planner accepts streams its
 /// rows through `run` as the scan reads them — the whole point of the event
 /// stream: the client sees rows while the scan runs, and the statement's peak
 /// memory is one chunk, not the result. Everything else executes exactly as
 /// before and returns its materialized result.
 fn exec_statement_streamed(
+    storage: &Storage,
+    statement: &Statement,
+    txn_ctx: &mut TxnContext,
+    run: &mut BatchRun<'_>,
+) -> Result<StatementOutcome, SqlError> {
+    // RCSI: a SELECT under READ COMMITTED with the database option on reads
+    // a statement snapshot instead of blocking on writers' locks. DML (and
+    // the reads inside it) stays lock-based — conservative versus SQL
+    // Server, which versions DML's reads too; the write locks it takes here
+    // subsume what versioning would relax.
+    let versioned = matches!(statement, Statement::Select(_))
+        && matches!(txn_ctx.isolation(), Isolation::ReadCommitted)
+        && storage.rcsi_enabled();
+    if versioned {
+        // The snapshot is the durable commit prefix, so the session's own
+        // just-committed statements must be fsync-durable before capture or
+        // the statement would not see them. Rowset-producing SELECTs already
+        // flushed in `run_block`; this covers assignment SELECTs (and then
+        // no-ops when nothing committed since the last durability point).
+        run.flush(storage)?;
+    }
+    let _snapshot_scope = versioned
+        .then(|| SnapshotScope::enter(storage, txn_ctx.txn.as_ref().map(StorageTxn::txn_id)));
+    exec_statement_streamed_inner(storage, statement, txn_ctx, run)
+}
+
+fn exec_statement_streamed_inner(
     storage: &Storage,
     statement: &Statement,
     txn_ctx: &mut TxnContext,
@@ -1074,6 +1143,7 @@ fn statement_may_commit(statement: &Statement) -> bool {
             | Statement::CreateIndex(_)
             | Statement::DropIndex(_)
             | Statement::AlterTable(_)
+            | Statement::AlterDatabase(_)
             | Statement::Exec(_)
             | Statement::Commit { .. }
     )
@@ -1392,6 +1462,13 @@ pub fn analyze_locks(
         )
     });
     let reads_lock = !matches!(isolation, Isolation::ReadUncommitted) || escalates_reads;
+    // Under READ_COMMITTED_SNAPSHOT, a READ COMMITTED SELECT reads a
+    // statement snapshot instead of blocking on writers: it takes Database IS
+    // only — the DDL fence for the batch's duration — and no Table S. A batch
+    // whose SET raises the level is analyzed lock-based (conservative: the
+    // raise is seen here, the exact statement boundary is not).
+    let versioned_reads =
+        matches!(isolation, Isolation::ReadCommitted) && !escalates_reads && storage.rcsi_enabled();
     let mut needs: std::collections::HashMap<Resource, LockMode> = std::collections::HashMap::new();
     let mut add = |resource: Resource, mode: LockMode| {
         needs
@@ -1414,7 +1491,9 @@ pub fn analyze_locks(
                 for name in tables {
                     for oid in read_lock_object_ids(storage, &name.value) {
                         add(Resource::Database, LockMode::IntentShared);
-                        add(Resource::Table(oid), LockMode::Shared);
+                        if !versioned_reads {
+                            add(Resource::Table(oid), LockMode::Shared);
+                        }
                     }
                 }
             }
@@ -1538,7 +1617,10 @@ pub fn analyze_locks(
             | Statement::DropView(_)
             | Statement::CreateIndex(_)
             | Statement::DropIndex(_)
-            | Statement::AlterTable(_) => {
+            | Statement::AlterTable(_)
+            // ALTER DATABASE quiesces the database: no snapshot may be live
+            // and no writer mid-transaction while the options flip.
+            | Statement::AlterDatabase(_) => {
                 add(Resource::Database, LockMode::Exclusive);
             }
             // EXEC sp_executesql with a LITERAL statement is analyzable up
@@ -1700,6 +1782,19 @@ fn exec_statement(
             }
             let eval_ctx = txn_ctx.eval_context();
             exec_alter_table(storage, alter, &eval_ctx)
+        }
+        Statement::AlterDatabase(alter) => {
+            if txn_ctx.in_txn() {
+                // SQL Server 226: ALTER DATABASE is not allowed inside a
+                // multi-statement transaction.
+                return Err(SqlError::new(
+                    226,
+                    16,
+                    6,
+                    "ALTER DATABASE statement not allowed within multi-statement transaction.",
+                ));
+            }
+            exec_alter_database(storage, alter, txn_ctx)
         }
         Statement::Insert(insert) => {
             let eval_ctx = txn_ctx.eval_context();
@@ -2840,6 +2935,9 @@ fn enforce_parent_fks(
                                     upper,
                                     None,
                                     false,
+                                    // Integrity probe: must see the current
+                                    // state, never a snapshot.
+                                    None,
                                 )
                                 .map_err(|e| map_storage_err(e, &child.name))?;
                             if !matches.is_empty() {
@@ -3197,6 +3295,42 @@ fn exec_drop_index(storage: &Storage, drop: &DropIndex) -> Result<StatementResul
 }
 
 // ---- ALTER TABLE --------------------------------------------------------
+
+/// `ALTER DATABASE {name | CURRENT} SET READ_COMMITTED_SNAPSHOT /
+/// ALLOW_SNAPSHOT_ISOLATION {ON|OFF}`. The batch's Database X lock has
+/// quiesced the store: no snapshot is live, no writer is mid-transaction.
+fn exec_alter_database(
+    storage: &Storage,
+    alter: &AlterDatabase,
+    txn_ctx: &TxnContext,
+) -> Result<StatementResult, SqlError> {
+    if let Some(name) = &alter.name
+        && !name.value.eq_ignore_ascii_case(&txn_ctx.database)
+    {
+        return Err(SqlError::new(
+            911,
+            16,
+            1,
+            format!(
+                "Database '{}' does not exist. Make sure that the name is entered correctly.",
+                name.value
+            ),
+        )
+        .at(name.span));
+    }
+    let mut rcsi = None;
+    let mut allow_snapshot = None;
+    for (option, on) in &alter.options {
+        match option {
+            DatabaseOption::ReadCommittedSnapshot => rcsi = Some(*on),
+            DatabaseOption::AllowSnapshotIsolation => allow_snapshot = Some(*on),
+        }
+    }
+    storage
+        .rel_set_db_options(rcsi, allow_snapshot)
+        .map_err(|err| map_storage_err(err, &txn_ctx.database))?;
+    Ok(StatementResult::Done)
+}
 
 fn exec_alter_table(
     storage: &Storage,
@@ -6164,21 +6298,36 @@ fn scan_select_rows(
 
     match &plan.access {
         plan::AccessPath::TableScan => {
-            let mut cursor = ScanCursor::start();
-            let mut slice: Vec<Vec<Datum>> = Vec::new();
-            'scan: while !cursor.done() {
-                cursor = storage
-                    .rel_scan_slice(
-                        &plan.table,
-                        cursor,
-                        SCAN_SLICE_ROWS,
-                        Some(&plan.needed),
-                        &mut slice,
-                    )
+            if let Some(snapshot) = current_snapshot() {
+                // A versioned reader holds no table lock, so the sliced
+                // cursor's between-slice contract does not hold for it; the
+                // snapshot scan reads the table atomically and merges the
+                // version store.
+                let rows = storage
+                    .rel_scan_snapshot(&plan.table, Some(&plan.needed), snapshot)
                     .map_err(|err| map_storage_err(err, &plan.table))?;
-                for row in slice.drain(..) {
+                for row in rows {
                     if !take(row)? {
-                        break 'scan;
+                        break;
+                    }
+                }
+            } else {
+                let mut cursor = ScanCursor::start();
+                let mut slice: Vec<Vec<Datum>> = Vec::new();
+                'scan: while !cursor.done() {
+                    cursor = storage
+                        .rel_scan_slice(
+                            &plan.table,
+                            cursor,
+                            SCAN_SLICE_ROWS,
+                            Some(&plan.needed),
+                            &mut slice,
+                        )
+                        .map_err(|err| map_storage_err(err, &plan.table))?;
+                    for row in slice.drain(..) {
+                        if !take(row)? {
+                            break 'scan;
+                        }
                     }
                 }
             }
@@ -6199,6 +6348,7 @@ fn scan_select_rows(
                     upper.clone(),
                     Some(&plan.needed),
                     plan.covering,
+                    current_snapshot(),
                 )
                 .map_err(|err| map_storage_err(err, &plan.table))?;
             for row in rows {
@@ -7284,10 +7434,20 @@ fn build_table_source(
                 // A scan is handed out LAZY: the consumer pulls slices, so a
                 // filtering/folding reader holds one slice, not the table
                 // (and the storage lock is still taken per slice, as before).
-                plan::AccessPath::TableScan => SourceRows::Scan(ScanStream {
-                    table: def.name.clone(),
-                    cursor: ScanCursor::start(),
-                }),
+                // Under a read snapshot the scan materializes atomically
+                // instead: a versioned reader holds no table lock, so the
+                // sliced cursor's contract does not hold for it.
+                plan::AccessPath::TableScan => match current_snapshot() {
+                    Some(snapshot) => SourceRows::Materialized(
+                        storage
+                            .rel_scan_snapshot(&def.name, None, snapshot)
+                            .map_err(|err| map_storage_err(err, &def.name))?,
+                    ),
+                    None => SourceRows::Scan(ScanStream {
+                        table: def.name.clone(),
+                        cursor: ScanCursor::start(),
+                    }),
+                },
                 plan::AccessPath::IndexSeek {
                     index_object_id,
                     lower,
@@ -7295,7 +7455,15 @@ fn build_table_source(
                     ..
                 } => SourceRows::Materialized(
                     storage
-                        .rel_index_scan(&def.name, index_object_id, lower, upper, None, false)
+                        .rel_index_scan(
+                            &def.name,
+                            index_object_id,
+                            lower,
+                            upper,
+                            None,
+                            false,
+                            current_snapshot(),
+                        )
                         .map_err(|err| map_storage_err(err, &def.name))?,
                 ),
             };

--- a/crates/truthdb-core/src/relstore/ctx.rs
+++ b/crates/truthdb-core/src/relstore/ctx.rs
@@ -72,6 +72,13 @@ pub(crate) struct TxnLink {
     pub txn_id: u64,
     pub last_lsn: u64,
     pub undo_log: Vec<(u64, PageOpUndo)>,
+    /// Row versions staged by the running statement (Stage 13), published to
+    /// the version store when the statement succeeds and discarded when it
+    /// rolls back. Empty unless a versioned isolation is enabled.
+    pub pending_versions: Vec<crate::relstore::version::PendingVersion>,
+    /// Versions this transaction has published, so a rollback (full or to a
+    /// savepoint) can reverse the publications exactly.
+    pub published_versions: Vec<crate::relstore::version::PublishRecord>,
 }
 
 /// A marker in a live transaction's log to which a later partial rollback can
@@ -81,6 +88,9 @@ pub(crate) struct TxnLink {
 pub(crate) struct Savepoint {
     pub undo_len: usize,
     pub last_lsn: u64,
+    /// Published-version count at capture, so a partial rollback unpublishes
+    /// exactly the versions of the statements it undoes.
+    pub published_len: usize,
 }
 
 impl TxnLink {
@@ -89,6 +99,7 @@ impl TxnLink {
         Savepoint {
             undo_len: self.undo_log.len(),
             last_lsn: self.last_lsn,
+            published_len: self.published_versions.len(),
         }
     }
 }
@@ -196,13 +207,17 @@ impl RelCtx<'_> {
             txn_id,
             last_lsn: lsn,
             undo_log: Vec::new(),
+            pending_versions: Vec::new(),
+            published_versions: Vec::new(),
         })
     }
 
     /// Commit = force the log at the commit record, then an end record. The
     /// end record is an ATT-cleanup optimization (analysis already treats
     /// COMMIT as terminal), so its failure must not fail a durable commit.
-    pub fn commit(&mut self, txn: TxnLink) -> Result<(), StorageError> {
+    /// Returns the commit record's LSN — the version store orders commits and
+    /// finds the durable prefix by it.
+    pub fn commit(&mut self, txn: TxnLink) -> Result<u64, StorageError> {
         // The commit record is written but NOT fsynced here: group commit makes
         // it durable via the log-writer once the executor calls
         // `Storage::ensure_durable` at the end of the batch, so one fsync serves
@@ -210,7 +225,7 @@ impl RelCtx<'_> {
         // batch is acknowledged; nothing before that ack depends on it.
         let commit_lsn = self.append(&RelRecord::txn_commit(txn.txn_id, txn.last_lsn), false)?;
         let _ = self.append(&RelRecord::txn_end(txn.txn_id, commit_lsn), false);
-        Ok(())
+        Ok(commit_lsn)
     }
 
     /// Applies a physiological op to its page and logs it. Callers must have

--- a/crates/truthdb-core/src/relstore/mod.rs
+++ b/crates/truthdb-core/src/relstore/mod.rs
@@ -19,6 +19,7 @@ pub mod spill;
 #[cfg(test)]
 mod tests;
 pub mod types;
+pub(crate) mod version;
 
 use std::collections::HashMap;
 

--- a/crates/truthdb-core/src/relstore/recovery.rs
+++ b/crates/truthdb-core/src/relstore/recovery.rs
@@ -181,6 +181,8 @@ pub(crate) fn undo_losers(
                         txn_id,
                         last_lsn,
                         undo_log: Vec::new(),
+                        pending_versions: Vec::new(),
+                        published_versions: Vec::new(),
                     },
                 ),
             )

--- a/crates/truthdb-core/src/relstore/version.rs
+++ b/crates/truthdb-core/src/relstore/version.rs
@@ -182,10 +182,18 @@ impl VersionState {
 
     /// The snapshot sequence as of `durable_lsn`: the newest commit whose
     /// record the log-writer has already made durable.
+    ///
+    /// Strictly `<`: the stored LSN is the commit record's START offset,
+    /// while durability watermarks count covered bytes (end offsets), and
+    /// every flush target lands on an entry boundary — so a record whose
+    /// start equals the watermark is entirely NOT durable, and one whose
+    /// start is below it is entirely durable (no boundary falls inside a
+    /// record). `<=` here counted an unflushed commit as visible, breaking
+    /// this module's crash-visibility contract by exactly one record.
     pub fn durable_seq(&self, durable_lsn: u64) -> u64 {
         let idx = self
             .commit_points
-            .partition_point(|&(lsn, _)| lsn <= durable_lsn);
+            .partition_point(|&(lsn, _)| lsn < durable_lsn);
         if idx == 0 {
             self.durable_floor
         } else {
@@ -663,10 +671,11 @@ mod tests {
             10,
         );
         v.record_commit(10, 500);
-        // The commit record sits at LSN 500; a snapshot captured while the
-        // durable watermark is below it must not see the commit.
+        // The commit record STARTS at LSN 500; watermarks count covered
+        // bytes. A watermark at exactly 500 covers nothing of the record —
+        // the commit must stay invisible until the watermark passes it.
         let undurable = ReadSnapshot {
-            seq: v.durable_seq(499),
+            seq: v.durable_seq(500),
             own_txn: None,
         };
         assert_eq!(
@@ -674,7 +683,7 @@ mod tests {
             Some(Resolved::Image(b"old".to_vec()))
         );
         let durable = ReadSnapshot {
-            seq: v.durable_seq(500),
+            seq: v.durable_seq(501),
             own_txn: None,
         };
         assert_eq!(v.resolve(OID, b"k", durable), Some(Resolved::Current));

--- a/crates/truthdb-core/src/relstore/version.rs
+++ b/crates/truthdb-core/src/relstore/version.rs
@@ -1,0 +1,753 @@
+//! Stage 13 version store: row versions for READ COMMITTED SNAPSHOT (and,
+//! next, SNAPSHOT isolation), kept entirely in memory.
+//!
+//! Why in memory and not on rows or temp extents: the row codec is positional
+//! with no per-row header (a version stamp would change the on-disk format for
+//! every table), deletes are physical (a snapshot reader could never encounter
+//! a deleted row's ghost), and — decisively — version state has no durability
+//! requirement at all. A snapshot exists only inside a running process; after
+//! a restart there are none, so every physical row is visible to every new
+//! snapshot and an empty store is correct by construction.
+//!
+//! Shape: per table (object id), a map from *row identity* — the clustered key
+//! bytes for a tree table, the stable home RID for a heap — to a chain of
+//! versions, newest first. The chain's head describes the current physical
+//! state (present, with the bytes living in the table itself; or deleted);
+//! older entries carry the row image that was current until the next-newer
+//! entry's writer replaced it. Everything is read and written under the one
+//! storage mutex, so publication is atomic with the page mutations it
+//! describes.
+//!
+//! Timestamps are *commit sequence numbers* assigned under the storage mutex
+//! in commit order. A snapshot is the durable prefix of that order: the last
+//! sequence whose commit record the group-commit log-writer has fsynced. A
+//! commit that is appended but not yet durable is invisible — its writer has
+//! not been acknowledged, so no reader may report state that a crash could
+//! take back. Lock-based readers get the same guarantee from release timing
+//! (locks release only after the batch's fsync), so versioned reads never see
+//! more than locked reads could.
+
+use std::collections::{BTreeMap, HashMap, HashSet};
+
+/// Stamp for row images that predate tracking (the row existed before the
+/// first tracked modification): visible to every snapshot.
+const ANCIENT_TXN: u64 = 0;
+
+/// A statement's (or, for SNAPSHOT isolation, a transaction's) read view:
+/// commits with sequence `<= seq` are visible, plus the session's own open
+/// transaction.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct ReadSnapshot {
+    pub seq: u64,
+    pub own_txn: Option<u64>,
+}
+
+/// One staged row change, recorded by the DML paths as each page op succeeds
+/// and published to the store when the statement completes (same mutex hold),
+/// so readers never see pages and chains disagree.
+pub(crate) struct PendingVersion {
+    pub object_id: u32,
+    pub identity: Vec<u8>,
+    pub change: RowChange,
+}
+
+pub(crate) enum RowChange {
+    Insert,
+    Update { prior: Vec<u8> },
+    Delete { prior: Vec<u8> },
+}
+
+/// How a publish altered its chain — kept in the transaction's publish log so
+/// rollback (full or to a savepoint) can reverse the publication exactly.
+pub(crate) struct PublishRecord {
+    object_id: u32,
+    identity: Vec<u8>,
+    kind: PublishKind,
+}
+
+enum PublishKind {
+    /// The chain did not exist; the publish created it (and, for update or
+    /// delete, seeded the pre-tracking image below the new head).
+    FreshChain,
+    /// The head was a present row: it was demoted to an image and the new
+    /// state pushed above it.
+    OnExisting,
+    /// The head was a deleted marker (an insert re-creating the identity):
+    /// the new state was pushed above it, nothing was demoted.
+    OnDeleted,
+}
+
+/// What a snapshot sees for one identity.
+#[derive(Debug, PartialEq)]
+pub(crate) enum Resolved {
+    /// The current physical row is the visible version.
+    Current,
+    /// This older image is visible instead of the physical state.
+    Image(Vec<u8>),
+    /// No version is visible (created after the snapshot, or deleted before
+    /// it and re-created after).
+    Gone,
+}
+
+enum EntryState {
+    /// Row physically present as of this entry. `image` is `None` only at the
+    /// chain head — the bytes are the table's — and `Some` everywhere below.
+    Present {
+        image: Option<Vec<u8>>,
+    },
+    Deleted,
+}
+
+struct VersionEntry {
+    txn: u64,
+    state: EntryState,
+}
+
+/// Newest first; the head describes the current physical state.
+struct Chain {
+    entries: Vec<VersionEntry>,
+}
+
+#[derive(Default)]
+pub(crate) struct VersionState {
+    /// Database options (mirrored to the superblock's reserved area).
+    pub rcsi: bool,
+    pub allow_snapshot: bool,
+    /// Committed transactions -> commit sequence. Entries live until no chain
+    /// references them and the watermark has passed (pruned together with the
+    /// chains). A transaction absent here is running or rolled back — either
+    /// way invisible to every snapshot but its own.
+    commits: HashMap<u64, u64>,
+    /// (commit-record LSN, sequence), ascending in both (assigned under one
+    /// mutex in one order) — the durable-prefix search for snapshot capture.
+    commit_points: Vec<(u64, u64)>,
+    /// The largest sequence pruned out of `commit_points` (its LSN was already
+    /// durable), so capture never loses it.
+    durable_floor: u64,
+    /// Next commit sequence (0 is reserved for [`ANCIENT_TXN`]).
+    next_seq: u64,
+    /// object id -> identity -> chain.
+    tables: HashMap<u32, HashMap<Vec<u8>, Chain>>,
+    /// Active snapshots by sequence (multiset): the prune watermark.
+    snapshots: BTreeMap<u64, usize>,
+}
+
+impl VersionState {
+    /// Whether writes must publish versions (any versioned isolation can be
+    /// in use).
+    pub fn publishing(&self) -> bool {
+        self.rcsi || self.allow_snapshot
+    }
+
+    /// Applies `ALTER DATABASE` option changes. Turning the last option off
+    /// resets the store: the ALTER holds Database X, so no snapshot can be
+    /// live and no chain can be needed again.
+    pub fn set_options(&mut self, rcsi: Option<bool>, allow_snapshot: Option<bool>) {
+        if let Some(on) = rcsi {
+            self.rcsi = on;
+        }
+        if let Some(on) = allow_snapshot {
+            self.allow_snapshot = on;
+        }
+        if !self.publishing() {
+            debug_assert!(self.snapshots.is_empty());
+            self.tables.clear();
+            self.commits.clear();
+            self.commit_points.clear();
+            self.durable_floor = 0;
+        }
+    }
+
+    /// The two option bits as persisted in the superblock reserved area.
+    pub fn options_byte(&self) -> u8 {
+        (self.rcsi as u8) | ((self.allow_snapshot as u8) << 1)
+    }
+
+    pub fn set_options_byte(&mut self, byte: u8) {
+        self.rcsi = byte & 1 != 0;
+        self.allow_snapshot = byte & 2 != 0;
+    }
+
+    /// Records a commit, assigning its sequence. Called under the storage
+    /// mutex immediately after the commit record is appended.
+    pub fn record_commit(&mut self, txn_id: u64, commit_lsn: u64) {
+        if !self.publishing() {
+            return;
+        }
+        self.next_seq += 1;
+        let seq = self.next_seq;
+        self.commits.insert(txn_id, seq);
+        self.commit_points.push((commit_lsn, seq));
+    }
+
+    /// The snapshot sequence as of `durable_lsn`: the newest commit whose
+    /// record the log-writer has already made durable.
+    pub fn durable_seq(&self, durable_lsn: u64) -> u64 {
+        let idx = self
+            .commit_points
+            .partition_point(|&(lsn, _)| lsn <= durable_lsn);
+        if idx == 0 {
+            self.durable_floor
+        } else {
+            self.commit_points[idx - 1].1
+        }
+    }
+
+    pub fn register_snapshot(&mut self, seq: u64) {
+        *self.snapshots.entry(seq).or_insert(0) += 1;
+    }
+
+    pub fn release_snapshot(&mut self, seq: u64) {
+        if let Some(count) = self.snapshots.get_mut(&seq) {
+            *count -= 1;
+            if *count == 0 {
+                self.snapshots.remove(&seq);
+            }
+        } else {
+            debug_assert!(false, "released a snapshot that was not registered");
+        }
+    }
+
+    fn visible(&self, txn: u64, snap: ReadSnapshot) -> bool {
+        txn == ANCIENT_TXN
+            || snap.own_txn == Some(txn)
+            || self.commits.get(&txn).is_some_and(|&seq| seq <= snap.seq)
+    }
+
+    /// True if any identity of this table has a chain (the read paths' fast
+    /// gate: no chains, no merge work).
+    pub fn table_has_chains(&self, object_id: u32) -> bool {
+        self.tables
+            .get(&object_id)
+            .is_some_and(|chains| !chains.is_empty())
+    }
+
+    /// What `snap` sees for this identity; `None` = no chain (the physical
+    /// state is the only version and is visible).
+    pub fn resolve(&self, object_id: u32, identity: &[u8], snap: ReadSnapshot) -> Option<Resolved> {
+        let chain = self.tables.get(&object_id)?.get(identity)?;
+        for (idx, entry) in chain.entries.iter().enumerate() {
+            if !self.visible(entry.txn, snap) {
+                continue;
+            }
+            return Some(match &entry.state {
+                EntryState::Present { image: None } => {
+                    debug_assert_eq!(idx, 0, "imageless entry below the chain head");
+                    Resolved::Current
+                }
+                EntryState::Present { image: Some(image) } => Resolved::Image(image.clone()),
+                EntryState::Deleted => Resolved::Gone,
+            });
+        }
+        Some(Resolved::Gone)
+    }
+
+    /// Images visible to `snap` for identities a physical read did not
+    /// encounter: rows deleted (or re-keyed away, or whose index entry moved)
+    /// by writers the snapshot does not see. The caller appends them and lets
+    /// its predicate re-check each.
+    pub fn unseen_images(
+        &self,
+        object_id: u32,
+        seen: &HashSet<Vec<u8>>,
+        snap: ReadSnapshot,
+    ) -> Vec<Vec<u8>> {
+        let Some(chains) = self.tables.get(&object_id) else {
+            return Vec::new();
+        };
+        let mut out = Vec::new();
+        for identity in chains.keys() {
+            if seen.contains(identity) {
+                continue;
+            }
+            // Only images are appended: `Current` for an unseen identity
+            // means the visible version is the physical row itself, and a
+            // physical read that did not produce it has already decided it
+            // does not qualify (an index seek whose range the row's current
+            // value is outside).
+            if let Some(Resolved::Image(image)) = self.resolve(object_id, identity, snap) {
+                out.push(image);
+            }
+        }
+        out
+    }
+
+    /// Publishes one staged change under `txn_id`, returning the record that
+    /// lets a rollback reverse it.
+    pub fn publish(&mut self, pending: PendingVersion, txn_id: u64) -> PublishRecord {
+        let PendingVersion {
+            object_id,
+            identity,
+            change,
+        } = pending;
+        // An insert has no prior image; updates and deletes carry the bytes
+        // that were current until now.
+        let (is_delete, prior) = match change {
+            RowChange::Insert => (false, None),
+            RowChange::Update { prior } => (false, Some(prior)),
+            RowChange::Delete { prior } => (true, Some(prior)),
+        };
+        let new_head = VersionEntry {
+            txn: txn_id,
+            state: if is_delete {
+                EntryState::Deleted
+            } else {
+                EntryState::Present { image: None }
+            },
+        };
+        let chains = self.tables.entry(object_id).or_default();
+        let kind = match (chains.get_mut(&identity), prior) {
+            (None, prior) => {
+                let mut entries = vec![new_head];
+                // The row existed before tracking: seed its pre-tracking
+                // image, visible to every snapshot.
+                if let Some(prior) = prior {
+                    entries.push(VersionEntry {
+                        txn: ANCIENT_TXN,
+                        state: EntryState::Present { image: Some(prior) },
+                    });
+                }
+                chains.insert(identity.clone(), Chain { entries });
+                PublishKind::FreshChain
+            }
+            (Some(chain), Some(prior)) => {
+                // Update/delete: demote the present head to an image, push
+                // the new state above it.
+                if let Some(head) = chain.entries.first_mut() {
+                    debug_assert!(
+                        matches!(head.state, EntryState::Present { image: None }),
+                        "update/delete over a chain whose head is not the current row"
+                    );
+                    if let EntryState::Present { image } = &mut head.state {
+                        *image = Some(prior);
+                    }
+                }
+                chain.entries.insert(0, new_head);
+                PublishKind::OnExisting
+            }
+            (Some(chain), None) => {
+                // Insert re-creating a deleted identity: nothing to demote.
+                debug_assert!(
+                    matches!(chain.entries.first(), Some(e) if matches!(e.state, EntryState::Deleted)),
+                    "insert over a chain whose head is a present row"
+                );
+                chain.entries.insert(0, new_head);
+                PublishKind::OnDeleted
+            }
+        };
+        PublishRecord {
+            object_id,
+            identity,
+            kind,
+        }
+    }
+
+    /// Reverses one publish (rollback). Must be called in reverse publish
+    /// order so nested demotions unwind correctly.
+    pub fn unpublish(&mut self, record: PublishRecord, txn_id: u64) {
+        let Some(chains) = self.tables.get_mut(&record.object_id) else {
+            debug_assert!(false, "unpublish for a table with no chains");
+            return;
+        };
+        match record.kind {
+            PublishKind::FreshChain => {
+                let removed = chains.remove(&record.identity);
+                debug_assert!(
+                    removed.is_some_and(|c| c.entries.first().is_some_and(|e| e.txn == txn_id)),
+                    "fresh-chain unpublish found someone else's chain"
+                );
+            }
+            PublishKind::OnDeleted | PublishKind::OnExisting => {
+                let Some(chain) = chains.get_mut(&record.identity) else {
+                    debug_assert!(false, "unpublish for a missing chain");
+                    return;
+                };
+                debug_assert!(chain.entries.first().is_some_and(|e| e.txn == txn_id));
+                chain.entries.remove(0);
+                if matches!(record.kind, PublishKind::OnExisting) {
+                    // The entry below was the head we demoted: the physical
+                    // undo restored exactly its image, so it is the current
+                    // row again.
+                    if let Some(head) = chain.entries.first_mut()
+                        && let EntryState::Present { image } = &mut head.state
+                    {
+                        *image = None;
+                    }
+                }
+            }
+        }
+        if chains.is_empty() {
+            self.tables.remove(&record.object_id);
+        }
+    }
+
+    /// The oldest sequence any live snapshot needs, or `fallback` (the current
+    /// durable sequence) when none is active.
+    pub fn watermark(&self, fallback: u64) -> u64 {
+        self.snapshots
+            .keys()
+            .next()
+            .copied()
+            .unwrap_or(fallback)
+            .min(fallback)
+    }
+
+    /// Drops chain history no snapshot at or below `watermark` can need,
+    /// chains of dropped tables, and commit records nothing references.
+    /// `alive` is the set of object ids still in the catalog.
+    pub fn prune(&mut self, watermark: u64, alive: &HashSet<u32>) {
+        let snap = ReadSnapshot {
+            seq: watermark,
+            own_txn: None,
+        };
+        // Collect visibility decisions first: `visible` borrows `self`.
+        let mut keep: HashMap<u32, HashMap<Vec<u8>, usize>> = HashMap::new();
+        for (&oid, chains) in &self.tables {
+            let per_table = keep.entry(oid).or_default();
+            for (identity, chain) in chains {
+                let newest_visible = chain.entries.iter().position(|e| self.visible(e.txn, snap));
+                // Entries below the newest watermark-visible one can never be
+                // served again; usize::MAX = keep everything (nothing visible
+                // yet: every entry belongs to newer commits or open txns).
+                per_table.insert(identity.clone(), newest_visible.unwrap_or(usize::MAX));
+            }
+        }
+        for (oid, chains) in &mut self.tables {
+            if !alive.contains(oid) {
+                chains.clear();
+                continue;
+            }
+            let per_table = &keep[oid];
+            chains.retain(|identity, chain| {
+                let cut = per_table[identity];
+                if cut == usize::MAX {
+                    return true;
+                }
+                chain.entries.truncate(cut + 1);
+                // A chain reduced to its head alone carries no history: the
+                // physical state is the only version, which is what "no
+                // chain" already means.
+                chain.entries.len() > 1
+            });
+        }
+        self.tables.retain(|_, chains| !chains.is_empty());
+
+        // Commits: referenced by a surviving chain, or newer than the
+        // watermark (a live or future snapshot may still need the sequence).
+        let mut referenced: HashSet<u64> = HashSet::new();
+        for chains in self.tables.values() {
+            for chain in chains.values() {
+                for entry in &chain.entries {
+                    referenced.insert(entry.txn);
+                }
+            }
+        }
+        self.commits
+            .retain(|txn, seq| *seq > watermark || referenced.contains(txn));
+        // Commit points whose sequence the watermark has passed are only
+        // needed as the durable floor.
+        let cut = self
+            .commit_points
+            .partition_point(|&(_, seq)| seq <= watermark);
+        if cut > 0 {
+            self.durable_floor = self.durable_floor.max(self.commit_points[cut - 1].1);
+            self.commit_points.drain(..cut);
+        }
+    }
+
+    /// Test observability: chains held for one table.
+    #[cfg(test)]
+    pub fn chain_count(&self, object_id: u32) -> usize {
+        self.tables.get(&object_id).map_or(0, HashMap::len)
+    }
+}
+
+/// The stable identity of a heap row: its home RID, encoded.
+pub(crate) fn rid_identity(rid: crate::relstore::heap::Rid) -> Vec<u8> {
+    let mut out = Vec::with_capacity(10);
+    out.extend_from_slice(&rid.page.to_le_bytes());
+    out.extend_from_slice(&rid.slot.to_le_bytes());
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const OID: u32 = 7;
+
+    fn on() -> VersionState {
+        let mut v = VersionState::default();
+        v.set_options(Some(true), None);
+        v
+    }
+
+    fn snap(v: &VersionState) -> ReadSnapshot {
+        ReadSnapshot {
+            seq: v.durable_seq(u64::MAX),
+            own_txn: None,
+        }
+    }
+
+    fn pending(identity: &[u8], change: RowChange) -> PendingVersion {
+        PendingVersion {
+            object_id: OID,
+            identity: identity.to_vec(),
+            change,
+        }
+    }
+
+    #[test]
+    fn an_update_serves_the_old_image_until_its_commit_is_visible() {
+        let mut v = on();
+        // Snapshot taken before txn 10 touches the row.
+        let before = snap(&v);
+        let _ = v.publish(
+            pending(
+                b"k",
+                RowChange::Update {
+                    prior: b"old".to_vec(),
+                },
+            ),
+            10,
+        );
+        assert_eq!(
+            v.resolve(OID, b"k", before),
+            Some(Resolved::Image(b"old".to_vec())),
+            "an uncommitted writer's row serves its prior image"
+        );
+        // The writer's own snapshot sees the current row.
+        let own = ReadSnapshot {
+            seq: before.seq,
+            own_txn: Some(10),
+        };
+        assert_eq!(v.resolve(OID, b"k", own), Some(Resolved::Current));
+        v.record_commit(10, 100);
+        assert_eq!(
+            v.resolve(OID, b"k", before),
+            Some(Resolved::Image(b"old".to_vec())),
+            "a snapshot from before the commit still reads the old image"
+        );
+        let after = snap(&v);
+        assert_eq!(v.resolve(OID, b"k", after), Some(Resolved::Current));
+    }
+
+    #[test]
+    fn a_delete_is_gone_after_commit_and_an_unseen_image_before() {
+        let mut v = on();
+        let before = snap(&v);
+        let _ = v.publish(
+            pending(
+                b"k",
+                RowChange::Delete {
+                    prior: b"row".to_vec(),
+                },
+            ),
+            10,
+        );
+        // The physical row is gone: the scan never encounters `k`, and the
+        // merge pass serves its image to the older snapshot.
+        let unseen = v.unseen_images(OID, &HashSet::new(), before);
+        assert_eq!(unseen, vec![b"row".to_vec()]);
+        v.record_commit(10, 100);
+        let after = snap(&v);
+        assert!(v.unseen_images(OID, &HashSet::new(), after).is_empty());
+        assert_eq!(v.resolve(OID, b"k", after), Some(Resolved::Gone));
+    }
+
+    #[test]
+    fn an_insert_is_invisible_until_commit() {
+        let mut v = on();
+        let before = snap(&v);
+        let _ = v.publish(pending(b"k", RowChange::Insert), 10);
+        assert_eq!(
+            v.resolve(OID, b"k", before),
+            Some(Resolved::Gone),
+            "a row inserted by an invisible transaction does not exist yet"
+        );
+        v.record_commit(10, 100);
+        assert_eq!(v.resolve(OID, b"k", snap(&v)), Some(Resolved::Current));
+    }
+
+    #[test]
+    fn unpublish_reverses_in_reverse_order_including_double_touch() {
+        let mut v = on();
+        // Txn 10 updates the same row twice, then rolls back.
+        let r1 = v.publish(
+            pending(
+                b"k",
+                RowChange::Update {
+                    prior: b"v0".to_vec(),
+                },
+            ),
+            10,
+        );
+        let r2 = v.publish(
+            pending(
+                b"k",
+                RowChange::Update {
+                    prior: b"v1".to_vec(),
+                },
+            ),
+            10,
+        );
+        let s = snap(&v);
+        assert_eq!(
+            v.resolve(OID, b"k", s),
+            Some(Resolved::Image(b"v0".to_vec()))
+        );
+        v.unpublish(r2, 10);
+        v.unpublish(r1, 10);
+        assert_eq!(
+            v.resolve(OID, b"k", s),
+            None,
+            "a fully unpublished chain is gone (the physical row is the only version)"
+        );
+        assert_eq!(v.chain_count(OID), 0);
+    }
+
+    #[test]
+    fn a_key_swap_keeps_both_histories_in_op_order() {
+        let mut v = on();
+        let before = snap(&v);
+        // UPDATE swapping keys A and B: deletes first, inserts after, exactly
+        // as the tree applies them.
+        let _ = v.publish(
+            pending(
+                b"a",
+                RowChange::Delete {
+                    prior: b"rowA".to_vec(),
+                },
+            ),
+            10,
+        );
+        let _ = v.publish(
+            pending(
+                b"b",
+                RowChange::Delete {
+                    prior: b"rowB".to_vec(),
+                },
+            ),
+            10,
+        );
+        let _ = v.publish(pending(b"b", RowChange::Insert), 10);
+        let _ = v.publish(pending(b"a", RowChange::Insert), 10);
+        // Both identities are physically present (re-inserted), so a real
+        // scan encounters them and nothing is unseen.
+        let seen: HashSet<Vec<u8>> = [b"a".to_vec(), b"b".to_vec()].into();
+        assert!(v.unseen_images(OID, &seen, before).is_empty());
+        assert_eq!(
+            v.resolve(OID, b"a", before),
+            Some(Resolved::Image(b"rowA".to_vec()))
+        );
+        assert_eq!(
+            v.resolve(OID, b"b", before),
+            Some(Resolved::Image(b"rowB".to_vec()))
+        );
+        v.record_commit(10, 100);
+        let after = snap(&v);
+        assert_eq!(v.resolve(OID, b"a", after), Some(Resolved::Current));
+        assert_eq!(v.resolve(OID, b"b", after), Some(Resolved::Current));
+    }
+
+    #[test]
+    fn snapshots_are_bounded_by_the_durable_prefix() {
+        let mut v = on();
+        let _ = v.publish(
+            pending(
+                b"k",
+                RowChange::Update {
+                    prior: b"old".to_vec(),
+                },
+            ),
+            10,
+        );
+        v.record_commit(10, 500);
+        // The commit record sits at LSN 500; a snapshot captured while the
+        // durable watermark is below it must not see the commit.
+        let undurable = ReadSnapshot {
+            seq: v.durable_seq(499),
+            own_txn: None,
+        };
+        assert_eq!(
+            v.resolve(OID, b"k", undurable),
+            Some(Resolved::Image(b"old".to_vec()))
+        );
+        let durable = ReadSnapshot {
+            seq: v.durable_seq(500),
+            own_txn: None,
+        };
+        assert_eq!(v.resolve(OID, b"k", durable), Some(Resolved::Current));
+    }
+
+    #[test]
+    fn prune_respects_the_oldest_live_snapshot_and_drops_after_release() {
+        let mut v = on();
+        let alive: HashSet<u32> = [OID].into();
+        let before = snap(&v);
+        v.register_snapshot(before.seq);
+        let _ = v.publish(
+            pending(
+                b"k",
+                RowChange::Update {
+                    prior: b"old".to_vec(),
+                },
+            ),
+            10,
+        );
+        v.record_commit(10, 100);
+        let fallback = v.durable_seq(u64::MAX);
+        v.prune(v.watermark(fallback), &alive);
+        assert_eq!(
+            v.resolve(OID, b"k", before),
+            Some(Resolved::Image(b"old".to_vec())),
+            "a live snapshot pins the history it may still read"
+        );
+        v.release_snapshot(before.seq);
+        let fallback = v.durable_seq(u64::MAX);
+        v.prune(v.watermark(fallback), &alive);
+        assert_eq!(v.chain_count(OID), 0, "released history is dropped");
+        assert_eq!(v.resolve(OID, b"k", snap(&v)), None);
+    }
+
+    #[test]
+    fn prune_drops_chains_of_dropped_tables_but_keeps_open_transactions() {
+        let mut v = on();
+        let _ = v.publish(
+            pending(
+                b"k",
+                RowChange::Update {
+                    prior: b"old".to_vec(),
+                },
+            ),
+            10,
+        );
+        // Txn 10 is still open (no commit): its history must survive any
+        // prune — a snapshot captured after its commit may need the image.
+        let fallback = v.durable_seq(u64::MAX);
+        v.prune(v.watermark(fallback), &[OID].into());
+        assert_eq!(v.chain_count(OID), 1);
+        // The table is dropped: the chain goes regardless.
+        v.prune(v.watermark(fallback), &HashSet::new());
+        assert_eq!(v.chain_count(OID), 0);
+    }
+
+    #[test]
+    fn turning_the_last_option_off_resets_the_store() {
+        let mut v = on();
+        let _ = v.publish(
+            pending(
+                b"k",
+                RowChange::Update {
+                    prior: b"old".to_vec(),
+                },
+            ),
+            10,
+        );
+        v.record_commit(10, 100);
+        v.set_options(Some(false), None);
+        assert!(!v.publishing());
+        assert_eq!(v.chain_count(OID), 0);
+        assert_eq!(v.options_byte(), 0);
+    }
+}

--- a/crates/truthdb-core/src/session.rs
+++ b/crates/truthdb-core/src/session.rs
@@ -1024,6 +1024,10 @@ fn maintenance_loop(shared: &Arc<Shared>) {
             sched.reap_expired(&shared.engine);
             sched.reap_idle_txns(&shared.engine);
         }
+        // Version-store upkeep (Stage 13): drop row-version history no live
+        // snapshot can need. Outside the scheduler lock — it takes the
+        // storage lock, and nothing here depends on lock-table state.
+        shared.engine.version_prune();
         // Unconditionally, not just when something was released. Workers now
         // block indefinitely on the inbox, so a nudge that should have been
         // sent and was not is a batch parked forever rather than a batch
@@ -3929,5 +3933,390 @@ mod tests {
         let mut named = int_param(9);
         named.name = "@extra".into();
         assert!(bind_decl_names("", vec![named]).is_ok());
+    }
+
+    // ---- READ_COMMITTED_SNAPSHOT (Stage 13) ------------------------------
+
+    /// A harness with RCSI on and `t (id PK, v)` seeded with (1,10), (2,20).
+    async fn rcsi_harness() -> (Harness, SessionId, SessionId) {
+        let h = start(Duration::from_secs(30));
+        let a = h.handle.open_session(String::new(), String::new()).await;
+        let b = h.handle.open_session(String::new(), String::new()).await;
+        for sql in [
+            "ALTER DATABASE CURRENT SET READ_COMMITTED_SNAPSHOT ON",
+            "CREATE TABLE t (id INT NOT NULL PRIMARY KEY, v INT)",
+            "INSERT INTO t VALUES (1, 10), (2, 20)",
+        ] {
+            let reply = h.handle.run_batch(a, sql.into()).await.unwrap();
+            assert_eq!(
+                error_number(&reply),
+                None,
+                "{sql}: {:?}",
+                reply.outcome.error
+            );
+        }
+        (h, a, b)
+    }
+
+    /// Runs a batch under a 2 s timeout: an RCSI reader must never park
+    /// behind a writer, so a hang here is the failure being tested for.
+    async fn must_not_block(h: &Harness, s: SessionId, sql: &str) -> BatchReply {
+        tokio::time::timeout(Duration::from_secs(2), h.handle.run_batch(s, sql.into()))
+            .await
+            .expect("an RCSI read must not block on a writer")
+            .unwrap()
+    }
+
+    /// Column 0 of the first rowset as i64s, asserting the batch succeeded.
+    fn values(reply: &BatchReply) -> Vec<i64> {
+        assert_eq!(error_number(reply), None, "{:?}", reply.outcome.error);
+        ids(reply)
+    }
+
+    #[tokio::test]
+    async fn rcsi_select_reads_committed_state_without_waiting_for_the_writer() {
+        let (h, a, b) = rcsi_harness().await;
+        h.handle
+            .run_batch(a, "BEGIN TRAN; UPDATE t SET v = 99 WHERE id = 1;".into())
+            .await
+            .unwrap();
+        // B reads the pre-update value while A's transaction holds its X
+        // lock: the value is the proof there was no wait (a lock-based
+        // reader could only return 99, after A commits).
+        let reply = must_not_block(&h, b, "SELECT v FROM t WHERE id = 1").await;
+        assert_eq!(values(&reply), vec![10]);
+        h.handle.run_batch(a, "COMMIT".into()).await.unwrap();
+        let reply = must_not_block(&h, b, "SELECT v FROM t WHERE id = 1").await;
+        assert_eq!(values(&reply), vec![99]);
+    }
+
+    #[tokio::test]
+    async fn without_rcsi_the_same_reader_waits_for_the_commit() {
+        // The control for the test above — and the teeth of the
+        // `rcsi_enabled` gate: with the option off, the reader parks on the
+        // writer's lock and can only ever see the committed value.
+        let h = start(Duration::from_secs(30));
+        let a = h.handle.open_session(String::new(), String::new()).await;
+        let b = h.handle.open_session(String::new(), String::new()).await;
+        h.handle
+            .run_batch(
+                a,
+                "CREATE TABLE t (id INT NOT NULL PRIMARY KEY, v INT); \
+                 INSERT INTO t VALUES (1, 10);"
+                    .into(),
+            )
+            .await
+            .unwrap();
+        h.handle
+            .run_batch(a, "BEGIN TRAN; UPDATE t SET v = 99 WHERE id = 1;".into())
+            .await
+            .unwrap();
+        let reader = {
+            let handle = h.handle.clone();
+            tokio::spawn(async move { handle.run_batch(b, "SELECT v FROM t".into()).await })
+        };
+        h.handle.run_batch(a, "COMMIT".into()).await.unwrap();
+        let reply = reader.await.unwrap().unwrap();
+        assert_eq!(
+            values(&reply),
+            vec![99],
+            "a lock-based reader sees only the commit"
+        );
+    }
+
+    #[tokio::test]
+    async fn rcsi_reader_sees_a_deleted_row_until_the_delete_commits() {
+        let (h, a, b) = rcsi_harness().await;
+        h.handle
+            .run_batch(a, "BEGIN TRAN; DELETE FROM t WHERE id = 1;".into())
+            .await
+            .unwrap();
+        // The row is physically gone from the page; the scan's merge pass
+        // serves it from its version image.
+        let reply = must_not_block(&h, b, "SELECT id FROM t").await;
+        let mut got = values(&reply);
+        got.sort();
+        assert_eq!(got, vec![1, 2]);
+        h.handle.run_batch(a, "COMMIT".into()).await.unwrap();
+        let reply = must_not_block(&h, b, "SELECT id FROM t").await;
+        assert_eq!(values(&reply), vec![2]);
+    }
+
+    #[tokio::test]
+    async fn rcsi_insert_is_invisible_until_it_commits() {
+        let (h, a, b) = rcsi_harness().await;
+        h.handle
+            .run_batch(a, "BEGIN TRAN; INSERT INTO t VALUES (3, 30);".into())
+            .await
+            .unwrap();
+        let reply = must_not_block(&h, b, "SELECT id FROM t").await;
+        let mut got = values(&reply);
+        got.sort();
+        assert_eq!(
+            got,
+            vec![1, 2],
+            "an uncommitted insert does not exist for the snapshot"
+        );
+        h.handle.run_batch(a, "COMMIT".into()).await.unwrap();
+        let reply = must_not_block(&h, b, "SELECT id FROM t").await;
+        let mut got = values(&reply);
+        got.sort();
+        assert_eq!(got, vec![1, 2, 3]);
+    }
+
+    #[tokio::test]
+    async fn rcsi_rekey_update_shows_the_old_row_until_commit() {
+        let (h, a, b) = rcsi_harness().await;
+        h.handle
+            .run_batch(a, "BEGIN TRAN; UPDATE t SET id = 9 WHERE id = 1;".into())
+            .await
+            .unwrap();
+        let reply = must_not_block(&h, b, "SELECT id FROM t").await;
+        let mut got = values(&reply);
+        got.sort();
+        assert_eq!(
+            got,
+            vec![1, 2],
+            "the re-key is invisible: old identity present, new absent"
+        );
+        h.handle.run_batch(a, "COMMIT".into()).await.unwrap();
+        let reply = must_not_block(&h, b, "SELECT id FROM t").await;
+        let mut got = values(&reply);
+        got.sort();
+        assert_eq!(got, vec![2, 9]);
+    }
+
+    #[tokio::test]
+    async fn rcsi_index_seek_serves_the_snapshot_row() {
+        let (h, a, b) = rcsi_harness().await;
+        // Enough rows that the planner takes the seek (tiny tables demote to
+        // scans), plus an index on v.
+        let mut fill = String::from("INSERT INTO t VALUES ");
+        for i in 3..=25 {
+            fill.push_str(&format!("({}, {}),", i, i * 100));
+        }
+        fill.pop();
+        h.handle.run_batch(a, fill).await.unwrap();
+        h.handle
+            .run_batch(a, "CREATE INDEX ix_v ON t (v)".into())
+            .await
+            .unwrap();
+        h.handle
+            .run_batch(a, "BEGIN TRAN; UPDATE t SET v = 4242 WHERE id = 1;".into())
+            .await
+            .unwrap();
+        // The uncommitted update moved the index entry from 10 to 4242. The
+        // snapshot must still find id=1 under v=10 (its entry is gone — the
+        // merge pass restores it) and must not find it under v=4242 (the
+        // entry exists, but the visible image fails the predicate).
+        let reply = must_not_block(&h, b, "SELECT id FROM t WHERE v = 10").await;
+        assert_eq!(values(&reply), vec![1]);
+        let reply = must_not_block(&h, b, "SELECT id FROM t WHERE v = 4242").await;
+        assert_eq!(values(&reply), Vec::<i64>::new());
+        h.handle.run_batch(a, "COMMIT".into()).await.unwrap();
+        let reply = must_not_block(&h, b, "SELECT id FROM t WHERE v = 4242").await;
+        assert_eq!(values(&reply), vec![1]);
+        let reply = must_not_block(&h, b, "SELECT id FROM t WHERE v = 10").await;
+        assert_eq!(values(&reply), Vec::<i64>::new());
+    }
+
+    #[tokio::test]
+    async fn rcsi_reader_sees_its_own_uncommitted_writes() {
+        let (h, a, _b) = rcsi_harness().await;
+        h.handle
+            .run_batch(a, "BEGIN TRAN; UPDATE t SET v = 55 WHERE id = 1;".into())
+            .await
+            .unwrap();
+        let reply = must_not_block(&h, a, "SELECT v FROM t WHERE id = 1").await;
+        assert_eq!(
+            values(&reply),
+            vec![55],
+            "a session always sees its own writes"
+        );
+        h.handle.run_batch(a, "ROLLBACK".into()).await.unwrap();
+        let reply = must_not_block(&h, a, "SELECT v FROM t WHERE id = 1").await;
+        assert_eq!(values(&reply), vec![10]);
+    }
+
+    #[tokio::test]
+    async fn rcsi_same_batch_write_then_read_sees_the_write() {
+        // The durable-prefix rule must not hide the session's own
+        // just-committed statement from a later statement in the same batch
+        // (the flush-before-capture path).
+        let (h, a, _b) = rcsi_harness().await;
+        let reply = must_not_block(
+            &h,
+            a,
+            "UPDATE t SET v = 11 WHERE id = 1; SELECT v FROM t WHERE id = 1",
+        )
+        .await;
+        assert_eq!(values(&reply), vec![11]);
+    }
+
+    #[tokio::test]
+    async fn rollback_after_publish_keeps_chains_sound_for_reuse() {
+        // A rolled-back insert must unpublish its version entries: the next
+        // insert of the same key builds a fresh chain (the debug asserts on
+        // chain-head invariants fire here if it does not), and readers see
+        // only the committed state.
+        let (h, a, b) = rcsi_harness().await;
+        h.handle
+            .run_batch(a, "BEGIN TRAN; INSERT INTO t VALUES (5, 50);".into())
+            .await
+            .unwrap();
+        h.handle.run_batch(a, "ROLLBACK".into()).await.unwrap();
+        let reply = h
+            .handle
+            .run_batch(a, "INSERT INTO t VALUES (5, 55)".into())
+            .await
+            .unwrap();
+        assert_eq!(error_number(&reply), None, "{:?}", reply.outcome.error);
+        let reply = must_not_block(&h, b, "SELECT v FROM t WHERE id = 5").await;
+        assert_eq!(values(&reply), vec![55]);
+    }
+
+    #[tokio::test]
+    async fn savepoint_rollback_unpublishes_the_rolled_back_statements() {
+        let (h, a, b) = rcsi_harness().await;
+        h.handle
+            .run_batch(
+                a,
+                "BEGIN TRAN; UPDATE t SET v = 100 WHERE id = 1; \
+                 SAVE TRANSACTION s; UPDATE t SET v = 200 WHERE id = 2; \
+                 ROLLBACK TRANSACTION s;"
+                    .into(),
+            )
+            .await
+            .unwrap();
+        // While A is open, B sees both originals (100 and 200 are invisible
+        // either way — the discriminator is after the commit).
+        let reply = must_not_block(&h, b, "SELECT v FROM t WHERE id = 2").await;
+        assert_eq!(values(&reply), vec![20]);
+        h.handle.run_batch(a, "COMMIT".into()).await.unwrap();
+        let reply = must_not_block(&h, b, "SELECT v FROM t WHERE id = 1").await;
+        assert_eq!(values(&reply), vec![100], "the kept update committed");
+        let reply = must_not_block(&h, b, "SELECT v FROM t WHERE id = 2").await;
+        assert_eq!(
+            values(&reply),
+            vec![20],
+            "the savepoint-rolled-back update did not"
+        );
+    }
+
+    #[tokio::test]
+    async fn rcsi_assignment_select_sees_the_same_batch_commit() {
+        // An assignment SELECT opens no rowset, so it skips `run_block`'s
+        // pre-rowset durability flush — the snapshot capture must flush on
+        // its own or the durable-prefix rule hides the batch's own
+        // just-committed UPDATE from it.
+        let (h, a, _b) = rcsi_harness().await;
+        let reply = must_not_block(
+            &h,
+            a,
+            "UPDATE t SET v = 42 WHERE id = 1; \
+             DECLARE @x INT; SELECT @x = v FROM t WHERE id = 1; SELECT @x",
+        )
+        .await;
+        assert_eq!(values(&reply), vec![42]);
+    }
+
+    #[tokio::test]
+    async fn repeatable_read_still_blocks_under_rcsi() {
+        // RCSI changes READ COMMITTED only. A REPEATABLE READ reader keeps
+        // its Table S request and parks behind the writer.
+        let (h, a, b) = rcsi_harness().await;
+        h.handle
+            .run_batch(b, "SET TRANSACTION ISOLATION LEVEL REPEATABLE READ".into())
+            .await
+            .unwrap();
+        h.handle
+            .run_batch(a, "BEGIN TRAN; UPDATE t SET v = 99 WHERE id = 1;".into())
+            .await
+            .unwrap();
+        let reader = {
+            let handle = h.handle.clone();
+            tokio::spawn(async move {
+                handle
+                    .run_batch(b, "SELECT v FROM t WHERE id = 1".into())
+                    .await
+            })
+        };
+        h.handle.run_batch(a, "COMMIT".into()).await.unwrap();
+        let reply = reader.await.unwrap().unwrap();
+        assert_eq!(
+            values(&reply),
+            vec![99],
+            "an RR reader sees only committed state, by waiting"
+        );
+    }
+
+    #[tokio::test]
+    async fn rcsi_heap_table_serves_snapshot_rows() {
+        let h = start(Duration::from_secs(30));
+        let a = h.handle.open_session(String::new(), String::new()).await;
+        let b = h.handle.open_session(String::new(), String::new()).await;
+        for sql in [
+            "ALTER DATABASE CURRENT SET READ_COMMITTED_SNAPSHOT ON",
+            "CREATE TABLE hp (v INT)",
+            "INSERT INTO hp VALUES (10), (20)",
+        ] {
+            h.handle.run_batch(a, sql.into()).await.unwrap();
+        }
+        h.handle
+            .run_batch(
+                a,
+                "BEGIN TRAN; UPDATE hp SET v = 99 WHERE v = 10; DELETE FROM hp WHERE v = 20;"
+                    .into(),
+            )
+            .await
+            .unwrap();
+        let reply = must_not_block(&h, b, "SELECT v FROM hp").await;
+        let mut got = values(&reply);
+        got.sort();
+        assert_eq!(
+            got,
+            vec![10, 20],
+            "heap identities (RIDs) version like tree keys"
+        );
+        h.handle.run_batch(a, "ROLLBACK".into()).await.unwrap();
+        let reply = must_not_block(&h, b, "SELECT v FROM hp").await;
+        let mut got = values(&reply);
+        got.sort();
+        assert_eq!(got, vec![10, 20]);
+    }
+
+    #[tokio::test]
+    async fn alter_database_rejects_wrong_names_and_open_transactions() {
+        let h = start(Duration::from_secs(30));
+        let s = h.handle.open_session("truthdb".into(), "sa".into()).await;
+        let reply = h
+            .handle
+            .run_batch(
+                s,
+                "ALTER DATABASE nosuch SET READ_COMMITTED_SNAPSHOT ON".into(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(error_number(&reply), Some(911));
+        let reply = h
+            .handle
+            .run_batch(
+                s,
+                "BEGIN TRAN; ALTER DATABASE CURRENT SET READ_COMMITTED_SNAPSHOT ON;".into(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(error_number(&reply), Some(226));
+        h.handle.run_batch(s, "ROLLBACK".into()).await.unwrap();
+        // The session's own database by name works, and the option sticks.
+        let reply = h
+            .handle
+            .run_batch(
+                s,
+                "ALTER DATABASE truthdb SET READ_COMMITTED_SNAPSHOT ON".into(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(error_number(&reply), None, "{:?}", reply.outcome.error);
     }
 }

--- a/crates/truthdb-core/src/session.rs
+++ b/crates/truthdb-core/src/session.rs
@@ -1274,6 +1274,7 @@ fn dispatch_batch(
         let isolation = sched.isolation(session);
         // Parameters are values, not statements, so they never change which
         // locks the batch needs — analyse the statement text as usual.
+        let epoch = shared.engine.lock_analysis_epoch();
         let needs = shared.engine.analyze_locks(&sql, isolation);
         if sched.try_acquire(session.raw(), &needs, true) {
             sched.sessions.touch(session);
@@ -1296,6 +1297,7 @@ fn dispatch_batch(
                 reply,
                 needs,
                 deadline,
+                epoch,
             });
             // The new waiter may have closed a lock-wait cycle; break it now
             // rather than waiting for the deadline backstop.
@@ -1353,7 +1355,7 @@ fn drain_ready(shared: &Arc<Shared>) {
     loop {
         let work = {
             let mut sched = shared.scheduler.lock().expect("scheduler poisoned");
-            sched.next_grantable()
+            sched.next_grantable(&shared.engine)
         };
         match work {
             Some(work) => run_and_finish(shared, work),
@@ -1372,6 +1374,12 @@ struct Parked {
     reply: BatchSink,
     needs: Vec<(Resource, LockMode)>,
     deadline: Instant,
+    /// The lock-analysis epoch `needs` was computed under. A pending `ALTER
+    /// DATABASE` option flip bumps the epoch; a parked batch whose epoch is
+    /// stale is re-analyzed before it can be granted, so the lock set it
+    /// runs with always matches the versioning regime it will execute under
+    /// (analyzed-versioned-but-executes-lock-based was a dirty read).
+    epoch: u64,
 }
 
 /// The scheduler's mutable world: the sessions, the lock manager, and the FIFO
@@ -1543,9 +1551,21 @@ impl Scheduler {
     /// grantable, having granted them and taken its session's transaction
     /// context out to run with. `None` if none can proceed. The caller runs it
     /// with the scheduler lock released, then calls again.
-    fn next_grantable(&mut self) -> Option<Runnable> {
+    fn next_grantable(&mut self, engine: &Engine) -> Option<Runnable> {
+        let current_epoch = engine.lock_analysis_epoch();
         let mut i = 0;
         while i < self.parked.len() {
+            // An ALTER DATABASE option flip since this batch was analyzed may
+            // have changed which locks its reads need (versioned vs Table S):
+            // re-analyze before considering the grant, so the lock set always
+            // matches the regime the batch will execute under. The deadlock
+            // graph may see one sweep of stale needs; the grant path never
+            // does.
+            if self.parked[i].epoch != current_epoch {
+                let isolation = self.isolation(self.parked[i].session);
+                self.parked[i].needs = engine.analyze_locks(&self.parked[i].sql, isolation);
+                self.parked[i].epoch = current_epoch;
+            }
             let owner = self.parked[i].session.raw();
             if self.grantable(i) {
                 let parked = self.parked.remove(i).expect("index in bounds");
@@ -2342,6 +2362,7 @@ mod tests {
             reply,
             needs: Vec::new(),
             deadline: Instant::now() + Duration::from_secs(5),
+            epoch: 0,
         });
         assert!(
             !sched.reap_idle_txns(&engine),
@@ -2453,6 +2474,7 @@ mod tests {
             reply,
             needs: vec![(Resource::Table(1), LockMode::Shared)],
             deadline: Instant::now() - Duration::from_secs(60),
+            epoch: 0,
         });
         let shared = Arc::new(Shared {
             engine: Arc::new(engine),
@@ -2578,6 +2600,7 @@ mod tests {
             reply,
             needs: vec![(Resource::Table(1), LockMode::Shared)],
             deadline: Instant::now() - Duration::from_secs(60),
+            epoch: 0,
         });
         sched.reap_expired(&engine);
         assert_eq!(
@@ -4318,5 +4341,238 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(error_number(&reply), None, "{:?}", reply.outcome.error);
+    }
+
+    // The next six tests came out of the adversarial review: the first two
+    // pin its confirmed findings (both reproduced as dirty reads before the
+    // fixes), the rest are its passing probes kept as regressions.
+
+    #[tokio::test]
+    async fn serializable_exec_literal_select_must_not_dirty_read_under_rcsi() {
+        // A SERIALIZABLE session EXECs a literal SELECT while another
+        // session's transaction holds an uncommitted UPDATE. The reader must
+        // wait for the writer (SERIALIZABLE reads lock) and, after the
+        // writer's ROLLBACK, see the original value 10. A dirty read
+        // returns 99 — a value that never committed.
+        let (h, a, b) = rcsi_harness().await;
+        h.handle
+            .run_batch(b, "SET TRANSACTION ISOLATION LEVEL SERIALIZABLE".into())
+            .await
+            .unwrap();
+        h.handle
+            .run_batch(a, "BEGIN TRAN; UPDATE t SET v = 99 WHERE id = 1;".into())
+            .await
+            .unwrap();
+        let reader = {
+            let handle = h.handle.clone();
+            tokio::spawn(async move {
+                handle
+                    .run_batch(
+                        b,
+                        "EXEC sp_executesql N'SELECT v FROM t WHERE id = 1'".into(),
+                    )
+                    .await
+            })
+        };
+        // Give the reader time to (incorrectly) run without blocking.
+        tokio::time::sleep(Duration::from_millis(300)).await;
+        h.handle.run_batch(a, "ROLLBACK".into()).await.unwrap();
+        let reply = reader.await.unwrap().unwrap();
+        assert_eq!(
+            values(&reply),
+            vec![10],
+            "a SERIALIZABLE reader must never see the uncommitted 99"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_parked_reader_is_reanalyzed_when_rcsi_flips_off() {
+        // A reader analyzed while RCSI is ON (Database IS only, no Table S)
+        // parks behind a pending ALTER ... OFF; when granted, RCSI is OFF so
+        // it executes lock-based — with the stale (versioned) lock set. A
+        // concurrent uncommitted writer is then readable: dirty read at
+        // READ COMMITTED with RCSI off.
+        for round in 0..5 {
+            let (h, a, b) = rcsi_harness().await;
+            let c = h.handle.open_session(String::new(), String::new()).await;
+            // Writer A holds Database IX -> the ALTER (Database X) parks.
+            h.handle
+                .run_batch(a, "BEGIN TRAN; UPDATE t SET v = 55 WHERE id = 2;".into())
+                .await
+                .unwrap();
+            let admin = {
+                let handle = h.handle.clone();
+                let s = h.handle.open_session(String::new(), String::new()).await;
+                tokio::spawn(async move {
+                    handle
+                        .run_batch(
+                            s,
+                            "ALTER DATABASE CURRENT SET READ_COMMITTED_SNAPSHOT OFF".into(),
+                        )
+                        .await
+                })
+            };
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            // Writer C parks behind the ALTER (fairness on Database).
+            let writer = {
+                let handle = h.handle.clone();
+                tokio::spawn(async move {
+                    handle
+                        .run_batch(c, "BEGIN TRAN; UPDATE t SET v = 777 WHERE id = 1;".into())
+                        .await
+                })
+            };
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            // Reader B analyzed NOW (RCSI still on -> no Table S), parks.
+            let reader = {
+                let handle = h.handle.clone();
+                tokio::spawn(async move {
+                    handle
+                        .run_batch(b, "SELECT v FROM t WHERE id = 1".into())
+                        .await
+                })
+            };
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            // A commits: the ALTER runs and flips RCSI off. B's lock set was
+            // analyzed under RCSI-on (no Table S); the grant path must
+            // re-analyze it, so B now blocks behind C's open transaction
+            // instead of reading its uncommitted 777 lock-free.
+            h.handle.run_batch(a, "COMMIT".into()).await.unwrap();
+            // C's UPDATE batch completes (transaction stays open, holding
+            // its locks); B must still be waiting on them.
+            tokio::time::timeout(Duration::from_secs(5), writer)
+                .await
+                .expect("writer hung")
+                .unwrap()
+                .unwrap();
+            h.handle.run_batch(c, "ROLLBACK".into()).await.unwrap();
+            let reply = tokio::time::timeout(Duration::from_secs(5), reader)
+                .await
+                .expect("reader hung")
+                .unwrap()
+                .unwrap();
+            let seen = values(&reply);
+            assert_eq!(
+                seen,
+                vec![10],
+                "round {round}: the reader may only see committed state \
+                 (777 never committed — seeing it is the dirty read)"
+            );
+            admin.await.unwrap().unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn rcsi_insert_after_delete_in_one_txn_serves_the_old_image() {
+        let (h, a, b) = rcsi_harness().await;
+        h.handle
+            .run_batch(
+                a,
+                "BEGIN TRAN; DELETE FROM t WHERE id = 1; INSERT INTO t VALUES (1, 111);".into(),
+            )
+            .await
+            .unwrap();
+        let reply = must_not_block(&h, b, "SELECT v FROM t WHERE id = 1").await;
+        assert_eq!(values(&reply), vec![10], "pre-txn image, not the re-insert");
+        h.handle.run_batch(a, "ROLLBACK".into()).await.unwrap();
+        let reply = must_not_block(&h, b, "SELECT v FROM t WHERE id = 1").await;
+        assert_eq!(values(&reply), vec![10]);
+        h.handle
+            .run_batch(
+                a,
+                "BEGIN TRAN; DELETE FROM t WHERE id = 1; INSERT INTO t VALUES (1, 222);".into(),
+            )
+            .await
+            .unwrap();
+        h.handle.run_batch(a, "COMMIT".into()).await.unwrap();
+        let reply = must_not_block(&h, b, "SELECT v FROM t WHERE id = 1").await;
+        assert_eq!(values(&reply), vec![222]);
+    }
+
+    #[tokio::test]
+    async fn rcsi_aggregates_and_subqueries_read_the_snapshot() {
+        let (h, a, b) = rcsi_harness().await;
+        h.handle
+            .run_batch(
+                a,
+                "BEGIN TRAN; DELETE FROM t WHERE id = 2; UPDATE t SET v = 99 WHERE id = 1;".into(),
+            )
+            .await
+            .unwrap();
+        // Aggregate over the collecting path (build_table_source).
+        let reply = must_not_block(&h, b, "SELECT COUNT(*) FROM t").await;
+        assert_eq!(
+            values(&reply),
+            vec![2],
+            "the uncommitted delete is invisible"
+        );
+        let reply = must_not_block(&h, b, "SELECT SUM(v) FROM t").await;
+        assert_eq!(values(&reply), vec![30], "10 + 20, not 99 + (deleted)");
+        // Uncorrelated subquery: reads t under the same statement snapshot.
+        let reply =
+            must_not_block(&h, b, "SELECT v FROM t WHERE id = (SELECT MAX(id) FROM t)").await;
+        assert_eq!(values(&reply), vec![20], "MAX(id) = 2 in the snapshot");
+        h.handle.run_batch(a, "COMMIT".into()).await.unwrap();
+        let reply = must_not_block(&h, b, "SELECT COUNT(*) FROM t").await;
+        assert_eq!(values(&reply), vec![1]);
+    }
+
+    #[tokio::test]
+    async fn rcsi_range_seek_does_not_double_count_a_moved_entry() {
+        let (h, a, b) = rcsi_harness().await;
+        let mut fill = String::from("INSERT INTO t VALUES ");
+        for i in 3..=25 {
+            fill.push_str(&format!("({}, {}),", i, i * 100));
+        }
+        fill.pop();
+        h.handle.run_batch(a, fill).await.unwrap();
+        h.handle
+            .run_batch(a, "CREATE INDEX ix_v ON t (v)".into())
+            .await
+            .unwrap();
+        // Uncommitted: moves id=1's entry from v=10 to v=15 — both inside
+        // the seek range below.
+        h.handle
+            .run_batch(a, "BEGIN TRAN; UPDATE t SET v = 15 WHERE id = 1;".into())
+            .await
+            .unwrap();
+        let reply = must_not_block(
+            &h,
+            b,
+            "SELECT id FROM t WHERE v >= 5 AND v <= 20 ORDER BY id",
+        )
+        .await;
+        assert_eq!(
+            values(&reply),
+            vec![1, 2],
+            "id=1 exactly once (image v=10), id=2 (v=20); no double count"
+        );
+        h.handle.run_batch(a, "ROLLBACK".into()).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn rcsi_covering_seek_serves_a_deleted_row_image() {
+        let (h, a, b) = rcsi_harness().await;
+        let mut fill = String::from("INSERT INTO t VALUES ");
+        for i in 3..=25 {
+            fill.push_str(&format!("({}, {}),", i, i * 100));
+        }
+        fill.pop();
+        h.handle.run_batch(a, fill).await.unwrap();
+        h.handle
+            .run_batch(a, "CREATE INDEX ix_vc ON t (v) INCLUDE (v, id)".into())
+            .await
+            .unwrap();
+        h.handle
+            .run_batch(a, "BEGIN TRAN; DELETE FROM t WHERE id = 1;".into())
+            .await
+            .unwrap();
+        // The deleted row's index entry is gone; the covering seek must
+        // append its image from the version store.
+        let reply = must_not_block(&h, b, "SELECT id FROM t WHERE v = 10").await;
+        assert_eq!(values(&reply), vec![1], "the deleted row's image is served");
+        h.handle.run_batch(a, "COMMIT".into()).await.unwrap();
+        let reply = must_not_block(&h, b, "SELECT id FROM t WHERE v = 10").await;
+        assert_eq!(values(&reply), Vec::<i64>::new());
     }
 }

--- a/crates/truthdb-core/src/storage.rs
+++ b/crates/truthdb-core/src/storage.rs
@@ -19,6 +19,7 @@ use crate::relstore::key::encode_key;
 use crate::relstore::recovery as rel_recovery;
 use crate::relstore::row::{Column, Schema, decode_row, decode_row_projected, encode_row};
 use crate::relstore::types::{Datum, TypeError};
+use crate::relstore::version::{PendingVersion, ReadSnapshot, Resolved, RowChange, rid_identity};
 use crate::storage_layout::{
     FileHeader, PAGE_SIZE, SNAPSHOT_DESCRIPTOR_SIZE, SUPERBLOCK_ACTIVE_A, SUPERBLOCK_ACTIVE_B,
     SnapshotDescriptor, Superblock, WAL_ENTRY_TYPE_REL, WAL_MAX_BYTES, WAL_MIN_BYTES, align_down,
@@ -133,6 +134,11 @@ pub struct Storage {
     gc: Arc<GroupCommit>,
     /// The log-writer thread's join handle, taken in `Drop` after signalling it.
     log_writer: Option<JoinHandle<()>>,
+    /// `READ_COMMITTED_SNAPSHOT` / `ALLOW_SNAPSHOT_ISOLATION` mirrors of the
+    /// version store's options, readable without the storage mutex (lock
+    /// analysis and the per-statement snapshot gate are on the hot path).
+    rcsi: std::sync::atomic::AtomicBool,
+    allow_snapshot: std::sync::atomic::AtomicBool,
     /// Scan slices read, so a test can prove a scan stopped early rather than
     /// reading the table and discarding the rest. On the instance and not in a
     /// `static`: the suite runs in parallel in one binary, so a static would
@@ -199,11 +205,15 @@ impl Storage {
     fn with_log_writer(path: PathBuf, file: StorageFile) -> Result<Self, StorageError> {
         let wal_fd = file.try_clone_wal_fd()?;
         let (gc, log_writer) = GroupCommit::start(wal_fd);
+        let rcsi = file.version.rcsi;
+        let allow_snapshot = file.version.allow_snapshot;
         Ok(Storage {
             path,
             inner: std::sync::Mutex::new(file),
             gc,
             log_writer: Some(log_writer),
+            rcsi: std::sync::atomic::AtomicBool::new(rcsi),
+            allow_snapshot: std::sync::atomic::AtomicBool::new(allow_snapshot),
             #[cfg(test)]
             scan_slices: std::sync::atomic::AtomicUsize::new(0),
             #[cfg(test)]
@@ -487,6 +497,7 @@ impl Storage {
         self.lock().rel_row_count(table)
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn rel_index_scan(
         &self,
         table: &str,
@@ -495,14 +506,110 @@ impl Storage {
         upper: Option<Vec<u8>>,
         projection: Option<&[usize]>,
         covering: bool,
+        snapshot: Option<ReadSnapshot>,
     ) -> Result<Vec<Vec<Datum>>, StorageError> {
         #[cfg(test)]
         if covering {
             self.covering_scans
                 .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         }
-        self.lock()
-            .rel_index_scan(table, index_object_id, lower, upper, projection, covering)
+        self.lock().rel_index_scan(
+            table,
+            index_object_id,
+            lower,
+            upper,
+            projection,
+            covering,
+            snapshot,
+        )
+    }
+
+    /// Whether `READ_COMMITTED_SNAPSHOT` is on (readable without the storage
+    /// mutex — checked per statement and during lock analysis).
+    pub(crate) fn rcsi_enabled(&self) -> bool {
+        self.rcsi.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// Whether `ALLOW_SNAPSHOT_ISOLATION` is on.
+    #[allow(dead_code)] // consumed when SNAPSHOT isolation lands
+    pub(crate) fn snapshot_isolation_allowed(&self) -> bool {
+        self.allow_snapshot
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// Applies `ALTER DATABASE SET` option changes: updates the version
+    /// store, persists the options in the superblocks, and refreshes the
+    /// lock-free mirrors. The caller holds Database X, so no snapshot is live
+    /// and no writer is mid-transaction.
+    pub(crate) fn rel_set_db_options(
+        &self,
+        rcsi: Option<bool>,
+        allow_snapshot: Option<bool>,
+    ) -> Result<(), StorageError> {
+        let mut guard = self.lock();
+        guard.set_db_options(rcsi, allow_snapshot)?;
+        let (rcsi_now, allow_now) = (guard.version.rcsi, guard.version.allow_snapshot);
+        drop(guard);
+        self.rcsi
+            .store(rcsi_now, std::sync::atomic::Ordering::Relaxed);
+        self.allow_snapshot
+            .store(allow_now, std::sync::atomic::Ordering::Relaxed);
+        Ok(())
+    }
+
+    /// Captures a read snapshot: the durable commit prefix as of now, plus
+    /// the session's own open transaction. Registered so pruning cannot drop
+    /// versions the snapshot may still need; the caller MUST pair this with
+    /// [`Self::release_read_snapshot`].
+    pub(crate) fn capture_read_snapshot(&self, own_txn: Option<u64>) -> ReadSnapshot {
+        let durable = self.gc.flushed();
+        let mut guard = self.lock();
+        // Whichever watermark is ahead: the group-commit fsync or a direct
+        // WAL sync (rollbacks, checkpoints) — both are durability floors.
+        let durable = durable.max(guard.wal.flushed_lsn());
+        let seq = guard.version.durable_seq(durable);
+        guard.version.register_snapshot(seq);
+        ReadSnapshot { seq, own_txn }
+    }
+
+    pub(crate) fn release_read_snapshot(&self, seq: u64) {
+        self.lock().version.release_snapshot(seq);
+    }
+
+    /// Atomic snapshot scan: the whole table under one storage-lock hold
+    /// (a versioned reader holds no table lock, so a sliced cursor could be
+    /// restructured under it mid-walk), merged against the version store.
+    pub(crate) fn rel_scan_snapshot(
+        &self,
+        name: &str,
+        projection: Option<&[usize]>,
+        snapshot: ReadSnapshot,
+    ) -> Result<Vec<Vec<Datum>>, StorageError> {
+        self.lock().rel_scan_snapshot(name, projection, snapshot)
+    }
+
+    /// Drops version history no live snapshot can need (runs on the
+    /// maintenance thread; cheap when nothing is versioned).
+    pub(crate) fn version_prune(&self) {
+        let durable = self.gc.flushed();
+        let mut guard = self.lock();
+        let durable = durable.max(guard.wal.flushed_lsn());
+        let fallback = guard.version.durable_seq(durable);
+        let watermark = guard.version.watermark(fallback);
+        let alive: std::collections::HashSet<u32> =
+            guard.rel.tables.values().map(|def| def.object_id).collect();
+        guard.version.prune(watermark, &alive);
+    }
+
+    /// Test observability: version chains held for `table`.
+    #[cfg(test)]
+    pub(crate) fn version_chain_count(&self, table: &str) -> usize {
+        let guard = self.lock();
+        guard
+            .rel
+            .tables
+            .get(table)
+            .map_or(0, |def| guard.version.chain_count(def.object_id))
     }
 
     pub fn rel_insert(&self, name: &str, values: Vec<Datum>) -> Result<(), StorageError> {
@@ -880,6 +987,14 @@ pub(crate) struct StorageTxn {
     roots: std::collections::HashMap<u32, u64>,
 }
 
+impl StorageTxn {
+    /// The transaction's id — a versioned reader's "own transaction" for
+    /// visibility of its own uncommitted writes.
+    pub(crate) fn txn_id(&self) -> u64 {
+        self.txn.txn_id
+    }
+}
+
 /// The transaction a statement runs under.
 pub(crate) enum TxnScope<'a> {
     /// Autocommit: begin + commit around the single statement.
@@ -917,6 +1032,11 @@ struct StorageFile {
     /// this at CREATE TABLE and stored with it, so the column keeps the
     /// collation it was created under even if the default later changes.
     default_collation: Option<String>,
+    /// Stage 13 version store: row-version chains for snapshot reads, plus
+    /// the RCSI / ALLOW_SNAPSHOT_ISOLATION options (persisted in the
+    /// superblock reserved area; the chains themselves are memory-only — no
+    /// snapshot survives a restart, so neither must they).
+    version: crate::relstore::version::VersionState,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1384,6 +1504,7 @@ impl StorageFile {
         self.rel_ctx().counter_read(page).ok()
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn rel_index_scan(
         &mut self,
         table: &str,
@@ -1392,6 +1513,7 @@ impl StorageFile {
         upper: Option<Vec<u8>>,
         projection: Option<&[usize]>,
         covering: bool,
+        snapshot: Option<ReadSnapshot>,
     ) -> Result<Vec<Vec<Datum>>, StorageError> {
         self.ensure_rel_usable()?;
         let (def, schema) = self.rel_def(table)?;
@@ -1401,13 +1523,58 @@ impl StorageFile {
             .find(|i| i.object_id == index_object_id)
             .cloned()
             .ok_or_else(|| StorageError::InvalidConfig("unknown index".to_string()))?;
-        let mut ctx = self.rel_ctx();
-        let index_tree = BTree {
-            object_id: index.object_id,
-            root: index.root_page,
+        let entries = {
+            let mut ctx = self.rel_ctx();
+            let index_tree = BTree {
+                object_id: index.object_id,
+                root: index.root_page,
+            };
+            index_tree.scan_range(&mut ctx, lower.as_deref(), upper.as_deref())?
         };
-        let entries = index_tree.scan_range(&mut ctx, lower.as_deref(), upper.as_deref())?;
-        let mut rows = Vec::with_capacity(entries.len());
+        // The leaf-value format depends on the index: an INCLUDE index
+        // length-prefixes its locator (a Key locator's payload would
+        // otherwise swallow the include bytes that follow it).
+        let locator_of = |value: &[u8]| -> Locator {
+            if index.include.is_empty() {
+                index::decode_locator(value)
+            } else {
+                index::decode_leaf_value_with_include(value).0
+            }
+        };
+        // Resolve each entry against the version store first (a snapshot
+        // reader may need an entry's row served from an older image, or
+        // dropped when its writer is invisible), then do the page lookups.
+        // Rows the seek could not encounter — their index entry was moved or
+        // removed by a writer the snapshot does not see — are appended from
+        // their chain images; the executor's predicate re-checks every row,
+        // so over-returning is filtered, never wrong.
+        enum Entry {
+            Physical(Vec<u8>),
+            Image(Vec<u8>),
+        }
+        let merging = snapshot.is_some_and(|_| self.version.table_has_chains(def.object_id));
+        let mut decided: Vec<Entry> = Vec::with_capacity(entries.len());
+        let mut extra_images: Vec<Vec<u8>> = Vec::new();
+        if let (Some(snap), true) = (snapshot, merging) {
+            let mut seen: std::collections::HashSet<Vec<u8>> = std::collections::HashSet::new();
+            for (_, value) in entries {
+                let identity = match locator_of(&value) {
+                    Locator::Key(pk) => pk,
+                    Locator::Rid(rid) => rid_identity(rid),
+                };
+                match self.version.resolve(def.object_id, &identity, snap) {
+                    None | Some(Resolved::Current) => decided.push(Entry::Physical(value)),
+                    Some(Resolved::Image(image)) => decided.push(Entry::Image(image)),
+                    Some(Resolved::Gone) => {}
+                }
+                seen.insert(identity);
+            }
+            extra_images = self.version.unseen_images(def.object_id, &seen, snap);
+        } else {
+            decided.extend(entries.into_iter().map(|(_, value)| Entry::Physical(value)));
+        }
+
+        let mut rows = Vec::with_capacity(decided.len());
         if covering {
             // Answer from the leaves alone: every projected column's original
             // value is stored in the entry (after the length-prefixed
@@ -1428,33 +1595,39 @@ impl StorageFile {
                     })
                 })
                 .collect::<Result<_, _>>()?;
-            for (_, value) in entries {
-                let (_, include_bytes) = index::decode_leaf_value_with_include(&value);
-                let decoded = index::decode_include(&schema, &index.include, include_bytes)
-                    .map_err(|err| StorageError::InvalidFile(err.0))?;
-                rows.push(positions.iter().map(|&p| decoded[p].clone()).collect());
+            for entry in decided {
+                match entry {
+                    Entry::Physical(value) => {
+                        let (_, include_bytes) = index::decode_leaf_value_with_include(&value);
+                        let decoded = index::decode_include(&schema, &index.include, include_bytes)
+                            .map_err(|err| StorageError::InvalidFile(err.0))?;
+                        rows.push(positions.iter().map(|&p| decoded[p].clone()).collect());
+                    }
+                    // A version image is the full row: project it directly.
+                    Entry::Image(image) => {
+                        rows.push(decode_row_projected(&schema, &image, projection)?);
+                    }
+                }
             }
         } else {
-            // The leaf-value format depends on the index: an INCLUDE index
-            // length-prefixes its locator (a Key locator's payload would
-            // otherwise swallow the include bytes that follow it).
-            let locator_of = |value: &[u8]| -> Locator {
-                if index.include.is_empty() {
-                    index::decode_locator(value)
-                } else {
-                    index::decode_leaf_value_with_include(value).0
-                }
-            };
+            let mut ctx = self.rel_ctx();
             if def.is_tree() {
                 let base = BTree {
                     object_id: def.object_id,
                     root: def.root_page,
                 };
-                for (_, value) in entries {
-                    if let Locator::Key(pk) = locator_of(&value)
-                        && let Some(row) = base.get(&mut ctx, &pk)?
-                    {
-                        rows.push(decode_projected(&schema, &row, projection)?);
+                for entry in decided {
+                    match entry {
+                        Entry::Physical(value) => {
+                            if let Locator::Key(pk) = locator_of(&value)
+                                && let Some(row) = base.get(&mut ctx, &pk)?
+                            {
+                                rows.push(decode_projected(&schema, &row, projection)?);
+                            }
+                        }
+                        Entry::Image(image) => {
+                            rows.push(decode_projected(&schema, &image, projection)?);
+                        }
                     }
                 }
             } else {
@@ -1462,14 +1635,24 @@ impl StorageFile {
                     object_id: def.object_id,
                     first_page: def.root_page,
                 };
-                for (_, value) in entries {
-                    if let Locator::Rid(rid) = locator_of(&value)
-                        && let Some(row) = heap.read_row(&mut ctx, rid)?
-                    {
-                        rows.push(decode_projected(&schema, &row, projection)?);
+                for entry in decided {
+                    match entry {
+                        Entry::Physical(value) => {
+                            if let Locator::Rid(rid) = locator_of(&value)
+                                && let Some(row) = heap.read_row(&mut ctx, rid)?
+                            {
+                                rows.push(decode_projected(&schema, &row, projection)?);
+                            }
+                        }
+                        Entry::Image(image) => {
+                            rows.push(decode_projected(&schema, &image, projection)?);
+                        }
                     }
                 }
             }
+        }
+        for image in extra_images {
+            rows.push(decode_projected(&schema, &image, projection)?);
         }
         Ok(rows)
     }
@@ -1507,6 +1690,7 @@ impl StorageFile {
         let collations = def.collations.clone();
         let counter_page = def.counter_page;
         let inserted = rows.len() as i64;
+        let publishing = self.version.publishing();
         if def.is_tree() {
             let tree = BTree {
                 object_id: def.object_id,
@@ -1533,6 +1717,13 @@ impl StorageFile {
                         values,
                         &Locator::Key(key.clone()),
                     )?;
+                    if publishing {
+                        txn.pending_versions.push(PendingVersion {
+                            object_id: tree.object_id,
+                            identity: key.clone(),
+                            change: RowChange::Insert,
+                        });
+                    }
                 }
                 if let Some(page) = counter_page {
                     ctx.counter_add(txn, page, inserted)?;
@@ -1557,6 +1748,13 @@ impl StorageFile {
                         values,
                         &Locator::Rid(rid),
                     )?;
+                    if publishing {
+                        txn.pending_versions.push(PendingVersion {
+                            object_id: heap.object_id,
+                            identity: rid_identity(rid),
+                            change: RowChange::Insert,
+                        });
+                    }
                 }
                 if let Some(page) = counter_page {
                     ctx.counter_add(txn, page, inserted)?;
@@ -1674,6 +1872,67 @@ impl StorageFile {
         raw.into_iter()
             .map(|row| decode_row(&schema, &row).map_err(StorageError::from))
             .collect()
+    }
+
+    /// Snapshot scan (Stage 13): the whole table read atomically under this
+    /// one lock hold, each row resolved through the version store — a row
+    /// last written by a transaction the snapshot cannot see is served from
+    /// its chain image instead — plus the images of rows the physical walk
+    /// could not encounter (deleted or re-keyed by writers the snapshot does
+    /// not see). Atomic because a versioned reader holds no table lock, so a
+    /// sliced cursor could be restructured under it mid-walk.
+    fn rel_scan_snapshot(
+        &mut self,
+        name: &str,
+        projection: Option<&[usize]>,
+        snapshot: ReadSnapshot,
+    ) -> Result<Vec<Vec<Datum>>, StorageError> {
+        self.ensure_rel_usable()?;
+        let (def, schema) = self.rel_def(name)?;
+        let physical: Vec<(Vec<u8>, Vec<u8>)> = {
+            let mut ctx = self.rel_ctx();
+            if def.is_tree() {
+                let tree = BTree {
+                    object_id: def.object_id,
+                    root: def.root_page,
+                };
+                tree.scan(&mut ctx)?
+            } else {
+                let heap = Heap {
+                    object_id: def.object_id,
+                    first_page: def.root_page,
+                };
+                heap.scan(&mut ctx)?
+                    .into_iter()
+                    .map(|(rid, row)| (rid_identity(rid), row))
+                    .collect()
+            }
+        };
+        let mut out = Vec::with_capacity(physical.len());
+        if !self.version.table_has_chains(def.object_id) {
+            for (_, row) in physical {
+                out.push(decode_projected(&schema, &row, projection)?);
+            }
+            return Ok(out);
+        }
+        let mut seen: std::collections::HashSet<Vec<u8>> =
+            std::collections::HashSet::with_capacity(physical.len());
+        for (identity, row) in physical {
+            match self.version.resolve(def.object_id, &identity, snapshot) {
+                None | Some(Resolved::Current) => {
+                    out.push(decode_projected(&schema, &row, projection)?);
+                }
+                Some(Resolved::Image(image)) => {
+                    out.push(decode_projected(&schema, &image, projection)?);
+                }
+                Some(Resolved::Gone) => {}
+            }
+            seen.insert(identity);
+        }
+        for image in self.version.unseen_images(def.object_id, &seen, snapshot) {
+            out.push(decode_projected(&schema, &image, projection)?);
+        }
+        Ok(out)
     }
 
     /// Deletes every row where `column = value`; returns the count. Targets
@@ -1879,7 +2138,7 @@ impl StorageFile {
         scope: &mut TxnScope,
     ) -> Result<usize, StorageError> {
         self.ensure_rel_usable()?;
-        let (def, _schema) = self.rel_def(name)?;
+        let (def, schema) = self.rel_def(name)?;
         let count = targets.len();
         if count == 0 {
             return Ok(0);
@@ -1887,6 +2146,17 @@ impl StorageFile {
         let indexes = def.indexes.clone();
         let collations = def.collations.clone();
         let counter_page = def.counter_page;
+        // Version staging: the deleted rows' images, encoded up front (the
+        // schema stays out of the closure), indexed alongside `targets`.
+        let publishing = self.version.publishing();
+        let priors: Vec<Option<Vec<u8>>> = if publishing {
+            targets
+                .iter()
+                .map(|(_, values)| encode_row(&schema, values).map(Some))
+                .collect::<Result<_, _>>()?
+        } else {
+            targets.iter().map(|_| None).collect()
+        };
         // The counter follows the rows actually removed inside the statement,
         // which the arms count as they go (a locator of the wrong kind is
         // skipped, exactly as the row loop skips it).
@@ -1897,7 +2167,7 @@ impl StorageFile {
             };
             self.rel_statement_scoped(scope, move |ctx, txn| {
                 let mut removed: i64 = 0;
-                for (loc, values) in &targets {
+                for ((loc, values), prior) in targets.iter().zip(priors) {
                     if let RowLocator::Key(key) = loc {
                         tree.delete(ctx, &mut OpMode::Txn(txn), key)?;
                         index_delete_row(
@@ -1908,6 +2178,13 @@ impl StorageFile {
                             values,
                             &Locator::Key(key.clone()),
                         )?;
+                        if let Some(prior) = prior {
+                            txn.pending_versions.push(PendingVersion {
+                                object_id: tree.object_id,
+                                identity: key.clone(),
+                                change: RowChange::Delete { prior },
+                            });
+                        }
                         removed += 1;
                     }
                 }
@@ -1923,7 +2200,7 @@ impl StorageFile {
             };
             self.rel_statement_scoped(scope, move |ctx, txn| {
                 let mut removed: i64 = 0;
-                for (loc, values) in &targets {
+                for ((loc, values), prior) in targets.iter().zip(priors) {
                     if let RowLocator::Rid(rid) = loc {
                         heap.delete(ctx, txn, *rid)?;
                         index_delete_row(
@@ -1934,6 +2211,13 @@ impl StorageFile {
                             values,
                             &Locator::Rid(*rid),
                         )?;
+                        if let Some(prior) = prior {
+                            txn.pending_versions.push(PendingVersion {
+                                object_id: heap.object_id,
+                                identity: rid_identity(*rid),
+                                change: RowChange::Delete { prior },
+                            });
+                        }
                         removed += 1;
                     }
                 }
@@ -1967,6 +2251,7 @@ impl StorageFile {
         }
         let indexes = def.indexes.clone();
         let collations = def.collations.clone();
+        let publishing = self.version.publishing();
         // (old values, old locator, new values, new locator) for index upkeep.
         let mut idx_ops: Vec<(Vec<Datum>, Locator, Vec<Datum>, Locator)> = Vec::new();
         if def.is_tree() {
@@ -1977,6 +2262,13 @@ impl StorageFile {
             // Partition into in-place (key unchanged) and re-key (key changed).
             let mut in_place: Vec<(Vec<u8>, Vec<u8>)> = Vec::new();
             let mut rekey: Vec<(Vec<u8>, Vec<u8>, Vec<u8>)> = Vec::new();
+            // Version staging, split to mirror the closure's op order (all
+            // re-key deletes, then re-key inserts, then in-place updates), so
+            // an identity touched twice in one statement — a key swap — has
+            // its chain built in the order the physical states change.
+            let mut staged_rekey_del: Vec<PendingVersion> = Vec::new();
+            let mut staged_rekey_ins: Vec<PendingVersion> = Vec::new();
+            let mut staged_in_place: Vec<PendingVersion> = Vec::new();
             for (loc, old_values, new_values) in updates {
                 let RowLocator::Key(old_key) = loc else {
                     return Err(StorageError::InvalidConfig(
@@ -1986,6 +2278,11 @@ impl StorageFile {
                 validate_not_null(&schema, &new_values)?;
                 let row = encode_row(&schema, &new_values)?;
                 let new_key = encode_key(&schema, &def.key_columns, &new_values)?;
+                let prior = if publishing {
+                    Some(encode_row(&schema, &old_values)?)
+                } else {
+                    None
+                };
                 if !indexes.is_empty() {
                     idx_ops.push((
                         old_values,
@@ -1995,8 +2292,29 @@ impl StorageFile {
                     ));
                 }
                 if new_key == old_key {
+                    if let Some(prior) = prior {
+                        staged_in_place.push(PendingVersion {
+                            object_id: tree.object_id,
+                            identity: old_key.clone(),
+                            change: RowChange::Update { prior },
+                        });
+                    }
                     in_place.push((old_key, row));
                 } else {
+                    if let Some(prior) = prior {
+                        // A key change is a delete of the old identity and an
+                        // insert of the new one, exactly as the tree applies it.
+                        staged_rekey_del.push(PendingVersion {
+                            object_id: tree.object_id,
+                            identity: old_key.clone(),
+                            change: RowChange::Delete { prior },
+                        });
+                        staged_rekey_ins.push(PendingVersion {
+                            object_id: tree.object_id,
+                            identity: new_key.clone(),
+                            change: RowChange::Insert,
+                        });
+                    }
                     rekey.push((old_key, new_key, row));
                 }
             }
@@ -2019,6 +2337,9 @@ impl StorageFile {
                     tree.update(ctx, &mut OpMode::Txn(txn), key, row)?;
                 }
                 apply_index_updates(ctx, txn, &indexes, &schema, &collations, &idx_ops)?;
+                txn.pending_versions.extend(staged_rekey_del);
+                txn.pending_versions.extend(staged_rekey_ins);
+                txn.pending_versions.extend(staged_in_place);
                 Ok(())
             })?;
         } else {
@@ -2027,6 +2348,7 @@ impl StorageFile {
                 first_page: def.root_page,
             };
             let mut encoded: Vec<(Rid, Vec<u8>)> = Vec::with_capacity(count);
+            let mut staged: Vec<PendingVersion> = Vec::new();
             for (loc, old_values, new_values) in updates {
                 let RowLocator::Rid(rid) = loc else {
                     return Err(StorageError::InvalidConfig(
@@ -2035,6 +2357,15 @@ impl StorageFile {
                 };
                 validate_not_null(&schema, &new_values)?;
                 encoded.push((rid, encode_row(&schema, &new_values)?));
+                if publishing {
+                    staged.push(PendingVersion {
+                        object_id: heap.object_id,
+                        identity: rid_identity(rid),
+                        change: RowChange::Update {
+                            prior: encode_row(&schema, &old_values)?,
+                        },
+                    });
+                }
                 if !indexes.is_empty() {
                     // Heap RIDs are stable across an update.
                     idx_ops.push((old_values, Locator::Rid(rid), new_values, Locator::Rid(rid)));
@@ -2045,6 +2376,7 @@ impl StorageFile {
                     heap.update(ctx, txn, *rid, row)?;
                 }
                 apply_index_updates(ctx, txn, &indexes, &schema, &collations, &idx_ops)?;
+                txn.pending_versions.extend(staged);
                 Ok(())
             })?;
         }
@@ -2332,6 +2664,8 @@ impl StorageFile {
                 Some((active_sb.metadata_root - layout.data_offset) / PAGE_SIZE as u64);
         }
 
+        let mut version = crate::relstore::version::VersionState::default();
+        version.set_options_byte(active_sb.db_options());
         let mut storage = StorageFile {
             default_collation: header.default_collation(),
             file,
@@ -2343,6 +2677,7 @@ impl StorageFile {
             allocator: PageAllocator::new(layout.data_size),
             rel,
             replay_cache: scan.records,
+            version,
         };
         storage.recover_allocator()?;
 
@@ -2434,6 +2769,7 @@ impl StorageFile {
             allocator: PageAllocator::new(layout.data_size),
             rel: RelState::new(DEFAULT_CAPACITY_BYTES),
             replay_cache: Vec::new(),
+            version: crate::relstore::version::VersionState::default(),
         })
     }
 
@@ -2534,15 +2870,25 @@ impl StorageFile {
         let roots = self.rel.tree_roots();
         let mut ctx = self.rel_ctx();
         let mut txn = ctx.begin(txn_id)?;
+        // Staged versions publish only on a successful commit — and inside
+        // this same mutex hold, so no reader can see pages and version
+        // chains disagree. A statement error discards them with `txn`.
+        let mut publish: Option<(Vec<PendingVersion>, u64)> = None;
         let (result, wedged) = match f(&mut ctx, &mut txn) {
-            Ok(value) => match ctx.commit(txn) {
-                Ok(()) => (Ok(value), false),
-                // The commit record may or may not have reached the disk;
-                // writing CLRs now could undo a durable commit. Wedge and
-                // let restart recovery decide (commit durable -> winner,
-                // else -> loser undone).
-                Err(err) => (Err(err), true),
-            },
+            Ok(value) => {
+                let pending = std::mem::take(&mut txn.pending_versions);
+                match ctx.commit(txn) {
+                    Ok(commit_lsn) => {
+                        publish = Some((pending, commit_lsn));
+                        (Ok(value), false)
+                    }
+                    // The commit record may or may not have reached the disk;
+                    // writing CLRs now could undo a durable commit. Wedge and
+                    // let restart recovery decide (commit durable -> winner,
+                    // else -> loser undone).
+                    Err(err) => (Err(err), true),
+                }
+            }
             Err(err) => match rel_recovery::rollback(&mut ctx, txn, &roots) {
                 Ok(()) => {
                     let _ = ctx.io.wal.sync_all();
@@ -2557,6 +2903,14 @@ impl StorageFile {
         let _ = ctx;
         if wedged {
             self.rel.wedged = true;
+        }
+        if let Some((pending, commit_lsn)) = publish {
+            for version in pending {
+                // Autocommit: the transaction is already committed, so the
+                // publish records (rollback bookkeeping) are not needed.
+                let _ = self.version.publish(version, txn_id);
+            }
+            self.version.record_commit(txn_id, commit_lsn);
         }
         result
     }
@@ -2582,6 +2936,8 @@ impl StorageFile {
                 let (result, wedged) = match f(&mut ctx, &mut stx.txn) {
                     Ok(value) => (Ok(value), false),
                     Err(err) => {
+                        // The failed statement's staged versions die with it.
+                        stx.txn.pending_versions.clear();
                         match rel_recovery::rollback_to(&mut ctx, &mut stx.txn, savepoint, &roots) {
                             Ok(()) => (Err(err), false),
                             // A half-undone statement the WAL cannot explain:
@@ -2594,6 +2950,20 @@ impl StorageFile {
                 let _ = ctx;
                 if wedged {
                     self.rel.wedged = true;
+                }
+                // Publish the successful statement's versions inside this
+                // mutex hold (atomic with its page mutations, as far as any
+                // reader can tell), stamped with the still-open transaction —
+                // invisible to every snapshot until the commit is recorded,
+                // which is exactly how a versioned reader sees the pre-image
+                // of a row a running transaction has already changed.
+                if result.is_ok() && !stx.txn.pending_versions.is_empty() {
+                    let txn_id = stx.txn.txn_id;
+                    let pending = std::mem::take(&mut stx.txn.pending_versions);
+                    for version in pending {
+                        let record = self.version.publish(version, txn_id);
+                        stx.txn.published_versions.push(record);
+                    }
                 }
                 result
             }
@@ -2620,9 +2990,22 @@ impl StorageFile {
     fn commit_txn(&mut self, stx: StorageTxn) -> Result<(), StorageError> {
         // The transaction is ending (the `StorageTxn` is consumed either way).
         self.rel.active_txn_begins.remove(&stx.txn.txn_id);
-        let mut ctx = self.rel_ctx();
-        match ctx.commit(stx.txn) {
-            Ok(()) => Ok(()),
+        let txn_id = stx.txn.txn_id;
+        debug_assert!(
+            stx.txn.pending_versions.is_empty(),
+            "versions staged but never published by their statement"
+        );
+        let commit = {
+            let mut ctx = self.rel_ctx();
+            ctx.commit(stx.txn)
+        };
+        match commit {
+            Ok(commit_lsn) => {
+                // The recorded sequence is what flips this transaction's
+                // published versions visible, atomically under this hold.
+                self.version.record_commit(txn_id, commit_lsn);
+                Ok(())
+            }
             Err(err) => {
                 self.rel.wedged = true;
                 Err(err)
@@ -2631,20 +3014,32 @@ impl StorageFile {
     }
 
     /// Rolls back a caller-held transaction via its in-memory undo log (CLRs).
-    fn rollback_txn(&mut self, stx: StorageTxn) -> Result<(), StorageError> {
+    fn rollback_txn(&mut self, mut stx: StorageTxn) -> Result<(), StorageError> {
         self.rel.active_txn_begins.remove(&stx.txn.txn_id);
+        let txn_id = stx.txn.txn_id;
+        let published = std::mem::take(&mut stx.txn.published_versions);
         let roots = stx.roots;
-        let mut ctx = self.rel_ctx();
-        match rel_recovery::rollback(&mut ctx, stx.txn, &roots) {
-            Ok(()) => {
-                let _ = ctx.io.wal.sync_all();
-                Ok(())
+        let result = {
+            let mut ctx = self.rel_ctx();
+            match rel_recovery::rollback(&mut ctx, stx.txn, &roots) {
+                Ok(()) => {
+                    let _ = ctx.io.wal.sync_all();
+                    Ok(())
+                }
+                Err(err) => Err(err),
             }
-            Err(err) => {
-                self.rel.wedged = true;
-                Err(err)
-            }
+        };
+        // Reverse the publications (newest first, so nested demotions unwind)
+        // whether or not the physical rollback succeeded — a failure wedges
+        // the store and nothing reads it again, but the chains must not claim
+        // a rolled-back writer owns current rows.
+        for record in published.into_iter().rev() {
+            self.version.unpublish(record, txn_id);
         }
+        if result.is_err() {
+            self.rel.wedged = true;
+        }
+        result
     }
 
     /// Rolls a still-open transaction back to a savepoint (partial rollback,
@@ -2656,18 +3051,30 @@ impl StorageFile {
         savepoint: crate::relstore::ctx::Savepoint,
     ) -> Result<(), StorageError> {
         self.ensure_rel_usable()?;
+        let txn_id = stx.txn.txn_id;
+        let published = stx.txn.published_versions.split_off(
+            savepoint
+                .published_len
+                .min(stx.txn.published_versions.len()),
+        );
         let roots = stx.roots.clone();
-        let mut ctx = self.rel_ctx();
-        match rel_recovery::rollback_to(&mut ctx, &mut stx.txn, savepoint, &roots) {
-            Ok(()) => {
-                let _ = ctx.io.wal.sync_all();
-                Ok(())
+        let result = {
+            let mut ctx = self.rel_ctx();
+            match rel_recovery::rollback_to(&mut ctx, &mut stx.txn, savepoint, &roots) {
+                Ok(()) => {
+                    let _ = ctx.io.wal.sync_all();
+                    Ok(())
+                }
+                Err(err) => Err(err),
             }
-            Err(err) => {
-                self.rel.wedged = true;
-                Err(err)
-            }
+        };
+        for record in published.into_iter().rev() {
+            self.version.unpublish(record, txn_id);
         }
+        if result.is_err() {
+            self.rel.wedged = true;
+        }
+        result
     }
 
     /// Whether any explicit transaction is open.
@@ -2849,6 +3256,65 @@ impl StorageFile {
         let offset = self.layout.data_offset + page * PAGE_SIZE as u64;
         self.file.read_page_into(offset, &mut frame)?;
         out.copy_from_slice(frame.as_slice());
+        Ok(())
+    }
+
+    /// Applies `ALTER DATABASE SET` option changes and persists them durably
+    /// in both superblocks (generation-bumped, active slot first with an
+    /// fsync between — a torn first write falls back to the backup with the
+    /// old options, and the un-acknowledged ALTER is simply lost).
+    fn set_db_options(
+        &mut self,
+        rcsi: Option<bool>,
+        allow_snapshot: Option<bool>,
+    ) -> Result<(), StorageError> {
+        self.ensure_rel_usable()?;
+        self.version.set_options(rcsi, allow_snapshot);
+        let byte = self.version.options_byte();
+        let generation = self
+            .superblock_a
+            .generation
+            .max(self.superblock_b.generation)
+            .saturating_add(1);
+        // The lazy active-slot rewrite leaves the backup's dynamic fields
+        // stale; both slots get the same generation here, so equalize them
+        // from the active slot (whichever wins at open must carry the
+        // freshest recovery hints).
+        let (active, backup_flag) = match self.active_superblock {
+            ActiveSuperblock::A => (self.superblock_a, SUPERBLOCK_ACTIVE_B),
+            ActiveSuperblock::B => (self.superblock_b, SUPERBLOCK_ACTIVE_A),
+        };
+        let mut equalized = active;
+        equalized.active = backup_flag;
+        match self.active_superblock {
+            ActiveSuperblock::A => self.superblock_b = equalized,
+            ActiveSuperblock::B => self.superblock_a = equalized,
+        }
+        for sb in [&mut self.superblock_a, &mut self.superblock_b] {
+            sb.set_db_options(byte);
+            sb.generation = generation;
+            sb.checksum = sb.compute_checksum();
+        }
+        let (primary, primary_offset, backup, backup_offset) = match self.active_superblock {
+            ActiveSuperblock::A => (
+                self.superblock_a,
+                self.layout.superblock_a_offset,
+                self.superblock_b,
+                self.layout.superblock_b_offset,
+            ),
+            ActiveSuperblock::B => (
+                self.superblock_b,
+                self.layout.superblock_b_offset,
+                self.superblock_a,
+                self.layout.superblock_a_offset,
+            ),
+        };
+        self.file
+            .write_all_at(primary_offset, &primary.to_le_bytes_with_checksum())?;
+        self.file.sync_data()?;
+        self.file
+            .write_all_at(backup_offset, &backup.to_le_bytes_with_checksum())?;
+        self.file.sync_data()?;
         Ok(())
     }
 
@@ -3068,16 +3534,20 @@ impl StorageFile {
             .catalog_root
             .map(|page| self.layout.data_offset + page * PAGE_SIZE as u64)
             .unwrap_or(0);
+        let db_options = self.version.options_byte();
         let new_sb = |active_flag: u8| -> Superblock {
-            let mut sb = Superblock::default();
-            sb.generation = generation;
-            sb.active = active_flag;
-            sb.wal_head = head;
-            sb.wal_tail = tail;
-            sb.last_committed_seq = checkpoint_seq;
-            sb.snapshot_root = desc_offset;
-            sb.data_root = data_write_offset;
-            sb.metadata_root = metadata_root;
+            let mut sb = Superblock {
+                generation,
+                active: active_flag,
+                wal_head: head,
+                wal_tail: tail,
+                last_committed_seq: checkpoint_seq,
+                snapshot_root: desc_offset,
+                data_root: data_write_offset,
+                metadata_root,
+                ..Superblock::default()
+            };
+            sb.set_db_options(db_options);
             sb.checksum = sb.compute_checksum();
             sb
         };
@@ -3525,6 +3995,310 @@ mod tests {
             "an inner SET raise must lock the inner reads: {needs:?}"
         );
 
+        drop(storage);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// The Stage 13 database options round-trip the superblock: they survive
+    /// a reopen, and a checkpoint — which rebuilds both superblocks from
+    /// scratch — must carry them forward rather than silently resetting them.
+    #[test]
+    fn db_options_persist_across_reopen_and_checkpoint() {
+        use crate::rel::{TxnContext, execute_batch};
+
+        let path = unique_temp_path("db-options");
+        let storage = Storage::create(path.clone(), test_storage_options()).expect("create");
+        assert!(!storage.rcsi_enabled());
+        assert!(!storage.snapshot_isolation_allowed());
+        let mut ctx = TxnContext::default();
+        let outcome = execute_batch(
+            &storage,
+            "ALTER DATABASE CURRENT SET READ_COMMITTED_SNAPSHOT ON, ALLOW_SNAPSHOT_ISOLATION ON",
+            &mut ctx,
+        );
+        assert!(outcome.error.is_none(), "{:?}", outcome.error);
+        assert!(storage.rcsi_enabled());
+        assert!(storage.snapshot_isolation_allowed());
+        drop(storage);
+
+        let storage = Storage::open(path.clone()).expect("reopen");
+        assert!(storage.rcsi_enabled(), "RCSI survives a restart");
+        assert!(storage.snapshot_isolation_allowed());
+
+        // One option off, then a checkpoint, then a reopen: the checkpoint's
+        // fresh superblocks must keep the surviving option.
+        let mut ctx = TxnContext::default();
+        let outcome = execute_batch(
+            &storage,
+            "ALTER DATABASE CURRENT SET ALLOW_SNAPSHOT_ISOLATION OFF",
+            &mut ctx,
+        );
+        assert!(outcome.error.is_none(), "{:?}", outcome.error);
+        storage
+            .write_checkpoint(b"cp", 1, 2, 1)
+            .expect("checkpoint");
+        drop(storage);
+        let storage = Storage::open(path.clone()).expect("reopen after checkpoint");
+        assert!(
+            storage.rcsi_enabled(),
+            "the checkpoint must not reset the option"
+        );
+        assert!(!storage.snapshot_isolation_allowed());
+        drop(storage);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// A READ COMMITTED SELECT under RCSI takes only Database IS — no Table
+    /// S — which is the entire readers-don't-block mechanism; and the other
+    /// levels are untouched by the option.
+    #[test]
+    fn analyze_locks_drops_table_s_under_rcsi() {
+        use crate::lock::{LockMode, Resource};
+        use crate::rel::{Isolation, TxnContext, execute_batch};
+
+        let path = unique_temp_path("rcsi-locks");
+        let storage = Storage::create(path.clone(), test_storage_options()).expect("create");
+        let mut ctx = TxnContext::default();
+        let outcome = execute_batch(
+            &storage,
+            "CREATE TABLE t (id INT NOT NULL PRIMARY KEY, v INT)",
+            &mut ctx,
+        );
+        assert!(outcome.error.is_none(), "{:?}", outcome.error);
+
+        let table_s = |needs: &[(Resource, LockMode)]| {
+            needs
+                .iter()
+                .any(|(r, m)| matches!(r, Resource::Table(_)) && *m == LockMode::Shared)
+        };
+
+        // Off: the SELECT read-locks, as ever.
+        let needs =
+            crate::rel::analyze_locks(&storage, "SELECT v FROM t", Isolation::ReadCommitted);
+        assert!(
+            table_s(&needs),
+            "without RCSI a RC SELECT takes Table S: {needs:?}"
+        );
+
+        let outcome = execute_batch(
+            &storage,
+            "ALTER DATABASE CURRENT SET READ_COMMITTED_SNAPSHOT ON",
+            &mut ctx,
+        );
+        assert!(outcome.error.is_none(), "{:?}", outcome.error);
+
+        // On: Database IS only — the DDL fence — and no Table S.
+        let needs =
+            crate::rel::analyze_locks(&storage, "SELECT v FROM t", Isolation::ReadCommitted);
+        assert!(
+            !table_s(&needs),
+            "under RCSI a RC SELECT takes no Table S: {needs:?}"
+        );
+        assert!(
+            needs.contains(&(Resource::Database, LockMode::IntentShared)),
+            "the Database IS fence stays: {needs:?}"
+        );
+
+        // The other levels are untouched: RR still read-locks, RU still
+        // takes nothing, and a batch that raises isolation falls back to
+        // locking even though the session level is RC.
+        let needs =
+            crate::rel::analyze_locks(&storage, "SELECT v FROM t", Isolation::RepeatableRead);
+        assert!(table_s(&needs), "RR is not versioned: {needs:?}");
+        let needs =
+            crate::rel::analyze_locks(&storage, "SELECT v FROM t", Isolation::ReadUncommitted);
+        assert!(needs.is_empty(), "RU takes no locks at all: {needs:?}");
+        let needs = crate::rel::analyze_locks(
+            &storage,
+            "SET TRANSACTION ISOLATION LEVEL SERIALIZABLE; SELECT v FROM t",
+            Isolation::ReadCommitted,
+        );
+        assert!(
+            table_s(&needs),
+            "a raising SET disables the snapshot path: {needs:?}"
+        );
+
+        drop(storage);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// A covering (INCLUDE) seek must serve the snapshot's image, not the
+    /// index leaf's freshly-updated include payload — pinned on the covering
+    /// path itself via the covering-scan counter.
+    #[test]
+    fn covering_seek_serves_the_snapshot_image() {
+        use crate::rel::{StatementResult, TxnContext, execute_batch};
+
+        let path = unique_temp_path("rcsi-covering");
+        let storage = Storage::create(path.clone(), test_storage_options()).expect("create");
+        let mut writer = TxnContext::default();
+        let mut fill = String::from("INSERT INTO c VALUES ");
+        for i in 1..=25 {
+            fill.push_str(&format!("({}, {}, {}),", i, i * 10, i * 1000));
+        }
+        fill.pop();
+        for sql in [
+            "ALTER DATABASE CURRENT SET READ_COMMITTED_SNAPSHOT ON",
+            "CREATE TABLE c (id INT NOT NULL PRIMARY KEY, v INT, w INT)",
+            fill.as_str(),
+            "CREATE INDEX ix_cv ON c (v) INCLUDE (v, w)",
+            // The open transaction updates only the INCLUDE column: the
+            // seek still finds the entry under v = 10, now carrying the NEW
+            // include bytes.
+            "BEGIN TRAN; UPDATE c SET w = 777 WHERE id = 1;",
+        ] {
+            let outcome = execute_batch(&storage, sql, &mut writer);
+            assert!(outcome.error.is_none(), "{sql}: {:?}", outcome.error);
+        }
+
+        let select = |label: &str| {
+            let mut reader = TxnContext::default();
+            let outcome = execute_batch(&storage, "SELECT w FROM c WHERE v = 10", &mut reader);
+            assert!(outcome.error.is_none(), "{label}: {:?}", outcome.error);
+            match &outcome.results[0] {
+                StatementResult::Rows(rowset) => rowset.rows.clone(),
+                other => panic!("{label}: expected rows, got {other:?}"),
+            }
+        };
+
+        let covering_before = storage.covering_scans();
+        let rows = select("during the writer's transaction");
+        assert!(
+            storage.covering_scans() > covering_before,
+            "the read must have gone down the covering path for this to test anything"
+        );
+        assert_eq!(
+            rows,
+            vec![vec![Datum::Int(1000)]],
+            "the snapshot image, not the new include payload"
+        );
+
+        let outcome = execute_batch(&storage, "COMMIT", &mut writer);
+        assert!(outcome.error.is_none(), "{:?}", outcome.error);
+        assert_eq!(rows_i32(&select("after the commit")), vec![777]);
+
+        drop(storage);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    fn rows_i32(rows: &[Vec<Datum>]) -> Vec<i32> {
+        rows.iter()
+            .map(|row| match row[0] {
+                Datum::Int(v) => v,
+                ref other => panic!("expected INT, got {other:?}"),
+            })
+            .collect()
+    }
+
+    /// Rollback unpublishes: a rolled-back transaction leaves no version
+    /// chains behind (pruning would otherwise treat its entries as an open
+    /// transaction's and pin them forever), and pruning drops the history of
+    /// committed transactions once no snapshot is live.
+    #[test]
+    fn rollback_unpublishes_and_prune_drops_settled_history() {
+        use crate::rel::{TxnContext, execute_batch};
+
+        let path = unique_temp_path("rcsi-prune");
+        let storage = Storage::create(path.clone(), test_storage_options()).expect("create");
+        let mut ctx = TxnContext::default();
+        for sql in [
+            "ALTER DATABASE CURRENT SET READ_COMMITTED_SNAPSHOT ON",
+            "CREATE TABLE t (id INT NOT NULL PRIMARY KEY, v INT)",
+            "INSERT INTO t VALUES (1, 10), (2, 20)",
+        ] {
+            let outcome = execute_batch(&storage, sql, &mut ctx);
+            assert!(outcome.error.is_none(), "{sql}: {:?}", outcome.error);
+        }
+
+        // The seed INSERTs published their own (committed) chains; settle
+        // them first so the rollback assertion sees only the rollback's work.
+        storage
+            .ensure_durable(storage.wal_tail())
+            .expect("durability");
+        storage.version_prune();
+        assert_eq!(storage.version_chain_count("t"), 0);
+
+        // Rolled back: the chains its statements published are reversed.
+        let outcome = execute_batch(
+            &storage,
+            "BEGIN TRAN; UPDATE t SET v = 99 WHERE id = 1; ROLLBACK",
+            &mut ctx,
+        );
+        assert!(outcome.error.is_none(), "{:?}", outcome.error);
+        assert_eq!(
+            storage.version_chain_count("t"),
+            0,
+            "a rolled-back transaction leaves no chains"
+        );
+
+        // Committed: the chain exists until pruning decides nothing can need
+        // it (no live snapshot, commit durable).
+        let outcome = execute_batch(&storage, "UPDATE t SET v = 11 WHERE id = 1", &mut ctx);
+        assert!(outcome.error.is_none(), "{:?}", outcome.error);
+        assert_eq!(storage.version_chain_count("t"), 1);
+        storage
+            .ensure_durable(storage.wal_tail())
+            .expect("durability");
+        storage.version_prune();
+        assert_eq!(
+            storage.version_chain_count("t"),
+            0,
+            "settled history is dropped by the maintenance prune"
+        );
+
+        drop(storage);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// Publishing versions changes nothing about crash recovery: the store
+    /// (chains and commit table) is memory-only, so a kill-and-reopen with
+    /// RCSI on recovers exactly the committed state, options intact, chains
+    /// empty.
+    #[test]
+    fn rcsi_survives_a_crash_with_clean_recovery() {
+        use crate::rel::{StatementResult, TxnContext, execute_batch};
+
+        let path = unique_temp_path("rcsi-crash");
+        let storage = Storage::create(path.clone(), test_storage_options()).expect("create");
+        let mut ctx = TxnContext::default();
+        for sql in [
+            "ALTER DATABASE CURRENT SET READ_COMMITTED_SNAPSHOT ON",
+            "CREATE TABLE t (id INT NOT NULL PRIMARY KEY, v INT)",
+            "INSERT INTO t VALUES (1, 10), (2, 20)",
+            "UPDATE t SET v = 11 WHERE id = 1",
+        ] {
+            let outcome = execute_batch(&storage, sql, &mut ctx);
+            assert!(outcome.error.is_none(), "{sql}: {:?}", outcome.error);
+        }
+        // An open transaction with published versions dies with the crash.
+        let outcome = execute_batch(
+            &storage,
+            "BEGIN TRAN; UPDATE t SET v = 999 WHERE id = 2;",
+            &mut ctx,
+        );
+        assert!(outcome.error.is_none(), "{:?}", outcome.error);
+        // Kill without checkpoint: drop the handle mid-transaction.
+        drop(ctx);
+        drop(storage);
+
+        let storage = Storage::open(path.clone()).expect("recovery");
+        assert!(storage.rcsi_enabled());
+        assert_eq!(
+            storage.version_chain_count("t"),
+            0,
+            "chains do not survive a restart"
+        );
+        let mut ctx = TxnContext::default();
+        let outcome = execute_batch(&storage, "SELECT v FROM t ORDER BY id", &mut ctx);
+        assert!(outcome.error.is_none(), "{:?}", outcome.error);
+        match &outcome.results[0] {
+            StatementResult::Rows(rowset) => assert_eq!(
+                rows_i32(&rowset.rows),
+                vec![11, 20],
+                "committed wins, the in-flight update is undone"
+            ),
+            other => panic!("expected rows, got {other:?}"),
+        }
         drop(storage);
         let _ = std::fs::remove_file(&path);
     }

--- a/crates/truthdb-core/src/storage.rs
+++ b/crates/truthdb-core/src/storage.rs
@@ -139,6 +139,10 @@ pub struct Storage {
     /// analysis and the per-statement snapshot gate are on the hot path).
     rcsi: std::sync::atomic::AtomicBool,
     allow_snapshot: std::sync::atomic::AtomicBool,
+    /// Bumped whenever the options change: a parked batch whose lock set was
+    /// analyzed under an older epoch is re-analyzed before it can be granted
+    /// (its versioned-read decision may no longer match execution).
+    lock_epoch: std::sync::atomic::AtomicU64,
     /// Scan slices read, so a test can prove a scan stopped early rather than
     /// reading the table and discarding the rest. On the instance and not in a
     /// `static`: the suite runs in parallel in one binary, so a static would
@@ -214,6 +218,7 @@ impl Storage {
             log_writer: Some(log_writer),
             rcsi: std::sync::atomic::AtomicBool::new(rcsi),
             allow_snapshot: std::sync::atomic::AtomicBool::new(allow_snapshot),
+            lock_epoch: std::sync::atomic::AtomicU64::new(0),
             #[cfg(test)]
             scan_slices: std::sync::atomic::AtomicUsize::new(0),
             #[cfg(test)]
@@ -554,7 +559,17 @@ impl Storage {
             .store(rcsi_now, std::sync::atomic::Ordering::Relaxed);
         self.allow_snapshot
             .store(allow_now, std::sync::atomic::Ordering::Relaxed);
+        // After the mirrors, so a batch analyzed against a stale epoch is
+        // always re-analyzed against the settled options.
+        self.lock_epoch
+            .fetch_add(1, std::sync::atomic::Ordering::Release);
         Ok(())
+    }
+
+    /// The lock-analysis epoch: parked batches analyzed under an older value
+    /// are re-analyzed before grant (see the scheduler).
+    pub(crate) fn lock_analysis_epoch(&self) -> u64 {
+        self.lock_epoch.load(std::sync::atomic::Ordering::Acquire)
     }
 
     /// Captures a read snapshot: the durable commit prefix as of now, plus
@@ -3269,8 +3284,23 @@ impl StorageFile {
         allow_snapshot: Option<bool>,
     ) -> Result<(), StorageError> {
         self.ensure_rel_usable()?;
-        self.version.set_options(rcsi, allow_snapshot);
-        let byte = self.version.options_byte();
+        // Build the new superblocks in LOCALS and write them BEFORE mutating
+        // any in-memory state: a failed write must leave the version store,
+        // the option mirrors, and the cached superblocks exactly as they
+        // were (a half-applied OFF would otherwise stop publishing while
+        // readers still take the versioned path — silent dirty reads), and
+        // a later lazy active-slot rewrite must not leak the failed ALTER's
+        // options to disk.
+        let byte = {
+            let mut next = self.version.options_byte();
+            if let Some(on) = rcsi {
+                next = (next & !1) | (on as u8);
+            }
+            if let Some(on) = allow_snapshot {
+                next = (next & !2) | ((on as u8) << 1);
+            }
+            next
+        };
         let generation = self
             .superblock_a
             .generation
@@ -3284,28 +3314,21 @@ impl StorageFile {
             ActiveSuperblock::A => (self.superblock_a, SUPERBLOCK_ACTIVE_B),
             ActiveSuperblock::B => (self.superblock_b, SUPERBLOCK_ACTIVE_A),
         };
-        let mut equalized = active;
-        equalized.active = backup_flag;
-        match self.active_superblock {
-            ActiveSuperblock::A => self.superblock_b = equalized,
-            ActiveSuperblock::B => self.superblock_a = equalized,
-        }
-        for sb in [&mut self.superblock_a, &mut self.superblock_b] {
+        let mut primary = active;
+        let mut backup = active;
+        backup.active = backup_flag;
+        for sb in [&mut primary, &mut backup] {
             sb.set_db_options(byte);
             sb.generation = generation;
             sb.checksum = sb.compute_checksum();
         }
-        let (primary, primary_offset, backup, backup_offset) = match self.active_superblock {
+        let (primary_offset, backup_offset) = match self.active_superblock {
             ActiveSuperblock::A => (
-                self.superblock_a,
                 self.layout.superblock_a_offset,
-                self.superblock_b,
                 self.layout.superblock_b_offset,
             ),
             ActiveSuperblock::B => (
-                self.superblock_b,
                 self.layout.superblock_b_offset,
-                self.superblock_a,
                 self.layout.superblock_a_offset,
             ),
         };
@@ -3315,6 +3338,18 @@ impl StorageFile {
         self.file
             .write_all_at(backup_offset, &backup.to_le_bytes_with_checksum())?;
         self.file.sync_data()?;
+        // Durable on disk — now commit to memory.
+        match self.active_superblock {
+            ActiveSuperblock::A => {
+                self.superblock_a = primary;
+                self.superblock_b = backup;
+            }
+            ActiveSuperblock::B => {
+                self.superblock_b = primary;
+                self.superblock_a = backup;
+            }
+        }
+        self.version.set_options(rcsi, allow_snapshot);
         Ok(())
     }
 

--- a/crates/truthdb-core/src/storage_layout.rs
+++ b/crates/truthdb-core/src/storage_layout.rs
@@ -310,6 +310,18 @@ impl Superblock {
         out[72..80].copy_from_slice(&0u64.to_le_bytes());
         xxh64(&out, 0)
     }
+
+    /// Stage 13 database options, persisted as a bitfield in the first
+    /// reserved byte (zero on files created before the options existed —
+    /// both off, the defaults): bit 0 = `READ_COMMITTED_SNAPSHOT`, bit 1 =
+    /// `ALLOW_SNAPSHOT_ISOLATION`.
+    pub fn db_options(&self) -> u8 {
+        self.reserved[0]
+    }
+
+    pub fn set_db_options(&mut self, byte: u8) {
+        self.reserved[0] = byte;
+    }
 }
 
 #[repr(C)]

--- a/crates/truthdb-core/tests/slt/alter_database.slt
+++ b/crates/truthdb-core/tests/slt/alter_database.slt
@@ -1,0 +1,73 @@
+# ALTER DATABASE (Stage 13): the two versioning options parse, persist, and
+# gate. Same-session results are unchanged by RCSI (a session always sees its
+# own writes and everything committed); the cross-session semantics live in
+# the session tests.
+
+statement ok
+ALTER DATABASE CURRENT SET READ_COMMITTED_SNAPSHOT ON
+
+statement ok
+ALTER DATABASE CURRENT SET ALLOW_SNAPSHOT_ISOLATION ON, READ_COMMITTED_SNAPSHOT ON
+
+# Only the recognized options are accepted; anything else is a syntax error,
+# never a silent no-op (these options change what concurrent readers see).
+statement error
+ALTER DATABASE CURRENT SET RECOVERY SIMPLE
+
+statement error
+ALTER DATABASE CURRENT SET READ_COMMITTED_SNAPSHOT MAYBE
+
+# ALTER DATABASE is not allowed inside a multi-statement transaction (226).
+statement ok
+BEGIN TRANSACTION
+
+statement error
+ALTER DATABASE CURRENT SET READ_COMMITTED_SNAPSHOT OFF
+
+statement ok
+ROLLBACK
+
+# Ordinary single-session work behaves identically under RCSI: own writes and
+# committed state are always visible.
+statement ok
+CREATE TABLE opt (id INT NOT NULL PRIMARY KEY, v INT)
+
+statement ok
+INSERT INTO opt VALUES (1, 10), (2, 20)
+
+statement ok
+UPDATE opt SET v = 11 WHERE id = 1
+
+query II rowsort
+SELECT id, v FROM opt
+----
+1 11
+2 20
+
+statement ok
+BEGIN TRANSACTION
+
+statement ok
+UPDATE opt SET v = 12 WHERE id = 1
+
+# The updating transaction reads its own uncommitted write.
+query I
+SELECT v FROM opt WHERE id = 1
+----
+12
+
+statement ok
+ROLLBACK
+
+query I
+SELECT v FROM opt WHERE id = 1
+----
+11
+
+statement ok
+ALTER DATABASE CURRENT SET READ_COMMITTED_SNAPSHOT OFF, ALLOW_SNAPSHOT_ISOLATION OFF
+
+query I
+SELECT v FROM opt WHERE id = 1
+----
+11

--- a/crates/truthdb-sql/src/ast.rs
+++ b/crates/truthdb-sql/src/ast.rs
@@ -40,6 +40,8 @@ pub enum Statement {
     Set(SetStatement),
     /// `ALTER TABLE ...`.
     AlterTable(AlterTable),
+    /// `ALTER DATABASE {name | CURRENT} SET <option> {ON|OFF} [, ...]`.
+    AlterDatabase(AlterDatabase),
     /// `DECLARE @a TYPE [= expr], ...` — batch variable declarations.
     Declare(Vec<Declaration>),
     /// `EXEC[UTE] <proc> [args...]` — the T-SQL text path to the system
@@ -97,6 +99,21 @@ pub enum AlterAction {
     AddForeignKey(ForeignKey),
     /// `DROP CONSTRAINT <name>`.
     DropConstraint(Name),
+}
+
+/// `ALTER DATABASE {name | CURRENT} SET <option> {ON|OFF} [, ...]`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct AlterDatabase {
+    /// `None` = `CURRENT`.
+    pub name: Option<Name>,
+    pub options: Vec<(DatabaseOption, bool)>,
+    pub span: Span,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DatabaseOption {
+    ReadCommittedSnapshot,
+    AllowSnapshotIsolation,
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/crates/truthdb-sql/src/parser.rs
+++ b/crates/truthdb-sql/src/parser.rs
@@ -1008,6 +1008,9 @@ impl Parser {
 
     fn parse_alter(&mut self) -> SqlResult<Statement> {
         let start = self.expect_keyword("ALTER")?;
+        if self.peek_keyword().as_deref() == Some("DATABASE") {
+            return self.parse_alter_database(start);
+        }
         self.expect_keyword("TABLE")?;
         let table = self.parse_name()?;
         let (action, end) = match self.peek_keyword().as_deref() {
@@ -1051,6 +1054,46 @@ impl Parser {
         Ok(Statement::AlterTable(AlterTable {
             table,
             action,
+            span: start.to(end),
+        }))
+    }
+
+    // ---- ALTER DATABASE -------------------------------------------------
+
+    /// `ALTER DATABASE {name | CURRENT} SET <option> {ON|OFF} [, ...]`.
+    /// Only the Stage 13 versioning options are recognized; anything else is
+    /// a syntax error rather than a silent no-op (these options change what
+    /// concurrent readers see).
+    fn parse_alter_database(&mut self, start: Span) -> SqlResult<Statement> {
+        self.expect_keyword("DATABASE")?;
+        let name = if self.peek_keyword().as_deref() == Some("CURRENT") {
+            self.bump();
+            None
+        } else {
+            Some(self.parse_name()?)
+        };
+        self.expect_keyword("SET")?;
+        let mut options = Vec::new();
+        let mut end;
+        loop {
+            let option = match self.peek_keyword().as_deref() {
+                Some("READ_COMMITTED_SNAPSHOT") => DatabaseOption::ReadCommittedSnapshot,
+                Some("ALLOW_SNAPSHOT_ISOLATION") => DatabaseOption::AllowSnapshotIsolation,
+                _ => {
+                    let token = self.peek().clone();
+                    return Err(SqlError::syntax(self.token_text(&token), token.span));
+                }
+            };
+            end = self.bump().span;
+            let on = self.parse_on_off()?;
+            options.push((option, on));
+            if !self.eat(&TokenKind::Comma) {
+                break;
+            }
+        }
+        Ok(Statement::AlterDatabase(AlterDatabase {
+            name,
+            options,
             span: start.to(end),
         }))
     }


### PR DESCRIPTION
## Stage 13, part 1: READ_COMMITTED_SNAPSHOT

`ALTER DATABASE {name | CURRENT} SET READ_COMMITTED_SNAPSHOT {ON|OFF}` (and `ALLOW_SNAPSHOT_ISOLATION`, whose consumer lands next) now exists, persists in the superblock reserved area, and — with RCSI on — a READ COMMITTED SELECT reads a per-statement snapshot instead of blocking on writers' locks.

### The design, audited against the code

The plan's bullet sketched rows carrying a version pointer + txn timestamp with prior versions copied to temp extents. That design was audited against the storage layer and replaced:

- The row codec is positional with no per-row header, and its decoder rejects trailing bytes — a row-carried stamp is a format change for every table (the same finding that made ALTER ADD a full rewrite in #115).
- Deletes are physical (tree cells removed, heap slots zeroed), so a snapshot reader can never encounter a deleted row's ghost; version state must be reachable *without* the row.
- Decisively: version state has **no durability requirement**. A snapshot exists only inside a running process — after a restart there are none, so every physical row is visible to every new snapshot and an empty store is correct by construction.

So the version store is an in-memory side structure (`relstore/version.rs`): per table, row identity (clustered key bytes / heap home RID) → a chain of versions, newest first; the head describes the current physical state, older entries carry the images that were current before. Everything runs under the one storage mutex, so publication is atomic with the page mutations it describes.

### Snapshots are the durable commit prefix

Commits get sequence numbers under the storage mutex; a snapshot is the newest sequence whose commit record the group-commit log-writer has fsynced. A committed-but-unflushed transaction is invisible — its writer has not been acknowledged, so no reader may report state a crash could take back. That is exactly the guarantee lock-based readers already get from release timing (locks release after the batch fsync). Within a batch, `INSERT; SELECT` flushes the durability point before capture, so a statement always sees its session's own earlier commits (pinned by the assignment-SELECT test, which skips the pre-rowset flush).

### Reads

A versioned SELECT takes only Database IS (the DDL fence for the batch) — no Table S — and reads atomically under one storage-lock hold (`rel_scan_snapshot`): a reader that holds no table lock cannot use the sliced cursor, whose between-slice contract assumes writers are locked out. Index seeks merge too: an entry whose row was modified by an invisible writer serves the snapshot image (covering seeks included — the image overrides freshly-updated INCLUDE payloads), and rows whose entries an invisible writer moved or removed are appended from their chains; the executor re-applies the full WHERE to every row, so over-returning is filtered, never wrong. DML and integrity probes (FK, WITH CHECK) stay lock-based and read current state.

### Writes, rollback, pruning

DML paths stage versions as ops succeed and publish on statement success under the same mutex hold; a statement error discards them. Explicit transactions log every publish and reverse them exactly on rollback — full or to a savepoint — so chains never claim a rolled-back writer owns a row (pruning would otherwise treat its entries as an open transaction's and pin them forever). The maintenance thread prunes history below the watermark (oldest live snapshot, else the current durable sequence) and drops chains of dropped tables.

### Tests

- 9 version-store unit tests (chain mechanics: demote/resolve/unpublish, key swaps, durable-prefix bounds, prune pinning).
- 12 two-session tests: readers-don't-block (value-proven: the reader returns the pre-update value while the writer's transaction is open — a lock-based reader could only ever return the committed one, which the RCSI-off control pins), deleted-row and re-key visibility, index-seek and covering merges, own writes, same-batch read-your-writes, savepoint/rollback unpublish, RR-still-blocks, heap tables, ALTER DATABASE gating (226 in-txn, 911 wrong name).
- Storage tests: options survive reopen and checkpoint (a checkpoint rebuilds superblocks from scratch and must carry them), rollback-unpublish + prune via the chain-count hook, crash recovery with RCSI on (chains are memory-only; recovery is untouched).
- slt: ALTER DATABASE forms and single-session behavior under RCSI.

### Adversarial review

The review (own worktree, live repros, mutation teeth-checks) confirmed the chain machinery sound — identity byte-consistency across publish and both read paths, chain lifecycle under key swaps / insert-after-delete / nested savepoints, capture-release pairing on every exit path, and the prune-vs-capture race refuted by the durable-floor clamp — and found four real defects at the seams between static lock analysis and the dynamic versioned-read decision, all fixed here and the two confirmed ones pinned as regression tests:

1. **EXEC-literal isolation collapse (HIGH, live repro):** the lock-analysis recursion turned every read-locking level into READ COMMITTED, which under RCSI dropped the inner Table S while execution ran lock-based at the outer level — a SERIALIZABLE session could dirty-read through `EXEC sp_executesql N'SELECT ...'`.
2. **Parked-batch staleness across an option flip (MEDIUM, live repro):** a batch analyzed under RCSI-on could be granted its stale no-Table-S lock set after `ALTER ... OFF` and read a concurrent writer's uncommitted rows. Option flips now bump a lock-analysis epoch and the grant path re-analyzes stale entries (verified by mutation: disabling the re-analysis dirty-reads on round 0).
3. **Durable-prefix off-by-one:** a commit whose record starts exactly at the flushed watermark was counted durable.
4. **ALTER error-path ordering:** a failed superblock write left the version store flipped while the lock-free mirrors and disk said otherwise; memory now commits only after both writes fsync.

One review observation stands as a documented cost, not a defect: versioned scans materialize the table under a single storage-mutex hold (the sliced cursor's contract needs a lock the reader deliberately no longer takes). RCSI is opt-in; bounding that is future work alongside the buffer-pool latch note from #119.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
