### PR TITLE
Stage 13: SNAPSHOT isolation, the five-level driver matrix, and cleanup under load

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,6 +223,9 @@ jobs:
       - name: Conformance — pytds prepared statements (sp_prepare family)
         run: python3 scripts/tds_conformance_prepared.py 127.0.0.1 1433 sa secret
 
+      - name: Conformance — pytds isolation matrix (five levels, Stage 13)
+        run: python3 scripts/tds_isolation_matrix.py 127.0.0.1 1433 sa secret
+
       - name: Conformance — pytds over TLS (tunneled handshake)
         run: python3 scripts/tds_conformance_tls.py 127.0.0.1 1433 sa secret /etc/truthdb/tls.crt
 

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -1102,6 +1102,22 @@ impl Drop for TxnSnapshotScope {
     }
 }
 
+/// Whether a statement touches any base table: DML always does; a SELECT
+/// only when its FROM/subqueries name one. `SELECT 1` under SNAPSHOT must
+/// neither raise 3952 nor establish the transaction's snapshot — SQL Server
+/// defers both to the first read of an actual object.
+fn statement_reads_tables(statement: &Statement) -> bool {
+    match statement {
+        Statement::Select(select) => {
+            let expanded = expand_ctes(select);
+            let mut tables = Vec::new();
+            collect_locked_tables(&expanded, &mut tables);
+            !tables.is_empty()
+        }
+        _ => true,
+    }
+}
+
 /// SQL Server 3952: SNAPSHOT isolation used while the database does not
 /// allow it — raised at data access, not at SET, exactly as SQL Server does.
 fn snapshot_not_allowed_error(database: &str) -> SqlError {
@@ -1157,7 +1173,7 @@ fn exec_statement_streamed(
                 txn_ctx.txn.as_ref().map(StorageTxn::txn_id),
             ));
         }
-        Isolation::Snapshot if data_access => {
+        Isolation::Snapshot if data_access && statement_reads_tables(statement) => {
             if !storage.snapshot_isolation_allowed() {
                 if txn_ctx.in_txn() {
                     txn_ctx.doomed = true;
@@ -3458,6 +3474,23 @@ fn exec_alter_database(
             ),
         )
         .at(name.span));
+    }
+    // A SNAPSHOT transaction idle between batches holds no locks, so the
+    // batch's Database X does not prove no snapshot is live. Flipping the
+    // options under one would reset (or stop publishing to) the store its
+    // reads depend on; SQL Server waits the transactions out, TruthDB
+    // refuses and lets the operator retry.
+    if storage.has_registered_snapshots() {
+        return Err(SqlError::new(
+            5061,
+            16,
+            1,
+            format!(
+                "ALTER DATABASE failed because a lock could not be placed on database '{}'. \
+                 Try again later.",
+                txn_ctx.database
+            ),
+        ));
     }
     let mut rcsi = None;
     let mut allow_snapshot = None;

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -34,7 +34,7 @@ use crate::relstore::catalog::{self, TableDef};
 use crate::relstore::row::{Column, Schema};
 use crate::relstore::types::{ColumnType, Datum};
 use crate::relstore::version::ReadSnapshot;
-use crate::storage::{Storage, StorageError, StorageTxn, TxnScope};
+use crate::storage::{RowLocator, Storage, StorageError, StorageTxn, TxnScope};
 
 /// Per-session transaction state carried across statements/batches. Lives in
 /// the session (engine thread); autocommit statements use `Default`.
@@ -71,6 +71,10 @@ pub struct TxnContext {
     /// nested `TRY`/`CATCH` restore the outer error on exit). `ERROR_*()` read
     /// the top; empty outside any `CATCH` block.
     error_stack: Vec<truthdb_sql::eval::ErrorInfo>,
+    /// The SNAPSHOT-isolation transaction's read view, captured (and
+    /// registered against pruning) at its first data access and released
+    /// when the transaction ends — commit, rollback, reap, or disconnect.
+    txn_snapshot: Option<ReadSnapshot>,
     /// Set when the idle reaper rolled this session's transaction back. The
     /// session's next batch fails with 1205 and clears it, so a client that
     /// comes back believing it is still in a transaction is told the
@@ -88,6 +92,9 @@ pub enum Isolation {
     ReadCommitted,
     RepeatableRead,
     Serializable,
+    /// Transaction-scoped versioned reads (Stage 13): one snapshot at the
+    /// transaction's first data access, reused by every statement in it.
+    Snapshot,
 }
 
 impl TxnContext {
@@ -184,9 +191,19 @@ impl TxnContext {
         if let Some(txn) = self.txn.take() {
             let _ = storage.rel_rollback(txn);
         }
+        self.release_txn_snapshot(storage);
         self.trancount = 0;
         self.doomed = false;
         self.savepoints.clear();
+    }
+
+    /// Releases the SNAPSHOT transaction's registered read view, if any —
+    /// called on every transaction-ending path (a leaked registration pins
+    /// the version store's prune watermark forever).
+    fn release_txn_snapshot(&mut self, storage: &Storage) {
+        if let Some(snap) = self.txn_snapshot.take() {
+            storage.release_read_snapshot(snap.seq);
+        }
     }
 
     /// Rolls back this session's transaction because it sat idle too long, and
@@ -1067,6 +1084,39 @@ impl Drop for SnapshotScope<'_> {
     }
 }
 
+/// Statement-scoped view of a TRANSACTION's snapshot (SNAPSHOT isolation):
+/// sets the thread-local for this statement and clears it on exit, but the
+/// registration lives with the transaction, not the statement.
+struct TxnSnapshotScope;
+
+impl TxnSnapshotScope {
+    fn enter(snap: ReadSnapshot) -> Self {
+        CURRENT_SNAPSHOT.set(Some(snap));
+        TxnSnapshotScope
+    }
+}
+
+impl Drop for TxnSnapshotScope {
+    fn drop(&mut self) {
+        CURRENT_SNAPSHOT.set(None);
+    }
+}
+
+/// SQL Server 3952: SNAPSHOT isolation used while the database does not
+/// allow it — raised at data access, not at SET, exactly as SQL Server does.
+fn snapshot_not_allowed_error(database: &str) -> SqlError {
+    SqlError::new(
+        3952,
+        16,
+        1,
+        format!(
+            "Snapshot isolation transaction failed accessing database '{database}' because \
+             snapshot isolation is not allowed in this database. Use ALTER DATABASE to allow \
+             snapshot isolation."
+        ),
+    )
+}
+
 /// Runs one statement. A plain `SELECT` the scan planner accepts streams its
 /// rows through `run` as the scan reads them — the whole point of the event
 /// stream: the client sees rows while the scan runs, and the statement's peak
@@ -1078,24 +1128,59 @@ fn exec_statement_streamed(
     txn_ctx: &mut TxnContext,
     run: &mut BatchRun<'_>,
 ) -> Result<StatementOutcome, SqlError> {
-    // RCSI: a SELECT under READ COMMITTED with the database option on reads
-    // a statement snapshot instead of blocking on writers' locks. DML (and
-    // the reads inside it) stays lock-based — conservative versus SQL
-    // Server, which versions DML's reads too; the write locks it takes here
-    // subsume what versioning would relax.
-    let versioned = matches!(statement, Statement::Select(_))
-        && matches!(txn_ctx.isolation(), Isolation::ReadCommitted)
-        && storage.rcsi_enabled();
-    if versioned {
-        // The snapshot is the durable commit prefix, so the session's own
-        // just-committed statements must be fsync-durable before capture or
-        // the statement would not see them. Rowset-producing SELECTs already
-        // flushed in `run_block`; this covers assignment SELECTs (and then
-        // no-ops when nothing committed since the last durability point).
-        run.flush(storage)?;
+    // Versioned reads (Stage 13). RCSI: a SELECT under READ COMMITTED with
+    // the option on reads a per-statement snapshot instead of blocking on
+    // writers' locks (DML and the reads inside it stay lock-based —
+    // conservative versus SQL Server; the write locks subsume what
+    // versioning would relax). SNAPSHOT isolation: every data-access
+    // statement shares the transaction's snapshot, captured at its first
+    // data access; outside a transaction each statement is its own.
+    let data_access = matches!(
+        statement,
+        Statement::Select(_) | Statement::Insert(_) | Statement::Update(_) | Statement::Delete(_)
+    );
+    let mut _stmt_scope = None;
+    let mut _txn_scope = None;
+    match txn_ctx.isolation() {
+        Isolation::ReadCommitted
+            if matches!(statement, Statement::Select(_)) && storage.rcsi_enabled() =>
+        {
+            // The snapshot is the durable commit prefix, so the session's
+            // own just-committed statements must be fsync-durable before
+            // capture or the statement would not see them. Rowset-producing
+            // SELECTs already flushed in `run_block`; this covers assignment
+            // SELECTs (and then no-ops when nothing committed since the
+            // last durability point).
+            run.flush(storage)?;
+            _stmt_scope = Some(SnapshotScope::enter(
+                storage,
+                txn_ctx.txn.as_ref().map(StorageTxn::txn_id),
+            ));
+        }
+        Isolation::Snapshot if data_access => {
+            if !storage.snapshot_isolation_allowed() {
+                if txn_ctx.in_txn() {
+                    txn_ctx.doomed = true;
+                }
+                return Err(snapshot_not_allowed_error(&txn_ctx.database));
+            }
+            if txn_ctx.in_txn() {
+                if txn_ctx.txn_snapshot.is_none() {
+                    // First data access establishes the transaction's view.
+                    run.flush(storage)?;
+                    let own = txn_ctx.txn.as_ref().map(StorageTxn::txn_id);
+                    txn_ctx.txn_snapshot = Some(storage.capture_read_snapshot(own));
+                }
+                _txn_scope = txn_ctx.txn_snapshot.map(TxnSnapshotScope::enter);
+            } else {
+                // Autocommit: the statement is its own transaction, so its
+                // snapshot is statement-scoped, like RCSI's.
+                run.flush(storage)?;
+                _stmt_scope = Some(SnapshotScope::enter(storage, None));
+            }
+        }
+        _ => {}
     }
-    let _snapshot_scope = versioned
-        .then(|| SnapshotScope::enter(storage, txn_ctx.txn.as_ref().map(StorageTxn::txn_id)));
     exec_statement_streamed_inner(storage, statement, txn_ctx, run)
 }
 
@@ -1454,21 +1539,35 @@ pub fn analyze_locks(
     // READ UNCOMMITTED on entry — otherwise the post-SET read would run
     // unlocked. We therefore take read locks unless the whole batch is READ
     // UNCOMMITTED: the session is RU and no SET raises it above RU.
+    // SNAPSHOT is a versioned level, not a raise: a SET to it must not force
+    // lock-based analysis (its whole point is to read without Table S).
     let escalates_reads = statements.iter().any(|s| {
         matches!(
             s,
             Statement::Set(SetStatement::IsolationLevel(level))
-                if !matches!(level, IsolationLevel::ReadUncommitted)
+                if !matches!(level, IsolationLevel::ReadUncommitted | IsolationLevel::Snapshot)
         )
     });
-    let reads_lock = !matches!(isolation, Isolation::ReadUncommitted) || escalates_reads;
-    // Under READ_COMMITTED_SNAPSHOT, a READ COMMITTED SELECT reads a
-    // statement snapshot instead of blocking on writers: it takes Database IS
-    // only — the DDL fence for the batch's duration — and no Table S. A batch
+    // A batch that SETs SNAPSHOT mid-stream still read-locks (statements
+    // before the SET run at the session level, and batch analysis cannot see
+    // the boundary) — but it must at least hold the Database IS fence, so an
+    // RU session's `SET SNAPSHOT; SELECT` is not entirely lock-free.
+    let sets_snapshot = statements.iter().any(|s| {
+        matches!(
+            s,
+            Statement::Set(SetStatement::IsolationLevel(IsolationLevel::Snapshot))
+        )
+    });
+    let reads_lock =
+        !matches!(isolation, Isolation::ReadUncommitted) || escalates_reads || sets_snapshot;
+    // Versioned reads take Database IS only — the DDL fence for the batch's
+    // duration — and no Table S: READ COMMITTED under RCSI (per-statement
+    // snapshots) and SNAPSHOT isolation (the transaction's snapshot). A batch
     // whose SET raises the level is analyzed lock-based (conservative: the
     // raise is seen here, the exact statement boundary is not).
-    let versioned_reads =
-        matches!(isolation, Isolation::ReadCommitted) && !escalates_reads && storage.rcsi_enabled();
+    let versioned_reads = !escalates_reads
+        && (matches!(isolation, Isolation::Snapshot)
+            || (matches!(isolation, Isolation::ReadCommitted) && storage.rcsi_enabled()));
     let mut needs: std::collections::HashMap<Resource, LockMode> = std::collections::HashMap::new();
     let mut add = |resource: Resource, mode: LockMode| {
         needs
@@ -1647,8 +1746,15 @@ pub fn analyze_locks(
                     // (caught by the adversarial review). READ COMMITTED is
                     // passed only when it truly is the effective level.
                     let inner_isolation = if reads_lock {
-                        if matches!(isolation, Isolation::ReadCommitted) && !escalates_reads {
-                            Isolation::ReadCommitted
+                        if matches!(
+                            isolation,
+                            Isolation::ReadCommitted | Isolation::Snapshot
+                        ) && !escalates_reads
+                        {
+                            // Both survive the recursion faithfully: the
+                            // inner analysis reaches the same versioned/
+                            // lock-based decision execution will.
+                            isolation
                         } else {
                             Isolation::RepeatableRead
                         }
@@ -1746,6 +1852,24 @@ fn exec_statement(
             "The current transaction cannot be committed and cannot support operations that write to the log file. Roll back the transaction.",
         ));
     }
+    let result = exec_statement_dispatch(storage, statement, txn_ctx);
+    // SQL Server rolls a SNAPSHOT transaction back entirely on an update
+    // conflict — "transaction aborted", not statement-failed-transaction-
+    // doomed. @@TRANCOUNT drops to zero and the session continues.
+    if let Err(error) = &result
+        && error.number == 3960
+        && txn_ctx.in_txn()
+    {
+        txn_ctx.abort(storage);
+    }
+    result
+}
+
+fn exec_statement_dispatch(
+    storage: &Storage,
+    statement: &Statement,
+    txn_ctx: &mut TxnContext,
+) -> Result<StatementResult, SqlError> {
     match statement {
         Statement::BeginTransaction { .. } => exec_begin(storage, txn_ctx),
         Statement::Commit { .. } => exec_commit(storage, txn_ctx),
@@ -2000,6 +2124,8 @@ fn exec_commit(storage: &Storage, ctx: &mut TxnContext) -> Result<StatementResul
         && let Some(txn) = ctx.txn.take()
     {
         ctx.savepoints.clear();
+        // The transaction is over either way the commit goes.
+        ctx.release_txn_snapshot(storage);
         storage
             .rel_commit(txn)
             .map_err(|e| map_storage_err(e, ""))?;
@@ -2059,6 +2185,7 @@ fn exec_rollback(
             .map_err(|e| map_storage_err(e, "")),
         None => Ok(()),
     };
+    ctx.release_txn_snapshot(storage);
     ctx.trancount = 0;
     ctx.doomed = false;
     ctx.savepoints.clear();
@@ -2091,6 +2218,7 @@ fn exec_set(ctx: &mut TxnContext, set: &SetStatement) -> Result<StatementResult,
                 IsolationLevel::ReadCommitted => Isolation::ReadCommitted,
                 IsolationLevel::RepeatableRead => Isolation::RepeatableRead,
                 IsolationLevel::Serializable => Isolation::Serializable,
+                IsolationLevel::Snapshot => Isolation::Snapshot,
             }
         }
         SetStatement::ShowplanText(on) => ctx.showplan_text = *on,
@@ -3865,6 +3993,46 @@ fn identity_datum(column_type: &ColumnType, v: i64) -> Result<Datum, SqlError> {
 
 // ---- UPDATE / DELETE ----------------------------------------------------
 
+/// The DML target scan: current rows under lock-based isolation; under
+/// SNAPSHOT isolation (the statement's thread-local snapshot is set), the
+/// transaction-snapshot rows instead, each carrying a conflict mark when its
+/// current state was changed or deleted by a writer the snapshot cannot see.
+/// Targeting a marked row is SQL Server's 3960 update conflict.
+fn scan_located_for_dml(
+    storage: &Storage,
+    def: &TableDef,
+) -> Result<Vec<(RowLocator, Vec<Datum>, bool)>, SqlError> {
+    match current_snapshot() {
+        Some(snap) => storage
+            .rel_scan_located_snapshot(&def.name, snap)
+            .map_err(|e| map_storage_err(e, &def.name)),
+        None => Ok(storage
+            .rel_scan_located(&def.name)
+            .map_err(|e| map_storage_err(e, &def.name))?
+            .into_iter()
+            .map(|(locator, row)| (locator, row, false))
+            .collect()),
+    }
+}
+
+/// SQL Server 3960: a SNAPSHOT transaction tried to write a row a later
+/// committed transaction already changed. The whole transaction is rolled
+/// back (see `exec_statement`'s 3960 handling), as SQL Server does.
+fn update_conflict_error(table: &str, database: &str) -> SqlError {
+    SqlError::new(
+        3960,
+        16,
+        1,
+        format!(
+            "Snapshot isolation transaction aborted due to update conflict. You cannot use \
+             snapshot isolation to access table '{table}' directly or indirectly in database \
+             '{database}' to update, delete, or insert the row that has been modified or \
+             deleted by another transaction. Retry the transaction or change the isolation \
+             level for the update/delete statement."
+        ),
+    )
+}
+
 fn exec_update(
     storage: &Storage,
     update: &Update,
@@ -3914,15 +4082,16 @@ fn exec_update(
 
     // Materialize the whole table (Halloween-safe), filter, and compute new
     // rows before any mutation.
-    let located = storage
-        .rel_scan_located(&def.name)
-        .map_err(|e| map_storage_err(e, &def.name))?;
+    let located = scan_located_for_dml(storage, &def)?;
     let types = schema_types(&schema);
     let mut updates = Vec::new();
-    for (locator, row) in located {
+    for (locator, row, conflict) in located {
         check_cancelled()?;
         if !predicate_true(&update.where_clause, &row, &types, &resolver, eval_ctx)? {
             continue;
+        }
+        if conflict {
+            return Err(update_conflict_error(&def.name, &eval_ctx.database));
         }
         // Every SET expression sees the pre-update row; keep the old values
         // for secondary-index maintenance.
@@ -4032,13 +4201,14 @@ fn exec_delete(
     let resolver = SchemaScope { schema: &schema };
 
     let types = schema_types(&schema);
-    let located = storage
-        .rel_scan_located(&def.name)
-        .map_err(|e| map_storage_err(e, &def.name))?;
+    let located = scan_located_for_dml(storage, &def)?;
     let mut targets = Vec::new();
-    for (locator, row) in located {
+    for (locator, row, conflict) in located {
         check_cancelled()?;
         if predicate_true(&delete.where_clause, &row, &types, &resolver, eval_ctx)? {
+            if conflict {
+                return Err(update_conflict_error(&def.name, &eval_ctx.database));
+            }
             // Keep the row values for secondary-index maintenance.
             targets.push((locator, row));
         }
@@ -8475,6 +8645,17 @@ fn map_storage_err(err: StorageError, table: &str) -> SqlError {
             SqlError::new(515, 16, 2, msg)
         }
         StorageError::Constraint(msg) => SqlError::new(547, 16, 0, msg),
+        StorageError::SnapshotSchemaChange(name) => SqlError::new(
+            3961,
+            16,
+            1,
+            format!(
+                "Snapshot isolation transaction failed in database because the object accessed \
+                 by the statement has been modified by a DDL statement in another concurrent \
+                 transaction since the start of this transaction. It is disallowed because the \
+                 metadata is not versioned. Object: '{name}'."
+            ),
+        ),
         StorageError::InvalidConfig(msg) => SqlError::new(1701, 16, 1, msg),
         other => SqlError::new(
             3621,

--- a/crates/truthdb-core/src/relstore/version.rs
+++ b/crates/truthdb-core/src/relstore/version.rs
@@ -225,6 +225,11 @@ impl VersionState {
         }
     }
 
+    /// Whether any snapshot is registered.
+    pub fn has_snapshots(&self) -> bool {
+        !self.snapshots.is_empty()
+    }
+
     pub fn register_snapshot(&mut self, seq: u64) {
         *self.snapshots.entry(seq).or_insert(0) += 1;
     }

--- a/crates/truthdb-core/src/relstore/version.rs
+++ b/crates/truthdb-core/src/relstore/version.rs
@@ -128,6 +128,11 @@ pub(crate) struct VersionState {
     next_seq: u64,
     /// object id -> identity -> chain.
     tables: HashMap<u32, HashMap<Vec<u8>, Chain>>,
+    /// object id -> commit sequence of the last schema-changing DDL (ALTER
+    /// TABLE ADD column — the one DDL that re-encodes rows, so version images
+    /// from before it cannot decode under the live schema). A SNAPSHOT
+    /// transaction whose view predates the stamp gets 3961 at access.
+    schema_stamps: HashMap<u32, u64>,
     /// Active snapshots by sequence (multiset): the prune watermark.
     snapshots: BTreeMap<u64, usize>,
 }
@@ -154,8 +159,27 @@ impl VersionState {
             self.tables.clear();
             self.commits.clear();
             self.commit_points.clear();
+            self.schema_stamps.clear();
             self.durable_floor = 0;
         }
+    }
+
+    /// Records that a schema-changing DDL just committed against `object_id`
+    /// (called under the storage mutex right after its commit was recorded,
+    /// so the newest assigned sequence is the DDL's own).
+    pub fn stamp_schema(&mut self, object_id: u32) {
+        if self.publishing() {
+            self.schema_stamps.insert(object_id, self.next_seq);
+        }
+    }
+
+    /// Whether a schema-changing DDL committed after this snapshot's view —
+    /// the 3961 gate for SNAPSHOT transactions (statement snapshots cannot
+    /// race DDL: their batch's Database IS fences it out).
+    pub fn schema_changed_after(&self, object_id: u32, snap: ReadSnapshot) -> bool {
+        self.schema_stamps
+            .get(&object_id)
+            .is_some_and(|&seq| seq > snap.seq)
     }
 
     /// The two option bits as persisted in the superblock reserved area.
@@ -275,6 +299,29 @@ impl VersionState {
             // value is outside).
             if let Some(Resolved::Image(image)) = self.resolve(object_id, identity, snap) {
                 out.push(image);
+            }
+        }
+        out
+    }
+
+    /// [`Self::unseen_images`], but pairing each image with its identity —
+    /// the SNAPSHOT DML target scan synthesizes locators from them.
+    pub fn unseen_images_with_identity(
+        &self,
+        object_id: u32,
+        seen: &HashSet<Vec<u8>>,
+        snap: ReadSnapshot,
+    ) -> Vec<(Vec<u8>, Vec<u8>)> {
+        let Some(chains) = self.tables.get(&object_id) else {
+            return Vec::new();
+        };
+        let mut out = Vec::new();
+        for identity in chains.keys() {
+            if seen.contains(identity) {
+                continue;
+            }
+            if let Some(Resolved::Image(image)) = self.resolve(object_id, identity, snap) {
+                out.push((identity.clone(), image));
             }
         }
         out
@@ -452,6 +499,7 @@ impl VersionState {
         }
         self.commits
             .retain(|txn, seq| *seq > watermark || referenced.contains(txn));
+        self.schema_stamps.retain(|_, seq| *seq > watermark);
         // Commit points whose sequence the watermark has passed are only
         // needed as the durable floor.
         let cut = self
@@ -476,6 +524,15 @@ pub(crate) fn rid_identity(rid: crate::relstore::heap::Rid) -> Vec<u8> {
     out.extend_from_slice(&rid.page.to_le_bytes());
     out.extend_from_slice(&rid.slot.to_le_bytes());
     out
+}
+
+/// Inverse of [`rid_identity`].
+pub(crate) fn decode_rid_identity(identity: &[u8]) -> crate::relstore::heap::Rid {
+    debug_assert_eq!(identity.len(), 10);
+    crate::relstore::heap::Rid {
+        page: u64::from_le_bytes(identity[0..8].try_into().expect("rid identity page")),
+        slot: u16::from_le_bytes(identity[8..10].try_into().expect("rid identity slot")),
+    }
 }
 
 #[cfg(test)]

--- a/crates/truthdb-core/src/session.rs
+++ b/crates/truthdb-core/src/session.rs
@@ -1499,12 +1499,17 @@ impl Scheduler {
                 // running is not time spent idle.
                 state.last_activity = Instant::now();
                 let open = state.txn_ctx.has_open_transaction();
-                let is_read_committed =
-                    matches!(state.txn_ctx.isolation(), Isolation::ReadCommitted);
+                // READ COMMITTED shared locks do not survive the batch, and a
+                // SNAPSHOT transaction holds no read locks between batches at
+                // all (its Database IS is the running batch's DDL fence; the
+                // snapshot itself is what protects its reads).
+                let releases_read_locks = matches!(
+                    state.txn_ctx.isolation(),
+                    Isolation::ReadCommitted | Isolation::Snapshot
+                );
                 if open {
-                    // Transaction still open: keep write locks. Under READ
-                    // COMMITTED shared locks do not survive the statement.
-                    if is_read_committed {
+                    // Transaction still open: keep write locks.
+                    if releases_read_locks {
                         self.locks.release_read_locks(owner);
                     }
                     true
@@ -4574,5 +4579,279 @@ mod tests {
         h.handle.run_batch(a, "COMMIT".into()).await.unwrap();
         let reply = must_not_block(&h, b, "SELECT id FROM t WHERE v = 10").await;
         assert_eq!(values(&reply), Vec::<i64>::new());
+    }
+
+    // ---- SNAPSHOT isolation (Stage 13) -----------------------------------
+
+    /// ALLOW_SNAPSHOT_ISOLATION on (RCSI deliberately off — SNAPSHOT must
+    /// stand alone), `t (id PK, v)` = (1,10), (2,20); session B is SNAPSHOT.
+    async fn si_harness() -> (Harness, SessionId, SessionId) {
+        let h = start(Duration::from_secs(30));
+        let a = h.handle.open_session(String::new(), String::new()).await;
+        let b = h.handle.open_session(String::new(), String::new()).await;
+        for sql in [
+            "ALTER DATABASE CURRENT SET ALLOW_SNAPSHOT_ISOLATION ON",
+            "CREATE TABLE t (id INT NOT NULL PRIMARY KEY, v INT)",
+            "INSERT INTO t VALUES (1, 10), (2, 20)",
+        ] {
+            let reply = h.handle.run_batch(a, sql.into()).await.unwrap();
+            assert_eq!(
+                error_number(&reply),
+                None,
+                "{sql}: {:?}",
+                reply.outcome.error
+            );
+        }
+        h.handle
+            .run_batch(b, "SET TRANSACTION ISOLATION LEVEL SNAPSHOT".into())
+            .await
+            .unwrap();
+        (h, a, b)
+    }
+
+    #[tokio::test]
+    async fn snapshot_reads_are_repeatable_and_block_nobody() {
+        let (h, a, b) = si_harness().await;
+        h.handle.run_batch(b, "BEGIN TRAN".into()).await.unwrap();
+        let reply = must_not_block(&h, b, "SELECT v FROM t WHERE id = 1").await;
+        assert_eq!(
+            values(&reply),
+            vec![10],
+            "first access establishes the view"
+        );
+        // A writer neither blocks the snapshot reader nor is blocked by it.
+        let reply = must_not_block(&h, a, "UPDATE t SET v = 99 WHERE id = 1").await;
+        assert_eq!(error_number(&reply), None, "{:?}", reply.outcome.error);
+        let reply = must_not_block(&h, b, "SELECT v FROM t WHERE id = 1").await;
+        assert_eq!(
+            values(&reply),
+            vec![10],
+            "the committed 99 postdates the transaction's snapshot — repeatable read"
+        );
+        h.handle.run_batch(b, "COMMIT".into()).await.unwrap();
+        let reply = must_not_block(&h, b, "SELECT v FROM t WHERE id = 1").await;
+        assert_eq!(
+            values(&reply),
+            vec![99],
+            "a new transaction sees the new state"
+        );
+    }
+
+    #[tokio::test]
+    async fn snapshot_autocommit_statements_take_fresh_snapshots() {
+        let (h, a, b) = si_harness().await;
+        let reply = must_not_block(&h, b, "SELECT v FROM t WHERE id = 1").await;
+        assert_eq!(values(&reply), vec![10]);
+        h.handle
+            .run_batch(a, "UPDATE t SET v = 99 WHERE id = 1".into())
+            .await
+            .unwrap();
+        let reply = must_not_block(&h, b, "SELECT v FROM t WHERE id = 1").await;
+        assert_eq!(
+            values(&reply),
+            vec![99],
+            "outside a transaction each statement is its own snapshot"
+        );
+    }
+
+    #[tokio::test]
+    async fn snapshot_update_conflict_is_3960_and_rolls_the_transaction_back() {
+        let (h, a, b) = si_harness().await;
+        h.handle.run_batch(b, "BEGIN TRAN".into()).await.unwrap();
+        let reply = must_not_block(&h, b, "SELECT v FROM t WHERE id = 1").await;
+        assert_eq!(values(&reply), vec![10]);
+        // A commits a change B's snapshot cannot see...
+        h.handle
+            .run_batch(a, "UPDATE t SET v = 99 WHERE id = 1".into())
+            .await
+            .unwrap();
+        // ...so B writing the same row is the classic update conflict.
+        let reply = h
+            .handle
+            .run_batch(b, "UPDATE t SET v = 100 WHERE id = 1".into())
+            .await
+            .unwrap();
+        assert_eq!(
+            error_number(&reply),
+            Some(3960),
+            "{:?}",
+            reply.outcome.error
+        );
+        // SQL Server ABORTS the transaction (not merely dooms it): a COMMIT
+        // now has nothing to commit.
+        let reply = h.handle.run_batch(b, "COMMIT".into()).await.unwrap();
+        assert_eq!(error_number(&reply), Some(3902), "the transaction is gone");
+        // The conflicting write never landed; A's did.
+        let reply = must_not_block(&h, b, "SELECT v FROM t WHERE id = 1").await;
+        assert_eq!(values(&reply), vec![99]);
+    }
+
+    #[tokio::test]
+    async fn snapshot_delete_of_a_row_deleted_since_the_snapshot_is_3960() {
+        let (h, a, b) = si_harness().await;
+        h.handle.run_batch(b, "BEGIN TRAN".into()).await.unwrap();
+        let reply = must_not_block(&h, b, "SELECT v FROM t WHERE id = 2").await;
+        assert_eq!(values(&reply), vec![20]);
+        h.handle
+            .run_batch(a, "DELETE FROM t WHERE id = 2".into())
+            .await
+            .unwrap();
+        // The row is physically gone, but B's snapshot still sees it — and
+        // targeting it must conflict, not silently affect zero rows.
+        let reply = h
+            .handle
+            .run_batch(b, "DELETE FROM t WHERE id = 2".into())
+            .await
+            .unwrap();
+        assert_eq!(
+            error_number(&reply),
+            Some(3960),
+            "{:?}",
+            reply.outcome.error
+        );
+    }
+
+    #[tokio::test]
+    async fn snapshot_dml_targets_snapshot_rows_not_current_ones() {
+        let (h, a, b) = si_harness().await;
+        h.handle.run_batch(b, "BEGIN TRAN".into()).await.unwrap();
+        let reply = must_not_block(&h, b, "SELECT v FROM t WHERE id = 1").await;
+        assert_eq!(values(&reply), vec![10]);
+        // A moves the row INTO the predicate's range after B's snapshot.
+        h.handle
+            .run_batch(a, "UPDATE t SET v = 77 WHERE id = 1".into())
+            .await
+            .unwrap();
+        // B's WHERE v = 77 matches the CURRENT row but not the snapshot's
+        // version: nothing is targeted, no conflict — current-based targeting
+        // would wrongly update it.
+        let reply = h
+            .handle
+            .run_batch(b, "UPDATE t SET v = 1000 WHERE v = 77".into())
+            .await
+            .unwrap();
+        assert_eq!(error_number(&reply), None, "{:?}", reply.outcome.error);
+        match reply.outcome.results.as_slice() {
+            [StatementResult::RowsAffected(n)] => {
+                assert_eq!(*n, 0, "the snapshot's rows decide targeting")
+            }
+            other => panic!("expected RowsAffected, got {other:?}"),
+        }
+        h.handle.run_batch(b, "ROLLBACK".into()).await.unwrap();
+        let reply = must_not_block(&h, b, "SELECT v FROM t WHERE id = 1").await;
+        assert_eq!(values(&reply), vec![77], "A's committed value is untouched");
+    }
+
+    #[tokio::test]
+    async fn snapshot_without_allow_option_is_3952_at_access() {
+        let h = start(Duration::from_secs(30));
+        let a = h.handle.open_session(String::new(), String::new()).await;
+        h.handle
+            .run_batch(
+                a,
+                "CREATE TABLE t (id INT NOT NULL PRIMARY KEY); INSERT INTO t VALUES (1);".into(),
+            )
+            .await
+            .unwrap();
+        // The SET itself succeeds (SQL Server defers the check to access).
+        let reply = h
+            .handle
+            .run_batch(a, "SET TRANSACTION ISOLATION LEVEL SNAPSHOT".into())
+            .await
+            .unwrap();
+        assert_eq!(error_number(&reply), None, "{:?}", reply.outcome.error);
+        let reply = h
+            .handle
+            .run_batch(a, "SELECT id FROM t".into())
+            .await
+            .unwrap();
+        assert_eq!(
+            error_number(&reply),
+            Some(3952),
+            "{:?}",
+            reply.outcome.error
+        );
+        // Inside a transaction the failure dooms it: COMMIT is refused until
+        // the rollback.
+        h.handle.run_batch(a, "BEGIN TRAN".into()).await.unwrap();
+        let reply = h
+            .handle
+            .run_batch(a, "SELECT id FROM t".into())
+            .await
+            .unwrap();
+        assert_eq!(error_number(&reply), Some(3952));
+        let reply = h.handle.run_batch(a, "COMMIT".into()).await.unwrap();
+        assert_eq!(
+            error_number(&reply),
+            Some(3930),
+            "doomed: only ROLLBACK is allowed"
+        );
+        let reply = h.handle.run_batch(a, "ROLLBACK".into()).await.unwrap();
+        assert_eq!(error_number(&reply), None, "{:?}", reply.outcome.error);
+    }
+
+    #[tokio::test]
+    async fn snapshot_schema_change_since_the_snapshot_is_3961() {
+        let (h, a, b) = si_harness().await;
+        h.handle
+            .run_batch(a, "CREATE TABLE other (id INT NOT NULL PRIMARY KEY)".into())
+            .await
+            .unwrap();
+        h.handle.run_batch(b, "BEGIN TRAN".into()).await.unwrap();
+        let reply = must_not_block(&h, b, "SELECT v FROM t WHERE id = 1").await;
+        assert_eq!(values(&reply), vec![10]);
+        // The ALTER re-encodes every row of t; B's images predate it.
+        h.handle
+            .run_batch(a, "ALTER TABLE t ADD extra INT DEFAULT 5".into())
+            .await
+            .unwrap();
+        let reply = h
+            .handle
+            .run_batch(b, "SELECT v FROM t WHERE id = 1".into())
+            .await
+            .unwrap();
+        assert_eq!(
+            error_number(&reply),
+            Some(3961),
+            "{:?}",
+            reply.outcome.error
+        );
+        // 3961 fails the statement, not the transaction: other tables still
+        // read, and the transaction can end normally.
+        let reply = must_not_block(&h, b, "SELECT id FROM other").await;
+        assert_eq!(error_number(&reply), None, "{:?}", reply.outcome.error);
+        let reply = h.handle.run_batch(b, "COMMIT".into()).await.unwrap();
+        assert_eq!(error_number(&reply), None, "{:?}", reply.outcome.error);
+    }
+
+    #[tokio::test]
+    async fn snapshot_inserts_do_not_conflict_and_stay_isolated() {
+        let (h, a, b) = si_harness().await;
+        h.handle.run_batch(b, "BEGIN TRAN".into()).await.unwrap();
+        let reply = must_not_block(&h, b, "SELECT id FROM t").await;
+        let mut got = values(&reply);
+        got.sort();
+        assert_eq!(got, vec![1, 2]);
+        h.handle
+            .run_batch(a, "INSERT INTO t VALUES (3, 30)".into())
+            .await
+            .unwrap();
+        // B's own insert succeeds (insert-insert is a key collision question,
+        // not a version conflict) and B still does not see A's row.
+        let reply = must_not_block(&h, b, "INSERT INTO t VALUES (4, 40)").await;
+        assert_eq!(error_number(&reply), None, "{:?}", reply.outcome.error);
+        let reply = must_not_block(&h, b, "SELECT id FROM t").await;
+        let mut got = values(&reply);
+        got.sort();
+        assert_eq!(
+            got,
+            vec![1, 2, 4],
+            "own insert visible, A's post-snapshot one not"
+        );
+        h.handle.run_batch(b, "COMMIT".into()).await.unwrap();
+        let reply = must_not_block(&h, b, "SELECT id FROM t").await;
+        let mut got = values(&reply);
+        got.sort();
+        assert_eq!(got, vec![1, 2, 3, 4]);
     }
 }

--- a/crates/truthdb-core/src/session.rs
+++ b/crates/truthdb-core/src/session.rs
@@ -4854,4 +4854,423 @@ mod tests {
         got.sort();
         assert_eq!(got, vec![1, 2, 3, 4]);
     }
+
+    // ---- SI review PoC tests ---------------------------------------------
+
+    /// Attack A: a row re-keyed by a snapshot-invisible writer. Targeting the
+    /// snapshot row by its OLD key must be 3960 (its current state was
+    /// produced by an invisible writer); targeting the NEW key must affect
+    /// nothing (the snapshot has no such row) and must not touch the current
+    /// row.
+    #[tokio::test]
+    async fn snapshot_rekeyed_row_conflicts_on_old_key_and_misses_on_new_key() {
+        let (h, a, b) = si_harness().await;
+        h.handle.run_batch(b, "BEGIN TRAN".into()).await.unwrap();
+        let reply = must_not_block(&h, b, "SELECT v FROM t WHERE id = 2").await;
+        assert_eq!(values(&reply), vec![20]);
+        // A re-keys row 2 -> 5 after B's snapshot.
+        let reply = h
+            .handle
+            .run_batch(a, "UPDATE t SET id = 5 WHERE id = 2".into())
+            .await
+            .unwrap();
+        assert_eq!(error_number(&reply), None, "{:?}", reply.outcome.error);
+        // Targeting by the NEW key: the snapshot has no row with id = 5.
+        let reply = h
+            .handle
+            .run_batch(b, "DELETE FROM t WHERE id = 5".into())
+            .await
+            .unwrap();
+        assert_eq!(error_number(&reply), None, "{:?}", reply.outcome.error);
+        match reply.outcome.results.as_slice() {
+            [StatementResult::RowsAffected(n)] => assert_eq!(*n, 0, "snapshot has no id = 5"),
+            other => panic!("expected RowsAffected, got {other:?}"),
+        }
+        // Targeting by the OLD key: the snapshot row exists but its current
+        // state was produced by an invisible writer - update conflict.
+        let reply = h
+            .handle
+            .run_batch(b, "UPDATE t SET v = 200 WHERE id = 2".into())
+            .await
+            .unwrap();
+        assert_eq!(
+            error_number(&reply),
+            Some(3960),
+            "{:?}",
+            reply.outcome.error
+        );
+        // The 3960 rolled B back; the current row was never touched by the
+        // no-op DELETE or the conflicting UPDATE.
+        let reply = must_not_block(&h, a, "SELECT v FROM t WHERE id = 5").await;
+        assert_eq!(values(&reply), vec![20], "A's re-keyed row survived");
+        let reply = must_not_block(&h, a, "SELECT COUNT(*) FROM t").await;
+        assert_eq!(values(&reply), vec![2]);
+    }
+
+    /// Attack E: an index created AFTER the snapshot only contains
+    /// post-snapshot states. A seek through it must still produce exactly the
+    /// snapshot's rows: old values found via chain images, new values
+    /// filtered out.
+    #[tokio::test]
+    async fn snapshot_reads_merge_through_an_index_created_after_the_snapshot() {
+        let (h, a, b) = si_harness().await;
+        h.handle.run_batch(b, "BEGIN TRAN".into()).await.unwrap();
+        let reply = must_not_block(&h, b, "SELECT v FROM t WHERE id = 1").await;
+        assert_eq!(values(&reply), vec![10]);
+        // Post-snapshot: an index on v, then an update that moves row 1's
+        // entry from 10 to 99 (the new index only ever contains 99).
+        let reply = h
+            .handle
+            .run_batch(a, "CREATE INDEX ix_v ON t (v)".into())
+            .await
+            .unwrap();
+        assert_eq!(error_number(&reply), None, "{:?}", reply.outcome.error);
+        let reply = h
+            .handle
+            .run_batch(a, "UPDATE t SET v = 99 WHERE id = 1".into())
+            .await
+            .unwrap();
+        assert_eq!(error_number(&reply), None, "{:?}", reply.outcome.error);
+        // Seek for the snapshot's value: nothing physical in range, so the
+        // row must come from its chain image.
+        let reply = must_not_block(&h, b, "SELECT id FROM t WHERE v = 10").await;
+        assert_eq!(
+            values(&reply),
+            vec![1],
+            "the snapshot's v = 10 row must be found through the new index"
+        );
+        // Seek for the current value: the physical entry resolves to an
+        // image with v = 10, which the predicate must filter out.
+        let reply = must_not_block(&h, b, "SELECT id FROM t WHERE v = 99").await;
+        assert_eq!(
+            values(&reply),
+            Vec::<i64>::new(),
+            "the current v = 99 row postdates the snapshot"
+        );
+        h.handle.run_batch(b, "COMMIT".into()).await.unwrap();
+    }
+
+    /// Attack C: EXEC of a literal shares the transaction's snapshot - the
+    /// inner statement both CAPTURES it (first access inside an EXEC) and
+    /// REUSES it, and 3952 fires at the inner statement's access when the
+    /// option is off.
+    #[tokio::test]
+    async fn exec_literal_shares_the_transaction_snapshot() {
+        let (h, a, b) = si_harness().await;
+        h.handle.run_batch(b, "BEGIN TRAN".into()).await.unwrap();
+        // First data access happens INSIDE the EXEC: it must establish the
+        // transaction's snapshot.
+        let reply =
+            must_not_block(&h, b, "EXEC sp_executesql N'SELECT v FROM t WHERE id = 1'").await;
+        assert_eq!(values(&reply), vec![10]);
+        h.handle
+            .run_batch(a, "UPDATE t SET v = 99 WHERE id = 1".into())
+            .await
+            .unwrap();
+        // Both a plain statement and another EXEC read the SAME view.
+        let reply = must_not_block(&h, b, "SELECT v FROM t WHERE id = 1").await;
+        assert_eq!(
+            values(&reply),
+            vec![10],
+            "captured inside EXEC, reused outside"
+        );
+        let reply =
+            must_not_block(&h, b, "EXEC sp_executesql N'SELECT v FROM t WHERE id = 1'").await;
+        assert_eq!(values(&reply), vec![10], "reused inside EXEC");
+        h.handle.run_batch(b, "COMMIT".into()).await.unwrap();
+    }
+
+    /// Attack C/D: without ALLOW_SNAPSHOT_ISOLATION, the 3952 fires at the
+    /// INNER statement of an EXEC too, and dooms the open transaction.
+    #[tokio::test]
+    async fn exec_literal_under_snapshot_without_allow_is_3952() {
+        let h = start(Duration::from_secs(30));
+        let a = h.handle.open_session(String::new(), String::new()).await;
+        h.handle
+            .run_batch(
+                a,
+                "CREATE TABLE t (id INT NOT NULL PRIMARY KEY); INSERT INTO t VALUES (1);".into(),
+            )
+            .await
+            .unwrap();
+        h.handle
+            .run_batch(a, "SET TRANSACTION ISOLATION LEVEL SNAPSHOT".into())
+            .await
+            .unwrap();
+        h.handle.run_batch(a, "BEGIN TRAN".into()).await.unwrap();
+        let reply = h
+            .handle
+            .run_batch(a, "EXEC sp_executesql N'SELECT id FROM t'".into())
+            .await
+            .unwrap();
+        assert_eq!(
+            error_number(&reply),
+            Some(3952),
+            "{:?}",
+            reply.outcome.error
+        );
+        let reply = h.handle.run_batch(a, "COMMIT".into()).await.unwrap();
+        assert_eq!(error_number(&reply), Some(3930), "doomed");
+        let reply = h.handle.run_batch(a, "ROLLBACK".into()).await.unwrap();
+        assert_eq!(error_number(&reply), None, "{:?}", reply.outcome.error);
+        // The session is usable again (autocommit statements still 3952
+        // until the level changes, but the SET path works).
+        h.handle
+            .run_batch(a, "SET TRANSACTION ISOLATION LEVEL READ COMMITTED".into())
+            .await
+            .unwrap();
+        let reply = must_not_block(&h, a, "SELECT id FROM t").await;
+        assert_eq!(values(&reply), vec![1]);
+    }
+
+    /// Attack B / leak audit: nested BEGIN and a savepoint rollback keep the
+    /// transaction - and must keep its snapshot.
+    #[tokio::test]
+    async fn nested_begin_and_savepoint_rollback_keep_the_snapshot() {
+        let (h, a, b) = si_harness().await;
+        h.handle.run_batch(b, "BEGIN TRAN".into()).await.unwrap();
+        let reply = must_not_block(&h, b, "SELECT v FROM t WHERE id = 1").await;
+        assert_eq!(values(&reply), vec![10]);
+        h.handle
+            .run_batch(a, "UPDATE t SET v = 99 WHERE id = 1".into())
+            .await
+            .unwrap();
+        // Nested BEGIN + inner COMMIT: trancount 2 -> 1, transaction alive.
+        h.handle.run_batch(b, "BEGIN TRAN".into()).await.unwrap();
+        h.handle.run_batch(b, "COMMIT".into()).await.unwrap();
+        let reply = must_not_block(&h, b, "SELECT v FROM t WHERE id = 1").await;
+        assert_eq!(
+            values(&reply),
+            vec![10],
+            "inner COMMIT must not drop the view"
+        );
+        // Savepoint rollback: own write undone, transaction and view alive.
+        h.handle.run_batch(b, "SAVE TRAN sp1".into()).await.unwrap();
+        let reply = h
+            .handle
+            .run_batch(b, "UPDATE t SET v = 500 WHERE id = 2".into())
+            .await
+            .unwrap();
+        assert_eq!(error_number(&reply), None, "{:?}", reply.outcome.error);
+        h.handle
+            .run_batch(b, "ROLLBACK TRAN sp1".into())
+            .await
+            .unwrap();
+        let reply = must_not_block(&h, b, "SELECT v FROM t WHERE id = 2").await;
+        assert_eq!(
+            values(&reply),
+            vec![20],
+            "own write rolled back to the savepoint"
+        );
+        let reply = must_not_block(&h, b, "SELECT v FROM t WHERE id = 1").await;
+        assert_eq!(
+            values(&reply),
+            vec![10],
+            "the view survives the savepoint rollback"
+        );
+        h.handle.run_batch(b, "COMMIT".into()).await.unwrap();
+        let reply = must_not_block(&h, b, "SELECT v FROM t WHERE id = 1").await;
+        assert_eq!(values(&reply), vec![99]);
+    }
+
+    /// Attack E (option toggle): ALTER DATABASE SET ALLOW_SNAPSHOT_ISOLATION
+    /// OFF while a SNAPSHOT transaction holds a registered snapshot between
+    /// batches (it holds no locks then, so Database X does not exclude it).
+    /// Expected correct behavior: the toggle succeeds (or waits), the
+    /// snapshot transaction gets 3952 at its next access, and the session
+    /// recovers. Today the version store's reset debug_asserts that no
+    /// snapshot is live - which is false here.
+    #[tokio::test]
+    async fn alter_options_refuse_while_a_snapshot_transaction_lives() {
+        // A SNAPSHOT transaction idle between batches holds no locks, so the
+        // ALTER's Database X grants — but flipping the options under its
+        // registered snapshot would reset the store its reads depend on
+        // (the review's HIGH: a debug panic, silent wrong data in release).
+        // The ALTER refuses with 5061 instead; SQL Server would wait.
+        let (h, a, b) = si_harness().await;
+        h.handle.run_batch(b, "BEGIN TRAN".into()).await.unwrap();
+        let reply = must_not_block(&h, b, "SELECT v FROM t WHERE id = 1").await;
+        assert_eq!(values(&reply), vec![10], "snapshot registered");
+        let reply = tokio::time::timeout(
+            Duration::from_secs(5),
+            h.handle.run_batch(
+                a,
+                "ALTER DATABASE CURRENT SET ALLOW_SNAPSHOT_ISOLATION OFF".into(),
+            ),
+        )
+        .await
+        .expect("the ALTER must not hang")
+        .unwrap();
+        assert_eq!(
+            error_number(&reply),
+            Some(5061),
+            "refused while the snapshot lives: {:?}",
+            reply.outcome.error
+        );
+        // The transaction is untouched — still repeatable.
+        let reply = must_not_block(&h, b, "SELECT v FROM t WHERE id = 1").await;
+        assert_eq!(values(&reply), vec![10]);
+        h.handle.run_batch(b, "COMMIT".into()).await.unwrap();
+        // Snapshot released: the retry succeeds, and SNAPSHOT access is gone.
+        let reply = h
+            .handle
+            .run_batch(
+                a,
+                "ALTER DATABASE CURRENT SET ALLOW_SNAPSHOT_ISOLATION OFF".into(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(error_number(&reply), None, "{:?}", reply.outcome.error);
+        let reply = h
+            .handle
+            .run_batch(b, "SELECT v FROM t WHERE id = 1".into())
+            .await
+            .unwrap();
+        assert_eq!(error_number(&reply), Some(3952));
+    }
+
+    /// A statement-scoped (autocommit) 3952 does not wedge the session.
+    #[tokio::test]
+    async fn autocommit_3952_leaves_the_session_usable() {
+        let h = start(Duration::from_secs(30));
+        let a = h.handle.open_session(String::new(), String::new()).await;
+        h.handle
+            .run_batch(
+                a,
+                "CREATE TABLE t (id INT NOT NULL PRIMARY KEY); INSERT INTO t VALUES (1);".into(),
+            )
+            .await
+            .unwrap();
+        h.handle
+            .run_batch(a, "SET TRANSACTION ISOLATION LEVEL SNAPSHOT".into())
+            .await
+            .unwrap();
+        let reply = h
+            .handle
+            .run_batch(a, "SELECT id FROM t".into())
+            .await
+            .unwrap();
+        assert_eq!(error_number(&reply), Some(3952));
+        // A table-free SELECT is not data access: no 3952, and it does not
+        // establish a snapshot (SQL Server defers both to the first read of
+        // an actual object) — the review's finding 3.
+        let reply = h.handle.run_batch(a, "SELECT 1".into()).await.unwrap();
+        assert_eq!(error_number(&reply), None, "{:?}", reply.outcome.error);
+        h.handle
+            .run_batch(a, "SET TRANSACTION ISOLATION LEVEL READ COMMITTED".into())
+            .await
+            .unwrap();
+        let reply = must_not_block(&h, a, "SELECT id FROM t").await;
+        assert_eq!(values(&reply), vec![1]);
+    }
+
+    /// 3961 completeness: DROP TABLE + CREATE TABLE of the same name between
+    /// a SNAPSHOT transaction's batches. SQL Server raises 3961 (metadata is
+    /// not versioned); at minimum the reader must not silently see the NEW
+    /// table's contents as if they were its snapshot.
+    #[tokio::test]
+    async fn snapshot_drop_and_recreate_between_batches_is_3961() {
+        let (h, a, b) = si_harness().await;
+        h.handle.run_batch(b, "BEGIN TRAN".into()).await.unwrap();
+        let reply = must_not_block(&h, b, "SELECT v FROM t WHERE id = 1").await;
+        assert_eq!(values(&reply), vec![10]);
+        for sql in [
+            "DROP TABLE t",
+            "CREATE TABLE t (id INT NOT NULL PRIMARY KEY, v INT)",
+            "INSERT INTO t VALUES (7, 70)",
+        ] {
+            let reply = h.handle.run_batch(a, sql.into()).await.unwrap();
+            assert_eq!(
+                error_number(&reply),
+                None,
+                "{sql}: {:?}",
+                reply.outcome.error
+            );
+        }
+        let reply = h
+            .handle
+            .run_batch(b, "SELECT v FROM t".into())
+            .await
+            .unwrap();
+        assert_eq!(
+            error_number(&reply),
+            Some(3961),
+            "SQL Server: DDL since the snapshot is 3961, got {:?} / rows {:?}",
+            reply.outcome.error,
+            reply.outcome.results
+        );
+        h.handle.run_batch(b, "ROLLBACK".into()).await.unwrap();
+    }
+
+    /// The heap arm of the SI DML target scan: conflicts through synthesized
+    /// RID locators (no primary key anywhere).
+    #[tokio::test]
+    async fn snapshot_heap_dml_conflicts_via_rid_identities() {
+        let h = start(Duration::from_secs(30));
+        let a = h.handle.open_session(String::new(), String::new()).await;
+        let b = h.handle.open_session(String::new(), String::new()).await;
+        for sql in [
+            "ALTER DATABASE CURRENT SET ALLOW_SNAPSHOT_ISOLATION ON",
+            "CREATE TABLE hp (v INT)",
+            "INSERT INTO hp VALUES (10), (20)",
+        ] {
+            let reply = h.handle.run_batch(a, sql.into()).await.unwrap();
+            assert_eq!(
+                error_number(&reply),
+                None,
+                "{sql}: {:?}",
+                reply.outcome.error
+            );
+        }
+        h.handle
+            .run_batch(b, "SET TRANSACTION ISOLATION LEVEL SNAPSHOT".into())
+            .await
+            .unwrap();
+        h.handle.run_batch(b, "BEGIN TRAN".into()).await.unwrap();
+        let reply = must_not_block(&h, b, "SELECT v FROM hp WHERE v = 10").await;
+        assert_eq!(values(&reply), vec![10]);
+        // A deletes the row B's snapshot still sees.
+        let reply = h
+            .handle
+            .run_batch(a, "DELETE FROM hp WHERE v = 10".into())
+            .await
+            .unwrap();
+        assert_eq!(error_number(&reply), None, "{:?}", reply.outcome.error);
+        // Targeting it via its synthesized RID locator is the conflict.
+        let reply = h
+            .handle
+            .run_batch(b, "DELETE FROM hp WHERE v = 10".into())
+            .await
+            .unwrap();
+        assert_eq!(
+            error_number(&reply),
+            Some(3960),
+            "{:?}",
+            reply.outcome.error
+        );
+        // B was rolled back; the surviving row is intact.
+        let reply = must_not_block(&h, b, "SELECT v FROM hp").await;
+        assert_eq!(values(&reply), vec![20]);
+    }
+
+    /// Full-table DML under SI: DELETE with no WHERE keeps every snapshot
+    /// row; if ANY of them was changed since the snapshot, 3960.
+    #[tokio::test]
+    async fn snapshot_full_table_delete_conflicts_when_any_row_changed() {
+        let (h, a, b) = si_harness().await;
+        h.handle.run_batch(b, "BEGIN TRAN".into()).await.unwrap();
+        let reply = must_not_block(&h, b, "SELECT v FROM t WHERE id = 1").await;
+        assert_eq!(values(&reply), vec![10]);
+        h.handle
+            .run_batch(a, "UPDATE t SET v = 99 WHERE id = 2".into())
+            .await
+            .unwrap();
+        let reply = h.handle.run_batch(b, "DELETE FROM t".into()).await.unwrap();
+        assert_eq!(
+            error_number(&reply),
+            Some(3960),
+            "{:?}",
+            reply.outcome.error
+        );
+    }
 }

--- a/crates/truthdb-core/src/storage.rs
+++ b/crates/truthdb-core/src/storage.rs
@@ -4430,6 +4430,75 @@ mod tests {
         let _ = std::fs::remove_file(&path);
     }
 
+    /// Version cleanup under load (Stage 13 exit): a live snapshot pins
+    /// exactly the history it may still read through sustained churn — and
+    /// keeps reading its own consistent view — while releasing it lets the
+    /// maintenance prune drop everything.
+    #[test]
+    fn version_cleanup_under_load_pins_then_drops_history() {
+        use crate::rel::{TxnContext, execute_batch};
+
+        let path = unique_temp_path("cleanup-load");
+        let storage = Storage::create(path.clone(), test_storage_options()).expect("create");
+        let mut ctx = TxnContext::default();
+        let mut seed = String::from("INSERT INTO t VALUES ");
+        for i in 0..100 {
+            seed.push_str(&format!("({i}, 0),"));
+        }
+        seed.pop();
+        for sql in [
+            "ALTER DATABASE CURRENT SET READ_COMMITTED_SNAPSHOT ON",
+            "CREATE TABLE t (id INT NOT NULL PRIMARY KEY, v INT)",
+            seed.as_str(),
+        ] {
+            let outcome = execute_batch(&storage, sql, &mut ctx);
+            assert!(outcome.error.is_none(), "{sql}: {:?}", outcome.error);
+        }
+        storage
+            .ensure_durable(storage.wal_tail())
+            .expect("durability");
+        storage.version_prune();
+        assert_eq!(storage.version_chain_count("t"), 0, "settled baseline");
+
+        // A long-lived snapshot (an idle SNAPSHOT transaction's view) while
+        // a writer churns every row, five rounds, pruning between rounds.
+        let pinned = storage.capture_read_snapshot(None);
+        for round in 1..=5 {
+            let outcome = execute_batch(&storage, &format!("UPDATE t SET v = {round}"), &mut ctx);
+            assert!(outcome.error.is_none(), "{:?}", outcome.error);
+            storage
+                .ensure_durable(storage.wal_tail())
+                .expect("durability");
+            storage.version_prune();
+        }
+        assert_eq!(
+            storage.version_chain_count("t"),
+            100,
+            "the live snapshot pins one chain per churned row"
+        );
+        // The pinned view still reads its consistent state through all of it.
+        let rows = storage
+            .rel_scan_snapshot("t", Some(&[1]), pinned)
+            .expect("snapshot scan");
+        assert_eq!(rows.len(), 100);
+        assert!(
+            rows.iter().all(|r| r == &vec![Datum::Int(0)]),
+            "the snapshot sees the pre-churn value on every row"
+        );
+
+        // Released: the next prune drops the whole store.
+        storage.release_read_snapshot(pinned.seq);
+        storage.version_prune();
+        assert_eq!(
+            storage.version_chain_count("t"),
+            0,
+            "released history is dropped, the store is bounded"
+        );
+
+        drop(storage);
+        let _ = std::fs::remove_file(&path);
+    }
+
     /// Publishing versions changes nothing about crash recovery: the store
     /// (chains and commit table) is memory-only, so a kill-and-reopen with
     /// RCSI on recovers exactly the committed state, options intact, chains

--- a/crates/truthdb-core/src/storage.rs
+++ b/crates/truthdb-core/src/storage.rs
@@ -19,7 +19,9 @@ use crate::relstore::key::encode_key;
 use crate::relstore::recovery as rel_recovery;
 use crate::relstore::row::{Column, Schema, decode_row, decode_row_projected, encode_row};
 use crate::relstore::types::{Datum, TypeError};
-use crate::relstore::version::{PendingVersion, ReadSnapshot, Resolved, RowChange, rid_identity};
+use crate::relstore::version::{
+    PendingVersion, ReadSnapshot, Resolved, RowChange, decode_rid_identity, rid_identity,
+};
 use crate::storage_layout::{
     FileHeader, PAGE_SIZE, SNAPSHOT_DESCRIPTOR_SIZE, SUPERBLOCK_ACTIVE_A, SUPERBLOCK_ACTIVE_B,
     SnapshotDescriptor, Superblock, WAL_ENTRY_TYPE_REL, WAL_MAX_BYTES, WAL_MIN_BYTES, align_down,
@@ -118,6 +120,12 @@ pub enum StorageError {
 
     #[error("constraint violation: {0}")]
     Constraint(String),
+
+    /// A SNAPSHOT transaction touched a table whose schema a later-committed
+    /// DDL changed (its version images cannot decode under the new schema).
+    /// Maps to SQL Server's 3961.
+    #[error("schema of '{0}' changed under the snapshot")]
+    SnapshotSchemaChange(String),
 }
 
 /// Thread-safe handle to the storage engine. All mutable state lives in a
@@ -536,7 +544,6 @@ impl Storage {
     }
 
     /// Whether `ALLOW_SNAPSHOT_ISOLATION` is on.
-    #[allow(dead_code)] // consumed when SNAPSHOT isolation lands
     pub(crate) fn snapshot_isolation_allowed(&self) -> bool {
         self.allow_snapshot
             .load(std::sync::atomic::Ordering::Relaxed)
@@ -762,6 +769,16 @@ impl Storage {
         name: &str,
     ) -> Result<Vec<(RowLocator, Vec<Datum>)>, StorageError> {
         self.lock().rel_scan_located(name)
+    }
+
+    /// SNAPSHOT-isolation DML target scan: snapshot rows plus a conflict mark
+    /// per row whose current state a snapshot-invisible writer produced.
+    pub(crate) fn rel_scan_located_snapshot(
+        &self,
+        name: &str,
+        snapshot: ReadSnapshot,
+    ) -> Result<Vec<(RowLocator, Vec<Datum>, bool)>, StorageError> {
+        self.lock().rel_scan_located_snapshot(name, snapshot)
     }
 
     pub(crate) fn rel_delete_located(
@@ -1465,6 +1482,13 @@ impl StorageFile {
             Ok(def)
         })?;
         self.rel.tables.insert(table.to_string(), updated);
+        // ALTER ADD re-encodes every row: version images from before it
+        // cannot decode under the widened schema, so a SNAPSHOT transaction
+        // whose view predates this commit gets 3961 at its next access
+        // (statement snapshots cannot be live here — the ALTER holds
+        // Database X). Stamped with this ALTER's own commit sequence, the
+        // newest assigned (recorded a moment ago in `rel_statement`).
+        self.version.stamp_schema(object_id);
         Ok(())
     }
 
@@ -1538,6 +1562,11 @@ impl StorageFile {
             .find(|i| i.object_id == index_object_id)
             .cloned()
             .ok_or_else(|| StorageError::InvalidConfig("unknown index".to_string()))?;
+        if let Some(snap) = snapshot
+            && self.version.schema_changed_after(def.object_id, snap)
+        {
+            return Err(StorageError::SnapshotSchemaChange(def.name));
+        }
         let entries = {
             let mut ctx = self.rel_ctx();
             let index_tree = BTree {
@@ -1904,6 +1933,9 @@ impl StorageFile {
     ) -> Result<Vec<Vec<Datum>>, StorageError> {
         self.ensure_rel_usable()?;
         let (def, schema) = self.rel_def(name)?;
+        if self.version.schema_changed_after(def.object_id, snapshot) {
+            return Err(StorageError::SnapshotSchemaChange(def.name));
+        }
         let physical: Vec<(Vec<u8>, Vec<u8>)> = {
             let mut ctx = self.rel_ctx();
             if def.is_tree() {
@@ -2139,6 +2171,89 @@ impl StorageFile {
             };
             for (rid, row) in heap.scan(&mut ctx)? {
                 out.push((RowLocator::Rid(rid), decode_row(&schema, &row)?));
+            }
+        }
+        Ok(out)
+    }
+
+    /// The SNAPSHOT-isolation DML target scan: like [`Self::rel_scan_located`]
+    /// but rows are the snapshot's versions, and each carries a conflict mark
+    /// when its current state was produced by a writer the snapshot cannot
+    /// see — physically present rows served from an older image, and rows
+    /// deleted (or re-keyed away) since the snapshot, whose locators are
+    /// synthesized from their identities. Targeting a marked row is a 3960
+    /// update conflict; the mark is computed here because only this layer
+    /// sees both the physical state and the chains, atomically under the
+    /// storage mutex. (A marked row can also mean a live writer is mid-flight
+    /// on it — but the caller holds the statement's X locks, so a marked row
+    /// it actually targets can only be a committed-invisible change.)
+    fn rel_scan_located_snapshot(
+        &mut self,
+        name: &str,
+        snapshot: ReadSnapshot,
+    ) -> Result<Vec<(RowLocator, Vec<Datum>, bool)>, StorageError> {
+        self.ensure_rel_usable()?;
+        let (def, schema) = self.rel_def(name)?;
+        if self.version.schema_changed_after(def.object_id, snapshot) {
+            return Err(StorageError::SnapshotSchemaChange(def.name));
+        }
+        let physical: Vec<(Vec<u8>, RowLocator, Vec<u8>)> = {
+            let mut ctx = self.rel_ctx();
+            if def.is_tree() {
+                let tree = BTree {
+                    object_id: def.object_id,
+                    root: def.root_page,
+                };
+                tree.scan(&mut ctx)?
+                    .into_iter()
+                    .map(|(key, row)| (key.clone(), RowLocator::Key(key), row))
+                    .collect()
+            } else {
+                let heap = Heap {
+                    object_id: def.object_id,
+                    first_page: def.root_page,
+                };
+                heap.scan(&mut ctx)?
+                    .into_iter()
+                    .map(|(rid, row)| (rid_identity(rid), RowLocator::Rid(rid), row))
+                    .collect()
+            }
+        };
+        let merging = self.version.table_has_chains(def.object_id);
+        let mut out = Vec::with_capacity(physical.len());
+        let mut seen: std::collections::HashSet<Vec<u8>> =
+            std::collections::HashSet::with_capacity(if merging { physical.len() } else { 0 });
+        for (identity, locator, row) in physical {
+            if !merging {
+                out.push((locator, decode_row(&schema, &row)?, false));
+                continue;
+            }
+            match self.version.resolve(def.object_id, &identity, snapshot) {
+                None | Some(Resolved::Current) => {
+                    out.push((locator, decode_row(&schema, &row)?, false));
+                }
+                // Served from an older image: the current row belongs to a
+                // writer the snapshot cannot see.
+                Some(Resolved::Image(image)) => {
+                    out.push((locator, decode_row(&schema, &image)?, true));
+                }
+                Some(Resolved::Gone) => {}
+            }
+            seen.insert(identity);
+        }
+        if merging {
+            for (identity, image) in
+                self.version
+                    .unseen_images_with_identity(def.object_id, &seen, snapshot)
+            {
+                // Deleted or re-keyed since the snapshot: visible to it, but
+                // its current state is gone — always a conflict if targeted.
+                let locator = if def.is_tree() {
+                    RowLocator::Key(identity)
+                } else {
+                    RowLocator::Rid(decode_rid_identity(&identity))
+                };
+                out.push((locator, decode_row(&schema, &image)?, true));
             }
         }
         Ok(out)
@@ -4151,6 +4266,36 @@ mod tests {
         assert!(
             table_s(&needs),
             "a raising SET disables the snapshot path: {needs:?}"
+        );
+
+        // SNAPSHOT isolation is versioned regardless of RCSI: Database IS
+        // only, and the EXEC-literal recursion preserves the level (the
+        // #120 review's collapse bug, from the other direction).
+        let needs = crate::rel::analyze_locks(&storage, "SELECT v FROM t", Isolation::Snapshot);
+        assert!(
+            !table_s(&needs),
+            "SNAPSHOT reads take no Table S: {needs:?}"
+        );
+        assert!(needs.contains(&(Resource::Database, LockMode::IntentShared)));
+        let needs = crate::rel::analyze_locks(
+            &storage,
+            "EXEC sp_executesql N'SELECT v FROM t'",
+            Isolation::Snapshot,
+        );
+        assert!(
+            !table_s(&needs),
+            "the recursion must not turn SNAPSHOT into a locking level: {needs:?}"
+        );
+        // ...and a SET SNAPSHOT inside a batch is not a lock-escalating
+        // raise, but the batch still holds the Database IS fence.
+        let needs = crate::rel::analyze_locks(
+            &storage,
+            "SET TRANSACTION ISOLATION LEVEL SNAPSHOT; SELECT v FROM t",
+            Isolation::ReadUncommitted,
+        );
+        assert!(
+            needs.contains(&(Resource::Database, LockMode::IntentShared)),
+            "SET SNAPSHOT from RU keeps the DDL fence: {needs:?}"
         );
 
         drop(storage);

--- a/crates/truthdb-core/src/storage.rs
+++ b/crates/truthdb-core/src/storage.rs
@@ -610,6 +610,13 @@ impl Storage {
         self.lock().rel_scan_snapshot(name, projection, snapshot)
     }
 
+    /// Whether any read snapshot is registered (an idle SNAPSHOT transaction
+    /// between batches — running batches are excluded by the caller's
+    /// Database X). `ALTER DATABASE` option flips refuse while one lives.
+    pub(crate) fn has_registered_snapshots(&self) -> bool {
+        self.lock().version.has_snapshots()
+    }
+
     /// Drops version history no live snapshot can need (runs on the
     /// maintenance thread; cheap when nothing is versioned).
     pub(crate) fn version_prune(&self) {
@@ -1226,6 +1233,11 @@ impl StorageFile {
             Ok(def)
         })?;
         self.rel.next_object_id += 1;
+        // Stamp the new object: a SNAPSHOT transaction whose view predates
+        // this CREATE must 3961 rather than silently read the (possibly
+        // same-named, post-DROP) new table as empty — its snapshot has no
+        // history for an object that did not exist.
+        self.version.stamp_schema(def.object_id);
         self.rel.tables.insert(name.to_string(), def);
         Ok(())
     }
@@ -4493,6 +4505,78 @@ mod tests {
             storage.version_chain_count("t"),
             0,
             "released history is dropped, the store is bounded"
+        );
+
+        drop(storage);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// SI review PoC: the 3960 auto-abort path must release the
+    /// transaction's snapshot registration - a leak would pin the prune
+    /// watermark forever. Observable through pruning: while the snapshot is
+    /// registered the conflicting chain must survive a prune; after the 3960
+    /// rolled the transaction back, the same prune must drop it.
+    #[test]
+    fn a_3960_abort_releases_the_snapshot_registration() {
+        use crate::rel::{TxnContext, execute_batch};
+
+        let path = unique_temp_path("si-3960-release");
+        let storage = Storage::create(path.clone(), test_storage_options()).expect("create");
+        let mut setup = TxnContext::default();
+        for sql in [
+            "ALTER DATABASE CURRENT SET ALLOW_SNAPSHOT_ISOLATION ON",
+            "CREATE TABLE t (id INT NOT NULL PRIMARY KEY, v INT)",
+            "INSERT INTO t VALUES (1, 10)",
+        ] {
+            let outcome = execute_batch(&storage, sql, &mut setup);
+            assert!(outcome.error.is_none(), "{sql}: {:?}", outcome.error);
+        }
+        storage
+            .ensure_durable(storage.wal_tail())
+            .expect("durability");
+        storage.version_prune();
+        assert_eq!(storage.version_chain_count("t"), 0);
+
+        // B: SNAPSHOT transaction, snapshot captured at first access.
+        let mut b = TxnContext::default();
+        let outcome = execute_batch(
+            &storage,
+            "SET TRANSACTION ISOLATION LEVEL SNAPSHOT; BEGIN TRAN; SELECT v FROM t",
+            &mut b,
+        );
+        assert!(outcome.error.is_none(), "{:?}", outcome.error);
+
+        // A: a conflicting committed write B's snapshot cannot see.
+        let mut a = TxnContext::default();
+        let outcome = execute_batch(&storage, "UPDATE t SET v = 99 WHERE id = 1", &mut a);
+        assert!(outcome.error.is_none(), "{:?}", outcome.error);
+
+        // While B's snapshot is registered, its history is pinned.
+        storage
+            .ensure_durable(storage.wal_tail())
+            .expect("durability");
+        storage.version_prune();
+        assert_eq!(
+            storage.version_chain_count("t"),
+            1,
+            "a registered snapshot pins the chain"
+        );
+
+        // B writes the same row: 3960, and the whole transaction (with its
+        // snapshot registration) must be gone.
+        let outcome = execute_batch(&storage, "UPDATE t SET v = 100 WHERE id = 1", &mut b);
+        assert_eq!(
+            outcome.error.as_ref().map(|e| e.number),
+            Some(3960),
+            "{:?}",
+            outcome.error
+        );
+
+        storage.version_prune();
+        assert_eq!(
+            storage.version_chain_count("t"),
+            0,
+            "the 3960 abort must release the snapshot registration"
         );
 
         drop(storage);

--- a/crates/truthdb-core/tests/slt/snapshot_isolation.slt
+++ b/crates/truthdb-core/tests/slt/snapshot_isolation.slt
@@ -1,0 +1,74 @@
+# SNAPSHOT isolation (Stage 13), single-session surface: the SET is always
+# accepted; data access without ALLOW_SNAPSHOT_ISOLATION is 3952; with it,
+# statements read/write normally (own writes always visible; the concurrency
+# semantics live in the session tests).
+
+statement ok
+CREATE TABLE snap (id INT NOT NULL PRIMARY KEY, v INT)
+
+statement ok
+INSERT INTO snap VALUES (1, 10), (2, 20)
+
+statement ok
+SET TRANSACTION ISOLATION LEVEL SNAPSHOT
+
+# The option is off: the SET stood, the ACCESS fails (SQL Server defers the
+# check exactly this way).
+statement error
+SELECT v FROM snap
+
+statement ok
+ALTER DATABASE CURRENT SET ALLOW_SNAPSHOT_ISOLATION ON
+
+query II rowsort
+SELECT id, v FROM snap
+----
+1 10
+2 20
+
+statement ok
+BEGIN TRANSACTION
+
+statement ok
+UPDATE snap SET v = 11 WHERE id = 1
+
+# The snapshot transaction reads its own writes.
+query I
+SELECT v FROM snap WHERE id = 1
+----
+11
+
+statement ok
+ROLLBACK
+
+query I
+SELECT v FROM snap WHERE id = 1
+----
+10
+
+statement ok
+BEGIN TRANSACTION
+
+statement ok
+DELETE FROM snap WHERE id = 2
+
+query I
+SELECT COUNT(*) FROM snap
+----
+1
+
+statement ok
+COMMIT
+
+query I
+SELECT COUNT(*) FROM snap
+----
+1
+
+statement ok
+SET TRANSACTION ISOLATION LEVEL READ COMMITTED
+
+query I
+SELECT COUNT(*) FROM snap
+----
+1

--- a/crates/truthdb-sql/src/ast.rs
+++ b/crates/truthdb-sql/src/ast.rs
@@ -168,6 +168,9 @@ pub enum IsolationLevel {
     ReadCommitted,
     RepeatableRead,
     Serializable,
+    /// `SNAPSHOT` — transaction-scoped versioned reads (Stage 13). Gated at
+    /// data access on `ALLOW_SNAPSHOT_ISOLATION` (3952), not at SET.
+    Snapshot,
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/crates/truthdb-sql/src/parser.rs
+++ b/crates/truthdb-sql/src/parser.rs
@@ -505,6 +505,10 @@ impl Parser {
                 self.bump();
                 Ok(IsolationLevel::Serializable)
             }
+            Some("SNAPSHOT") => {
+                self.bump();
+                Ok(IsolationLevel::Snapshot)
+            }
             _ => {
                 let token = self.peek().clone();
                 Err(SqlError::syntax(self.token_text(&token), token.span))

--- a/crates/truthdb-tds/src/server.rs
+++ b/crates/truthdb-tds/src/server.rs
@@ -374,7 +374,8 @@ fn isolation_set_clause(isolation: u8) -> Option<&'static str> {
         2 => Some("SET TRANSACTION ISOLATION LEVEL READ COMMITTED"),
         3 => Some("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ"),
         4 => Some("SET TRANSACTION ISOLATION LEVEL SERIALIZABLE"),
-        // 0 (unspecified) and 5 (snapshot, unsupported) keep the default.
+        5 => Some("SET TRANSACTION ISOLATION LEVEL SNAPSHOT"),
+        // 0 (unspecified) keeps the default.
         _ => None,
     }
 }

--- a/scripts/tds_isolation_matrix.py
+++ b/scripts/tds_isolation_matrix.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""The five-isolation-level matrix over a real TDS driver (pytds), two
+connections — Stage 13's exit demo. Each level is pinned by a value only its
+semantics can produce:
+
+  READ UNCOMMITTED  reader sees an uncommitted write (dirty read)
+  READ COMMITTED    reader waits for the writer's commit (lock-based)
+  RCSI              reader returns the PRE-update value while the writer's
+                    transaction is open (no wait — the whole point)
+  REPEATABLE READ   reader waits like RC (and RCSI must NOT apply to it)
+  SNAPSHOT          repeatable reads across the writer's commit, 3960 on a
+                    write conflict, 3952 when the option is off
+
+Usage: tds_isolation_matrix.py <host> <port> <user> <password>
+Exits non-zero on any mismatch.
+"""
+
+import sys
+import threading
+
+import pytds
+
+
+def connect(host, port, user, password, autocommit=True):
+    return pytds.connect(
+        host, "truthdb", user, password, port=port, login_timeout=10, autocommit=autocommit
+    )
+
+
+def error_number(exc):
+    number = getattr(exc, "number", None)
+    if number is not None:
+        return number
+    # pytds surfaces some server errors only through the message text.
+    text = str(exc)
+    for candidate in (3960, 3952, 3961, 1222, 1205):
+        if str(candidate) in text:
+            return candidate
+    return None
+
+
+def fetch_v(cur, conn_label):
+    cur.execute("SELECT v FROM iso WHERE id = 1")
+    row = cur.fetchone()
+    if row is None:
+        raise AssertionError(f"{conn_label}: no row for id = 1")
+    return row[0]
+
+
+def main() -> int:
+    host, port, user, password = sys.argv[1], int(sys.argv[2]), sys.argv[3], sys.argv[4]
+
+    admin = connect(host, port, user, password)
+    setup = admin.cursor()
+    setup.execute("CREATE TABLE iso (id INT NOT NULL PRIMARY KEY, v INT)")
+    setup.execute("INSERT INTO iso VALUES (1, 10), (2, 20)")
+
+    # ---- READ UNCOMMITTED: the dirty read --------------------------------
+    writer = connect(host, port, user, password, autocommit=False)
+    wcur = writer.cursor()
+    wcur.execute("UPDATE iso SET v = 99 WHERE id = 1")
+    ru = connect(host, port, user, password)
+    rcur = ru.cursor()
+    rcur.execute("SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED")
+    seen = fetch_v(rcur, "RU reader")
+    if seen != 99:
+        print(f"FAIL: READ UNCOMMITTED must dirty-read 99, got {seen}")
+        return 1
+    writer.rollback()
+    ru.close()
+
+    # ---- READ COMMITTED (lock-based): the reader waits -------------------
+    # The reader is started while the writer holds its X lock; it can only
+    # ever return the committed value, because it parks until the commit.
+    writer2 = connect(host, port, user, password, autocommit=False)
+    wcur = writer2.cursor()
+    wcur.execute("UPDATE iso SET v = 30 WHERE id = 1")
+    result = {}
+
+    def rc_read():
+        rc = connect(host, port, user, password)
+        cur = rc.cursor()
+        cur.execute("SET TRANSACTION ISOLATION LEVEL READ COMMITTED")
+        result["rc"] = fetch_v(cur, "RC reader")
+        rc.close()
+
+    t = threading.Thread(target=rc_read)
+    t.start()
+    t.join(timeout=1.0)
+    if not t.is_alive() and result.get("rc") == 10:
+        print("FAIL: lock-based READ COMMITTED returned the pre-update value "
+              "without waiting for the writer")
+        return 1
+    writer2.commit()
+    t.join(timeout=10)
+    if result.get("rc") != 30:
+        print(f"FAIL: READ COMMITTED must see only the commit (30), got {result.get('rc')}")
+        return 1
+
+    # ---- RCSI: the reader does not wait and sees the pre-update value ----
+    setup.execute("ALTER DATABASE CURRENT SET READ_COMMITTED_SNAPSHOT ON")
+    writer3 = connect(host, port, user, password, autocommit=False)
+    wcur = writer3.cursor()
+    wcur.execute("UPDATE iso SET v = 55 WHERE id = 1")
+    rcsi = connect(host, port, user, password)
+    cur = rcsi.cursor()
+    seen = fetch_v(cur, "RCSI reader")
+    if seen != 30:
+        print(f"FAIL: RCSI reader must see the committed 30 while the writer "
+              f"holds its lock, got {seen}")
+        return 1
+    writer3.commit()
+    seen = fetch_v(cur, "RCSI reader after commit")
+    if seen != 55:
+        print(f"FAIL: RCSI reader must see 55 after the commit, got {seen}")
+        return 1
+    rcsi.close()
+
+    # ---- REPEATABLE READ: still lock-based, RCSI does not apply ----------
+    writer4 = connect(host, port, user, password, autocommit=False)
+    wcur = writer4.cursor()
+    wcur.execute("UPDATE iso SET v = 60 WHERE id = 1")
+    result = {}
+
+    def rr_read():
+        rr = connect(host, port, user, password)
+        cur = rr.cursor()
+        cur.execute("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ")
+        result["rr"] = fetch_v(cur, "RR reader")
+        rr.close()
+
+    t = threading.Thread(target=rr_read)
+    t.start()
+    t.join(timeout=1.0)
+    if not t.is_alive() and result.get("rr") == 55:
+        print("FAIL: REPEATABLE READ returned the pre-update value without waiting")
+        return 1
+    writer4.commit()
+    t.join(timeout=10)
+    if result.get("rr") != 60:
+        print(f"FAIL: REPEATABLE READ must see only the commit (60), got {result.get('rr')}")
+        return 1
+
+    # ---- SNAPSHOT: 3952 while off, then repeatable + 3960 conflict -------
+    si = connect(host, port, user, password, autocommit=False)
+    scur = si.cursor()
+    scur.execute("SET TRANSACTION ISOLATION LEVEL SNAPSHOT")
+    try:
+        fetch_v(scur, "SI reader (option off)")
+        print("FAIL: SNAPSHOT access without ALLOW_SNAPSHOT_ISOLATION must be 3952")
+        return 1
+    except pytds.Error as exc:
+        if error_number(exc) != 3952:
+            print(f"FAIL: expected 3952, got {exc!r}")
+            return 1
+    si.rollback()
+
+    setup.execute("ALTER DATABASE CURRENT SET ALLOW_SNAPSHOT_ISOLATION ON")
+    seen = fetch_v(scur, "SI reader first access")
+    if seen != 60:
+        print(f"FAIL: SNAPSHOT first read must see 60, got {seen}")
+        return 1
+    # A committed writer change after the snapshot stays invisible...
+    setup.execute("UPDATE iso SET v = 70 WHERE id = 1")
+    seen = fetch_v(scur, "SI reader after external commit")
+    if seen != 60:
+        print(f"FAIL: SNAPSHOT read must stay at 60 (repeatable), got {seen}")
+        return 1
+    # ...and writing that row is the classic 3960 update conflict, which
+    # rolls the transaction back entirely.
+    try:
+        scur.execute("UPDATE iso SET v = 61 WHERE id = 1")
+        print("FAIL: SNAPSHOT update conflict did not raise")
+        return 1
+    except pytds.Error as exc:
+        if error_number(exc) != 3960:
+            print(f"FAIL: expected 3960, got {exc!r}")
+            return 1
+    # The server rolled the transaction back on the conflict; the driver
+    # still believes one is open, so its own rollback-on-close may error.
+    try:
+        si.close()
+    except pytds.Error:
+        pass
+
+    check = connect(host, port, user, password)
+    ccur = check.cursor()
+    seen = fetch_v(ccur, "post-matrix check")
+    if seen != 70:
+        print(f"FAIL: the conflicting write must not have landed; want 70, got {seen}")
+        return 1
+
+    # Leave the database as the other conformance scripts expect it.
+    ccur.execute("ALTER DATABASE CURRENT SET READ_COMMITTED_SNAPSHOT OFF, "
+                 "ALLOW_SNAPSHOT_ISOLATION OFF")
+    ccur.execute("DROP TABLE iso")
+    check.close()
+    admin.close()
+
+    print("tds isolation matrix: OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Stage 13, part 2: SNAPSHOT isolation

`SET TRANSACTION ISOLATION LEVEL SNAPSHOT` (TDS isolation byte 5 included) on the #120 version store: one read view per transaction, captured at its first data access and reused by every statement in it; autocommit statements take per-statement snapshots. The registration is released on every transaction-ending path — commit, rollback, 3960 abort, idle reap, disconnect — because a leaked one pins the prune watermark forever.

### The SQL Server error surface

- **3952** — data access under SNAPSHOT without `ALLOW_SNAPSHOT_ISOLATION`: raised at access (the SET itself succeeds, as SQL Server defers it), dooming an open transaction.
- **3960** — update conflict: raised when DML targets a row whose current state was produced by a writer the snapshot cannot see, and the transaction is rolled back entirely (SQL Server "aborted", not merely doomed — a following COMMIT answers 3902).
- **3961** — schema change under snapshot: `ALTER TABLE ADD` stamps its table with the DDL's commit sequence; a SNAPSHOT transaction whose view predates it fails the statement (its version images cannot decode under the widened schema) but keeps the transaction — other tables still read. Statement snapshots cannot race DDL at all (the batch's Database IS fences Database X out), so the stamp check never fires for RCSI.

### Snapshot-based DML targeting

UPDATE/DELETE under SNAPSHOT select their targets from the snapshot's rows, not the current ones: the target scan returns snapshot versions, with a conflict mark on rows served from an older image and on rows deleted or re-keyed since the snapshot (appended from their chains, locators synthesized from chain identities). A row matching the predicate only in its current version is not targeted at all — pinned by a test where the conflicting-looking update correctly affects zero rows. The mark is sound because the statement's X locks exclude live writers from any row it actually targets, so a marked target can only be a committed-invisible change.

### Lock analysis

SNAPSHOT is a versioned level: Database IS only, no Table S. A `SET ... SNAPSHOT` is excluded from the isolation-raise escalation (its whole point is lock-free reads) but still forces the Database IS fence, so an RU session's `SET SNAPSHOT; SELECT` batch is not entirely lock-free. The EXEC-literal recursion passes READ COMMITTED and SNAPSHOT through faithfully (the #120 review's collapse bug, guarded from the other direction). SNAPSHOT sessions release read locks at batch end like READ COMMITTED — between batches the snapshot itself is the protection.

### Driver adjudication in CI

`scripts/tds_isolation_matrix.py` runs the full five-level matrix over pytds with two live connections — the Stage 13 exit demo. Each level is pinned by a value only its semantics can produce: READ UNCOMMITTED dirty-reads, READ COMMITTED and REPEATABLE READ wait for the commit, RCSI returns the pre-update value while the writer's transaction is open, and SNAPSHOT reads repeat across an external commit, answer 3960 on conflict (with the transaction observably gone) and 3952 without the option. Verified locally against a loopback server before wiring into CI.

### Tests

Eight new two-session tests (repeatable reads across a writer's commit; fresh autocommit snapshots; 3960 with the transaction rolled back and the conflicting write absent; 3960 on a row deleted since the snapshot; snapshot-based targeting affecting zero rows where current-based would have written; 3952 at access with dooming; 3961 statement-level failure with the transaction surviving; inserts staying isolated without conflicting), lock-analysis pins (no Table S under SNAPSHOT, EXEC passthrough, the RU + SET SNAPSHOT fence), and a single-session slt file.

### Version cleanup under load

The last exit item: a live snapshot pins exactly the history it may still read through sustained churn (100 rows, five update rounds with pruning between — the pinned view keeps reading its consistent pre-churn state throughout), and releasing it lets the next prune drop the whole store.

### Adversarial review

The review (own worktree, live interleavings, four teeth-check mutations all caught by the right test) confirmed the conflict rule sound — re-keys, heap RID identities, full-table deletes, own-transaction chain states, EXEC nesting, and every snapshot-registration release path (commit, rollback, 3960 abort, reap, disconnect, nested BEGIN, savepoint rollback) — and found three boundary defects, fixed here with the repros kept as regressions:

1. **ALTER under a live transaction snapshot (HIGH, live repro):** an idle SNAPSHOT transaction holds no locks between batches, so `ALTER ... ALLOW_SNAPSHOT_ISOLATION OFF` could reset the version store under its registered view — a debug panic, silent wrong data in release after toggling back on. The ALTER now refuses with 5061 while any snapshot is registered (SQL Server waits instead; refusing is the honest small fix, race-free under the ALTER's own Database X).
2. **DROP+CREATE same-name evasion of 3961 (MEDIUM, live repro):** the recreated table has a new object id — no chains, no stamp — so a stale SNAPSHOT reader silently saw it empty. CREATE TABLE now stamps its object like ALTER ADD.
3. **Spurious 3952 for table-free SELECTs (LOW):** `SELECT 1` neither raises 3952 nor establishes the transaction snapshot anymore; both defer to the first statement that reads a base table, as SQL Server does.

One LOW stands as a documented conservative divergence: `INSERT ... SELECT` under SNAPSHOT still takes Table S on its source (execution reads it versioned; the lock is redundant, never wrong).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
