### PR TITLE
Stage 14: VARCHAR(MAX)-class types — overflow chains, PLP, 10 MiB round-trip

### DIFF
--- a/crates/truthdb-core/src/rel/hash.rs
+++ b/crates/truthdb-core/src/rel/hash.rs
@@ -100,12 +100,15 @@ pub fn hash_class(ty: ColumnType) -> HashClass {
         | ColumnType::Bit
         | ColumnType::Decimal { .. } => HashClass::ExactNumeric,
         ColumnType::Real | ColumnType::Float => HashClass::ApproxNumeric,
-        ColumnType::VarChar { .. } | ColumnType::NVarChar { .. } => HashClass::Str,
+        ColumnType::VarChar { .. }
+        | ColumnType::NVarChar { .. }
+        | ColumnType::VarCharMax
+        | ColumnType::NVarCharMax => HashClass::Str,
         ColumnType::Date => HashClass::Date,
         ColumnType::Time => HashClass::Time,
         ColumnType::DateTime2 => HashClass::DateTime2,
         ColumnType::UniqueIdentifier => HashClass::Guid,
-        ColumnType::VarBinary { .. } => HashClass::Binary,
+        ColumnType::VarBinary { .. } | ColumnType::VarBinaryMax => HashClass::Binary,
     }
 }
 

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -1073,6 +1073,9 @@ fn describe_type(column_type: &ColumnType) -> (i32, String) {
         ColumnType::VarChar { max_len } => (167, format!("varchar({max_len})")),
         ColumnType::NVarChar { max_len } => (231, format!("nvarchar({max_len})")),
         ColumnType::VarBinary { max_len } => (165, format!("varbinary({max_len})")),
+        ColumnType::VarCharMax => (167, "varchar(max)".into()),
+        ColumnType::NVarCharMax => (231, "nvarchar(max)".into()),
+        ColumnType::VarBinaryMax => (165, "varbinary(max)".into()),
     }
 }
 
@@ -2461,6 +2464,9 @@ fn exec_create_table(storage: &Storage, create: &CreateTable) -> Result<Statemen
                 ),
             ));
         }
+        if columns[index].column_type.is_max() {
+            return Err(max_key_column_error(&key.value, table_name).at(key.span));
+        }
         columns[index].nullable = false;
         key_names.push(columns[index].name.clone());
     }
@@ -3276,6 +3282,9 @@ fn data_type_to_column_type(data_type: &DataType, name: &str) -> Result<ColumnTy
         DataType::VarBinary(n) => ColumnType::VarBinary {
             max_len: length(*n, name)?,
         },
+        DataType::VarCharMax => ColumnType::VarCharMax,
+        DataType::NVarCharMax => ColumnType::NVarCharMax,
+        DataType::VarBinaryMax => ColumnType::VarBinaryMax,
     })
 }
 
@@ -3451,6 +3460,19 @@ fn exec_drop_view(storage: &Storage, drop: &DropView) -> Result<StatementResult,
 
 // ---- CREATE / DROP INDEX ------------------------------------------------
 
+/// SQL Server 1919: a (MAX)-class column cannot be an index/key column.
+fn max_key_column_error(column: &str, table: &str) -> SqlError {
+    SqlError::new(
+        1919,
+        16,
+        1,
+        format!(
+            "Column '{column}' in table '{table}' is of a type that is invalid for use as a \
+             key column in an index."
+        ),
+    )
+}
+
 fn exec_create_index(storage: &Storage, create: &CreateIndex) -> Result<StatementResult, SqlError> {
     let def = resolve_table(storage, &create.table.value)
         .ok_or_else(|| SqlError::invalid_object(&create.table.value).at(create.table.span))?;
@@ -3463,6 +3485,9 @@ fn exec_create_index(storage: &Storage, create: &CreateIndex) -> Result<Statemen
             .iter()
             .position(|c| c.name.eq_ignore_ascii_case(&col.name.value))
             .ok_or_else(|| index_column_missing(&col.name.value, &def.name).at(col.name.span))?;
+        if schema.columns[index].column_type.is_max() {
+            return Err(max_key_column_error(&col.name.value, &def.name).at(col.name.span));
+        }
         columns.push((index, col.ascending));
     }
     // INCLUDE columns: resolved against the schema, no duplicates (1909, as
@@ -3477,6 +3502,12 @@ fn exec_create_index(storage: &Storage, create: &CreateIndex) -> Result<Statemen
             .iter()
             .position(|c| c.name.eq_ignore_ascii_case(&col.value))
             .ok_or_else(|| index_column_missing(&col.value, &def.name).at(col.span))?;
+        // (MAX) columns cannot be INCLUDEd either — a divergence from SQL
+        // Server (whose row-overflow indexes can carry them): our include
+        // payloads live in ordinary index leaf cells under the tree cell cap.
+        if schema.columns[index].column_type.is_max() {
+            return Err(max_key_column_error(&col.value, &def.name).at(col.span));
+        }
         if include.contains(&index) {
             return Err(SqlError::new(
                 1909,

--- a/crates/truthdb-core/src/rel/value.rs
+++ b/crates/truthdb-core/src/rel/value.rs
@@ -88,6 +88,11 @@ pub fn display(datum: &Datum, column_type: &ColumnType) -> Option<String> {
 pub fn datum_to_sql(datum: &Datum, column_type: &ColumnType) -> SqlValue {
     match datum {
         Datum::Null => SqlValue::Null,
+        // Resolved by every storage read path before rows escape; reaching
+        // the executor means a resolve hook was missed.
+        Datum::OverflowRef { .. } => {
+            unreachable!("overflow reference escaped the storage layer")
+        }
         Datum::TinyInt(v) => SqlValue::Int(*v as i64),
         Datum::SmallInt(v) => SqlValue::Int(*v as i64),
         Datum::Int(v) => SqlValue::Int(*v as i64),
@@ -230,6 +235,14 @@ pub fn sql_to_datum(
             }
             _ => Err(clash()),
         },
+        // (MAX) types have no declared-length cap: 8152 never fires; the
+        // storage layer decides in-row vs overflow.
+        ColumnType::VarCharMax => Ok(Datum::VarChar(to_string_value(value))),
+        ColumnType::NVarCharMax => Ok(Datum::NVarChar(to_string_value(value))),
+        ColumnType::VarBinaryMax => match value {
+            SqlValue::Binary(b) => Ok(Datum::VarBinary(b.clone())),
+            _ => Err(clash()),
+        },
     }
 }
 
@@ -319,6 +332,9 @@ fn convert_fail(text: &str, target: &str) -> SqlError {
 fn datum_display(datum: &Datum, column_type: &ColumnType) -> Option<String> {
     match datum {
         Datum::Null => None,
+        Datum::OverflowRef { .. } => {
+            unreachable!("overflow reference escaped the storage layer")
+        }
         Datum::Bit(b) => Some(if *b { "1" } else { "0" }.to_string()),
         Datum::Real(v) => Some(format_float(*v as f64)),
         Datum::Float(v) => Some(format_float(*v)),

--- a/crates/truthdb-core/src/relstore/key.rs
+++ b/crates/truthdb-core/src/relstore/key.rs
@@ -92,6 +92,11 @@ pub fn encode_datum(value: &Datum, out: &mut Vec<u8>) -> Result<(), TypeError> {
     }
     out.push(VALUE_MARKER);
     match value {
+        Datum::OverflowRef { .. } => {
+            return Err(TypeError(
+                "(MAX) values cannot be index or key columns".to_string(),
+            ));
+        }
         Datum::TinyInt(v) => out.push(*v),
         Datum::SmallInt(v) => out.extend_from_slice(&((*v as u16) ^ 0x8000).to_be_bytes()),
         Datum::Int(v) => out.extend_from_slice(&((*v as u32) ^ 0x8000_0000).to_be_bytes()),

--- a/crates/truthdb-core/src/relstore/mod.rs
+++ b/crates/truthdb-core/src/relstore/mod.rs
@@ -11,6 +11,7 @@ pub(crate) mod ctx;
 pub mod heap;
 pub mod index;
 pub mod key;
+pub(crate) mod overflow;
 pub mod page;
 pub mod recovery;
 pub mod row;

--- a/crates/truthdb-core/src/relstore/overflow.rs
+++ b/crates/truthdb-core/src/relstore/overflow.rs
@@ -1,0 +1,112 @@
+//! Overflow page chains (Stage 14): storage for (MAX)-class values above the
+//! in-row threshold.
+//!
+//! A chain is a singly-linked run of [`page::PAGE_TYPE_OVERFLOW`] pages, each
+//! `[32B page header | next_page u64 | len u16 | data]`, written once and
+//! **immutable** thereafter: every page is logged as a full system image (like
+//! B+ tree split pages), so redo replays it wholesale and nothing ever undoes
+//! it. A statement that fails after writing a chain leaks its pages — the
+//! same posture as dropped tables and indexes — and superseded chains (the
+//! old value of an UPDATE, a DELETEd row's value) leak too. That immutability
+//! is load-bearing for the version store: a row image holding an overflow
+//! REFERENCE stays readable for as long as any snapshot can resolve it,
+//! because the chain it points at is never freed or rewritten.
+//!
+//! The row carries `[total_len u64 | first_page u64]` behind the codec's MAX
+//! tag byte (see `row.rs`); values at or below the inline threshold skip all
+//! of this and live in the row.
+
+use crate::relstore::ctx::RelCtx;
+use crate::relstore::page::{self, PAGE_HEADER_SIZE};
+use crate::storage::StorageError;
+use crate::storage_layout::PAGE_SIZE;
+
+/// (MAX) values longer than this many bytes go to an overflow chain; at or
+/// below it they stay in the row (behind the same tag byte).
+pub const OVERFLOW_INLINE_MAX: usize = 256;
+
+const NEXT_OFFSET: usize = PAGE_HEADER_SIZE; // u64
+const LEN_OFFSET: usize = NEXT_OFFSET + 8; // u16
+const DATA_OFFSET: usize = LEN_OFFSET + 2;
+/// Payload bytes per chain page.
+pub const OVERFLOW_PAGE_DATA: usize = PAGE_SIZE - DATA_OFFSET;
+
+/// No next page.
+const CHAIN_END: u64 = u64::MAX;
+
+/// Writes `bytes` as a new overflow chain and returns its first page. Pages
+/// are allocated first (WAL-logged), then filled back to front so every next
+/// pointer is final before its page is imaged.
+pub(crate) fn write_chain(ctx: &mut RelCtx<'_>, bytes: &[u8]) -> Result<u64, StorageError> {
+    debug_assert!(!bytes.is_empty(), "empty values are inline");
+    let pages_needed = bytes.len().div_ceil(OVERFLOW_PAGE_DATA);
+    let mut pages = Vec::with_capacity(pages_needed);
+    for _ in 0..pages_needed {
+        pages.push(ctx.allocate_page(0)?);
+    }
+    for (index, chunk) in bytes.chunks(OVERFLOW_PAGE_DATA).enumerate() {
+        let page_no = pages[index];
+        let next = pages.get(index + 1).copied().unwrap_or(CHAIN_END);
+        let frame = ctx.fetch_zeroed(page_no)?;
+        {
+            let buf = ctx.pool.page_mut(frame);
+            page::write_header(
+                buf,
+                &page::PageHeader {
+                    page_lsn: 0,
+                    page_type: page::PAGE_TYPE_OVERFLOW,
+                    flags: 0,
+                    object_id: 0,
+                    page_no,
+                },
+            );
+            buf[NEXT_OFFSET..NEXT_OFFSET + 8].copy_from_slice(&next.to_le_bytes());
+            buf[LEN_OFFSET..LEN_OFFSET + 2].copy_from_slice(&(chunk.len() as u16).to_le_bytes());
+            buf[DATA_OFFSET..DATA_OFFSET + chunk.len()].copy_from_slice(chunk);
+        }
+        ctx.pool.unpin(frame);
+        ctx.log_system_image(page_no)?;
+    }
+    Ok(pages[0])
+}
+
+/// Reads a whole chain back. `total_len` bounds the walk: a chain that ends
+/// early or runs long is corruption, reported rather than mis-read.
+pub(crate) fn read_chain(
+    ctx: &mut RelCtx<'_>,
+    first_page: u64,
+    total_len: u64,
+) -> Result<Vec<u8>, StorageError> {
+    let mut out = Vec::with_capacity(total_len as usize);
+    let mut page_no = first_page;
+    while out.len() < total_len as usize {
+        if page_no == CHAIN_END {
+            return Err(StorageError::InvalidFile(format!(
+                "overflow chain ended at {} of {total_len} bytes",
+                out.len()
+            )));
+        }
+        let frame = ctx.fetch(page_no)?;
+        let buf = ctx.pool.page(frame);
+        let header = page::read_header(buf);
+        if header.page_type != page::PAGE_TYPE_OVERFLOW {
+            ctx.pool.unpin(frame);
+            return Err(StorageError::InvalidFile(format!(
+                "page {page_no} in an overflow chain has type {}",
+                header.page_type
+            )));
+        }
+        let next = u64::from_le_bytes(buf[NEXT_OFFSET..NEXT_OFFSET + 8].try_into().unwrap());
+        let len = u16::from_le_bytes(buf[LEN_OFFSET..LEN_OFFSET + 2].try_into().unwrap()) as usize;
+        if len > OVERFLOW_PAGE_DATA || out.len() + len > total_len as usize {
+            ctx.pool.unpin(frame);
+            return Err(StorageError::InvalidFile(
+                "overflow chain page length out of bounds".to_string(),
+            ));
+        }
+        out.extend_from_slice(&buf[DATA_OFFSET..DATA_OFFSET + len]);
+        ctx.pool.unpin(frame);
+        page_no = next;
+    }
+    Ok(out)
+}

--- a/crates/truthdb-core/src/relstore/overflow.rs
+++ b/crates/truthdb-core/src/relstore/overflow.rs
@@ -34,9 +34,9 @@ pub const OVERFLOW_PAGE_DATA: usize = PAGE_SIZE - DATA_OFFSET;
 /// No next page.
 const CHAIN_END: u64 = u64::MAX;
 
-/// Writes `bytes` as a new overflow chain and returns its first page. Pages
-/// are allocated first (WAL-logged), then filled back to front so every next
-/// pointer is final before its page is imaged.
+/// Writes `bytes` as a new overflow chain and returns its first page. All
+/// pages are allocated up front (WAL-logged), so every next pointer is known
+/// before any page is filled and imaged.
 pub(crate) fn write_chain(ctx: &mut RelCtx<'_>, bytes: &[u8]) -> Result<u64, StorageError> {
     debug_assert!(!bytes.is_empty(), "empty values are inline");
     let pages_needed = bytes.len().div_ceil(OVERFLOW_PAGE_DATA);

--- a/crates/truthdb-core/src/relstore/page.rs
+++ b/crates/truthdb-core/src/relstore/page.rs
@@ -26,6 +26,9 @@ pub const PAGE_TYPE_HEAP: u16 = 2;
 /// A table's row-counter page (planner statistics): one u64 count at
 /// [`COUNTER_OFFSET`], maintained transactionally via `CounterAdd` page ops.
 pub const PAGE_TYPE_COUNTER: u16 = 3;
+/// Overflow chain page for (MAX)-class values (Stage 14): immutable once
+/// written, `[header | next_page u64 | len u16 | data]`.
+pub const PAGE_TYPE_OVERFLOW: u16 = 4;
 /// Byte offset of the row count on a counter page (right after the header).
 pub const COUNTER_OFFSET: usize = PAGE_HEADER_SIZE;
 

--- a/crates/truthdb-core/src/relstore/row.rs
+++ b/crates/truthdb-core/src/relstore/row.rs
@@ -67,7 +67,35 @@ fn datum_matches(column_type: &ColumnType, datum: &Datum) -> bool {
             | (ColumnType::VarChar { .. }, Datum::VarChar(_))
             | (ColumnType::NVarChar { .. }, Datum::NVarChar(_))
             | (ColumnType::VarBinary { .. }, Datum::VarBinary(_))
+            | (ColumnType::VarCharMax, Datum::VarChar(_))
+            | (ColumnType::NVarCharMax, Datum::NVarChar(_))
+            | (ColumnType::VarBinaryMax, Datum::VarBinary(_))
+            | (ColumnType::VarCharMax, Datum::OverflowRef { .. })
+            | (ColumnType::NVarCharMax, Datum::OverflowRef { .. })
+            | (ColumnType::VarBinaryMax, Datum::OverflowRef { .. })
     )
+}
+
+/// The var payload of a (MAX) column: a tag byte, then either the inline
+/// base encoding (0) or a 16-byte overflow-chain reference (1).
+fn encode_max_var(value: &Datum) -> Vec<u8> {
+    match value {
+        Datum::OverflowRef {
+            total_len,
+            first_page,
+        } => {
+            let mut out = Vec::with_capacity(17);
+            out.push(1);
+            out.extend_from_slice(&total_len.to_le_bytes());
+            out.extend_from_slice(&first_page.to_le_bytes());
+            out
+        }
+        other => {
+            let mut out = vec![0u8];
+            out.extend(other.encode_var());
+            out
+        }
+    }
 }
 
 pub fn encode_row(schema: &Schema, values: &[Datum]) -> Result<Vec<u8>, TypeError> {
@@ -119,6 +147,8 @@ pub fn encode_row(schema: &Schema, values: &[Datum]) -> Result<Vec<u8>, TypeErro
         if column.column_type.fixed_size().is_none() {
             var_payloads.push(if value.is_null() {
                 Vec::new()
+            } else if column.column_type.is_max() {
+                encode_max_var(value)
             } else {
                 value.encode_var()
             });

--- a/crates/truthdb-core/src/relstore/spill.rs
+++ b/crates/truthdb-core/src/relstore/spill.rs
@@ -139,6 +139,9 @@ pub fn encode_spill_row(row: &[Datum]) -> Vec<u8> {
     for datum in row {
         match datum {
             Datum::Null => out.push(0),
+            Datum::OverflowRef { .. } => {
+                unreachable!("overflow reference escaped the storage layer")
+            }
             Datum::TinyInt(v) => {
                 out.push(1);
                 out.push(*v);

--- a/crates/truthdb-core/src/relstore/types.rs
+++ b/crates/truthdb-core/src/relstore/types.rs
@@ -44,6 +44,13 @@ pub enum ColumnType {
     VarBinary {
         max_len: u16,
     },
+    /// `VARCHAR(MAX)` (Stage 14): no declared length cap; values above the
+    /// in-row threshold live in overflow page chains.
+    VarCharMax,
+    /// `NVARCHAR(MAX)`.
+    NVarCharMax,
+    /// `VARBINARY(MAX)`.
+    VarBinaryMax,
 }
 
 impl ColumnType {
@@ -60,8 +67,20 @@ impl ColumnType {
             ColumnType::DateTime2 => Some(8),
             ColumnType::VarChar { .. }
             | ColumnType::NVarChar { .. }
-            | ColumnType::VarBinary { .. } => None,
+            | ColumnType::VarBinary { .. }
+            | ColumnType::VarCharMax
+            | ColumnType::NVarCharMax
+            | ColumnType::VarBinaryMax => None,
         }
+    }
+
+    /// Whether this is a (MAX)-class type: values may exceed the in-row cap
+    /// and are stored behind a tag byte (inline or an overflow-chain ref).
+    pub fn is_max(&self) -> bool {
+        matches!(
+            self,
+            ColumnType::VarCharMax | ColumnType::NVarCharMax | ColumnType::VarBinaryMax
+        )
     }
 
     /// Parses the debug-command type syntax: `int`, `varchar(30)`,
@@ -99,6 +118,9 @@ impl ColumnType {
             "time" => Ok(ColumnType::Time),
             "datetime2" => Ok(ColumnType::DateTime2),
             "uniqueidentifier" => Ok(ColumnType::UniqueIdentifier),
+            "varchar" if args == ["max"] => Ok(ColumnType::VarCharMax),
+            "nvarchar" if args == ["max"] => Ok(ColumnType::NVarCharMax),
+            "varbinary" if args == ["max"] => Ok(ColumnType::VarBinaryMax),
             "varchar" => Ok(ColumnType::VarChar {
                 max_len: one_arg(&args)?,
             }),
@@ -146,6 +168,9 @@ impl ColumnType {
             ColumnType::VarChar { max_len } => format!("varchar({max_len})"),
             ColumnType::NVarChar { max_len } => format!("nvarchar({max_len})"),
             ColumnType::VarBinary { max_len } => format!("varbinary({max_len})"),
+            ColumnType::VarCharMax => "varchar(max)".to_string(),
+            ColumnType::NVarCharMax => "nvarchar(max)".to_string(),
+            ColumnType::VarBinaryMax => "varbinary(max)".to_string(),
         }
     }
 }
@@ -164,6 +189,13 @@ impl std::fmt::Display for TypeError {
 #[derive(Debug, Clone, PartialEq)]
 pub enum Datum {
     Null,
+    /// A (MAX) value stored in an overflow page chain (Stage 14). Internal
+    /// to the storage layer: every public read path resolves it to the real
+    /// value before returning, and it never reaches the executor.
+    OverflowRef {
+        total_len: u64,
+        first_page: u64,
+    },
     TinyInt(u8),
     SmallInt(i16),
     Int(i32),
@@ -193,6 +225,7 @@ impl Datum {
     /// Fixed-width on-disk encoding (only valid for fixed-width types).
     pub fn encode_fixed(&self, out: &mut Vec<u8>) {
         match self {
+            Datum::OverflowRef { .. } => unreachable!("overflow refs are var-class"),
             Datum::TinyInt(v) => out.push(*v),
             Datum::SmallInt(v) => out.extend_from_slice(&v.to_le_bytes()),
             Datum::Int(v) => out.extend_from_slice(&v.to_le_bytes()),
@@ -274,6 +307,35 @@ impl Datum {
                 )
             }
             ColumnType::VarBinary { .. } => Datum::VarBinary(bytes.to_vec()),
+            // (MAX): a tag byte — 0 = inline (base encoding follows), 1 = an
+            // overflow-chain reference.
+            ColumnType::VarCharMax | ColumnType::NVarCharMax | ColumnType::VarBinaryMax => {
+                let (&tag, payload) = bytes
+                    .split_first()
+                    .ok_or_else(|| TypeError("missing (MAX) tag byte".to_string()))?;
+                match tag {
+                    0 => {
+                        let base = match column_type {
+                            ColumnType::VarCharMax => ColumnType::VarChar { max_len: u16::MAX },
+                            ColumnType::NVarCharMax => ColumnType::NVarChar { max_len: u16::MAX },
+                            _ => ColumnType::VarBinary { max_len: u16::MAX },
+                        };
+                        Datum::decode_var(&base, payload)?
+                    }
+                    1 => {
+                        if payload.len() != 16 {
+                            return Err(TypeError("corrupt overflow reference".to_string()));
+                        }
+                        Datum::OverflowRef {
+                            total_len: u64::from_le_bytes(payload[0..8].try_into().unwrap()),
+                            first_page: u64::from_le_bytes(payload[8..16].try_into().unwrap()),
+                        }
+                    }
+                    other => {
+                        return Err(TypeError(format!("unknown (MAX) tag byte {other}")));
+                    }
+                }
+            }
             _ => unreachable!("not a var-width type"),
         })
     }
@@ -386,6 +448,14 @@ impl Datum {
                 }
                 Ok(Datum::VarBinary(bytes))
             }
+            ColumnType::VarCharMax => Ok(Datum::VarChar(string_in()?.to_string())),
+            ColumnType::NVarCharMax => Ok(Datum::NVarChar(string_in()?.to_string())),
+            ColumnType::VarBinaryMax => {
+                let hex = string_in()?;
+                Ok(Datum::VarBinary(parse_hex(
+                    hex.strip_prefix("0x").unwrap_or(hex),
+                )?))
+            }
         }
     }
 
@@ -393,6 +463,9 @@ impl Datum {
     pub fn to_json(&self, column_type: &ColumnType) -> Json {
         match self {
             Datum::Null => Json::Null,
+            Datum::OverflowRef { .. } => {
+                unreachable!("overflow reference escaped the storage layer")
+            }
             Datum::TinyInt(v) => Json::from(*v),
             Datum::SmallInt(v) => Json::from(*v),
             Datum::Int(v) => Json::from(*v),

--- a/crates/truthdb-core/src/storage.rs
+++ b/crates/truthdb-core/src/storage.rs
@@ -16,9 +16,10 @@ use crate::relstore::ctx::{OpMode, PoolIo, RelCtx, TxnLink};
 use crate::relstore::heap::{Heap, Rid};
 use crate::relstore::index::{self, Locator};
 use crate::relstore::key::encode_key;
+use crate::relstore::overflow::{self, OVERFLOW_INLINE_MAX};
 use crate::relstore::recovery as rel_recovery;
 use crate::relstore::row::{Column, Schema, decode_row, decode_row_projected, encode_row};
-use crate::relstore::types::{Datum, TypeError};
+use crate::relstore::types::{ColumnType, Datum, TypeError};
 use crate::relstore::version::{
     PendingVersion, ReadSnapshot, Resolved, RowChange, decode_rid_identity, rid_identity,
 };
@@ -1010,6 +1011,18 @@ fn validate_not_null(schema: &Schema, values: &[Datum]) -> Result<(), StorageErr
     Ok(())
 }
 
+/// A row staged for insert: its clustered key (trees) and its encoding —
+/// `None` when the table has (MAX) columns, whose oversize values must spill
+/// inside the statement before the row can encode.
+type StagedInsert = (Option<Vec<u8>>, Option<Vec<u8>>);
+/// An in-place tree update: key, pre-encoded row or the values to encode
+/// in-statement ((MAX) tables).
+type StagedInPlace = (Vec<u8>, Option<Vec<u8>>, Option<Vec<Datum>>);
+/// A re-keying tree update: old key, new key, then as [`StagedInPlace`].
+type StagedRekey = (Vec<u8>, Vec<u8>, Option<Vec<u8>>, Option<Vec<Datum>>);
+/// A heap update: RID, then as [`StagedInPlace`]'s tail.
+type StagedHeapUpdate = (Rid, Option<Vec<u8>>, Option<Vec<Datum>>);
+
 /// Opaque handle to a stored row, addressing it for a targeted UPDATE/DELETE.
 /// Clustered tables locate by encoded PK key; heaps by RID.
 #[derive(Debug, Clone)]
@@ -1710,6 +1723,8 @@ impl StorageFile {
         for image in extra_images {
             rows.push(decode_projected(&schema, &image, projection)?);
         }
+        let types = Self::projected_types(&schema, projection);
+        self.resolve_overflow_rows(&types, &mut rows)?;
         Ok(rows)
     }
 
@@ -1729,11 +1744,19 @@ impl StorageFile {
         self.ensure_rel_usable()?;
         let (def, schema) = self.rel_def(name)?;
         // Encode and validate every row up front (cheap failures before any
-        // mutation), keeping the key alongside for tree tables.
-        let mut encoded: Vec<(Option<Vec<u8>>, Vec<u8>)> = Vec::with_capacity(rows.len());
+        // mutation), keeping the key alongside for tree tables. Rows with
+        // (MAX) columns encode inside the statement instead: their oversize
+        // values spill to overflow chains first, which needs the page
+        // context.
+        let has_max = schema.columns.iter().any(|c| c.column_type.is_max());
+        let mut encoded: Vec<StagedInsert> = Vec::with_capacity(rows.len());
         for values in &rows {
             validate_not_null(&schema, values)?;
-            let row = encode_row(&schema, values)?;
+            let row = if has_max {
+                None
+            } else {
+                Some(encode_row(&schema, values)?)
+            };
             let key = if def.is_tree() {
                 Some(encode_key(&schema, &def.key_columns, values)?)
             } else {
@@ -1753,9 +1776,16 @@ impl StorageFile {
                 root: def.root_page,
             };
             self.rel_statement_scoped(scope, move |ctx, txn| {
-                for ((key, row), values) in encoded.iter().zip(rows.iter()) {
-                    let key = key.as_ref().expect("tree row has a key");
-                    match tree.insert_unique(ctx, &mut OpMode::Txn(txn), key, row)? {
+                for ((key, pre), mut values) in encoded.into_iter().zip(rows.into_iter()) {
+                    let key = key.expect("tree row has a key");
+                    let row = match pre {
+                        Some(row) => row,
+                        None => {
+                            Self::spill_max_values(ctx, &schema, &mut values)?;
+                            encode_row(&schema, &values)?
+                        }
+                    };
+                    match tree.insert_unique(ctx, &mut OpMode::Txn(txn), &key, &row)? {
                         TreeInsert::Inserted => {}
                         TreeInsert::DuplicateKey => {
                             return Err(StorageError::Constraint(
@@ -1770,13 +1800,13 @@ impl StorageFile {
                         &indexes,
                         &schema,
                         &collations,
-                        values,
+                        &values,
                         &Locator::Key(key.clone()),
                     )?;
                     if publishing {
                         txn.pending_versions.push(PendingVersion {
                             object_id: tree.object_id,
-                            identity: key.clone(),
+                            identity: key,
                             change: RowChange::Insert,
                         });
                     }
@@ -1792,16 +1822,23 @@ impl StorageFile {
                 first_page: def.root_page,
             };
             self.rel_statement_scoped(scope, move |ctx, txn| {
-                for ((_, row), values) in encoded.iter().zip(rows.iter()) {
+                for ((_, pre), mut values) in encoded.into_iter().zip(rows.into_iter()) {
+                    let row = match pre {
+                        Some(row) => row,
+                        None => {
+                            Self::spill_max_values(ctx, &schema, &mut values)?;
+                            encode_row(&schema, &values)?
+                        }
+                    };
                     // Heap rows locate by their home RID.
-                    let rid = heap.insert(ctx, txn, row)?;
+                    let rid = heap.insert(ctx, txn, &row)?;
                     index_insert_row(
                         ctx,
                         txn,
                         &indexes,
                         &schema,
                         &collations,
-                        values,
+                        &values,
                         &Locator::Rid(rid),
                     )?;
                     if publishing {
@@ -1853,9 +1890,17 @@ impl StorageFile {
             object_id: def.object_id,
             root: def.root_page,
         };
-        let mut ctx = self.rel_ctx();
-        match tree.get(&mut ctx, &key)? {
-            Some(row) => Ok(Some(decode_row(&schema, &row)?)),
+        let fetched = {
+            let mut ctx = self.rel_ctx();
+            tree.get(&mut ctx, &key)?
+        };
+        match fetched {
+            Some(row) => {
+                let mut rows = vec![decode_row(&schema, &row)?];
+                let types = Self::projected_types(&schema, None);
+                self.resolve_overflow_rows(&types, &mut rows)?;
+                Ok(rows.pop())
+            }
             None => Ok(None),
         }
     }
@@ -1896,9 +1941,13 @@ impl StorageFile {
             raw.extend(located.into_iter().map(|(_, row)| row));
             next
         };
+        let start = out.len();
         for row in raw {
             out.push(decode_projected(&schema, &row, projection)?);
         }
+        let _ = ctx;
+        let types = Self::projected_types(&schema, projection);
+        self.resolve_overflow_rows(&types, &mut out[start..])?;
         Ok(next)
     }
 
@@ -1925,9 +1974,13 @@ impl StorageFile {
                 .map(|(_, row)| row)
                 .collect()
         };
-        raw.into_iter()
+        let mut rows = raw
+            .into_iter()
             .map(|row| decode_row(&schema, &row).map_err(StorageError::from))
-            .collect()
+            .collect::<Result<Vec<_>, _>>()?;
+        let types = Self::projected_types(&schema, None);
+        self.resolve_overflow_rows(&types, &mut rows)?;
+        Ok(rows)
     }
 
     /// Snapshot scan (Stage 13): the whole table read atomically under this
@@ -1972,6 +2025,8 @@ impl StorageFile {
             for (_, row) in physical {
                 out.push(decode_projected(&schema, &row, projection)?);
             }
+            let types = Self::projected_types(&schema, projection);
+            self.resolve_overflow_rows(&types, &mut out)?;
             return Ok(out);
         }
         let mut seen: std::collections::HashSet<Vec<u8>> =
@@ -1991,6 +2046,8 @@ impl StorageFile {
         for image in self.version.unseen_images(def.object_id, &seen, snapshot) {
             out.push(decode_projected(&schema, &image, projection)?);
         }
+        let types = Self::projected_types(&schema, projection);
+        self.resolve_overflow_rows(&types, &mut out)?;
         Ok(out)
     }
 
@@ -2185,6 +2242,28 @@ impl StorageFile {
                 out.push((RowLocator::Rid(rid), decode_row(&schema, &row)?));
             }
         }
+        let _ = ctx;
+        if schema.columns.iter().any(|c| c.column_type.is_max()) {
+            let types = Self::projected_types(&schema, None);
+            let mut ctx = self.rel_ctx();
+            for (_, row) in out.iter_mut() {
+                for (column_type, value) in types.iter().zip(row.iter_mut()) {
+                    if let Datum::OverflowRef {
+                        total_len,
+                        first_page,
+                    } = *value
+                    {
+                        let bytes = overflow::read_chain(&mut ctx, first_page, total_len)?;
+                        let base = match column_type {
+                            ColumnType::VarCharMax => ColumnType::VarChar { max_len: u16::MAX },
+                            ColumnType::NVarCharMax => ColumnType::NVarChar { max_len: u16::MAX },
+                            _ => ColumnType::VarBinary { max_len: u16::MAX },
+                        };
+                        *value = Datum::decode_var(&base, &bytes)?;
+                    }
+                }
+            }
+        }
         Ok(out)
     }
 
@@ -2268,6 +2347,27 @@ impl StorageFile {
                 out.push((locator, decode_row(&schema, &image)?, true));
             }
         }
+        if schema.columns.iter().any(|c| c.column_type.is_max()) {
+            let types = Self::projected_types(&schema, None);
+            let mut ctx = self.rel_ctx();
+            for (_, row, _) in out.iter_mut() {
+                for (column_type, value) in types.iter().zip(row.iter_mut()) {
+                    if let Datum::OverflowRef {
+                        total_len,
+                        first_page,
+                    } = *value
+                    {
+                        let bytes = overflow::read_chain(&mut ctx, first_page, total_len)?;
+                        let base = match column_type {
+                            ColumnType::VarCharMax => ColumnType::VarChar { max_len: u16::MAX },
+                            ColumnType::NVarCharMax => ColumnType::NVarChar { max_len: u16::MAX },
+                            _ => ColumnType::VarBinary { max_len: u16::MAX },
+                        };
+                        *value = Datum::decode_var(&base, &bytes)?;
+                    }
+                }
+            }
+        }
         Ok(out)
     }
 
@@ -2288,17 +2388,10 @@ impl StorageFile {
         let indexes = def.indexes.clone();
         let collations = def.collations.clone();
         let counter_page = def.counter_page;
-        // Version staging: the deleted rows' images, encoded up front (the
-        // schema stays out of the closure), indexed alongside `targets`.
+        // Version priors come from the physical pre-images inside the
+        // statement (raw bytes, overflow refs intact), not a re-encode.
         let publishing = self.version.publishing();
-        let priors: Vec<Option<Vec<u8>>> = if publishing {
-            targets
-                .iter()
-                .map(|(_, values)| encode_row(&schema, values).map(Some))
-                .collect::<Result<_, _>>()?
-        } else {
-            targets.iter().map(|_| None).collect()
-        };
+        let _ = &schema;
         // The counter follows the rows actually removed inside the statement,
         // which the arms count as they go (a locator of the wrong kind is
         // skipped, exactly as the row loop skips it).
@@ -2309,9 +2402,9 @@ impl StorageFile {
             };
             self.rel_statement_scoped(scope, move |ctx, txn| {
                 let mut removed: i64 = 0;
-                for ((loc, values), prior) in targets.iter().zip(priors) {
+                for (loc, values) in &targets {
                     if let RowLocator::Key(key) = loc {
-                        tree.delete(ctx, &mut OpMode::Txn(txn), key)?;
+                        let prior = tree.delete(ctx, &mut OpMode::Txn(txn), key)?;
                         index_delete_row(
                             ctx,
                             txn,
@@ -2320,7 +2413,7 @@ impl StorageFile {
                             values,
                             &Locator::Key(key.clone()),
                         )?;
-                        if let Some(prior) = prior {
+                        if publishing && let Some(prior) = prior {
                             txn.pending_versions.push(PendingVersion {
                                 object_id: tree.object_id,
                                 identity: key.clone(),
@@ -2342,8 +2435,13 @@ impl StorageFile {
             };
             self.rel_statement_scoped(scope, move |ctx, txn| {
                 let mut removed: i64 = 0;
-                for ((loc, values), prior) in targets.iter().zip(priors) {
+                for (loc, values) in &targets {
                     if let RowLocator::Rid(rid) = loc {
+                        let prior = if publishing {
+                            heap.read_row(ctx, *rid)?
+                        } else {
+                            None
+                        };
                         heap.delete(ctx, txn, *rid)?;
                         index_delete_row(
                             ctx,
@@ -2353,7 +2451,7 @@ impl StorageFile {
                             values,
                             &Locator::Rid(*rid),
                         )?;
-                        if let Some(prior) = prior {
+                        if publishing && let Some(prior) = prior {
                             txn.pending_versions.push(PendingVersion {
                                 object_id: heap.object_id,
                                 identity: rid_identity(*rid),
@@ -2394,6 +2492,7 @@ impl StorageFile {
         let indexes = def.indexes.clone();
         let collations = def.collations.clone();
         let publishing = self.version.publishing();
+        let has_max = schema.columns.iter().any(|c| c.column_type.is_max());
         // (old values, old locator, new values, new locator) for index upkeep.
         let mut idx_ops: Vec<(Vec<Datum>, Locator, Vec<Datum>, Locator)> = Vec::new();
         if def.is_tree() {
@@ -2401,16 +2500,14 @@ impl StorageFile {
                 object_id: def.object_id,
                 root: def.root_page,
             };
-            // Partition into in-place (key unchanged) and re-key (key changed).
-            let mut in_place: Vec<(Vec<u8>, Vec<u8>)> = Vec::new();
-            let mut rekey: Vec<(Vec<u8>, Vec<u8>, Vec<u8>)> = Vec::new();
-            // Version staging, split to mirror the closure's op order (all
-            // re-key deletes, then re-key inserts, then in-place updates), so
-            // an identity touched twice in one statement — a key swap — has
-            // its chain built in the order the physical states change.
-            let mut staged_rekey_del: Vec<PendingVersion> = Vec::new();
-            let mut staged_rekey_ins: Vec<PendingVersion> = Vec::new();
-            let mut staged_in_place: Vec<PendingVersion> = Vec::new();
+            // Partition into in-place (key unchanged) and re-key (key
+            // changed). Version priors are captured INSIDE the statement
+            // from the physical ops' returned pre-images — raw row bytes,
+            // so a (MAX) image keeps its overflow reference instead of
+            // re-inlining the whole value. (MAX) rows also encode inside,
+            // after their oversize values spill.
+            let mut in_place: Vec<StagedInPlace> = Vec::new();
+            let mut rekey: Vec<StagedRekey> = Vec::new();
             for (loc, old_values, new_values) in updates {
                 let RowLocator::Key(old_key) = loc else {
                     return Err(StorageError::InvalidConfig(
@@ -2418,12 +2515,11 @@ impl StorageFile {
                     ));
                 };
                 validate_not_null(&schema, &new_values)?;
-                let row = encode_row(&schema, &new_values)?;
                 let new_key = encode_key(&schema, &def.key_columns, &new_values)?;
-                let prior = if publishing {
-                    Some(encode_row(&schema, &old_values)?)
+                let (row, carried) = if has_max {
+                    (None, Some(new_values.clone()))
                 } else {
-                    None
+                    (Some(encode_row(&schema, &new_values)?), None)
                 };
                 if !indexes.is_empty() {
                     idx_ops.push((
@@ -2434,39 +2530,40 @@ impl StorageFile {
                     ));
                 }
                 if new_key == old_key {
-                    if let Some(prior) = prior {
-                        staged_in_place.push(PendingVersion {
-                            object_id: tree.object_id,
-                            identity: old_key.clone(),
-                            change: RowChange::Update { prior },
-                        });
-                    }
-                    in_place.push((old_key, row));
+                    in_place.push((old_key, row, carried));
                 } else {
-                    if let Some(prior) = prior {
-                        // A key change is a delete of the old identity and an
-                        // insert of the new one, exactly as the tree applies it.
-                        staged_rekey_del.push(PendingVersion {
-                            object_id: tree.object_id,
+                    rekey.push((old_key, new_key, row, carried));
+                }
+            }
+            let object_id = tree.object_id;
+            self.rel_statement_scoped(scope, move |ctx, txn| {
+                let encode_new = |ctx: &mut RelCtx<'_>,
+                                  row: Option<Vec<u8>>,
+                                  carried: Option<Vec<Datum>>|
+                 -> Result<Vec<u8>, StorageError> {
+                    match row {
+                        Some(row) => Ok(row),
+                        None => {
+                            let mut values = carried.expect("carried values for a MAX row");
+                            Self::spill_max_values(ctx, &schema, &mut values)?;
+                            Ok(encode_row(&schema, &values)?)
+                        }
+                    }
+                };
+                // Delete all re-keyed olds first so a new key may reuse one.
+                for (old_key, _, _, _) in &rekey {
+                    let prior = tree.delete(ctx, &mut OpMode::Txn(txn), old_key)?;
+                    if publishing && let Some(prior) = prior {
+                        txn.pending_versions.push(PendingVersion {
+                            object_id,
                             identity: old_key.clone(),
                             change: RowChange::Delete { prior },
                         });
-                        staged_rekey_ins.push(PendingVersion {
-                            object_id: tree.object_id,
-                            identity: new_key.clone(),
-                            change: RowChange::Insert,
-                        });
                     }
-                    rekey.push((old_key, new_key, row));
                 }
-            }
-            self.rel_statement_scoped(scope, move |ctx, txn| {
-                // Delete all re-keyed olds first so a new key may reuse one.
-                for (old_key, _, _) in &rekey {
-                    tree.delete(ctx, &mut OpMode::Txn(txn), old_key)?;
-                }
-                for (_, new_key, row) in &rekey {
-                    match tree.insert_unique(ctx, &mut OpMode::Txn(txn), new_key, row)? {
+                for (_, new_key, row, carried) in rekey {
+                    let row = encode_new(ctx, row, carried)?;
+                    match tree.insert_unique(ctx, &mut OpMode::Txn(txn), &new_key, &row)? {
                         TreeInsert::Inserted => {}
                         TreeInsert::DuplicateKey => {
                             return Err(StorageError::Constraint(
@@ -2474,14 +2571,26 @@ impl StorageFile {
                             ));
                         }
                     }
+                    if publishing {
+                        txn.pending_versions.push(PendingVersion {
+                            object_id,
+                            identity: new_key,
+                            change: RowChange::Insert,
+                        });
+                    }
                 }
-                for (key, row) in &in_place {
-                    tree.update(ctx, &mut OpMode::Txn(txn), key, row)?;
+                for (key, row, carried) in in_place {
+                    let row = encode_new(ctx, row, carried)?;
+                    let prior = tree.update(ctx, &mut OpMode::Txn(txn), &key, &row)?;
+                    if publishing && let Some(prior) = prior {
+                        txn.pending_versions.push(PendingVersion {
+                            object_id,
+                            identity: key,
+                            change: RowChange::Update { prior },
+                        });
+                    }
                 }
                 apply_index_updates(ctx, txn, &indexes, &schema, &collations, &idx_ops)?;
-                txn.pending_versions.extend(staged_rekey_del);
-                txn.pending_versions.extend(staged_rekey_ins);
-                txn.pending_versions.extend(staged_in_place);
                 Ok(())
             })?;
         } else {
@@ -2489,8 +2598,7 @@ impl StorageFile {
                 object_id: def.object_id,
                 first_page: def.root_page,
             };
-            let mut encoded: Vec<(Rid, Vec<u8>)> = Vec::with_capacity(count);
-            let mut staged: Vec<PendingVersion> = Vec::new();
+            let mut encoded: Vec<StagedHeapUpdate> = Vec::with_capacity(count);
             for (loc, old_values, new_values) in updates {
                 let RowLocator::Rid(rid) = loc else {
                     return Err(StorageError::InvalidConfig(
@@ -2498,15 +2606,10 @@ impl StorageFile {
                     ));
                 };
                 validate_not_null(&schema, &new_values)?;
-                encoded.push((rid, encode_row(&schema, &new_values)?));
-                if publishing {
-                    staged.push(PendingVersion {
-                        object_id: heap.object_id,
-                        identity: rid_identity(rid),
-                        change: RowChange::Update {
-                            prior: encode_row(&schema, &old_values)?,
-                        },
-                    });
+                if has_max {
+                    encoded.push((rid, None, Some(new_values.clone())));
+                } else {
+                    encoded.push((rid, Some(encode_row(&schema, &new_values)?), None));
                 }
                 if !indexes.is_empty() {
                     // Heap RIDs are stable across an update.
@@ -2514,11 +2617,32 @@ impl StorageFile {
                 }
             }
             self.rel_statement_scoped(scope, move |ctx, txn| {
-                for (rid, row) in &encoded {
-                    heap.update(ctx, txn, *rid, row)?;
+                for (rid, pre, carried) in encoded {
+                    let row = match pre {
+                        Some(row) => row,
+                        None => {
+                            let mut values = carried.expect("carried values for a MAX row");
+                            Self::spill_max_values(ctx, &schema, &mut values)?;
+                            encode_row(&schema, &values)?
+                        }
+                    };
+                    // The pre-image (raw bytes, overflow refs intact) is the
+                    // version prior; read before the in-place update.
+                    let prior = if publishing {
+                        heap.read_row(ctx, rid)?
+                    } else {
+                        None
+                    };
+                    heap.update(ctx, txn, rid, &row)?;
+                    if publishing && let Some(prior) = prior {
+                        txn.pending_versions.push(PendingVersion {
+                            object_id: heap.object_id,
+                            identity: rid_identity(rid),
+                            change: RowChange::Update { prior },
+                        });
+                    }
                 }
                 apply_index_updates(ctx, txn, &indexes, &schema, &collations, &idx_ops)?;
-                txn.pending_versions.extend(staged);
                 Ok(())
             })?;
         }
@@ -2999,6 +3123,85 @@ impl StorageFile {
             .map(|def| (def.name.clone(), def))
             .collect();
         Ok(())
+    }
+
+    /// Spills every (MAX) value above the inline threshold to an overflow
+    /// chain, replacing the datum with a reference. Runs inside statement
+    /// closures, before the row is encoded; chain pages are WAL-imaged, so
+    /// they are crash-durable with the statement (and leak if it fails —
+    /// the drop-table posture).
+    fn spill_max_values(
+        ctx: &mut RelCtx<'_>,
+        schema: &Schema,
+        values: &mut [Datum],
+    ) -> Result<(), StorageError> {
+        for (column, value) in schema.columns.iter().zip(values.iter_mut()) {
+            if !column.column_type.is_max() || value.is_null() {
+                continue;
+            }
+            let bytes = match value {
+                Datum::VarChar(_) | Datum::NVarChar(_) | Datum::VarBinary(_) => value.encode_var(),
+                _ => continue,
+            };
+            if bytes.len() <= OVERFLOW_INLINE_MAX {
+                continue;
+            }
+            let first_page = overflow::write_chain(ctx, &bytes)?;
+            *value = Datum::OverflowRef {
+                total_len: bytes.len() as u64,
+                first_page,
+            };
+        }
+        Ok(())
+    }
+
+    /// Resolves overflow references in decoded rows back to their values.
+    /// `types` must align with the rows' columns (the projection's types for
+    /// projected reads).
+    fn resolve_overflow_rows(
+        &mut self,
+        types: &[ColumnType],
+        rows: &mut [Vec<Datum>],
+    ) -> Result<(), StorageError> {
+        if !types.iter().any(ColumnType::is_max) {
+            return Ok(());
+        }
+        let mut ctx = self.rel_ctx();
+        for row in rows.iter_mut() {
+            for (column_type, value) in types.iter().zip(row.iter_mut()) {
+                if let Datum::OverflowRef {
+                    total_len,
+                    first_page,
+                } = *value
+                {
+                    let bytes = overflow::read_chain(&mut ctx, first_page, total_len)?;
+                    let base = match column_type {
+                        ColumnType::VarCharMax => ColumnType::VarChar { max_len: u16::MAX },
+                        ColumnType::NVarCharMax => ColumnType::NVarChar { max_len: u16::MAX },
+                        ColumnType::VarBinaryMax => ColumnType::VarBinary { max_len: u16::MAX },
+                        other => {
+                            return Err(StorageError::InvalidFile(format!(
+                                "overflow reference under non-MAX column type {}",
+                                other.name()
+                            )));
+                        }
+                    };
+                    *value = Datum::decode_var(&base, &bytes)?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// The column types a projection selects (`None` = every column).
+    fn projected_types(schema: &Schema, projection: Option<&[usize]>) -> Vec<ColumnType> {
+        match projection {
+            None => schema.columns.iter().map(|c| c.column_type).collect(),
+            Some(projection) => projection
+                .iter()
+                .map(|&i| schema.columns[i].column_type)
+                .collect(),
+        }
     }
 
     /// Runs one autocommit relational statement: begin, ops, commit (force
@@ -4583,6 +4786,152 @@ mod tests {
         let _ = std::fs::remove_file(&path);
     }
 
+    /// The Stage 14 exit criterion: a 10 MiB value round-trips through an
+    /// overflow chain, survives a kill-and-reopen, and a mid-transaction
+    /// update of it recovers to the committed value.
+    #[test]
+    fn ten_mib_value_round_trips_and_survives_a_crash() {
+        use crate::rel::RpcParam;
+        use crate::rel::{StatementResult, TxnContext, execute_batch, execute_batch_with_params};
+
+        let path = unique_temp_path("max-10mib");
+        let storage = Storage::create(path.clone(), test_storage_options()).expect("create");
+        let mut ctx = TxnContext::default();
+        for sql in [
+            "CREATE TABLE big (id INT NOT NULL PRIMARY KEY, body NVARCHAR(MAX))",
+            "INSERT INTO big VALUES (1, N'seed')",
+        ] {
+            let outcome = execute_batch(&storage, sql, &mut ctx);
+            assert!(outcome.error.is_none(), "{sql}: {:?}", outcome.error);
+        }
+        // 10 MiB of UTF-16 payload = 5 * 1024 * 1024 characters.
+        let big: String = "abcdefgh".repeat(5 * 1024 * 1024 / 8);
+        assert_eq!(big.encode_utf16().count() * 2, 10 * 1024 * 1024);
+        let outcome = execute_batch_with_params(
+            &storage,
+            "UPDATE big SET body = @v WHERE id = 1",
+            &mut ctx,
+            &[RpcParam {
+                name: "@v".into(),
+                column_type: ColumnType::NVarCharMax,
+                value: crate::relstore::types::Datum::NVarChar(big.clone()),
+            }],
+        );
+        assert!(outcome.error.is_none(), "{:?}", outcome.error);
+
+        let fetch = |storage: &Storage, ctx: &mut TxnContext| -> String {
+            let outcome = execute_batch(storage, "SELECT body FROM big WHERE id = 1", ctx);
+            assert!(outcome.error.is_none(), "{:?}", outcome.error);
+            match &outcome.results[0] {
+                StatementResult::Rows(rowset) => match &rowset.rows[0][0] {
+                    Datum::NVarChar(s) => s.clone(),
+                    other => panic!("expected NVARCHAR, got {other:?}"),
+                },
+                other => panic!("expected rows, got {other:?}"),
+            }
+        };
+        assert_eq!(
+            fetch(&storage, &mut ctx),
+            big,
+            "round-trip before the crash"
+        );
+
+        // An in-flight update dies with the crash; the committed 10 MiB
+        // value must recover intact.
+        let outcome = execute_batch(
+            &storage,
+            "BEGIN TRAN; UPDATE big SET body = N'doomed' WHERE id = 1;",
+            &mut ctx,
+        );
+        assert!(outcome.error.is_none(), "{:?}", outcome.error);
+        let _ = ctx;
+        drop(storage);
+
+        let storage = Storage::open(path.clone()).expect("recovery");
+        let mut ctx = TxnContext::default();
+        let recovered = fetch(&storage, &mut ctx);
+        assert_eq!(recovered.len(), big.len(), "length after recovery");
+        assert_eq!(
+            recovered, big,
+            "the committed chain survives, the loser is undone"
+        );
+
+        drop(storage);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// Versioning over (MAX): an RCSI reader sees the pre-update big value
+    /// through the version image's overflow REFERENCE (images carry raw row
+    /// bytes; chains are immutable and never freed, so the ref stays valid).
+    #[test]
+    fn rcsi_reads_the_old_big_value_through_the_image_reference() {
+        use crate::rel::{
+            RpcParam, StatementResult, TxnContext, execute_batch, execute_batch_with_params,
+        };
+
+        let path = unique_temp_path("max-rcsi");
+        let storage = Storage::create(path.clone(), test_storage_options()).expect("create");
+        let mut writer = TxnContext::default();
+        let big_old: String = "old-value".repeat(20_000); // ~180 KB
+        let big_new: String = "new-value".repeat(20_000);
+        for sql in [
+            "ALTER DATABASE CURRENT SET READ_COMMITTED_SNAPSHOT ON",
+            "CREATE TABLE big (id INT NOT NULL PRIMARY KEY, body NVARCHAR(MAX))",
+        ] {
+            let outcome = execute_batch(&storage, sql, &mut writer);
+            assert!(outcome.error.is_none(), "{sql}: {:?}", outcome.error);
+        }
+        let outcome = execute_batch_with_params(
+            &storage,
+            "INSERT INTO big VALUES (1, @v)",
+            &mut writer,
+            &[RpcParam {
+                name: "@v".into(),
+                column_type: ColumnType::NVarCharMax,
+                value: Datum::NVarChar(big_old.clone()),
+            }],
+        );
+        assert!(outcome.error.is_none(), "{:?}", outcome.error);
+
+        // Writer holds an uncommitted update to the big value...
+        let outcome = execute_batch(&storage, "BEGIN TRAN", &mut writer);
+        assert!(outcome.error.is_none());
+        let outcome = execute_batch_with_params(
+            &storage,
+            "UPDATE big SET body = @v WHERE id = 1",
+            &mut writer,
+            &[RpcParam {
+                name: "@v".into(),
+                column_type: ColumnType::NVarCharMax,
+                value: Datum::NVarChar(big_new.clone()),
+            }],
+        );
+        assert!(outcome.error.is_none(), "{:?}", outcome.error);
+
+        // ...and a snapshot reader gets the OLD value, resolved through the
+        // image's overflow reference.
+        let mut reader = TxnContext::default();
+        let outcome = execute_batch(&storage, "SELECT body FROM big WHERE id = 1", &mut reader);
+        assert!(outcome.error.is_none(), "{:?}", outcome.error);
+        match &outcome.results[0] {
+            StatementResult::Rows(rowset) => {
+                assert_eq!(rowset.rows[0][0], Datum::NVarChar(big_old.clone()));
+            }
+            other => panic!("expected rows, got {other:?}"),
+        }
+        let outcome = execute_batch(&storage, "COMMIT", &mut writer);
+        assert!(outcome.error.is_none(), "{:?}", outcome.error);
+        let outcome = execute_batch(&storage, "SELECT body FROM big WHERE id = 1", &mut reader);
+        match &outcome.results[0] {
+            StatementResult::Rows(rowset) => {
+                assert_eq!(rowset.rows[0][0], Datum::NVarChar(big_new.clone()));
+            }
+            other => panic!("expected rows, got {other:?}"),
+        }
+        drop(storage);
+        let _ = std::fs::remove_file(&path);
+    }
+
     /// Publishing versions changes nothing about crash recovery: the store
     /// (chains and commit table) is memory-only, so a kill-and-reopen with
     /// RCSI on recovers exactly the committed state, options intact, chains
@@ -4611,7 +4960,7 @@ mod tests {
         );
         assert!(outcome.error.is_none(), "{:?}", outcome.error);
         // Kill without checkpoint: drop the handle mid-transaction.
-        drop(ctx);
+        let _ = ctx;
         drop(storage);
 
         let storage = Storage::open(path.clone()).expect("recovery");

--- a/crates/truthdb-core/src/storage.rs
+++ b/crates/truthdb-core/src/storage.rs
@@ -1470,37 +1470,45 @@ impl StorageFile {
         def.collations.push(column.collation.clone());
         let new_schema = def.schema()?;
 
-        // Re-encode every row with the frozen fill appended.
-        let mut tree_rows: Vec<(Vec<u8>, Vec<u8>)> = Vec::new();
-        let mut heap_rows: Vec<(Rid, Vec<u8>)> = Vec::new();
+        // Every row gets the frozen fill appended; the re-encode happens
+        // INSIDE the statement so a (MAX) value the located scan resolved
+        // re-spills to a fresh overflow chain instead of blowing the in-row
+        // caps (the #123 review's finding: ALTER was unusable once a table
+        // held a real payload). Non-MAX tables pay one no-op spill scan.
+        let mut tree_rows: Vec<(Vec<u8>, Vec<Datum>)> = Vec::new();
+        let mut heap_rows: Vec<(Rid, Vec<Datum>)> = Vec::new();
         for (loc, mut values) in located {
             values.push(fill.clone());
-            let row = encode_row(&new_schema, &values)?;
             match loc {
-                RowLocator::Key(key) => tree_rows.push((key, row)),
-                RowLocator::Rid(rid) => heap_rows.push((rid, row)),
+                RowLocator::Key(key) => tree_rows.push((key, values)),
+                RowLocator::Rid(rid) => heap_rows.push((rid, values)),
             }
         }
 
         let is_tree = def.is_tree();
         let object_id = def.object_id;
         let root_page = def.root_page;
+        let closure_schema = new_schema.clone();
         let updated = self.rel_statement(move |ctx, txn| {
             if is_tree {
                 let tree = BTree {
                     object_id,
                     root: root_page,
                 };
-                for (key, row) in &tree_rows {
-                    tree.update(ctx, &mut OpMode::Txn(txn), key, row)?;
+                for (key, mut values) in tree_rows {
+                    Self::spill_max_values(ctx, &closure_schema, &mut values)?;
+                    let row = encode_row(&closure_schema, &values)?;
+                    tree.update(ctx, &mut OpMode::Txn(txn), &key, &row)?;
                 }
             } else {
                 let heap = Heap {
                     object_id,
                     first_page: root_page,
                 };
-                for (rid, row) in &heap_rows {
-                    heap.update(ctx, txn, *rid, row)?;
+                for (rid, mut values) in heap_rows {
+                    Self::spill_max_values(ctx, &closure_schema, &mut values)?;
+                    let row = encode_row(&closure_schema, &values)?;
+                    heap.update(ctx, txn, rid, &row)?;
                 }
             }
             catalog::update_table(ctx, &mut OpMode::Txn(txn), catalog_root, &def)?;
@@ -2053,6 +2061,10 @@ impl StorageFile {
 
     /// Deletes every row where `column = value`; returns the count. Targets
     /// are materialized before any mutation (Halloween avoidance).
+    ///
+    /// Test-only surface (no SQL path reaches it): it compares UNRESOLVED
+    /// rows, so a chained (MAX) value never matches, and it bypasses version
+    /// staging. Resolve and stage before wiring it to anything real.
     pub fn rel_delete_where(
         &mut self,
         name: &str,
@@ -4928,6 +4940,424 @@ mod tests {
             }
             other => panic!("expected rows, got {other:?}"),
         }
+        drop(storage);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// Review PoC: HEAP tables' version priors come from `heap.read_row`
+    /// pre-images. An RCSI reader must see the pre-update big value of a heap
+    /// row (resolved through the image's overflow reference), and a deleted
+    /// heap row must stay visible to the open snapshot.
+    #[test]
+    fn heap_rcsi_reads_old_big_value_through_preimage() {
+        use crate::rel::{
+            RpcParam, StatementResult, TxnContext, execute_batch, execute_batch_with_params,
+        };
+
+        let path = unique_temp_path("review-heap-rcsi");
+        let storage = Storage::create(path.clone(), test_storage_options()).expect("create");
+        let mut writer = TxnContext::default();
+        let big_old: String = "old-heap".repeat(10_000); // 80k chars -> chain
+        let big_new: String = "new-heap".repeat(10_000);
+        for sql in [
+            "ALTER DATABASE CURRENT SET READ_COMMITTED_SNAPSHOT ON",
+            // No PRIMARY KEY: a heap.
+            "CREATE TABLE hbig (id INT NOT NULL, body NVARCHAR(MAX))",
+        ] {
+            let outcome = execute_batch(&storage, sql, &mut writer);
+            assert!(outcome.error.is_none(), "{sql}: {:?}", outcome.error);
+        }
+        let outcome = execute_batch_with_params(
+            &storage,
+            "INSERT INTO hbig VALUES (1, @v)",
+            &mut writer,
+            &[RpcParam {
+                name: "@v".into(),
+                column_type: ColumnType::NVarCharMax,
+                value: Datum::NVarChar(big_old.clone()),
+            }],
+        );
+        assert!(outcome.error.is_none(), "{:?}", outcome.error);
+
+        let fetch = |ctx: &mut TxnContext| -> Option<Datum> {
+            let outcome = execute_batch(&storage, "SELECT body FROM hbig WHERE id = 1", ctx);
+            assert!(outcome.error.is_none(), "{:?}", outcome.error);
+            match &outcome.results[0] {
+                StatementResult::Rows(rowset) => rowset.rows.first().map(|r| r[0].clone()),
+                other => panic!("expected rows, got {other:?}"),
+            }
+        };
+
+        // Uncommitted UPDATE: the reader sees the old value via the image.
+        let outcome = execute_batch(&storage, "BEGIN TRAN", &mut writer);
+        assert!(outcome.error.is_none());
+        let outcome = execute_batch_with_params(
+            &storage,
+            "UPDATE hbig SET body = @v WHERE id = 1",
+            &mut writer,
+            &[RpcParam {
+                name: "@v".into(),
+                column_type: ColumnType::NVarCharMax,
+                value: Datum::NVarChar(big_new.clone()),
+            }],
+        );
+        assert!(outcome.error.is_none(), "{:?}", outcome.error);
+        let mut reader = TxnContext::default();
+        assert_eq!(
+            fetch(&mut reader),
+            Some(Datum::NVarChar(big_old.clone())),
+            "heap RCSI reader must get the pre-update value"
+        );
+        let outcome = execute_batch(&storage, "COMMIT", &mut writer);
+        assert!(outcome.error.is_none(), "{:?}", outcome.error);
+        assert_eq!(fetch(&mut reader), Some(Datum::NVarChar(big_new.clone())));
+
+        // Uncommitted DELETE: the reader still sees the (new) value.
+        let outcome = execute_batch(
+            &storage,
+            "BEGIN TRAN; DELETE FROM hbig WHERE id = 1;",
+            &mut writer,
+        );
+        assert!(outcome.error.is_none(), "{:?}", outcome.error);
+        assert_eq!(
+            fetch(&mut reader),
+            Some(Datum::NVarChar(big_new.clone())),
+            "heap RCSI reader must see the row an open txn deleted"
+        );
+        let outcome = execute_batch(&storage, "COMMIT", &mut writer);
+        assert!(outcome.error.is_none(), "{:?}", outcome.error);
+        assert_eq!(fetch(&mut reader), None);
+
+        drop(storage);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// Review PoC: a heap row that has MOVED (forwarding stub at its home
+    /// RID) must still read correctly, version correctly (the pre-image is
+    /// read through the stub), and keep its overflow value.
+    #[test]
+    fn moved_heap_row_versions_and_resolves_through_the_stub() {
+        use crate::rel::{
+            RpcParam, StatementResult, TxnContext, execute_batch, execute_batch_with_params,
+        };
+
+        let path = unique_temp_path("review-heap-moved");
+        let storage = Storage::create(path.clone(), test_storage_options()).expect("create");
+        let mut writer = TxnContext::default();
+        let big_old: String = "moved-old".repeat(5_000); // 45k chars -> chain
+        let big_new: String = "moved-new".repeat(5_000);
+        for sql in [
+            "ALTER DATABASE CURRENT SET READ_COMMITTED_SNAPSHOT ON",
+            "CREATE TABLE hm (id INT NOT NULL, pad VARCHAR(3000), body NVARCHAR(MAX))",
+        ] {
+            let outcome = execute_batch(&storage, sql, &mut writer);
+            assert!(outcome.error.is_none(), "{sql}: {:?}", outcome.error);
+        }
+        // Row 1 small; row 2 fills most of the first heap page, so growing
+        // row 1's pad to 3000 bytes cannot fit and must move the row.
+        let outcome = execute_batch_with_params(
+            &storage,
+            "INSERT INTO hm VALUES (1, 'a', @v)",
+            &mut writer,
+            &[RpcParam {
+                name: "@v".into(),
+                column_type: ColumnType::NVarCharMax,
+                value: Datum::NVarChar(big_old.clone()),
+            }],
+        );
+        assert!(outcome.error.is_none(), "{:?}", outcome.error);
+        let filler = "f".repeat(3000);
+        let outcome = execute_batch(
+            &storage,
+            &format!("INSERT INTO hm VALUES (2, '{filler}', NULL)"),
+            &mut writer,
+        );
+        assert!(outcome.error.is_none(), "{:?}", outcome.error);
+        let grown = "g".repeat(3000);
+        let outcome = execute_batch(
+            &storage,
+            &format!("UPDATE hm SET pad = '{grown}' WHERE id = 1"),
+            &mut writer,
+        );
+        assert!(outcome.error.is_none(), "{:?}", outcome.error);
+
+        // The moved row still resolves its chain.
+        let fetch_body = |ctx: &mut TxnContext| -> Option<Datum> {
+            let outcome = execute_batch(&storage, "SELECT body FROM hm WHERE id = 1", ctx);
+            assert!(outcome.error.is_none(), "{:?}", outcome.error);
+            match &outcome.results[0] {
+                StatementResult::Rows(rowset) => rowset.rows.first().map(|r| r[0].clone()),
+                other => panic!("expected rows, got {other:?}"),
+            }
+        };
+        assert_eq!(
+            fetch_body(&mut writer),
+            Some(Datum::NVarChar(big_old.clone())),
+            "moved row reads its chain"
+        );
+
+        // Version an update of the moved row: the prior must be read through
+        // the forwarding stub, and the reader must get the old big value.
+        let outcome = execute_batch(&storage, "BEGIN TRAN", &mut writer);
+        assert!(outcome.error.is_none());
+        let outcome = execute_batch_with_params(
+            &storage,
+            "UPDATE hm SET body = @v WHERE id = 1",
+            &mut writer,
+            &[RpcParam {
+                name: "@v".into(),
+                column_type: ColumnType::NVarCharMax,
+                value: Datum::NVarChar(big_new.clone()),
+            }],
+        );
+        assert!(outcome.error.is_none(), "{:?}", outcome.error);
+        let mut reader = TxnContext::default();
+        assert_eq!(
+            fetch_body(&mut reader),
+            Some(Datum::NVarChar(big_old.clone())),
+            "RCSI reader must get the pre-update value of a MOVED heap row"
+        );
+        // The pad read through the same image must be the grown one.
+        let outcome = execute_batch(&storage, "SELECT pad FROM hm WHERE id = 1", &mut reader);
+        assert!(outcome.error.is_none(), "{:?}", outcome.error);
+        match &outcome.results[0] {
+            StatementResult::Rows(rowset) => {
+                assert_eq!(rowset.rows[0][0], Datum::VarChar(grown.clone()));
+            }
+            other => panic!("expected rows, got {other:?}"),
+        }
+        let outcome = execute_batch(&storage, "COMMIT", &mut writer);
+        assert!(outcome.error.is_none(), "{:?}", outcome.error);
+        assert_eq!(fetch_body(&mut reader), Some(Datum::NVarChar(big_new)));
+
+        drop(storage);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// Review PoC: a statement that spills a chain and THEN fails (duplicate
+    /// key on a later row) must roll back cleanly — the chain leaks, the rows
+    /// do not land, the store stays usable, and recovery after a kill agrees.
+    #[test]
+    fn failed_statement_after_spill_rolls_back_cleanly() {
+        use crate::rel::{
+            RpcParam, StatementResult, TxnContext, execute_batch, execute_batch_with_params,
+        };
+
+        let path = unique_temp_path("review-spill-fail");
+        let storage = Storage::create(path.clone(), test_storage_options()).expect("create");
+        let mut ctx = TxnContext::default();
+        for sql in [
+            "CREATE TABLE sf (id INT NOT NULL PRIMARY KEY, body NVARCHAR(MAX))",
+            "INSERT INTO sf VALUES (7, N'anchor')",
+        ] {
+            let outcome = execute_batch(&storage, sql, &mut ctx);
+            assert!(outcome.error.is_none(), "{sql}: {:?}", outcome.error);
+        }
+        let big: String = "spilled".repeat(10_000); // 70k chars -> chain
+        // Row 1 spills its chain, row 2 hits the duplicate key: the whole
+        // statement must fail and undo row 1.
+        let outcome = execute_batch_with_params(
+            &storage,
+            "INSERT INTO sf VALUES (1, @v), (7, N'dup')",
+            &mut ctx,
+            &[RpcParam {
+                name: "@v".into(),
+                column_type: ColumnType::NVarCharMax,
+                value: Datum::NVarChar(big.clone()),
+            }],
+        );
+        assert!(outcome.error.is_some(), "duplicate key must fail");
+
+        let count = |ctx: &mut TxnContext| -> Datum {
+            let outcome = execute_batch(&storage, "SELECT COUNT(*) FROM sf", ctx);
+            assert!(outcome.error.is_none(), "{:?}", outcome.error);
+            match &outcome.results[0] {
+                StatementResult::Rows(rowset) => rowset.rows[0][0].clone(),
+                other => panic!("expected rows, got {other:?}"),
+            }
+        };
+        assert_eq!(count(&mut ctx), Datum::BigInt(1), "only the anchor row");
+
+        // The store is still usable: the same big value inserts fine now.
+        let outcome = execute_batch_with_params(
+            &storage,
+            "INSERT INTO sf VALUES (1, @v)",
+            &mut ctx,
+            &[RpcParam {
+                name: "@v".into(),
+                column_type: ColumnType::NVarCharMax,
+                value: Datum::NVarChar(big.clone()),
+            }],
+        );
+        assert!(outcome.error.is_none(), "{:?}", outcome.error);
+        assert_eq!(count(&mut ctx), Datum::BigInt(2));
+
+        // Kill and reopen: recovery replays the leaked chain's images and
+        // the committed rows; the value survives.
+        drop(storage);
+        let storage = Storage::open(path.clone()).expect("recovery");
+        let mut ctx = TxnContext::default();
+        let outcome = execute_batch(&storage, "SELECT body FROM sf WHERE id = 1", &mut ctx);
+        assert!(outcome.error.is_none(), "{:?}", outcome.error);
+        match &outcome.results[0] {
+            StatementResult::Rows(rowset) => {
+                assert_eq!(rowset.rows[0][0], Datum::NVarChar(big));
+            }
+            other => panic!("expected rows, got {other:?}"),
+        }
+        drop(storage);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// Review PoC: ALTER TABLE ADD on a table with spilled (MAX) values.
+    /// The rewrite resolves every row and re-encodes it WITHOUT re-spilling,
+    /// so a chain value small enough for the row cap is silently re-inlined
+    /// (and must survive), while a big one fails the whole ALTER — which must
+    /// fail CLEANLY, leaving the table intact and the store usable.
+    #[test]
+    fn alter_add_column_respills_max_values() {
+        use crate::rel::{
+            RpcParam, StatementResult, TxnContext, execute_batch, execute_batch_with_params,
+        };
+
+        let path = unique_temp_path("review-alter-max");
+        let storage = Storage::create(path.clone(), test_storage_options()).expect("create");
+        let mut ctx = TxnContext::default();
+
+        // Case A: a 300-byte chain value fits back inline; ALTER succeeds.
+        let small_chain = "s".repeat(300); // VARCHAR: 300 bytes > 256 -> chain
+        for sql in [
+            "CREATE TABLE amax (id INT NOT NULL PRIMARY KEY, body VARCHAR(MAX))".to_string(),
+            format!("INSERT INTO amax VALUES (1, '{small_chain}')"),
+            "ALTER TABLE amax ADD extra INT NULL".to_string(),
+        ] {
+            let outcome = execute_batch(&storage, &sql, &mut ctx);
+            assert!(outcome.error.is_none(), "{sql}: {:?}", outcome.error);
+        }
+        let outcome = execute_batch(&storage, "SELECT body, extra FROM amax", &mut ctx);
+        assert!(outcome.error.is_none(), "{:?}", outcome.error);
+        match &outcome.results[0] {
+            StatementResult::Rows(rowset) => {
+                assert_eq!(rowset.rows[0][0], Datum::VarChar(small_chain));
+                assert_eq!(rowset.rows[0][1], Datum::Null);
+            }
+            other => panic!("expected rows, got {other:?}"),
+        }
+
+        // Case B: a 10k value re-spills to a fresh chain during the ALTER's
+        // rewrite (the review found the original rewrite re-inlined and
+        // failed; the re-encode now runs inside the statement with
+        // spill_max_values, like every other write path).
+        let big: String = "b".repeat(10_000);
+        let outcome = execute_batch_with_params(
+            &storage,
+            "CREATE TABLE bmax (id INT NOT NULL PRIMARY KEY, body VARCHAR(MAX)); \
+             INSERT INTO bmax VALUES (1, @v);",
+            &mut ctx,
+            &[RpcParam {
+                name: "@v".into(),
+                column_type: ColumnType::VarCharMax,
+                value: Datum::VarChar(big.clone()),
+            }],
+        );
+        assert!(outcome.error.is_none(), "{:?}", outcome.error);
+        let outcome = execute_batch(&storage, "ALTER TABLE bmax ADD extra INT NULL", &mut ctx);
+        assert!(
+            outcome.error.is_none(),
+            "the rewrite must spill, not re-inline: {:?}",
+            outcome.error
+        );
+        let outcome = execute_batch(
+            &storage,
+            "SELECT body, extra FROM bmax WHERE id = 1",
+            &mut ctx,
+        );
+        assert!(outcome.error.is_none(), "{:?}", outcome.error);
+        match &outcome.results[0] {
+            StatementResult::Rows(rowset) => {
+                assert_eq!(rowset.rows[0][0], Datum::VarChar(big.clone()));
+                assert_eq!(rowset.rows[0][1], Datum::Null, "the frozen fill");
+            }
+            other => panic!("expected rows, got {other:?}"),
+        }
+        // ...and the widened row survives a reopen (the fresh chain is
+        // durable with the ALTER's statement).
+        drop(ctx);
+        drop(storage);
+        let storage = Storage::open(path.clone()).expect("reopen");
+        let mut ctx = TxnContext::default();
+        let outcome = execute_batch(&storage, "SELECT body FROM bmax WHERE id = 1", &mut ctx);
+        assert!(outcome.error.is_none(), "{:?}", outcome.error);
+        match &outcome.results[0] {
+            StatementResult::Rows(rowset) => {
+                assert_eq!(rowset.rows[0][0], Datum::VarChar(big));
+            }
+            other => panic!("expected rows, got {other:?}"),
+        }
+        let outcome = execute_batch(&storage, "INSERT INTO bmax VALUES (2, 'ok', 5)", &mut ctx);
+        assert!(outcome.error.is_none(), "{:?}", outcome.error);
+
+        drop(storage);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// Review PoC: codec edges — empty string, the 256/257 inline threshold,
+    /// NULL, and a VARBINARY(MAX) value — all round-trip, including across a
+    /// reopen.
+    #[test]
+    fn max_codec_edges_round_trip() {
+        use crate::rel::{
+            RpcParam, StatementResult, TxnContext, execute_batch, execute_batch_with_params,
+        };
+
+        let path = unique_temp_path("review-max-edges");
+        let storage = Storage::create(path.clone(), test_storage_options()).expect("create");
+        let mut ctx = TxnContext::default();
+        let at_threshold = "t".repeat(256); // inline boundary
+        let over_threshold = "u".repeat(257); // first chained length
+        for sql in [
+            "CREATE TABLE edges (id INT NOT NULL PRIMARY KEY, v VARCHAR(MAX), b VARBINARY(MAX))"
+                .to_string(),
+            "INSERT INTO edges VALUES (1, '', NULL)".to_string(),
+            format!("INSERT INTO edges VALUES (2, '{at_threshold}', NULL)"),
+            format!("INSERT INTO edges VALUES (3, '{over_threshold}', NULL)"),
+            "INSERT INTO edges VALUES (4, NULL, NULL)".to_string(),
+        ] {
+            let outcome = execute_batch(&storage, &sql, &mut ctx);
+            assert!(outcome.error.is_none(), "{sql}: {:?}", outcome.error);
+        }
+        let blob = vec![0xABu8; 300]; // > 256 -> chain
+        let outcome = execute_batch_with_params(
+            &storage,
+            "INSERT INTO edges VALUES (5, NULL, @b)",
+            &mut ctx,
+            &[RpcParam {
+                name: "@b".into(),
+                column_type: ColumnType::VarBinaryMax,
+                value: Datum::VarBinary(blob.clone()),
+            }],
+        );
+        assert!(outcome.error.is_none(), "{:?}", outcome.error);
+
+        let check = |storage: &Storage, ctx: &mut TxnContext| {
+            let outcome = execute_batch(storage, "SELECT v, b FROM edges ORDER BY id", ctx);
+            assert!(outcome.error.is_none(), "{:?}", outcome.error);
+            match &outcome.results[0] {
+                StatementResult::Rows(rowset) => {
+                    assert_eq!(rowset.rows[0][0], Datum::VarChar(String::new()), "empty");
+                    assert_eq!(rowset.rows[1][0], Datum::VarChar(at_threshold.clone()));
+                    assert_eq!(rowset.rows[2][0], Datum::VarChar(over_threshold.clone()));
+                    assert_eq!(rowset.rows[3][0], Datum::Null);
+                    assert_eq!(rowset.rows[4][1], Datum::VarBinary(blob.clone()));
+                }
+                other => panic!("expected rows, got {other:?}"),
+            }
+        };
+        check(&storage, &mut ctx);
+        drop(storage);
+        let storage = Storage::open(path.clone()).expect("reopen");
+        let mut ctx = TxnContext::default();
+        check(&storage, &mut ctx);
         drop(storage);
         let _ = std::fs::remove_file(&path);
     }

--- a/crates/truthdb-core/tests/slt/max_types.slt
+++ b/crates/truthdb-core/tests/slt/max_types.slt
@@ -1,0 +1,73 @@
+# VARCHAR(MAX) / NVARCHAR(MAX) / VARBINARY(MAX) (Stage 14): declaration,
+# CRUD, CAST, and the key/index rejections. Values here are inline-sized;
+# the overflow-chain paths (and the 10 MiB round-trip) are pinned in the
+# engine tests, where big values are built programmatically.
+
+statement ok
+CREATE TABLE mx (id INT NOT NULL PRIMARY KEY, body NVARCHAR(MAX), raw VARBINARY(MAX))
+
+statement ok
+INSERT INTO mx VALUES (1, N'hello max', NULL), (2, NULL, NULL)
+
+query IT rowsort
+SELECT id, body FROM mx
+----
+1 hello max
+2 NULL
+
+statement ok
+UPDATE mx SET body = 'replaced' WHERE id = 1
+
+query T
+SELECT body FROM mx WHERE id = 1
+----
+replaced
+
+# No declared-length cap: a value longer than 8000 characters is legal (the
+# 8152 truncation error never fires for MAX).
+statement ok
+CREATE TABLE mx2 (id INT NOT NULL PRIMARY KEY, v VARCHAR(MAX))
+
+statement ok
+INSERT INTO mx2 VALUES (1, 'x')
+
+query I
+SELECT LEN(v) FROM mx2 WHERE id = 1
+----
+1
+
+# CAST to (MAX) types works and does not truncate.
+query T
+SELECT CAST('abc' AS VARCHAR(MAX))
+----
+abc
+
+query I
+SELECT LEN(CAST('abcdef' AS NVARCHAR(MAX)))
+----
+6
+
+# WHERE and expressions read (MAX) columns like any other.
+query I
+SELECT COUNT(*) FROM mx WHERE body = 'replaced'
+----
+1
+
+# (MAX) columns cannot be keys or index columns (1919), nor INCLUDEd (a
+# documented divergence — SQL Server allows INCLUDE).
+statement error
+CREATE TABLE bad (body NVARCHAR(MAX) NOT NULL PRIMARY KEY)
+
+statement error
+CREATE INDEX ix_mx ON mx (body)
+
+statement error
+CREATE INDEX ix_mx2 ON mx (id) INCLUDE (body)
+
+statement ok
+DELETE FROM mx WHERE id = 1
+
+query I
+SELECT COUNT(*) FROM mx
+----
+1

--- a/crates/truthdb-sql/src/ast.rs
+++ b/crates/truthdb-sql/src/ast.rs
@@ -270,7 +270,10 @@ pub enum DataType {
     Bit,
     Real,
     Float,
-    Decimal { precision: u8, scale: u8 },
+    Decimal {
+        precision: u8,
+        scale: u8,
+    },
     Date,
     Time,
     DateTime2,
@@ -278,6 +281,10 @@ pub enum DataType {
     VarChar(u32),
     NVarChar(u32),
     VarBinary(u32),
+    /// `VARCHAR(MAX)` — no declared length cap (Stage 14).
+    VarCharMax,
+    NVarCharMax,
+    VarBinaryMax,
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/crates/truthdb-sql/src/eval.rs
+++ b/crates/truthdb-sql/src/eval.rs
@@ -569,6 +569,8 @@ fn cast_value(value: SqlValue, target: &DataType) -> SqlResult<SqlValue> {
             let s: String = cast_to_string(&value).chars().take(*n as usize).collect();
             Ok(SqlValue::Str(s))
         }
+        // (MAX): no cap to truncate to.
+        DataType::VarCharMax | DataType::NVarCharMax => Ok(SqlValue::Str(cast_to_string(&value))),
         DataType::Date => match &value {
             SqlValue::Date(d) => Ok(SqlValue::Date(*d)),
             SqlValue::DateTime2(d, _) => Ok(SqlValue::Date(*d)),
@@ -606,6 +608,10 @@ fn cast_value(value: SqlValue, target: &DataType) -> SqlResult<SqlValue> {
             )),
             _ => Err(cfail("varbinary")),
         },
+        DataType::VarBinaryMax => match &value {
+            SqlValue::Binary(b) => Ok(SqlValue::Binary(b.clone())),
+            _ => Err(cfail("varbinary")),
+        },
     }
 }
 
@@ -623,9 +629,9 @@ fn type_label(target: &DataType) -> &'static str {
         DataType::Time => "time",
         DataType::DateTime2 => "datetime2",
         DataType::UniqueIdentifier => "uniqueidentifier",
-        DataType::VarChar(_) => "varchar",
-        DataType::NVarChar(_) => "nvarchar",
-        DataType::VarBinary(_) => "varbinary",
+        DataType::VarChar(_) | DataType::VarCharMax => "varchar",
+        DataType::NVarChar(_) | DataType::NVarCharMax => "nvarchar",
+        DataType::VarBinary(_) | DataType::VarBinaryMax => "varbinary",
     }
 }
 

--- a/crates/truthdb-sql/src/parser.rs
+++ b/crates/truthdb-sql/src/parser.rs
@@ -941,19 +941,19 @@ impl Parser {
         let keyword = token
             .keyword()
             .ok_or_else(|| SqlError::syntax(self.token_text(&token), span))?;
-        let with_len = |parser: &mut Self, default: u32| -> SqlResult<(u32, Span)> {
+        // `None` length = `(MAX)`.
+        let with_len = |parser: &mut Self, default: u32| -> SqlResult<(Option<u32>, Span)> {
             if parser.eat(&TokenKind::LParen) {
                 if parser.peek_keyword().as_deref() == Some("MAX") {
-                    return Err(SqlError::message_only(
-                        102,
-                        "(MAX) length types are not supported until a later stage.",
-                    ));
+                    parser.bump();
+                    let end = parser.expect(&TokenKind::RParen)?;
+                    return Ok((None, end));
                 }
                 let n = parser.parse_u32_literal()?;
                 let end = parser.expect(&TokenKind::RParen)?;
-                Ok((n, end))
+                Ok((Some(n), end))
             } else {
-                Ok((default, span))
+                Ok((Some(default), span))
             }
         };
         let data_type = match keyword.as_str() {
@@ -974,15 +974,33 @@ impl Parser {
             }
             "VARCHAR" | "CHAR" => {
                 let (n, end) = with_len(self, 1)?;
-                return Ok((DataType::VarChar(n), span.to(end)));
+                return Ok((
+                    match n {
+                        Some(n) => DataType::VarChar(n),
+                        None => DataType::VarCharMax,
+                    },
+                    span.to(end),
+                ));
             }
             "NVARCHAR" | "NCHAR" => {
                 let (n, end) = with_len(self, 1)?;
-                return Ok((DataType::NVarChar(n), span.to(end)));
+                return Ok((
+                    match n {
+                        Some(n) => DataType::NVarChar(n),
+                        None => DataType::NVarCharMax,
+                    },
+                    span.to(end),
+                ));
             }
             "VARBINARY" | "BINARY" => {
                 let (n, end) = with_len(self, 1)?;
-                return Ok((DataType::VarBinary(n), span.to(end)));
+                return Ok((
+                    match n {
+                        Some(n) => DataType::VarBinary(n),
+                        None => DataType::VarBinaryMax,
+                    },
+                    span.to(end),
+                ));
             }
             other => {
                 return Err(SqlError::message_only(

--- a/crates/truthdb-tds/src/typeinfo.rs
+++ b/crates/truthdb-tds/src/typeinfo.rs
@@ -39,6 +39,10 @@ enum TdsType {
     NVarChar(u16),
     VarChar(u16),
     VarBinary(u16),
+    /// (MAX) types: 0xFFFF max length in COLMETADATA, PLP-encoded values.
+    NVarCharMax,
+    VarCharMax,
+    VarBinaryMax,
 }
 
 fn tds_type(column_type: &ColumnType) -> TdsType {
@@ -57,6 +61,9 @@ fn tds_type(column_type: &ColumnType) -> TdsType {
         ColumnType::NVarChar { max_len } => TdsType::NVarChar((*max_len).max(1)),
         ColumnType::VarChar { max_len } => TdsType::VarChar((*max_len).max(1)),
         ColumnType::VarBinary { max_len } => TdsType::VarBinary((*max_len).max(1)),
+        ColumnType::NVarCharMax => TdsType::NVarCharMax,
+        ColumnType::VarCharMax => TdsType::VarCharMax,
+        ColumnType::VarBinaryMax => TdsType::VarBinaryMax,
         // TIME (rare) falls back to NVARCHAR of its rendered text.
         _ => TdsType::NVarChar(4000),
     }
@@ -121,8 +128,39 @@ pub fn encode_type_info(column_type: &ColumnType) -> Vec<u8> {
             out.extend_from_slice(&max_len.min(8000).to_le_bytes());
             out.extend_from_slice(&COLLATION);
         }
+        // (MAX): the 0xFFFF length IS the PLP marker drivers key on.
+        TdsType::NVarCharMax => {
+            out.push(NVARCHAR);
+            out.extend_from_slice(&0xffffu16.to_le_bytes());
+            out.extend_from_slice(&COLLATION);
+        }
+        TdsType::VarCharMax => {
+            out.push(BIGVARCHR);
+            out.extend_from_slice(&0xffffu16.to_le_bytes());
+            out.extend_from_slice(&COLLATION);
+        }
+        TdsType::VarBinaryMax => {
+            out.push(BIGVARBINARY);
+            out.extend_from_slice(&0xffffu16.to_le_bytes());
+        }
     }
     out
+}
+
+/// PLP (partially length-prefixed) value: total length u64, one data chunk,
+/// zero terminator. NULL is the PLP null sentinel.
+fn encode_plp(out: &mut Vec<u8>, bytes: Option<Vec<u8>>) {
+    match bytes {
+        None => out.extend_from_slice(&u64::MAX.to_le_bytes()),
+        Some(bytes) => {
+            out.extend_from_slice(&(bytes.len() as u64).to_le_bytes());
+            if !bytes.is_empty() {
+                out.extend_from_slice(&(bytes.len() as u32).to_le_bytes());
+                out.extend_from_slice(&bytes);
+            }
+            out.extend_from_slice(&0u32.to_le_bytes());
+        }
+    }
 }
 
 /// NVARCHAR max byte length, clamped to the non-MAX limit (8000 bytes).
@@ -229,6 +267,18 @@ pub fn encode_value(datum: &Datum, column_type: &ColumnType) -> Vec<u8> {
             }
             None => out.extend_from_slice(&0xffffu16.to_le_bytes()),
         },
+        TdsType::NVarCharMax => encode_plp(
+            &mut out,
+            string_value(datum).map(|s| s.encode_utf16().flat_map(|u| u.to_le_bytes()).collect()),
+        ),
+        TdsType::VarCharMax => encode_plp(&mut out, string_value(datum).map(|s| encode_cp1252(&s))),
+        TdsType::VarBinaryMax => encode_plp(
+            &mut out,
+            match datum {
+                Datum::VarBinary(bytes) => Some(bytes.clone()),
+                _ => None,
+            },
+        ),
     }
     out
 }
@@ -375,6 +425,37 @@ mod tests {
         let value = encode_value(&Datum::VarChar("café€中".to_string()), &ct);
         assert_eq!(u16::from_le_bytes([value[0], value[1]]), 6);
         assert_eq!(&value[2..], &[b'c', b'a', b'f', 0xE9, 0x80, b'?']);
+    }
+
+    /// (MAX) columns advertise the 0xFFFF PLP marker and their values ride
+    /// PLP framing: total u64, one chunk, zero terminator; NULL is the PLP
+    /// null sentinel. Byte-pinned — drivers key on exactly these shapes.
+    #[test]
+    fn max_types_are_plp_on_the_wire() {
+        let info = encode_type_info(&ColumnType::NVarCharMax);
+        assert_eq!(info[0], NVARCHAR);
+        assert_eq!(&info[1..3], &0xffffu16.to_le_bytes());
+        assert_eq!(&info[3..8], &COLLATION);
+
+        let value = encode_value(&Datum::NVarChar("hi".into()), &ColumnType::NVarCharMax);
+        let mut expected = Vec::new();
+        expected.extend_from_slice(&4u64.to_le_bytes()); // total bytes (UCS-2)
+        expected.extend_from_slice(&4u32.to_le_bytes()); // one chunk
+        expected.extend_from_slice(&[b'h', 0, b'i', 0]);
+        expected.extend_from_slice(&0u32.to_le_bytes()); // terminator
+        assert_eq!(value, expected);
+
+        assert_eq!(
+            encode_value(&Datum::Null, &ColumnType::VarBinaryMax),
+            u64::MAX.to_le_bytes().to_vec(),
+            "PLP NULL sentinel"
+        );
+
+        // An empty value is a zero total with just the terminator.
+        assert_eq!(
+            encode_value(&Datum::VarChar(String::new()), &ColumnType::VarCharMax),
+            [0u64.to_le_bytes().as_slice(), 0u32.to_le_bytes().as_slice()].concat(),
+        );
     }
 
     #[test]

--- a/scripts/tds_conformance.py
+++ b/scripts/tds_conformance.py
@@ -229,6 +229,23 @@ def main() -> int:
         print(f"FAIL: count must return after NOCOUNT OFF, got {cur.rowcount}")
         return 1
 
+    # Stage 14: NVARCHAR(MAX) — PLP in both directions. pytds sends a long
+    # parameter as PLP (the decoder's live pin) and reads the PLP-encoded
+    # column back; 100k chars forces the overflow-chain storage path.
+    cur.execute("CREATE TABLE maxi (id INT NOT NULL PRIMARY KEY, body NVARCHAR(MAX))")
+    payload = "λx." * 33000 + "end"  # 99003 chars, non-ASCII included
+    cur.execute("INSERT INTO maxi VALUES (%s, %s)", (1, payload))
+    cur.execute("SELECT LEN(body), body FROM maxi WHERE id = 1")
+    length, body = cur.fetchone()
+    if length != len(payload) or body != payload:
+        print(f"FAIL: NVARCHAR(MAX) round-trip: len {length} vs {len(payload)}, "
+              f"equal={body == payload}")
+        return 1
+    cur.execute("SELECT body FROM maxi WHERE body = %s", (payload,))
+    if cur.fetchone() is None:
+        print("FAIL: NVARCHAR(MAX) equality predicate")
+        return 1
+
     conn.close()
     print("tds conformance: OK")
     return 0


### PR DESCRIPTION
## Stage 14, part 2: VARCHAR(MAX)-class values

`VARCHAR(MAX)`, `NVARCHAR(MAX)` and `VARBINARY(MAX)` — overflow page chains under the in-row codec, PLP on the wire, and the stage's 10 MiB exit criterion pinned.

### Storage design

- **Explicit `*Max` type variants**, serialized through the catalog's existing name/parse string round-trip as `varchar(max)` — old catalogs never contain the spelling, so nothing re-interprets.
- **Overflow chains**: values above a 256-byte inline threshold live in immutable runs of a new page type, each logged as a full system image exactly like B+ tree split pages — redo replays them wholesale, nothing ever undoes them. Failed statements and superseded values **leak their chains** (the established dropped-table posture; a checkpoint-time vacuum is future work). That immutability is load-bearing for versioning: a version image holding a chain *reference* stays resolvable for as long as any snapshot needs it.
- **The row codec** stores MAX values behind a per-value tag byte — inline base encoding, or a 16-byte `[total_len | first_page]` reference. Schema-driven: non-MAX columns are byte-identical to before. Every storage read path resolves references before rows escape (`Datum::OverflowRef` is internal; an escape is a loud internal error, not silent corruption).
- **Version priors switched to raw physical pre-images** for every table: the bytes `tree.update`/`tree.delete` return, or a heap pre-read — not a re-encode of the decoded values, which would have re-inlined a 10 MiB value into the 64 KiB var-section cap. Cheaper for ordinary tables, and exactly what keeps big-value versioning correct.
- MAX tables encode rows inside the statement (spilling needs the page context); other tables keep the prepared-encoding fast path. `(MAX)` columns are rejected as PK / index key / INCLUDE columns with 1919 (INCLUDE is a documented divergence: our include payloads live in ordinary leaf cells under the tree cell cap).

### Wire

COLMETADATA advertises the 0xFFFF PLP marker for MAX columns; values ride PLP framing (total length, one chunk, terminator; PLP NULL sentinel) — byte-pinned in a unit test. The RPC parameter decoder already spoke PLP (drivers have been sending `NVARCHAR(MAX)` parameters since Stage 9); this PR closes the loop on output, and the pytds conformance script now round-trips 99k non-ASCII characters through both directions live in CI, including an equality predicate over the MAX column.

### Exit criteria

- A **10 MiB** value round-trips through a chain and **survives a kill-and-reopen** with an in-flight update of it correctly undone (the committed chain wins, the loser's is unreferenced).
- An RCSI reader gets the pre-update big value **through its version image's chain reference** while the writer's transaction is open, and the new value after commit.
- `max_types.slt`: declaration, CRUD, CAST-without-truncation, 8152-never-fires, and the 1919 rejections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
