### PR TITLE
Stage 14: offline file growth via the CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1181,6 +1181,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "toml",
+ "truthdb-core",
  "truthdb-net",
  "truthdb-proto",
 ]

--- a/crates/truthdb-cli/Cargo.toml
+++ b/crates/truthdb-cli/Cargo.toml
@@ -6,6 +6,7 @@ description = "Command-line client and REPL for TruthDB, speaking the truthdb bi
 license = "MIT"
 
 [dependencies]
+truthdb-core = { path = "../truthdb-core" }
 clap = { version = "4.5.53", features = ["derive", "env"] }
 anyhow = "1.0.100"
 thiserror = { workspace = true }

--- a/crates/truthdb-cli/src/main.rs
+++ b/crates/truthdb-cli/src/main.rs
@@ -38,6 +38,20 @@ struct Cli {
 enum Command {
     /// Start an interactive session (psql-like REPL).
     Repl,
+    /// OFFLINE: grow a stopped server's storage file by whole GiB. The
+    /// server must not be running — this rewrites the file's region layout
+    /// directly (crash-safe: the header flips last; a re-run completes an
+    /// interrupted grow).
+    Grow {
+        /// Path to the storage file (e.g. /var/lib/truthdb/truth.db).
+        #[arg(long)]
+        path: std::path::PathBuf,
+        /// GiB to add to the data region. A safe minimum applies (the
+        /// relocated tail regions must clear the old layout); the error
+        /// names it when the request is below it.
+        #[arg(long)]
+        add_gib: u64,
+    },
 }
 
 #[tokio::main]
@@ -50,6 +64,19 @@ async fn main() -> Result<()> {
 
     match cli.command.unwrap_or(Command::Repl) {
         Command::Repl => repl(&addr).await,
+        Command::Grow { path, add_gib } => {
+            match truthdb_core::storage::Storage::grow_data_region(&path, add_gib) {
+                Ok(data_pages) => {
+                    println!(
+                        "grew {} by {add_gib} GiB: data region now {data_pages} pages ({} GiB)",
+                        path.display(),
+                        data_pages * 4096 / (1024 * 1024 * 1024),
+                    );
+                    Ok(())
+                }
+                Err(err) => Err(anyhow::anyhow!("grow failed: {err}")),
+            }
+        }
     }
 }
 

--- a/crates/truthdb-core/src/direct_io.rs
+++ b/crates/truthdb-core/src/direct_io.rs
@@ -131,6 +131,12 @@ mod imp {
 
     pub struct DirectFile {
         file: File,
+        /// Holds the advisory lock (see [`Self::lock_exclusive`]). A separate
+        /// plain fd rather than a lock on `file`: the O_DIRECT fd is
+        /// registered with io_uring, whose kernel-side file release at ring
+        /// teardown is deferred, so a lock on it would linger past drop. This
+        /// fd closes synchronously, releasing the lock at drop.
+        _lock: Option<File>,
         ring: IoUring,
         buffers: Vec<AlignedBuffer>,
         next_user_data: u64,
@@ -144,12 +150,25 @@ mod imp {
 
     impl DirectFile {
         pub fn open_existing(path: PathBuf) -> io::Result<Self> {
+            let lock = Self::lock_exclusive(&path)?;
             let file = OpenOptions::new()
                 .read(true)
                 .write(true)
                 .custom_flags(libc::O_DIRECT)
                 .open(&path)?;
-            Self::from_file(file)
+            Self::from_file(file, Some(lock))
+        }
+
+        /// The storage layer's SECOND handle on a file its primary handle
+        /// already holds the advisory lock for (the log writer's). Taking
+        /// the lock here would conflict with our own primary.
+        pub fn open_existing_unlocked(path: PathBuf) -> io::Result<Self> {
+            let file = OpenOptions::new()
+                .read(true)
+                .write(true)
+                .custom_flags(libc::O_DIRECT)
+                .open(&path)?;
+            Self::from_file(file, None)
         }
 
         pub fn create_new(path: PathBuf, total_size: u64) -> io::Result<Self> {
@@ -160,11 +179,36 @@ mod imp {
                 .mode(0o644)
                 .custom_flags(libc::O_DIRECT)
                 .open(&path)?;
+            let lock = Self::lock_exclusive(&path)?;
             file.set_len(total_size)?;
-            Self::from_file(file)
+            Self::from_file(file, Some(lock))
         }
 
-        fn from_file(file: File) -> io::Result<Self> {
+        /// Advisory whole-file lock, held for the life of the handle: the
+        /// server keeps it while running, so the offline `grow` command's
+        /// open fails fast instead of operating under a live server (and a
+        /// second server open fails instead of corrupting). Advisory only —
+        /// it fences TruthDB processes, not arbitrary writers. flock is per
+        /// open file description, so two opens in one process conflict too.
+        fn lock_exclusive(path: &PathBuf) -> io::Result<File> {
+            let lock = OpenOptions::new().read(true).open(path)?;
+            if unsafe { libc::flock(lock.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } == 0 {
+                return Ok(lock);
+            }
+            let err = io::Error::last_os_error();
+            if err.kind() == io::ErrorKind::WouldBlock {
+                return Err(io::Error::new(
+                    io::ErrorKind::WouldBlock,
+                    format!(
+                        "{} is locked by another TruthDB process; stop it first",
+                        path.display()
+                    ),
+                ));
+            }
+            Err(err)
+        }
+
+        fn from_file(file: File, lock: Option<File>) -> io::Result<Self> {
             let len = file.metadata()?.len();
             let buffers = vec![AlignedBuffer::new(PAGE_SIZE, PAGE_SIZE)?];
             let ring = IoUring::new(IO_URING_ENTRIES).map_err(annotate_io_uring_error)?;
@@ -184,6 +228,7 @@ mod imp {
 
             Ok(Self {
                 file,
+                _lock: lock,
                 ring,
                 buffers,
                 next_user_data: 1,
@@ -552,6 +597,13 @@ mod imp {
 
     impl DirectFile {
         pub fn open_existing(path: std::path::PathBuf) -> io::Result<Self> {
+            Err(io::Error::other(format!(
+                "truthdb storage requires Linux io_uring; unsupported platform for {}",
+                path.display()
+            )))
+        }
+
+        pub fn open_existing_unlocked(path: std::path::PathBuf) -> io::Result<Self> {
             Err(io::Error::other(format!(
                 "truthdb storage requires Linux io_uring; unsupported platform for {}",
                 path.display()

--- a/crates/truthdb-core/src/storage.rs
+++ b/crates/truthdb-core/src/storage.rs
@@ -296,6 +296,110 @@ impl Storage {
         Self::with_log_writer(path, file)
     }
 
+    /// OFFLINE file growth (Stage 14): extends the data region of a CLOSED
+    /// store by `add_gib` GiB. The server must not have the file open.
+    ///
+    /// The data region ends where the tail regions (metadata, allocator,
+    /// snapshot, reserved) begin, so growth shifts the tail right by the
+    /// delta. Crash safety comes from a size floor, not ordering tricks: the
+    /// delta must be at least the tail's whole span, which puts every
+    /// relocated region entirely in the fresh extension — nothing the OLD
+    /// header points at is touched until the new header is stamped last
+    /// (fsync-fenced, the v1→v2 upgrade's commit-point pattern). A crash
+    /// before the stamp leaves a longer file under the old, fully valid
+    /// layout; re-running the grow completes it.
+    ///
+    /// Everything inside the regions survives untouched: page numbers, RIDs
+    /// and catalog roots are data-region-relative or absolute below the tail,
+    /// the WAL sits before the data region, and the allocator bitmap is
+    /// copied with zero (= free) extension bits — recovery replays pending
+    /// WAL allocations on top exactly as it would have.
+    pub fn grow_data_region(path: &Path, add_gib: u64) -> Result<u64, StorageError> {
+        if add_gib == 0 {
+            return Err(StorageError::InvalidConfig(
+                "growth must be at least 1 GiB".to_string(),
+            ));
+        }
+        let delta = add_gib.checked_mul(1024 * 1024 * 1024).ok_or_else(|| {
+            StorageError::InvalidConfig(format!("growth of {add_gib} GiB overflows"))
+        })?;
+        let mut file = DirectFile::open_existing(path.to_path_buf())?;
+        let mut header_bytes = [0u8; crate::storage_layout::FILE_HEADER_SIZE];
+        file.read_exact_at(0, &mut header_bytes)?;
+        let mut header = FileHeader::from_le_bytes(&header_bytes);
+        if header.magic != crate::storage_layout::FILE_MAGIC {
+            return Err(StorageError::InvalidFile("bad magic".to_string()));
+        }
+        if header.version != crate::storage_layout::FILE_VERSION {
+            return Err(StorageError::InvalidFile(format!(
+                "grow requires a v{} file, found v{}",
+                crate::storage_layout::FILE_VERSION,
+                header.version
+            )));
+        }
+        if header.header_checksum != header.compute_checksum() {
+            return Err(StorageError::InvalidFile(
+                "header checksum mismatch".to_string(),
+            ));
+        }
+
+        let tail_span = header.metadata_size
+            + header.allocator_size
+            + header.snapshot_size
+            + header.reserved_size;
+        if delta < tail_span {
+            return Err(StorageError::InvalidConfig(format!(
+                "growth of {add_gib} GiB is below the safe minimum of {} GiB for this file \
+                 (the relocated regions must clear the old layout entirely)",
+                tail_span.div_ceil(1024 * 1024 * 1024)
+            )));
+        }
+        let new_data_size = header.data_size + delta;
+        let new_data_pages = new_data_size / PAGE_SIZE as u64;
+        let new_bitmap_len = new_data_pages.div_ceil(8);
+        if new_bitmap_len > header.allocator_size {
+            return Err(StorageError::InvalidConfig(format!(
+                "the allocator region ({} bytes) cannot hold the bitmap for {} data pages",
+                header.allocator_size, new_data_pages
+            )));
+        }
+
+        // Read the payloads that move BEFORE any write: the allocator bitmap
+        // (as much of it as the old data region used) and both snapshot
+        // descriptor pages, verbatim.
+        let old_bitmap_len = (header.data_size / PAGE_SIZE as u64).div_ceil(8) as usize;
+        let mut bitmap = vec![0u8; old_bitmap_len];
+        file.read_exact_at(header.allocator_offset, &mut bitmap)?;
+        let mut descriptors = vec![0u8; 2 * PAGE_SIZE];
+        file.read_exact_at(header.snapshot_offset, &mut descriptors)?;
+
+        // Extend the file (a separate buffered handle; O_DIRECT is for page
+        // I/O, not metadata), fsynced before anything lands in the extension.
+        let old_total = header.reserved_offset + header.reserved_size;
+        let plain = std::fs::OpenOptions::new().write(true).open(path)?;
+        plain.set_len(old_total + delta)?;
+        plain.sync_all()?;
+        drop(plain);
+
+        // Write the relocated payloads into the extension (all beyond the
+        // old file end by the size floor above). The bitmap's new bytes stay
+        // zero — the grown pages are free.
+        file.write_all_at(header.allocator_offset + delta, &bitmap)?;
+        file.write_all_at(header.snapshot_offset + delta, &descriptors)?;
+        file.sync_data()?;
+
+        // Commit point: the header flips to the new layout.
+        header.data_size = new_data_size;
+        header.metadata_offset += delta;
+        header.allocator_offset += delta;
+        header.snapshot_offset += delta;
+        header.reserved_offset += delta;
+        header.header_checksum = header.compute_checksum();
+        file.write_all_at(0, &header.to_le_bytes_with_checksum())?;
+        file.sync_data()?;
+        Ok(new_data_pages)
+    }
+
     pub fn create(path: PathBuf, opts: StorageOptions) -> Result<Self, StorageError> {
         Self::create_with_wal_bounds(path, opts, WAL_MIN_BYTES, WAL_MAX_BYTES)
     }
@@ -2911,7 +3015,7 @@ impl StorageFile {
 
         // Recover the true WAL tail: trust the superblock's tail as a lower
         // bound and scan forward (CRC + LSN self-identity) past it.
-        let mut log_file = DirectFile::open_existing(path.clone())?;
+        let mut log_file = DirectFile::open_existing_unlocked(path.clone())?;
         let scan = scan_ring(
             &mut log_file,
             layout.wal_offset,
@@ -3033,7 +3137,7 @@ impl StorageFile {
         )?;
         file.sync_data()?;
 
-        let log_file = DirectFile::open_existing(path.clone())?;
+        let log_file = DirectFile::open_existing_unlocked(path.clone())?;
         let wal = WalWriter::open(log_file, layout.wal_offset, layout.wal_size, 0, 0)?;
 
         Ok(StorageFile {
@@ -5358,6 +5462,341 @@ mod tests {
         let storage = Storage::open(path.clone()).expect("reopen");
         let mut ctx = TxnContext::default();
         check(&storage, &mut ctx);
+        drop(storage);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// Offline growth (Stage 14): the data region extends, everything in it
+    /// survives, and the grown space is allocatable. Includes a second grow
+    /// (the re-run shape an interrupted grow needs).
+    #[test]
+    fn offline_grow_extends_the_data_region() {
+        use crate::rel::{StatementResult, TxnContext, execute_batch};
+
+        let path = unique_temp_path("grow");
+        let storage = Storage::create(path.clone(), test_storage_options()).expect("create");
+        let mut ctx = TxnContext::default();
+        for sql in [
+            "CREATE TABLE g (id INT NOT NULL PRIMARY KEY, v NVARCHAR(MAX))",
+            "INSERT INTO g VALUES (1, N'before growth')",
+        ] {
+            let outcome = execute_batch(&storage, sql, &mut ctx);
+            assert!(outcome.error.is_none(), "{sql}: {:?}", outcome.error);
+        }
+        let old_pages = storage.lock().layout.data_size / PAGE_SIZE as u64;
+        drop(ctx);
+        drop(storage);
+
+        let new_pages = Storage::grow_data_region(&path, 1).expect("grow");
+        assert_eq!(
+            new_pages,
+            old_pages + (1u64 << 30) / PAGE_SIZE as u64,
+            "one GiB of new data pages"
+        );
+
+        let storage = Storage::open(path.clone()).expect("reopen after grow");
+        assert_eq!(
+            storage.lock().layout.data_size / PAGE_SIZE as u64,
+            new_pages
+        );
+        let mut ctx = TxnContext::default();
+        let outcome = execute_batch(&storage, "SELECT v FROM g WHERE id = 1", &mut ctx);
+        assert!(outcome.error.is_none(), "{:?}", outcome.error);
+        match &outcome.results[0] {
+            StatementResult::Rows(rowset) => {
+                assert_eq!(rowset.rows[0][0], Datum::NVarChar("before growth".into()));
+            }
+            other => panic!("expected rows, got {other:?}"),
+        }
+        let outcome = execute_batch(&storage, "INSERT INTO g VALUES (2, N'after')", &mut ctx);
+        assert!(outcome.error.is_none(), "{:?}", outcome.error);
+        drop(ctx);
+        drop(storage);
+
+        // Growing again works (the re-run an interrupted grow performs).
+        let newer = Storage::grow_data_region(&path, 1).expect("second grow");
+        assert_eq!(newer, new_pages + (1u64 << 30) / PAGE_SIZE as u64);
+        let storage = Storage::open(path.clone()).expect("reopen after second grow");
+        let mut ctx = TxnContext::default();
+        let outcome = execute_batch(&storage, "SELECT COUNT(*) FROM g", &mut ctx);
+        assert!(outcome.error.is_none(), "{:?}", outcome.error);
+        drop(storage);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// The safe minimum: a delta below the tail span is refused with the
+    /// minimum named; nothing is touched.
+    #[test]
+    fn grow_refuses_below_the_safe_minimum() {
+        let path = unique_temp_path("grow-min");
+        // 4 GiB file: the tail regions span ~1.16 GiB, so +1 GiB is unsafe.
+        let mut opts = test_storage_options();
+        opts.size_gib = 4;
+        let storage = Storage::create(path.clone(), opts).expect("create");
+        drop(storage);
+        let err = Storage::grow_data_region(&path, 1).expect_err("must refuse");
+        assert!(
+            err.to_string().contains("safe minimum"),
+            "names the floor: {err}"
+        );
+        let storage = Storage::open(path.clone()).expect("file untouched");
+        drop(storage);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// Growth with a pending WAL (a crash-interrupted transaction) is safe:
+    /// the WAL sits before the data region and replays against the moved
+    /// bitmap exactly as it would have.
+    #[test]
+    fn grow_with_pending_wal_recovers_cleanly() {
+        use crate::rel::{StatementResult, TxnContext, execute_batch};
+
+        let path = unique_temp_path("grow-wal");
+        let storage = Storage::create(path.clone(), test_storage_options()).expect("create");
+        let mut ctx = TxnContext::default();
+        for sql in [
+            "CREATE TABLE g (id INT NOT NULL PRIMARY KEY, v INT)",
+            "INSERT INTO g VALUES (1, 10)",
+        ] {
+            let outcome = execute_batch(&storage, sql, &mut ctx);
+            assert!(outcome.error.is_none(), "{sql}: {:?}", outcome.error);
+        }
+        // An open transaction dies with the "crash" (drop without commit).
+        let outcome = execute_batch(
+            &storage,
+            "BEGIN TRAN; UPDATE g SET v = 999 WHERE id = 1;",
+            &mut ctx,
+        );
+        assert!(outcome.error.is_none(), "{:?}", outcome.error);
+        drop(ctx);
+        drop(storage);
+
+        Storage::grow_data_region(&path, 1).expect("grow with pending WAL");
+        let storage = Storage::open(path.clone()).expect("recovery after grow");
+        let mut ctx = TxnContext::default();
+        let outcome = execute_batch(&storage, "SELECT v FROM g WHERE id = 1", &mut ctx);
+        assert!(outcome.error.is_none(), "{:?}", outcome.error);
+        match &outcome.results[0] {
+            StatementResult::Rows(rowset) => {
+                assert_eq!(rowset.rows[0][0], Datum::Int(10), "the loser is undone");
+            }
+            other => panic!("expected rows, got {other:?}"),
+        }
+        drop(storage);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// The advisory file lock fences grow against a running server: grow
+    /// refuses while the store is open, and works after it closes. (flock is
+    /// per open file description, so two opens in one process conflict too.)
+    #[test]
+    fn grow_refuses_while_the_store_is_open() {
+        let path = unique_temp_path("grow-flock");
+        let storage = Storage::create(path.clone(), test_storage_options()).expect("create");
+        let err = Storage::grow_data_region(&path, 2).expect_err("must refuse while open");
+        assert!(
+            err.to_string()
+                .contains("locked by another TruthDB process"),
+            "names the lock: {err}"
+        );
+        drop(storage);
+        Storage::grow_data_region(&path, 2).expect("grow after close");
+        let storage = Storage::open(path.clone()).expect("reopen");
+        drop(storage);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// REVIEW POC: a crash after the extension writes but BEFORE the header
+    /// stamp leaves a longer file under the old header. The file must open
+    /// under the old layout, and a re-run of the grow must complete it.
+    /// Simulated by saving the original header page before the grow and
+    /// writing it back afterwards.
+    #[test]
+    fn grow_crash_before_header_stamp_is_recoverable() {
+        use crate::rel::{StatementResult, TxnContext, execute_batch};
+
+        let path = unique_temp_path("grow-crash");
+        let storage = Storage::create(path.clone(), test_storage_options()).expect("create");
+        let mut ctx = TxnContext::default();
+        for sql in [
+            "CREATE TABLE g (id INT NOT NULL PRIMARY KEY, v INT)",
+            "INSERT INTO g VALUES (1, 42)",
+        ] {
+            let outcome = execute_batch(&storage, sql, &mut ctx);
+            assert!(outcome.error.is_none(), "{sql}: {:?}", outcome.error);
+        }
+        // A real checkpoint makes the descriptor and bitmap copies
+        // load-bearing (fresh files have neither on disk).
+        storage
+            .write_checkpoint(b"crash-window-probe", 1, 2, 1)
+            .expect("checkpoint");
+        drop(ctx);
+        drop(storage);
+
+        // Save the pre-grow header page (the commit point the "crash" loses).
+        let old_header = {
+            let mut f = std::fs::File::open(&path).expect("open for header save");
+            let mut buf = vec![0u8; FILE_HEADER_SIZE];
+            f.read_exact(&mut buf).expect("read header");
+            buf
+        };
+
+        let old_pages = {
+            let storage = Storage::open(path.clone()).expect("preflight open");
+            let pages = storage.lock().layout.data_size / PAGE_SIZE as u64;
+            drop(storage);
+            pages
+        };
+
+        Storage::grow_data_region(&path, 1).expect("grow");
+
+        // Crash simulation: the extension writes are durable, the header
+        // stamp is not.
+        {
+            let mut f = std::fs::OpenOptions::new()
+                .write(true)
+                .open(&path)
+                .expect("open for header restore");
+            f.seek(SeekFrom::Start(0)).expect("seek");
+            f.write_all(&old_header).expect("restore old header");
+            f.sync_all().expect("sync");
+        }
+
+        // The old layout must be fully valid: data readable, snapshot loads.
+        let storage = Storage::open(path.clone()).expect("open under the OLD header");
+        assert_eq!(
+            storage.lock().layout.data_size / PAGE_SIZE as u64,
+            old_pages,
+            "still the old layout"
+        );
+        let snap = storage
+            .load_snapshot()
+            .expect("load snapshot under old header")
+            .expect("snapshot present");
+        assert_eq!(snap.data, b"crash-window-probe");
+        let mut ctx = TxnContext::default();
+        let outcome = execute_batch(&storage, "SELECT v FROM g WHERE id = 1", &mut ctx);
+        assert!(outcome.error.is_none(), "{:?}", outcome.error);
+        match &outcome.results[0] {
+            StatementResult::Rows(rowset) => {
+                assert_eq!(rowset.rows[0][0], Datum::Int(42));
+            }
+            other => panic!("expected rows, got {other:?}"),
+        }
+        drop(ctx);
+        drop(storage);
+
+        // Re-running the grow completes it.
+        let new_pages = Storage::grow_data_region(&path, 1).expect("re-run grow");
+        assert_eq!(new_pages, old_pages + (1u64 << 30) / PAGE_SIZE as u64);
+        let storage = Storage::open(path.clone()).expect("open after completed grow");
+        assert_eq!(
+            storage.lock().layout.data_size / PAGE_SIZE as u64,
+            new_pages
+        );
+        let snap = storage
+            .load_snapshot()
+            .expect("load snapshot after grow")
+            .expect("snapshot survived");
+        assert_eq!(snap.data, b"crash-window-probe");
+        let mut ctx = TxnContext::default();
+        let outcome = execute_batch(&storage, "INSERT INTO g VALUES (2, 43)", &mut ctx);
+        assert!(outcome.error.is_none(), "{:?}", outcome.error);
+        drop(storage);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// REVIEW POC (teeth): the checkpointed search snapshot must survive a
+    /// grow — the descriptor pages are the only pointer to it, and they move.
+    /// Fails if the grow skips the descriptor copy.
+    #[test]
+    fn grow_preserves_the_checkpointed_snapshot() {
+        let path = unique_temp_path("grow-snap");
+        let storage = Storage::create(path.clone(), test_storage_options()).expect("create");
+        storage
+            .write_checkpoint(b"survives-the-move", 1, 2, 1)
+            .expect("checkpoint");
+        drop(storage);
+
+        Storage::grow_data_region(&path, 1).expect("grow");
+
+        let storage = Storage::open(path.clone()).expect("reopen");
+        let snap = storage
+            .load_snapshot()
+            .expect("load")
+            .expect("snapshot survived the grow");
+        assert_eq!(snap.data, b"survives-the-move");
+        drop(storage);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// REVIEW POC (teeth): after a checkpoint the persisted bitmap is the
+    /// ONLY record of table extents (the WAL head has advanced past their
+    /// alloc records). If the grow loses the bitmap, a reopen sees every page
+    /// free and new allocations clobber existing tables. Fails if the grow
+    /// skips the bitmap copy.
+    #[test]
+    fn grow_preserves_the_persisted_allocator_bitmap() {
+        use crate::rel::{StatementResult, TxnContext, execute_batch};
+
+        let path = unique_temp_path("grow-bitmap");
+        let storage = Storage::create(path.clone(), test_storage_options()).expect("create");
+        let mut ctx = TxnContext::default();
+        for sql in [
+            "CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY, v NVARCHAR(60))",
+            "INSERT INTO t1 VALUES (1, N'pre-grow row')",
+        ] {
+            let outcome = execute_batch(&storage, sql, &mut ctx);
+            assert!(outcome.error.is_none(), "{sql}: {:?}", outcome.error);
+        }
+        drop(ctx);
+        // The checkpoint persists the bitmap and advances the WAL head past
+        // t1's extent-alloc records.
+        storage
+            .write_checkpoint(b"bitmap-probe", 1, 2, 1)
+            .expect("checkpoint");
+        drop(storage);
+
+        Storage::grow_data_region(&path, 1).expect("grow");
+
+        // Reopen and allocate heavily; with a lost bitmap these allocations
+        // land on t1's pages.
+        let storage = Storage::open(path.clone()).expect("reopen");
+        let mut ctx = TxnContext::default();
+        let outcome = execute_batch(
+            &storage,
+            "CREATE TABLE t2 (id INT NOT NULL PRIMARY KEY, v NVARCHAR(200))",
+            &mut ctx,
+        );
+        assert!(outcome.error.is_none(), "{:?}", outcome.error);
+        for batch in 0..20 {
+            let mut sql = String::from("INSERT INTO t2 VALUES ");
+            for i in 0..50 {
+                if i > 0 {
+                    sql.push(',');
+                }
+                let id = batch * 50 + i;
+                sql.push_str(&format!("({id}, N'filler row {id} {}')", "x".repeat(120)));
+            }
+            let outcome = execute_batch(&storage, &sql, &mut ctx);
+            assert!(
+                outcome.error.is_none(),
+                "batch {batch}: {:?}",
+                outcome.error
+            );
+        }
+        let outcome = execute_batch(&storage, "SELECT v FROM t1 WHERE id = 1", &mut ctx);
+        assert!(outcome.error.is_none(), "{:?}", outcome.error);
+        match &outcome.results[0] {
+            StatementResult::Rows(rowset) => {
+                assert_eq!(
+                    rowset.rows[0][0],
+                    Datum::NVarChar("pre-grow row".into()),
+                    "t1 must not be clobbered by post-grow allocations"
+                );
+            }
+            other => panic!("expected rows, got {other:?}"),
+        }
         drop(storage);
         let _ = std::fs::remove_file(&path);
     }


### PR DESCRIPTION
## Stage 14, part 3: offline file growth via the CLI

`truthdb-cli grow --path <file> --add-gib N` extends a stopped server's data region — the last Stage 14 bullet item.

### How it stays crash-safe

The data region ends where the tail regions (metadata, allocator, snapshot, reserved) begin, so growth shifts the tail right by the delta. Safety comes from a **size floor rather than ordering tricks**: the delta must clear the tail's whole span, which puts every relocated write entirely in the fresh extension — nothing the OLD header points at is touched until the new header is stamped last, fsync-fenced, the same commit-point pattern as the v1→v2 upgrade. A crash before the stamp leaves a longer file under the old, fully valid layout; re-running the grow completes it (pinned by the double-grow test and by the review's crash-window regression). Requests below the floor are refused with the minimum named.

### Why the contents survive untouched

Page numbers, RIDs and catalog roots are data-region-relative or absolute below the tail; the WAL sits before the data region and never moves; the allocator bitmap is copied with zero (= free) extension bits, so pending WAL allocations replay on top exactly as they would have — pinned by growing a file with a crash-interrupted transaction still in its WAL and watching recovery undo the loser afterwards. The bitmap must also still fit the (unmoved-size) allocator region, checked before anything is written.

### Adversarial review outcome

The focused review confirmed the surgery itself (floor arithmetic, commit-point ordering, checksum interplay, O_DIRECT partial-page tail reads over fresh holes) and found the defects around it, all fixed here:

- **Two test-teeth gaps (HIGH)**: skipping either the descriptor copy or the bitmap copy passed all three original tests, because fresh files recover everything from WAL replay — only a checkpointed store depends on the copies. The review's three probes land as regressions: `grow_preserves_the_checkpointed_snapshot`, `grow_preserves_the_persisted_allocator_bitmap` (fails with 2627 corruption under the mutation), and `grow_crash_before_header_stamp_is_recoverable`.
- **Concurrent-open hazard (MEDIUM)**: nothing stopped a grow while the server was running (or a second server on one file). The storage file now carries an advisory `flock(LOCK_EX | LOCK_NB)` for the life of the primary handle; grow's own open fails fast with the process named. The lock lives on a separate plain fd, not the O_DIRECT fd: that one is registered with io_uring, whose kernel-side file release at ring teardown is deferred, so a lock on it lingered briefly past drop and made reopen-after-close flaky. The log writer's second handle opens without locking (it would conflict with our own primary). Pinned by `grow_refuses_while_the_store_is_open`, mutation-checked (skip the flock and the test fails).
- **Unchecked `add_gib` multiply (LOW)**: `checked_mul`, matching `compute_layout`'s own guard.
- **Stale Cargo.lock (LOW)**: the truthdb-cli → truthdb-core dependency edge is now in the lock file.

### Tests

Grow → reopen → data intact → new inserts land → grow again (the re-run shape); the refusal path with the floor named and the file untouched; growth with pending WAL recovering cleanly; the three review regressions above over a checkpointed store; the flock refusal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
