### PR TITLE
Stage 15: the severity/abort truth table — THROW, RAISERROR, @@ERROR, fatal errors

### DIFF
--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -4154,6 +4154,655 @@ mod tests {
     }
 
     #[test]
+    fn raiserror_is_exempt_from_xact_abort() {
+        // SQL Server: "errors raised by RAISERROR are not affected by SET
+        // XACT_ABORT" — the batch continues and the transaction stays
+        // committable even under XACT_ABORT ON.
+        let path = unique_temp_path("raiserror-xact-exempt");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        batch(
+            &engine,
+            &mut ctx,
+            "CREATE TABLE t (id INT NOT NULL PRIMARY KEY)",
+        );
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "SET XACT_ABORT ON; \
+             BEGIN TRAN; \
+             INSERT INTO t VALUES (1); \
+             RAISERROR('mid-batch', 16, 1); \
+             INSERT INTO t VALUES (2); \
+             COMMIT",
+        );
+        // The RAISERROR is reported (the batch's continued error), but both
+        // INSERTs ran and the COMMIT succeeded.
+        assert_eq!(out.error.as_ref().map(|e| e.number), Some(50000));
+        assert!(!ctx.has_open_transaction(), "COMMIT went through");
+        let out = batch(&engine, &mut ctx, "SELECT id FROM t ORDER BY id");
+        assert_eq!(ids(&out), vec![1, 2], "the batch continued past RAISERROR");
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn raiserror_in_try_enters_catch_without_dooming() {
+        // Inside TRY, RAISERROR >= 11 transfers to CATCH — but even under
+        // XACT_ABORT ON the transaction is NOT doomed (the exemption again):
+        // XACT_STATE() reads 1 in the CATCH and COMMIT still works.
+        let path = unique_temp_path("raiserror-try-undoomed");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        batch(
+            &engine,
+            &mut ctx,
+            "CREATE TABLE t (id INT NOT NULL PRIMARY KEY)",
+        );
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "SET XACT_ABORT ON; \
+             BEGIN TRAN; \
+             INSERT INTO t VALUES (1); \
+             BEGIN TRY RAISERROR('caught', 16, 1); END TRY \
+             BEGIN CATCH SELECT XACT_STATE() AS n, ERROR_NUMBER() AS e; END CATCH; \
+             COMMIT",
+        );
+        assert!(out.error.is_none(), "caught: {:?}", out.error);
+        let rowset = out
+            .results
+            .iter()
+            .find_map(|r| match r {
+                StatementResult::Rows(rowset) => Some(rowset),
+                _ => None,
+            })
+            .expect("catch rowset");
+        assert_eq!(
+            rowset.rows[0],
+            vec![Datum::BigInt(1), Datum::BigInt(50000)],
+            "XACT_STATE 1 (not doomed), ERROR_NUMBER 50000"
+        );
+        assert!(!ctx.has_open_transaction(), "COMMIT went through");
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn throw_terminates_the_batch_without_dooming() {
+        // THROW ends the batch even when nothing dooms: under XACT_ABORT OFF
+        // the transaction stays open and committable from the next batch.
+        let path = unique_temp_path("throw-terminates");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        batch(
+            &engine,
+            &mut ctx,
+            "CREATE TABLE t (id INT NOT NULL PRIMARY KEY)",
+        );
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "BEGIN TRAN; \
+             INSERT INTO t VALUES (1); \
+             THROW 50001, 'stop here', 7; \
+             INSERT INTO t VALUES (2)",
+        );
+        let error = out.error.expect("THROW surfaces");
+        assert_eq!(
+            (error.number, error.level, error.state),
+            (50001, 16, 7),
+            "THROW's number/severity/state"
+        );
+        assert!(ctx.has_open_transaction(), "not doomed, still open");
+        let out = batch(&engine, &mut ctx, "COMMIT");
+        assert!(out.error.is_none(), "committable: {:?}", out.error);
+        let out = batch(&engine, &mut ctx, "SELECT id FROM t ORDER BY id");
+        assert_eq!(ids(&out), vec![1], "the second INSERT never ran");
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn throw_under_xact_abort_dooms() {
+        let path = unique_temp_path("throw-xact-dooms");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        batch(
+            &engine,
+            &mut ctx,
+            "CREATE TABLE t (id INT NOT NULL PRIMARY KEY)",
+        );
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "SET XACT_ABORT ON; BEGIN TRAN; INSERT INTO t VALUES (1); THROW 50001, 'x', 1;",
+        );
+        assert_eq!(out.error.as_ref().map(|e| e.number), Some(50001));
+        let out = batch(&engine, &mut ctx, "INSERT INTO t VALUES (2)");
+        assert_eq!(
+            out.error.as_ref().map(|e| e.number),
+            Some(3930),
+            "doomed: writes rejected"
+        );
+        batch(&engine, &mut ctx, "ROLLBACK");
+        let out = batch(&engine, &mut ctx, "SELECT id FROM t");
+        assert_eq!(ids(&out), Vec::<i32>::new(), "nothing survived");
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn bare_throw_rethrows_the_original_error() {
+        // A bare THROW in a CATCH re-raises the caught error verbatim —
+        // number, severity and state — and terminates the batch.
+        let path = unique_temp_path("bare-throw");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        batch(
+            &engine,
+            &mut ctx,
+            "CREATE TABLE t (id INT NOT NULL PRIMARY KEY)",
+        );
+        batch(&engine, &mut ctx, "INSERT INTO t VALUES (1)");
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "BEGIN TRY INSERT INTO t VALUES (1); END TRY \
+             BEGIN CATCH THROW; END CATCH; \
+             SELECT 99 AS n",
+        );
+        let error = out.error.as_ref().expect("re-thrown");
+        assert_eq!(error.number, 2627, "the ORIGINAL number");
+        assert_eq!(error.level, 14, "the ORIGINAL severity");
+        assert!(
+            !out.results
+                .iter()
+                .any(|r| matches!(r, StatementResult::Rows(_))),
+            "the statement after the construct never ran: {:?}",
+            out.results
+        );
+        // Outside any CATCH, a bare THROW is 10704.
+        let out = batch(&engine, &mut ctx, "THROW");
+        assert_eq!(out.error.as_ref().map(|e| e.number), Some(10704));
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn throw_number_below_50000_is_35100() {
+        let path = unique_temp_path("throw-range");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        let out = batch(&engine, &mut ctx, "THROW 999, 'too low', 1");
+        assert_eq!(out.error.as_ref().map(|e| e.number), Some(35100));
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn at_at_error_tracks_the_previous_statement() {
+        let path = unique_temp_path("at-at-error");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        batch(
+            &engine,
+            &mut ctx,
+            "CREATE TABLE t (id INT NOT NULL PRIMARY KEY)",
+        );
+        batch(&engine, &mut ctx, "INSERT INTO t VALUES (1)");
+        // The duplicate INSERT fails (batch continues under XACT_ABORT OFF,
+        // no transaction open): the next statement reads 2627, and the one
+        // after reads 0 — reading @@ERROR is itself a statement that resets.
+        // Inside a transaction (the batch-continue path; outside one an
+        // error terminates the batch — the recorded divergence).
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "BEGIN TRAN; \
+             INSERT INTO t VALUES (1); \
+             SELECT @@ERROR AS n; \
+             SELECT @@ERROR AS n; \
+             COMMIT",
+        );
+        let firsts: Vec<i64> = out
+            .results
+            .iter()
+            .filter_map(|r| match r {
+                StatementResult::Rows(rowset) => match rowset.rows[0][0] {
+                    Datum::Int(v) => Some(i64::from(v)),
+                    Datum::BigInt(v) => Some(v),
+                    ref other => panic!("expected int, got {other:?}"),
+                },
+                _ => None,
+            })
+            .collect();
+        assert_eq!(firsts, vec![2627, 0], "2627 then reset to 0");
+        // Capturing into a variable inside the CATCH: the CATCH's first
+        // statement still sees the number.
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "BEGIN TRY INSERT INTO t VALUES (1); END TRY \
+             BEGIN CATCH SELECT @@ERROR AS n; END CATCH",
+        );
+        assert_eq!(ids(&out), vec![2627], "@@ERROR visible in the CATCH");
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn raiserror_severity_10_is_informational() {
+        // Severity <= 10 is a message, not an error: the statement SUCCEEDS,
+        // the batch reports no error, and @@ERROR reads 0 — or 50000 under
+        // WITH SETERROR.
+        let path = unique_temp_path("raiserror-info");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "RAISERROR('just so you know', 10, 1); SELECT @@ERROR AS n",
+        );
+        assert!(out.error.is_none(), "informational: {:?}", out.error);
+        assert_eq!(ids(&out), vec![0], "@@ERROR is 0");
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "RAISERROR('noted', 5, 1) WITH SETERROR; SELECT @@ERROR AS n",
+        );
+        assert!(out.error.is_none());
+        assert_eq!(ids(&out), vec![50000], "SETERROR stamps 50000");
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn raiserror_formats_printf_arguments() {
+        let path = unique_temp_path("raiserror-printf");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "BEGIN TRY RAISERROR('%s took %d ms (0x%x)', 16, 1, 'scan', 42, 255); END TRY \
+             BEGIN CATCH SELECT ERROR_MESSAGE() AS m; END CATCH",
+        );
+        assert!(out.error.is_none());
+        let StatementResult::Rows(rows) = &out.results[0] else {
+            panic!("expected rows");
+        };
+        assert_eq!(
+            rows.rows[0][0],
+            Datum::NVarChar("scan took 42 ms (0xff)".into())
+        );
+        // A directive with a wrong-typed argument is 2786; an unsupported
+        // directive is 2787.
+        let out = batch(&engine, &mut ctx, "RAISERROR('%d', 16, 1, 'not an int')");
+        assert_eq!(out.error.as_ref().map(|e| e.number), Some(2786));
+        let out = batch(&engine, &mut ctx, "RAISERROR('%f', 16, 1, 1)");
+        assert_eq!(out.error.as_ref().map(|e| e.number), Some(2787));
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn raiserror_above_18_requires_with_log() {
+        let path = unique_temp_path("raiserror-log-gate");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        let out = batch(&engine, &mut ctx, "RAISERROR('big', 19, 1)");
+        assert_eq!(out.error.as_ref().map(|e| e.number), Some(2754));
+        // With the option, 19 raises normally (catchable, not fatal).
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "BEGIN TRY RAISERROR('big', 19, 1) WITH LOG; END TRY \
+             BEGIN CATCH SELECT ERROR_SEVERITY() AS n; END CATCH",
+        );
+        assert!(out.error.is_none());
+        assert_eq!(ids(&out), vec![19]);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn severity_20_bypasses_catch_and_dooms() {
+        // Severity >= 20 is fatal: no CATCH sees it, the transaction dooms,
+        // and (on TDS) the connection closes after delivery — the wire half
+        // is pinned in the TDS end-to-end suite.
+        let path = unique_temp_path("severity-20");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        batch(
+            &engine,
+            &mut ctx,
+            "CREATE TABLE t (id INT NOT NULL PRIMARY KEY)",
+        );
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "BEGIN TRAN; \
+             INSERT INTO t VALUES (1); \
+             BEGIN TRY RAISERROR('fatal', 20, 1) WITH LOG; END TRY \
+             BEGIN CATCH SELECT 1 AS caught; END CATCH",
+        );
+        let error = out
+            .error
+            .as_ref()
+            .expect("fatal error surfaces past the CATCH");
+        assert_eq!((error.number, error.level), (50000, 20));
+        assert!(
+            !out.results
+                .iter()
+                .any(|r| matches!(r, StatementResult::Rows(_))),
+            "the CATCH block never ran: {:?}",
+            out.results
+        );
+        let out = batch(&engine, &mut ctx, "INSERT INTO t VALUES (2)");
+        assert_eq!(out.error.as_ref().map(|e| e.number), Some(3930), "doomed");
+        batch(&engine, &mut ctx, "ROLLBACK");
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn exec_inner_raiserror_in_try_reaches_catch_undoomed() {
+        // The seam pin: a RAISERROR inside EXEC'd text, inside a TRY, under
+        // XACT_ABORT ON. The doom decision is made where the statement kind
+        // is known (the inner run_block) — the TRY and EXEC boundaries must
+        // not re-derive it, or the exemption is lost in transit.
+        let path = unique_temp_path("exec-raiserror-seam");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "SET XACT_ABORT ON; \
+             BEGIN TRAN; \
+             BEGIN TRY EXEC sp_executesql N'RAISERROR(''inner'', 16, 1)'; END TRY \
+             BEGIN CATCH SELECT XACT_STATE() AS n; END CATCH; \
+             COMMIT",
+        );
+        assert!(out.error.is_none(), "caught: {:?}", out.error);
+        assert_eq!(ids(&out), vec![1], "NOT doomed across both boundaries");
+        assert!(!ctx.has_open_transaction(), "COMMIT went through");
+        // Contrast: run_exec's OWN error (unknown proc) under the same setup
+        // dooms per the ordinary rule — decided at its source.
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "SET XACT_ABORT ON; \
+             BEGIN TRAN; \
+             BEGIN TRY EXEC no_such_proc; END TRY \
+             BEGIN CATCH SELECT XACT_STATE() AS n; END CATCH",
+        );
+        assert!(out.error.is_none(), "caught: {:?}", out.error);
+        assert_eq!(ids(&out), vec![-1], "doomed: the EXEC's own failure");
+        batch(&engine, &mut ctx, "ROLLBACK");
+        let _ = std::fs::remove_file(path);
+    }
+
+    // ---- Stage 15 adversarial-review PoCs (severity/abort truth table) ----
+
+    /// REVIEW PoC (defect: THROW loses its batch termination at the EXEC
+    /// seam). SQL Server: an uncaught THROW terminates the batch — including
+    /// the calling batch when it fires inside `sp_executesql` — without
+    /// rolling back the transaction under XACT_ABORT OFF. At e49a515 the
+    /// EXEC arm's fallback re-derives the continuation decision from
+    /// severity alone (16, non-dooming), so inside an open transaction the
+    /// OUTER batch continues past the EXEC. Pins the fixed behavior.
+    #[test]
+    fn review_poc_throw_inside_exec_terminates_the_outer_batch() {
+        let path = unique_temp_path("review-throw-exec-seam");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        batch(
+            &engine,
+            &mut ctx,
+            "CREATE TABLE t (id INT NOT NULL PRIMARY KEY)",
+        );
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "BEGIN TRAN; \
+             INSERT INTO t VALUES (1); \
+             EXEC sp_executesql N'THROW 50001, ''from inner'', 1'; \
+             INSERT INTO t VALUES (2); \
+             COMMIT",
+        );
+        assert_eq!(out.error.as_ref().map(|e| e.number), Some(50001));
+        // The batch terminated at the THROW: the trailing INSERT and COMMIT
+        // never ran, and the (undoomed) transaction is still open.
+        assert!(
+            ctx.has_open_transaction(),
+            "THROW must terminate the batch before the COMMIT"
+        );
+        let out = batch(&engine, &mut ctx, "COMMIT");
+        assert!(out.error.is_none(), "committable: {:?}", out.error);
+        let out = batch(&engine, &mut ctx, "SELECT id FROM t ORDER BY id");
+        assert_eq!(ids(&out), vec![1], "the INSERT after the EXEC never ran");
+        let _ = std::fs::remove_file(path);
+    }
+
+    /// REVIEW probe (passes): severity >= 20 raised inside EXEC'd text
+    /// bypasses a CATCH around the EXEC. No committed test covered the EXEC
+    /// route for a fatal error; this pins it. (The EXEC arm's own fatal
+    /// branch is behaviorally redundant — the in_try transfer plus the
+    /// TryCatch arm's fatal filter produce the same outcome — so no mutation
+    /// of that branch alone can fail a test; this pins the SEMANTICS.)
+    #[test]
+    fn review_poc_fatal_inside_exec_bypasses_catch() {
+        let path = unique_temp_path("review-exec-fatal");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "BEGIN TRY EXEC sp_executesql N'RAISERROR(''die'', 20, 1) WITH LOG'; END TRY \
+             BEGIN CATCH SELECT 1 AS caught; END CATCH",
+        );
+        let error = out.error.as_ref().expect("fatal surfaces past the CATCH");
+        assert_eq!((error.number, error.level), (50000, 20));
+        assert!(
+            !out.results
+                .iter()
+                .any(|r| matches!(r, StatementResult::Rows(_))),
+            "the CATCH never ran: {:?}",
+            out.results
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    /// REVIEW teeth probe (passes): @@ERROR is maintained by the EXEC arm's
+    /// own error exits — the in_try transfer (the CATCH's first statement
+    /// sees the EXEC's failure) and the batch-continue path (outside TRY,
+    /// inside an open transaction). Dropping the EXEC arm's
+    /// `txn_ctx.last_error` maintenance survives the committed suite; this
+    /// pins it.
+    #[test]
+    fn review_poc_at_at_error_after_a_failed_exec() {
+        let path = unique_temp_path("review-exec-at-at-error");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "BEGIN TRAN; EXEC no_such_proc; SELECT @@ERROR AS n; COMMIT",
+        );
+        assert_eq!(ids(&out), vec![2812], "@@ERROR after the failed EXEC");
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "BEGIN TRY EXEC also_missing; END TRY \
+             BEGIN CATCH SELECT @@ERROR AS n; END CATCH",
+        );
+        assert_eq!(ids(&out), vec![2812], "@@ERROR visible in the CATCH");
+        let _ = std::fs::remove_file(path);
+    }
+
+    /// REVIEW teeth probe (passes): a bare THROW re-raises the INNERMOST
+    /// CATCH's error. Reading `error_stack.first()` instead of `last()`
+    /// survives the committed suite (every committed bare-THROW test has a
+    /// one-deep stack); this pins the nested case.
+    #[test]
+    fn review_poc_bare_throw_in_nested_catch_rethrows_the_innermost() {
+        let path = unique_temp_path("review-nested-bare-throw");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "BEGIN TRY THROW 50001, 'outer', 1; END TRY \
+             BEGIN CATCH \
+               BEGIN TRY THROW 50002, 'inner', 5; END TRY \
+               BEGIN CATCH THROW; END CATCH \
+             END CATCH",
+        );
+        let error = out.error.as_ref().expect("re-thrown");
+        assert_eq!(
+            (error.number, error.level, error.state),
+            (50002, 16, 5),
+            "the INNERMOST caught error, not the outer one"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    /// REVIEW teeth probe (passes): RAISERROR state 0 reports as state 1.
+    /// Dropping the `.max(1)` survives the committed suite (the slt line is
+    /// a bare `statement ok`); this pins the reported state.
+    #[test]
+    fn review_poc_raiserror_state_zero_reports_as_one() {
+        let path = unique_temp_path("review-state-zero");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "BEGIN TRY RAISERROR('x', 16, 0); END TRY \
+             BEGIN CATCH SELECT ERROR_STATE() AS n; END CATCH",
+        );
+        assert!(out.error.is_none(), "caught: {:?}", out.error);
+        assert_eq!(ids(&out), vec![1], "state 0 reports as 1");
+        let _ = std::fs::remove_file(path);
+    }
+
+    /// REVIEW teeth probe (passes): the flush before a RAISERROR statement.
+    /// Removing `Statement::RaiseError` from run_block's flush condition
+    /// survives the committed suite (every committed RAISERROR opens its
+    /// batch, so no DONE is ever deferred when the INFO fires); with a
+    /// deferred DONE in flight the mutation trips `BatchRun::info`'s
+    /// debug_assert. This pins the shape.
+    #[test]
+    fn review_poc_info_after_a_write_flushes_the_deferred_dones() {
+        let path = unique_temp_path("review-info-flush");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        batch(
+            &engine,
+            &mut ctx,
+            "CREATE TABLE t (id INT NOT NULL PRIMARY KEY)",
+        );
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "INSERT INTO t VALUES (1); RAISERROR('fyi', 5, 1); SELECT id FROM t",
+        );
+        assert!(out.error.is_none(), "informational: {:?}", out.error);
+        assert_eq!(ids(&out), vec![1]);
+        let _ = std::fs::remove_file(path);
+    }
+
+    /// REVIEW record-only pin: an error raised while executing the RAISERROR
+    /// statement itself (here 2786, a missing substitution argument) takes
+    /// RAISERROR's lenient path — exempt from XACT_ABORT dooming, batch
+    /// continues — because run_block classifies by statement KIND, not by
+    /// which code produced the error. SQL Server's behavior for RAISERROR's
+    /// own gate errors under XACT_ABORT ON is not clearly documented;
+    /// pinned as-is so a change is deliberate.
+    #[test]
+    fn review_poc_raiserror_gate_errors_take_the_lenient_path() {
+        let path = unique_temp_path("review-gate-lenient");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        batch(
+            &engine,
+            &mut ctx,
+            "CREATE TABLE t (id INT NOT NULL PRIMARY KEY)",
+        );
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "SET XACT_ABORT ON; \
+             BEGIN TRAN; \
+             INSERT INTO t VALUES (1); \
+             RAISERROR('%d', 16, 1); \
+             INSERT INTO t VALUES (2); \
+             COMMIT",
+        );
+        assert_eq!(out.error.as_ref().map(|e| e.number), Some(2786));
+        assert!(!ctx.has_open_transaction(), "COMMIT went through");
+        let out = batch(&engine, &mut ctx, "SELECT id FROM t ORDER BY id");
+        assert_eq!(ids(&out), vec![1, 2], "the batch continued past 2786");
+        let _ = std::fs::remove_file(path);
+    }
+
+    /// REVIEW PoC (divergence, fix recommended): SQL Server substitutes
+    /// "(null)" for a NULL substitution argument; e49a515 raises 2786. Pins
+    /// the SQL Server behavior.
+    #[test]
+    fn review_poc_raiserror_null_argument_prints_null_marker() {
+        let path = unique_temp_path("review-null-arg");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "BEGIN TRY RAISERROR('v=%s', 16, 1, NULL); END TRY \
+             BEGIN CATCH SELECT ERROR_MESSAGE() AS m; END CATCH",
+        );
+        assert!(out.error.is_none(), "caught: {:?}", out.error);
+        let StatementResult::Rows(rows) = &out.results[0] else {
+            panic!("expected rows, got {:?}", out.results);
+        };
+        assert_eq!(rows.rows[0][0], Datum::NVarChar("v=(null)".into()));
+        let _ = std::fs::remove_file(path);
+    }
+
+    /// REVIEW PoC (divergence, fix recommended): RAISERROR's integer
+    /// substitution arguments are 32-bit in SQL Server (int is the widest
+    /// accepted argument type), so %x on -1 prints ffffffff and %u prints
+    /// 4294967295. e49a515 formats through u64 and prints the 64-bit
+    /// two's complement. Pins the 32-bit width.
+    #[test]
+    fn review_poc_raiserror_hex_width_is_32_bit() {
+        let path = unique_temp_path("review-hex-width");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "BEGIN TRY RAISERROR('%x %X %u', 16, 1, -1, -1, -1); END TRY \
+             BEGIN CATCH SELECT ERROR_MESSAGE() AS m; END CATCH",
+        );
+        assert!(out.error.is_none(), "caught: {:?}", out.error);
+        let StatementResult::Rows(rows) = &out.results[0] else {
+            panic!("expected rows, got {:?}", out.results);
+        };
+        assert_eq!(
+            rows.rows[0][0],
+            Datum::NVarChar("ffffffff FFFFFFFF 4294967295".into())
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    /// REVIEW probe (passes): THROW's bare-vs-args lookahead on tokens that
+    /// start neither form. `THROW -1, ...` reads as a bare THROW (Minus is
+    /// not an argument-start token) followed by junk, so the batch is a 102
+    /// syntax error — the shape SQL Server reports too (its THROW arguments
+    /// must be constants or variables).
+    #[test]
+    fn review_poc_throw_negative_number_is_a_syntax_error() {
+        let path = unique_temp_path("review-throw-negative");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        let out = batch(&engine, &mut ctx, "THROW -1, 'x', 1");
+        assert_eq!(out.error.as_ref().map(|e| e.number), Some(102));
+        let out = batch(&engine, &mut ctx, "THROW (SELECT 1), 'x', 1");
+        assert_eq!(out.error.as_ref().map(|e| e.number), Some(102));
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
     fn try_catch_nested_inner_handles_outer_continues() {
         // The inner CATCH handles the inner error; because it does not re-raise,
         // the outer TRY continues and the outer CATCH never runs.

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -17,7 +17,8 @@ use truthdb_sql::ast::{
     AlterAction, AlterDatabase, AlterTable, CheckConstraint, ColumnDef, CreateIndex, CreateTable,
     CreateView, DataType, DatabaseOption, Declaration, Delete, DropIndex, DropTable, DropView,
     ExecStatement, Expr, ExprKind, ForeignKey, Insert, InsertSource, IsolationLevel, JoinKind,
-    Name, OrderItem, Select, SelectItem, SetStatement, Statement, TableRef, Update,
+    Name, OrderItem, RaiseError, Select, SelectItem, SetStatement, Statement, TableRef, ThrowArgs,
+    ThrowStatement, Update,
 };
 use truthdb_sql::collation::CollationSensitivity;
 use truthdb_sql::error::SqlError;
@@ -57,6 +58,8 @@ pub struct TxnContext {
     nocount: bool,
     /// Rows affected/returned by the previous statement — `@@ROWCOUNT`.
     rowcount: i64,
+    /// The previous statement's error number, 0 on success — `@@ERROR`.
+    last_error: i32,
     /// `SET SHOWPLAN_TEXT ON` — a SELECT returns its plan text, not results.
     showplan_text: bool,
     /// Declared batch variables (name without `@`, lowercased) to their type
@@ -125,6 +128,7 @@ impl TxnContext {
             scope_identity: self.scope_identity,
             error: self.error_stack.last().cloned(),
             xact_state: self.xact_state(),
+            last_error: self.last_error,
         }
     }
 
@@ -258,6 +262,12 @@ pub struct RowSet {
 /// (2627/2601/515/547, severity 14–16) stay below it, so they roll back only the
 /// failing statement and the transaction survives.
 const XACT_ABORT_SEVERITY: u8 = 17;
+
+/// Error severity at or above which the error is fatal to the CONNECTION
+/// (SQL Server severity >= 20): it bypasses every `TRY`, dooms the
+/// transaction, and the protocol layers close the stream after delivering
+/// it. Only RAISERROR ... WITH LOG can currently produce one.
+pub const FATAL_SEVERITY: u8 = 20;
 
 /// A batch's outcome: the results of the statements that ran, plus the error
 /// that stopped the batch (if any). Statements before an error have already
@@ -393,6 +403,10 @@ pub trait BatchEmitter {
     /// renders the ENVCHANGE + 5701 INFO SSMS expects. Emitters that have no
     /// wire (the collecting native path, tests) ignore it.
     fn database_context(&mut self, _database: &str) {}
+
+    /// An informational message (RAISERROR severity <= 10): TDS renders an
+    /// INFO token in-stream, not an error. Emitters with no wire ignore it.
+    fn info(&mut self, _error: &SqlError) {}
 }
 
 /// Reassembles emitted results into the whole-batch [`BatchOutcome`] for the
@@ -527,6 +541,16 @@ impl BatchRun<'_> {
         self.emitter.database_context(database);
     }
 
+    /// Emits an informational message (RAISERROR severity <= 10). `run_block`
+    /// flushed the deferred DONEs before the statement, so stream order holds.
+    fn info(&mut self, error: SqlError) {
+        debug_assert!(
+            self.deferred.is_empty(),
+            "an INFO message over deferred DONEs"
+        );
+        self.emitter.info(&error);
+    }
+
     /// Ends a statement. Its DONE is deferred to the next durability point.
     fn done(&mut self, count: Option<u64>, in_transaction: bool, command: DoneCommand) {
         self.rowset_open = false;
@@ -652,27 +676,49 @@ thread_local! {
 /// sharing the transaction context. Each inner statement emits its own
 /// events, exactly like a top-level statement. Any other procedure answers
 /// 2812, the same as the RPC path.
+/// An EXEC failure, tagged by ORIGIN — the fact the EXEC arm needs and must
+/// not guess: `run_exec`'s own validation/depth errors are statement-scope at
+/// the EXEC site, while an error that crossed out of the inner batch already
+/// terminated it (batch-abort scope is the whole nest).
+enum ExecError {
+    Own(SqlError),
+    Inner(SqlError),
+}
+
+/// Applies the standard doom rule to an error raised outside any statement's
+/// own execution — `run_exec`'s validation and depth errors, which no inner
+/// `run_block` arm will see. The decision is made here, at the source, so the
+/// TRY boundary never has to re-derive it (it cannot know the error's origin).
+fn doom_per_rule(txn_ctx: &mut TxnContext, error: SqlError) -> SqlError {
+    if txn_ctx.in_txn() && (txn_ctx.xact_abort || error.level >= XACT_ABORT_SEVERITY) {
+        txn_ctx.doomed = true;
+    }
+    error
+}
+
 fn run_exec(
     storage: &Storage,
     exec: &ExecStatement,
     txn_ctx: &mut TxnContext,
     run: &mut BatchRun<'_>,
     in_try: bool,
-) -> Result<(), SqlError> {
+) -> Result<(), ExecError> {
     if !strip_schema(&exec.proc.value).eq_ignore_ascii_case("sp_executesql") {
-        return Err(SqlError::new(
+        let error = SqlError::new(
             2812,
             16,
             62,
             format!("Could not find stored procedure '{}'.", exec.proc.value),
         )
-        .at(exec.proc.span));
+        .at(exec.proc.span);
+        return Err(ExecError::Own(doom_per_rule(txn_ctx, error)));
     }
     let eval_ctx = txn_ctx.eval_context();
     let mut positional = Vec::new();
     let mut named: Vec<(String, SqlValue)> = Vec::new();
     for arg in &exec.args {
-        let value = eval_constant(&arg.value, &eval_ctx)?;
+        let value = eval_constant(&arg.value, &eval_ctx)
+            .map_err(|e| ExecError::Own(doom_per_rule(txn_ctx, e)))?;
         match &arg.name {
             Some(n) => named.push((n.value.clone(), value)),
             None => positional.push(value),
@@ -685,35 +731,39 @@ fn run_exec(
         Some(named.remove(index).1)
     };
     let mut positional = positional.into_iter();
-    let stmt = take_named(&mut named, &["stmt", "statement"])
-        .or_else(|| positional.next())
-        .ok_or_else(|| {
-            SqlError::new(
+    let stmt = match take_named(&mut named, &["stmt", "statement"]).or_else(|| positional.next()) {
+        Some(value) => value,
+        None => {
+            let error = SqlError::new(
                 214,
                 16,
                 2,
                 "Procedure expects parameter '@statement' of type 'ntext/nchar/nvarchar'.",
-            )
-        })?;
+            );
+            return Err(ExecError::Own(doom_per_rule(txn_ctx, error)));
+        }
+    };
     let SqlValue::Str(sql) = stmt else {
-        return Err(SqlError::new(
+        let error = SqlError::new(
             214,
             16,
             2,
             "Procedure expects parameter '@statement' of type 'ntext/nchar/nvarchar'.",
-        ));
+        );
+        return Err(ExecError::Own(doom_per_rule(txn_ctx, error)));
     };
     let decls =
         match take_named(&mut named, &["params", "parameters"]).or_else(|| positional.next()) {
             Some(SqlValue::Str(d)) => d,
             Some(SqlValue::Null) | None => String::new(),
             Some(_) => {
-                return Err(SqlError::new(
+                let error = SqlError::new(
                     214,
                     16,
                     3,
                     "Procedure expects parameter '@params' of type 'ntext/nchar/nvarchar'.",
-                ));
+                );
+                return Err(ExecError::Own(doom_per_rule(txn_ctx, error)));
             }
         };
     // Bind values: named ones by their own names, positional ones from the
@@ -722,16 +772,18 @@ fn run_exec(
     let mut seeded: Vec<(String, SqlValue)> = named;
     for (i, value) in positional.enumerate() {
         let Some(name) = names.get(i) else {
-            return Err(SqlError::new(
+            let error = SqlError::new(
                 8144,
                 16,
                 2,
                 "Procedure or function has too many arguments specified.",
-            ));
+            );
+            return Err(ExecError::Own(doom_per_rule(txn_ctx, error)));
         };
         seeded.push((name.clone(), value));
     }
-    let statements = truthdb_sql::parse(&sql)?;
+    let statements =
+        truthdb_sql::parse(&sql).map_err(|e| ExecError::Own(doom_per_rule(txn_ctx, e)))?;
 
     // The inner batch is its own variable scope, on the shared transaction —
     // and SET options revert at scope exit, as SQL Server reverts them: an
@@ -754,14 +806,17 @@ fn run_exec(
         v
     });
     let result = if depth > 32 {
-        Err(SqlError::new(
+        let error = SqlError::new(
             217,
             16,
             1,
             "Maximum stored procedure, function, trigger, or view nesting level exceeded (limit 32).",
-        ))
+        );
+        Err(ExecError::Own(doom_per_rule(txn_ctx, error)))
     } else {
-        run_block(storage, &statements, txn_ctx, run, in_try)
+        // An error crossing out of the inner batch already carries every
+        // decision (dooming, and by crossing at all: termination).
+        run_block(storage, &statements, txn_ctx, run, in_try).map_err(ExecError::Inner)
     };
     EXEC_DEPTH.with(|d| d.set(d.get() - 1));
     txn_ctx.variables = outer_vars;
@@ -789,30 +844,51 @@ fn run_block(
             // same shape as TRY/CATCH dispatch. Errors take the ordinary
             // statement path: cancels and durability failures propagate, a
             // TRY transfers to CATCH, XACT_ABORT OFF continues the batch.
-            let exec_result = run_exec(storage, exec, txn_ctx, run, in_try);
-            if exec_result.is_err() {
-                // A failed EXEC sets @@ROWCOUNT to 0 like any failed
-                // statement — run_exec's own error exits (unknown proc, 214,
-                // 8144, parse, nesting cap) never reach the generic Err arm.
-                txn_ctx.rowcount = 0;
-            }
-            match exec_result {
+            match run_exec(storage, exec, txn_ctx, run, in_try) {
                 Ok(()) => {}
-                Err(error) if error.number == CANCEL_ERROR => return Err(error),
-                Err(error) if run.durability_failed => return Err(error),
-                Err(error) if in_try => {
-                    run.abort_open_rowset(txn_ctx.in_txn());
-                    return Err(error);
-                }
-                Err(error) => {
-                    let dooms = txn_ctx.xact_abort || error.level >= XACT_ABORT_SEVERITY;
-                    if txn_ctx.in_txn() && !dooms {
+                Err(exec_error) => {
+                    // A failed EXEC sets @@ROWCOUNT to 0 like any failed
+                    // statement.
+                    txn_ctx.rowcount = 0;
+                    let (error, from_inner) = match exec_error {
+                        ExecError::Own(error) => (error, false),
+                        ExecError::Inner(error) => (error, true),
+                    };
+                    if error.number == CANCEL_ERROR {
+                        return Err(error);
+                    }
+                    txn_ctx.last_error = error.number;
+                    if run.durability_failed {
+                        return Err(error);
+                    }
+                    // Transfer to CATCH: decisions (dooming included) were
+                    // already made where the error arose — per-statement in
+                    // the inner `run_block`, or `doom_per_rule` for
+                    // `run_exec`'s own errors. A fatal (>= 20) error is
+                    // refused by the TryCatch arm's own filter.
+                    if in_try {
+                        run.abort_open_rowset(txn_ctx.in_txn());
+                        return Err(error);
+                    }
+                    // An error crossing OUT of the inner batch already
+                    // terminated it — and batch-abort scope is the whole
+                    // nest, so the outer batch ends too (a THROW inside
+                    // EXEC'd text ends the calling batch even when nothing
+                    // doomed; non-dooming ordinary errors never cross — the
+                    // inner run_block continued past them). Nothing is
+                    // re-derived from severity here: the review showed that
+                    // second derivation dropped THROW's termination.
+                    if from_inner {
+                        return Err(error);
+                    }
+                    // run_exec's OWN failure (unknown proc, 214, 8144, parse,
+                    // depth): statement-scope at the EXEC site. Dooming was
+                    // applied at the source; this decides only continuation.
+                    let terminates = txn_ctx.xact_abort || error.level >= XACT_ABORT_SEVERITY;
+                    if txn_ctx.in_txn() && !terminates {
                         run.abort_open_rowset(txn_ctx.in_txn());
                         run.last_error = Some(error);
                         continue;
-                    }
-                    if txn_ctx.in_txn() {
-                        txn_ctx.doomed = true;
                     }
                     return Err(error);
                 }
@@ -832,17 +908,22 @@ fn run_block(
                 // A durability failure wedged the store: no CATCH swallows a
                 // lost commit (the old batch-end fsync ran past every TRY).
                 Err(error) if run.durability_failed => return Err(error),
-                Err(error) => {
-                    // The failed statement's own writes were already undone to
-                    // its savepoint (`rel_statement_scoped`). `SET XACT_ABORT`
-                    // (or a high-severity error) still dooms the transaction —
-                    // but control transfers to CATCH either way (unlike outside
-                    // a TRY, where a dooming error ends the batch). Inside CATCH,
-                    // XACT_STATE() then reports -1 for a doomed transaction.
-                    let dooms = txn_ctx.xact_abort || error.level >= XACT_ABORT_SEVERITY;
-                    if txn_ctx.in_txn() && dooms {
+                // Severity >= 20 is fatal to the connection: no CATCH sees it.
+                Err(error) if error.level >= FATAL_SEVERITY => {
+                    txn_ctx.last_error = error.number;
+                    if txn_ctx.in_txn() {
                         txn_ctx.doomed = true;
                     }
+                    return Err(error);
+                }
+                Err(error) => {
+                    // The failed statement's own writes were already undone to
+                    // its savepoint (`rel_statement_scoped`), and the doom
+                    // decision was made where the statement failed — the inner
+                    // `run_block` knows the statement's kind (RAISERROR is
+                    // exempt from XACT_ABORT), this boundary does not. Control
+                    // transfers to CATCH either way; a doomed transaction
+                    // reports XACT_STATE() = -1 there.
                     txn_ctx.push_error(&error);
                     // The CATCH block runs in the *enclosing* try-context: its
                     // own errors are not caught here, so they propagate to an
@@ -858,7 +939,7 @@ fn run_block(
         // deferred DONEs must reach the stream before its columns do, and any
         // commit made so far must be fsync-durable before rows that can carry
         // its state (an identity value, via SCOPE_IDENTITY()) leave the server.
-        if produces_rowset(statement) {
+        if produces_rowset(statement) || matches!(statement, Statement::RaiseError(_)) {
             run.flush(storage)?;
         }
         // Flag durability by statement kind, before matching the result: a
@@ -869,6 +950,12 @@ fn run_block(
         run.committed |= statement_may_commit(statement);
         match exec_statement_streamed(storage, statement, txn_ctx, run) {
             Ok(outcome) => {
+                // The statement succeeded: `@@ERROR` reads 0 — except after a
+                // severity <= 10 RAISERROR, which set it itself (0, or 50000
+                // under SETERROR).
+                if !matches!(statement, Statement::RaiseError(_)) {
+                    txn_ctx.last_error = 0;
+                }
                 let in_transaction = txn_ctx.in_txn();
                 let command = done_command(statement);
                 // `SET NOCOUNT ON` suppresses the DONE's count on the wire;
@@ -923,29 +1010,65 @@ fn run_block(
                 // concurrently with an unrelated failure cannot suppress that
                 // failure's dooming. (No rowset close: the batch ends here, and
                 // its terminal DONE closes anything the statement left open.)
+                // A cancel is not a SQL error, so `@@ERROR` is untouched.
                 if error.number == CANCEL_ERROR {
                     return Err(error);
                 }
-                // Inside a TRY, any error transfers to the matching CATCH. The
-                // CATCH runs more statements, so a result set this one already
-                // started streaming must be closed first.
+                txn_ctx.last_error = error.number;
+                // A durability failure wedged the store (a flush inside the
+                // statement, e.g. before a snapshot capture): never continue
+                // past a lost commit.
+                if run.durability_failed {
+                    return Err(error);
+                }
+                // Severity >= 20 is fatal to the connection: it bypasses TRY
+                // (the TryCatch arm refuses it too), dooms the transaction,
+                // and the protocol layer closes the stream after delivering
+                // it.
+                if error.level >= FATAL_SEVERITY {
+                    if txn_ctx.in_txn() {
+                        txn_ctx.doomed = true;
+                    }
+                    return Err(error);
+                }
+                // The doom decision is made HERE, where the failing statement's
+                // kind is known — never re-derived at the TRY boundary, which
+                // cannot see it. `SET XACT_ABORT` (or severity >= 17) dooms the
+                // transaction; RAISERROR is exempt by definition (SQL Server:
+                // "errors raised by RAISERROR are not affected by SET
+                // XACT_ABORT") and never dooms.
+                let dooms = !matches!(statement, Statement::RaiseError(_))
+                    && (txn_ctx.xact_abort || error.level >= XACT_ABORT_SEVERITY);
+                if txn_ctx.in_txn() && dooms {
+                    txn_ctx.doomed = true;
+                }
+                // Inside a TRY, the error then transfers to the matching CATCH
+                // (which sees XACT_STATE() = -1 when it doomed). The CATCH runs
+                // more statements, so a result set this one already started
+                // streaming must be closed first.
                 if in_try {
                     run.abort_open_rowset(txn_ctx.in_txn());
                     return Err(error);
                 }
-                // Outside a TRY: `SET XACT_ABORT` (and error severity) decides
-                // the transaction's fate. OFF (the default) with a non-fatal
-                // error rolls back only the statement and the batch continues;
-                // ON — or a high-severity error — dooms the whole transaction
-                // (only ROLLBACK is then accepted, error 3930).
-                let dooms = txn_ctx.xact_abort || error.level >= XACT_ABORT_SEVERITY;
-                if txn_ctx.in_txn() && !dooms {
+                // RAISERROR is statement-scope: the batch always continues.
+                if matches!(statement, Statement::RaiseError(_)) {
                     run.abort_open_rowset(txn_ctx.in_txn());
                     run.last_error = Some(error);
                     continue;
                 }
-                if txn_ctx.in_txn() {
-                    txn_ctx.doomed = true;
+                // THROW always terminates the batch — even when it does not
+                // doom the transaction (XACT_ABORT OFF leaves the transaction
+                // open and committable from a later batch).
+                if matches!(statement, Statement::Throw(_)) {
+                    return Err(error);
+                }
+                // Other statements: a non-dooming error rolls back only the
+                // statement and the batch continues; a dooming one ends the
+                // batch (only ROLLBACK is then accepted, error 3930).
+                if txn_ctx.in_txn() && !dooms {
+                    run.abort_open_rowset(txn_ctx.in_txn());
+                    run.last_error = Some(error);
+                    continue;
                 }
                 return Err(error);
             }
@@ -1266,6 +1389,9 @@ fn exec_statement_streamed_inner(
     txn_ctx: &mut TxnContext,
     run: &mut BatchRun<'_>,
 ) -> Result<StatementOutcome, SqlError> {
+    if let Statement::RaiseError(raise) = statement {
+        return exec_raiserror(raise, txn_ctx, run);
+    }
     // The streamed shape: a plain SELECT — no SHOWPLAN (its rows are the plan's,
     // not the table's), no assignment (routed to exec_select_assign) — that
     // `scan_plan` accepts. A doomed transaction still allows reads, so the gate
@@ -1853,6 +1979,8 @@ pub fn analyze_locks(
             | Statement::Set(_)
             | Statement::Declare(_)
             | Statement::Use { .. }
+            | Statement::Throw(_)
+            | Statement::RaiseError(_)
             | Statement::TryCatch { .. } => {}
         }
     }
@@ -1950,6 +2078,10 @@ fn exec_statement_dispatch(
     match statement {
         Statement::BeginTransaction { .. } => exec_begin(storage, txn_ctx),
         Statement::Use { database, .. } => exec_use(database, txn_ctx),
+        Statement::Throw(throw) => Err(exec_throw(throw, txn_ctx)),
+        // Handled in `exec_statement_streamed_inner` (severity <= 10 emits an
+        // INFO event, which needs the emitter); nothing else routes it here.
+        Statement::RaiseError(_) => unreachable!("RAISERROR reaches only the streaming executor"),
         Statement::Commit { .. } => exec_commit(storage, txn_ctx),
         Statement::Rollback { name, .. } => exec_rollback(storage, txn_ctx, name.as_ref()),
         Statement::SaveTransaction { name, .. } => exec_save(storage, txn_ctx, name),
@@ -2079,6 +2211,8 @@ fn doomed_allows(statement: &Statement) -> bool {
             | Statement::Set(_)
             | Statement::Declare(_)
             | Statement::Use { .. }
+            | Statement::Throw(_)
+            | Statement::RaiseError(_)
             | Statement::Rollback { name: None, .. }
     )
 }
@@ -2197,6 +2331,280 @@ fn exec_use(database: &Name, ctx: &TxnContext) -> Result<StatementResult, SqlErr
         .at(database.span));
     }
     Ok(StatementResult::Done)
+}
+
+/// `THROW`: builds the error to raise (the caller returns it — `run_block`
+/// then applies THROW's batch-terminating rule). The bare form re-throws the
+/// innermost `CATCH`'s error verbatim, severity included; the argument form
+/// is always severity 16 with a user error number (>= 50000).
+fn exec_throw(throw: &ThrowStatement, ctx: &TxnContext) -> SqlError {
+    let Some(args) = &throw.args else {
+        return match ctx.error_stack.last() {
+            Some(info) => {
+                SqlError::new(info.number, info.severity, info.state, info.message.clone())
+            }
+            None => SqlError::new(
+                10704,
+                16,
+                1,
+                "To rethrow an error, a THROW statement must be used inside a CATCH block.",
+            ),
+        };
+    };
+    let eval_ctx = ctx.eval_context();
+    match exec_throw_args(args, &eval_ctx) {
+        // Both sides raise: the built error, or the argument evaluation's own.
+        Ok(error) | Err(error) => error,
+    }
+}
+
+fn exec_throw_args(args: &ThrowArgs, eval_ctx: &EvalContext) -> Result<SqlError, SqlError> {
+    let number = int_argument(&args.number, eval_ctx, "THROW", "error number")?;
+    if !(50_000..=i64::from(i32::MAX)).contains(&number) {
+        return Err(SqlError::new(
+            35100,
+            16,
+            1,
+            format!(
+                "Error number {number} in the THROW statement is outside the valid range. \
+                 Specify an error number in the valid range of 50000 to 2147483647."
+            ),
+        ));
+    }
+    let message = match eval_constant(&args.message, eval_ctx)? {
+        SqlValue::Str(text) => text,
+        other => {
+            return Err(SqlError::new(
+                102,
+                15,
+                1,
+                format!(
+                    "The THROW message must be a string, not {}.",
+                    other.type_name()
+                ),
+            ));
+        }
+    };
+    let state = int_argument(&args.state, eval_ctx, "THROW", "state")?;
+    if !(0..=255).contains(&state) {
+        return Err(SqlError::new(
+            102,
+            15,
+            1,
+            format!("The THROW state must be between 0 and 255, not {state}."),
+        ));
+    }
+    Ok(SqlError::new(number as i32, 16, state as u8, message))
+}
+
+/// `RAISERROR(msg, severity, state, args...)`. Severity decides the shape:
+/// <= 10 emits an informational message (a TDS INFO token, not an error) and
+/// the statement SUCCEEDS; 11..=18 raises an ordinary error (statement-scope
+/// — `run_block` exempts it from XACT_ABORT and never dooms for it);
+/// 19..=25 additionally require `WITH LOG`, and >= 20 is fatal to the
+/// connection. The error number is always 50000 (message-id RAISERROR needs
+/// `sys.messages`, which TruthDB does not have — 18054 like an unknown id).
+fn exec_raiserror(
+    raise: &RaiseError,
+    txn_ctx: &mut TxnContext,
+    run: &mut BatchRun<'_>,
+) -> Result<StatementOutcome, SqlError> {
+    let eval_ctx = txn_ctx.eval_context();
+    let severity = int_argument(&raise.severity, &eval_ctx, "RAISERROR", "severity")?;
+    if !(0..=25).contains(&severity) {
+        return Err(SqlError::new(
+            2754,
+            16,
+            1,
+            format!("Error severity {severity} is out of the range 0 through 25."),
+        ));
+    }
+    if severity > 18 && !raise.log {
+        return Err(SqlError::new(
+            2754,
+            16,
+            1,
+            "Error severity levels greater than 18 can only be specified by members of the \
+             sysadmin role, using the WITH LOG option.",
+        ));
+    }
+    // State 0 is reported as 1, as SQL Server does.
+    let state = int_argument(&raise.state, &eval_ctx, "RAISERROR", "state")?;
+    if !(0..=255).contains(&state) {
+        return Err(SqlError::new(
+            2753,
+            16,
+            1,
+            format!("The RAISERROR state must be between 0 and 255, not {state}."),
+        ));
+    }
+    let state = (state as u8).max(1);
+    let message = match eval_constant(&raise.message, &eval_ctx)? {
+        SqlValue::Str(format) => {
+            let mut args = Vec::with_capacity(raise.args.len());
+            for arg in &raise.args {
+                args.push(eval_constant(arg, &eval_ctx)?);
+            }
+            format_raiserror(&format, &args)?
+        }
+        // A message id: there is no `sys.messages`, so no id resolves.
+        SqlValue::Int(id) => {
+            return Err(SqlError::new(
+                18054,
+                16,
+                1,
+                format!(
+                    "Error {id}, severity {severity}, state {state} was raised, but no message \
+                     with that error number was found in sys.messages."
+                ),
+            ));
+        }
+        other => {
+            return Err(SqlError::new(
+                102,
+                15,
+                1,
+                format!(
+                    "The RAISERROR message must be a string or a message id, not {}.",
+                    other.type_name()
+                ),
+            ));
+        }
+    };
+    const AD_HOC_MESSAGE_NUMBER: i32 = 50000;
+    if severity <= 10 {
+        // Informational: `@@ERROR` reads 0 (or 50000 under SETERROR) — set
+        // here because `run_block`'s success path leaves RAISERROR's value.
+        txn_ctx.last_error = if raise.seterror {
+            AD_HOC_MESSAGE_NUMBER
+        } else {
+            0
+        };
+        run.info(SqlError::new(
+            AD_HOC_MESSAGE_NUMBER,
+            severity as u8,
+            state,
+            message,
+        ));
+        return Ok(StatementOutcome::Result(StatementResult::Done));
+    }
+    Err(SqlError::new(
+        AD_HOC_MESSAGE_NUMBER,
+        severity as u8,
+        state,
+        message,
+    ))
+}
+
+/// An integer statement argument (THROW/RAISERROR take constants or
+/// variables).
+fn int_argument(
+    expr: &Expr,
+    eval_ctx: &EvalContext,
+    statement: &str,
+    what: &str,
+) -> Result<i64, SqlError> {
+    match eval_constant(expr, eval_ctx)? {
+        SqlValue::Int(value) => Ok(value),
+        other => Err(SqlError::new(
+            102,
+            15,
+            1,
+            format!(
+                "The {statement} {what} must be an integer, not {}.",
+                other.type_name()
+            ),
+        )),
+    }
+}
+
+/// RAISERROR's printf subset: `%d`/`%i` (also `%u`, `%x`/`%X`, `%o`) for
+/// integer arguments, `%s` for strings, `%%` for a literal percent. Anything
+/// else is refused (2787), as is an argument of the wrong type or a missing
+/// one (2786). Surplus arguments are ignored, as SQL Server does.
+fn format_raiserror(format: &str, args: &[SqlValue]) -> Result<String, SqlError> {
+    let mut out = String::with_capacity(format.len());
+    let mut next_arg = 0usize;
+    let mut chars = format.chars();
+    while let Some(ch) = chars.next() {
+        if ch != '%' {
+            out.push(ch);
+            continue;
+        }
+        let Some(directive) = chars.next() else {
+            return Err(SqlError::new(
+                2787,
+                16,
+                1,
+                "Invalid format specification: '%' at the end of the message.",
+            ));
+        };
+        if directive == '%' {
+            out.push('%');
+            continue;
+        }
+        let argument = args.get(next_arg).ok_or_else(|| {
+            SqlError::new(
+                2786,
+                16,
+                1,
+                format!(
+                    "The data type of substitution parameter {} does not match the expected \
+                     type of the format specification (missing argument).",
+                    next_arg + 1
+                ),
+            )
+        })?;
+        let mismatch = || {
+            SqlError::new(
+                2786,
+                16,
+                1,
+                format!(
+                    "The data type of substitution parameter {} does not match the expected \
+                     type of the format specification.",
+                    next_arg + 1
+                ),
+            )
+        };
+        // A NULL argument prints "(null)" under every directive, as SQL
+        // Server does. Integer arguments are int-typed (32-bit) there, so
+        // the unsigned/hex forms wrap at 32 bits (-1 -> ffffffff) and a
+        // value outside int range is a type mismatch (2786, the bigint
+        // refusal).
+        if matches!(argument, SqlValue::Null) {
+            out.push_str("(null)");
+            next_arg += 1;
+            continue;
+        }
+        let int_arg = || -> Result<i32, SqlError> {
+            match argument {
+                SqlValue::Int(value) => i32::try_from(*value).map_err(|_| mismatch()),
+                _ => Err(mismatch()),
+            }
+        };
+        match directive {
+            'd' | 'i' => out.push_str(&int_arg()?.to_string()),
+            'u' => out.push_str(&(int_arg()? as u32).to_string()),
+            'x' => out.push_str(&format!("{:x}", int_arg()? as u32)),
+            'X' => out.push_str(&format!("{:X}", int_arg()? as u32)),
+            'o' => out.push_str(&format!("{:o}", int_arg()? as u32)),
+            's' => match argument {
+                SqlValue::Str(value) => out.push_str(value),
+                _ => return Err(mismatch()),
+            },
+            other => {
+                return Err(SqlError::new(
+                    2787,
+                    16,
+                    1,
+                    format!("Invalid format specification: '%{other}'."),
+                ));
+            }
+        }
+        next_arg += 1;
+    }
+    Ok(out)
 }
 
 fn exec_begin(storage: &Storage, ctx: &mut TxnContext) -> Result<StatementResult, SqlError> {

--- a/crates/truthdb-core/src/session.rs
+++ b/crates/truthdb-core/src/session.rs
@@ -119,6 +119,9 @@ pub enum BatchEvent {
     /// A SQL error that stopped the batch. The statements before it kept their
     /// results, which were already sent.
     Error(SqlError),
+    /// An informational message (RAISERROR severity <= 10): TDS renders an
+    /// INFO token in-stream; it is not an error and stops nothing.
+    Info(SqlError),
     /// The handle `sp_prepare`/`sp_prepexec` allocated, reported to the client
     /// as a RETURNVALUE token. Sent after every statement's events, just
     /// before `Complete` — where SQL Server puts return values.
@@ -319,6 +322,10 @@ impl crate::rel::BatchEmitter for BatchSink {
             database: database.to_string(),
         });
     }
+
+    fn info(&mut self, error: &truthdb_sql::error::SqlError) {
+        self.send(BatchEvent::Info(error.clone()));
+    }
 }
 
 /// Reassembles an event stream into a whole [`BatchReply`] — the shape every
@@ -360,6 +367,9 @@ async fn collect_reply(
             // database-context change (the ENVCHANGE is wire-only).
             BatchEvent::PreparedHandle(_) => {}
             BatchEvent::DatabaseContext { .. } => {}
+            // An informational message (RAISERROR <= 10) is wire-only too:
+            // it is not an error and carries no result.
+            BatchEvent::Info(_) => {}
             BatchEvent::Error(err) => error = Some(err),
             BatchEvent::Complete { in_transaction } => {
                 return Ok(BatchReply {

--- a/crates/truthdb-core/tests/slt/severity.slt
+++ b/crates/truthdb-core/tests/slt/severity.slt
@@ -1,0 +1,63 @@
+# THROW / RAISERROR severity semantics (Stage 15). The full truth-table
+# matrix (XACT_ABORT interplay, dooming, CATCH transfer, the EXEC seam) is
+# pinned in the engine tests; these pin the statement surface end to end.
+
+# Severity <= 10 is informational: the statement SUCCEEDS.
+statement ok
+RAISERROR('just a message', 10, 1)
+
+statement ok
+RAISERROR('state zero reports as one', 0, 0)
+
+# Severity 11..=18 raises a real error.
+statement error
+RAISERROR('a user error', 16, 1)
+
+# @@ERROR carries the raised number (50000 for ad-hoc messages) into the
+# next batch, and reading it resets it.
+query I
+SELECT @@ERROR
+----
+50000
+
+query I
+SELECT @@ERROR
+----
+0
+
+# Severity above 18 needs WITH LOG; out-of-range severity is refused.
+statement error
+RAISERROR('needs the option', 19, 1)
+
+statement error
+RAISERROR('out of range', 26, 1) WITH LOG
+
+# printf formatting, adjudicated through ERROR_MESSAGE() in a CATCH.
+query T
+BEGIN TRY RAISERROR('%s ran %d times', 16, 1, 'job', 3); END TRY BEGIN CATCH SELECT ERROR_MESSAGE(); END CATCH
+----
+job ran 3 times
+
+# A message id needs sys.messages, which does not exist: 18054.
+statement error
+RAISERROR(50001, 16, 1)
+
+# THROW: number below 50000 is out of range (35100); the argument form
+# raises with severity 16; a bare THROW outside any CATCH is 10704.
+statement error
+THROW 999, 'too low', 1
+
+statement error
+THROW 50001, 'raised', 1
+
+statement error
+THROW
+
+# A bare THROW in a CATCH re-raises the original error.
+statement error
+BEGIN TRY THROW 50002, 'original', 3; END TRY BEGIN CATCH THROW; END CATCH
+
+query I
+SELECT @@ERROR
+----
+50002

--- a/crates/truthdb-sql/src/ast.rs
+++ b/crates/truthdb-sql/src/ast.rs
@@ -61,6 +61,43 @@ pub enum Statement {
         catch_block: Vec<Statement>,
         span: Span,
     },
+    /// `THROW [number, message, state]` — raises a severity-16 error that
+    /// terminates the batch; the bare form re-throws inside a `CATCH`.
+    Throw(ThrowStatement),
+    /// `RAISERROR(msg, severity, state [, args...]) [WITH LOG|NOWAIT|SETERROR]`.
+    RaiseError(RaiseError),
+}
+
+/// `THROW [number, message, state]`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ThrowStatement {
+    /// `None` = the bare re-throw form.
+    pub args: Option<ThrowArgs>,
+    pub span: Span,
+}
+
+/// The three arguments of a parameterized `THROW`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ThrowArgs {
+    pub number: Expr,
+    pub message: Expr,
+    pub state: Expr,
+}
+
+/// `RAISERROR(msg, severity, state [, args...]) [WITH option, ...]`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RaiseError {
+    /// The message text (or a message id, which TruthDB rejects — there is no
+    /// `sys.messages`).
+    pub message: Expr,
+    pub severity: Expr,
+    pub state: Expr,
+    /// printf-style substitution arguments.
+    pub args: Vec<Expr>,
+    pub log: bool,
+    pub nowait: bool,
+    pub seterror: bool,
+    pub span: Span,
 }
 
 /// One `@name TYPE [= initializer]` in a `DECLARE`.

--- a/crates/truthdb-sql/src/eval.rs
+++ b/crates/truthdb-sql/src/eval.rs
@@ -96,6 +96,8 @@ pub struct EvalContext {
     /// `XACT_STATE()`: 1 = an active, committable transaction; -1 = an active
     /// but uncommittable (doomed) transaction; 0 = no transaction.
     pub xact_state: i8,
+    /// `@@ERROR` — the previous statement's error number, 0 on success.
+    pub last_error: i32,
 }
 
 /// The error captured by a `CATCH` block, surfaced by the `ERROR_*()`
@@ -241,7 +243,8 @@ fn eval_global_var(name: &str, ctx: &EvalContext) -> SqlResult<SqlValue> {
             "TruthDB - 16.0.1000.6\n\tMicrosoft SQL Server 2022 compatible edition".to_string(),
         )),
         "rowcount" => Ok(SqlValue::Int(ctx.rowcount)),
-        "error" | "identity" => Ok(SqlValue::Int(0)),
+        "error" => Ok(SqlValue::Int(ctx.last_error as i64)),
+        "identity" => Ok(SqlValue::Int(0)),
         other => Err(SqlError::message_only(
             102,
             format!("Incorrect syntax near '@@{other}'."),

--- a/crates/truthdb-sql/src/parser.rs
+++ b/crates/truthdb-sql/src/parser.rs
@@ -128,6 +128,8 @@ impl Parser {
             Some("DECLARE") => self.parse_declare(),
             Some("EXEC") | Some("EXECUTE") => self.parse_exec(),
             Some("USE") => self.parse_use(),
+            Some("THROW") => self.parse_throw(),
+            Some("RAISERROR") => self.parse_raiserror(),
             _ => {
                 let token = self.peek().clone();
                 Err(SqlError::syntax(self.token_text(&token), token.span))
@@ -362,6 +364,82 @@ impl Parser {
         let database = self.parse_name()?;
         let span = start.to(database.span);
         Ok(Statement::Use { database, span })
+    }
+
+    /// `THROW [number, message, state]`. The arguments are constants or
+    /// variables (SQL Server's rule); a bare `THROW` — the re-throw form — is
+    /// recognized by the next token NOT starting one.
+    fn parse_throw(&mut self) -> SqlResult<Statement> {
+        let start = self.expect_keyword("THROW")?;
+        let has_args = matches!(
+            self.peek().kind,
+            TokenKind::Int(_) | TokenKind::Number(_) | TokenKind::LocalVar(_)
+        );
+        if !has_args {
+            return Ok(Statement::Throw(ThrowStatement {
+                args: None,
+                span: start,
+            }));
+        }
+        let number = self.parse_expr()?;
+        self.expect(&TokenKind::Comma)?;
+        let message = self.parse_expr()?;
+        self.expect(&TokenKind::Comma)?;
+        let state = self.parse_expr()?;
+        let span = start.to(state.span);
+        Ok(Statement::Throw(ThrowStatement {
+            args: Some(ThrowArgs {
+                number,
+                message,
+                state,
+            }),
+            span,
+        }))
+    }
+
+    /// `RAISERROR(msg, severity, state [, args...]) [WITH LOG|NOWAIT|SETERROR]`.
+    fn parse_raiserror(&mut self) -> SqlResult<Statement> {
+        let start = self.expect_keyword("RAISERROR")?;
+        self.expect(&TokenKind::LParen)?;
+        let message = self.parse_expr()?;
+        self.expect(&TokenKind::Comma)?;
+        let severity = self.parse_expr()?;
+        self.expect(&TokenKind::Comma)?;
+        let state = self.parse_expr()?;
+        let mut args = Vec::new();
+        while self.eat(&TokenKind::Comma) {
+            args.push(self.parse_expr()?);
+        }
+        let mut end = self.expect(&TokenKind::RParen)?;
+        let (mut log, mut nowait, mut seterror) = (false, false, false);
+        if matches!(self.peek_keyword().as_deref(), Some("WITH")) {
+            self.bump();
+            loop {
+                match self.peek_keyword().as_deref() {
+                    Some("LOG") => log = true,
+                    Some("NOWAIT") => nowait = true,
+                    Some("SETERROR") => seterror = true,
+                    _ => {
+                        let token = self.peek().clone();
+                        return Err(SqlError::syntax(self.token_text(&token), token.span));
+                    }
+                }
+                end = self.bump().span;
+                if !self.eat(&TokenKind::Comma) {
+                    break;
+                }
+            }
+        }
+        Ok(Statement::RaiseError(RaiseError {
+            message,
+            severity,
+            state,
+            args,
+            log,
+            nowait,
+            seterror,
+            span: start.to(end),
+        }))
     }
 
     fn parse_set(&mut self) -> SqlResult<Statement> {

--- a/crates/truthdb-tds/src/server.rs
+++ b/crates/truthdb-tds/src/server.rs
@@ -501,6 +501,7 @@ where
     let mut hdr = [0u8; HEADER_LEN];
     let mut got = 0usize;
     let mut attention = false;
+    let mut fatal = false;
     'replies: while let Some(start) = source.next(&cancel) {
         let mut render = BatchRender {
             rpc,
@@ -623,6 +624,12 @@ where
                 },
             }
         }
+        if render.fatal {
+            // A fatal-severity error (>= 20): the reply is complete, and the
+            // connection dies with it — any RPCs not yet issued never run.
+            fatal = true;
+            break 'replies;
+        }
         if attention {
             // Everything after the Attention is discarded; the RPCs not yet
             // issued never run.
@@ -665,7 +672,7 @@ where
         // ack where the client is looking for it.
         write_attention_ack(&mut wr, packet_size).await?;
     }
-    Ok(true)
+    Ok(!fatal)
 }
 
 /// Starts one RPC on the engine, returning its reply stream.
@@ -749,6 +756,9 @@ struct BatchRender {
     /// Set once a batch-stopping ERROR has been written, so the final DONE
     /// carries `DONE_ERROR`.
     errored: bool,
+    /// Set when the written ERROR's severity was fatal (>= 20): the reply
+    /// finishes, then the connection closes, as SQL Server does.
+    fatal: bool,
     /// RPC response framing: per-statement DONEs render as DONEINPROC, and the
     /// response ends RETURNSTATUS → RETURNVALUE(s) → DONEPROC, as SQL Server
     /// frames a procedure's reply. A SQL batch keeps plain DONEs (the #97
@@ -862,6 +872,22 @@ impl BatchRender {
                 // RETURNVALUE, which precedes the final DONEPROC.
                 self.pending_handle = Some(handle);
             }
+            BatchEvent::Info(info) => {
+                // RAISERROR severity <= 10: an INFO token, not an error — the
+                // batch continues and no DONE flag changes. Pending DONEs go
+                // out first so stream order holds.
+                self.flush_pending(out, true).await?;
+                self.buf.clear();
+                token::info(
+                    &mut self.buf,
+                    info.number,
+                    info.state,
+                    info.level,
+                    &info.message,
+                );
+                out.write(&self.buf).await?;
+                self.buf.clear();
+            }
             BatchEvent::Error(error) => {
                 self.flush_pending(out, true).await?;
                 self.buf.clear();
@@ -874,6 +900,12 @@ impl BatchRender {
                 );
                 out.write(&self.buf).await?;
                 self.errored = true;
+                // Severity >= 20 kills the connection, as SQL Server does:
+                // the reply still finishes (error + final DONE) and then the
+                // connection loop closes the stream.
+                if error.level >= truthdb_core::rel::FATAL_SEVERITY {
+                    self.fatal = true;
+                }
             }
             BatchEvent::Complete { in_transaction } => {
                 if self.rpc {

--- a/crates/truthdb-tds/tests/tds_client.rs
+++ b/crates/truthdb-tds/tests/tds_client.rs
@@ -983,6 +983,194 @@ async fn use_statement_emits_the_database_envchange() {
     let _ = std::fs::remove_file(&path);
 }
 
+/// RAISERROR severity <= 10 arrives as an INFO token (0xAB), not an ERROR:
+/// the batch succeeds and its DONE is clean.
+#[tokio::test]
+async fn raiserror_low_severity_is_an_info_token() {
+    let path = temp_path("raiserror-info");
+    let engine = engine(&path);
+    let mut client = connect(engine.clone()).await;
+    client.prelogin().await;
+    client.login("sa", "secret").await;
+
+    let tokens = client
+        .batch("RAISERROR('for your information', 5, 1)")
+        .await;
+    assert!(
+        tokens
+            .iter()
+            .any(|t| matches!(t, Token::Info { number: 50000 })),
+        "an INFO 50000 token: {tokens:?}"
+    );
+    assert!(
+        !tokens.iter().any(|t| matches!(t, Token::Error { .. })),
+        "no ERROR token: {tokens:?}"
+    );
+    // The connection stays healthy.
+    let tokens = client.batch("SELECT 1 AS one").await;
+    assert!(tokens.iter().any(|t| matches!(t, Token::Row(_))));
+
+    let _ = std::fs::remove_file(&path);
+}
+
+/// Severity >= 20 is fatal: the error and its DONE are delivered, then the
+/// server closes the connection — as SQL Server drops the session.
+#[tokio::test]
+async fn fatal_severity_closes_the_connection() {
+    use tokio::io::AsyncReadExt;
+
+    let path = temp_path("raiserror-fatal");
+    let engine = engine(&path);
+    let mut client = connect(engine.clone()).await;
+    client.prelogin().await;
+    client.login("sa", "secret").await;
+
+    let tokens = client
+        .batch("RAISERROR('going down', 20, 1) WITH LOG")
+        .await;
+    assert!(
+        tokens
+            .iter()
+            .any(|t| matches!(t, Token::Error { number: 50000 })),
+        "the fatal error is delivered first: {tokens:?}"
+    );
+    // The server hangs up: the next read is EOF (no reply will ever come).
+    // Bounded, so a regression that keeps the connection open FAILS here in
+    // seconds instead of hanging the suite on a read that never returns.
+    let mut byte = [0u8; 1];
+    let read = tokio::time::timeout(
+        std::time::Duration::from_secs(5),
+        client.stream.read(&mut byte),
+    )
+    .await
+    .expect("the server must close the connection after a severity-20 error")
+    .expect("read after fatal");
+    assert_eq!(
+        read, 0,
+        "the connection is closed after a severity-20 error"
+    );
+
+    let _ = std::fs::remove_file(&path);
+}
+
+/// REVIEW probe (passes): severity >= 20 inside an RPC (sp_executesql)
+/// delivers the error inside the DONEPROC-framed reply and then closes the
+/// connection — the RPC reply path honors the same fatal flag as a batch.
+#[tokio::test]
+async fn review_poc_fatal_inside_an_rpc_closes_the_connection() {
+    use tokio::io::AsyncReadExt;
+
+    let path = temp_path("review-rpc-fatal");
+    let engine = engine(&path);
+    let mut client = connect(engine.clone()).await;
+    client.prelogin().await;
+    client.login("sa", "secret").await;
+
+    let tokens = client
+        .rpc(&sp_executesql_rpc("RAISERROR('die', 20, 1) WITH LOG"))
+        .await;
+    assert!(
+        tokens
+            .iter()
+            .any(|t| matches!(t, Token::Error { number: 50000 })),
+        "the fatal error is delivered: {tokens:?}"
+    );
+    let mut byte = [0u8; 1];
+    let read = tokio::time::timeout(
+        std::time::Duration::from_secs(5),
+        client.stream.read(&mut byte),
+    )
+    .await
+    .expect("the server must close the connection after a fatal RPC error")
+    .expect("read after fatal");
+    assert_eq!(read, 0, "closed after a severity-20 error in an RPC");
+
+    let _ = std::fs::remove_file(&path);
+}
+
+/// REVIEW probe (passes): a fatal error in the FIRST RPC of a multi-RPC
+/// request finishes that reply, never runs the remaining RPCs, and closes
+/// the connection.
+#[tokio::test]
+async fn review_poc_fatal_in_a_multi_rpc_request_skips_the_rest() {
+    use tokio::io::AsyncReadExt;
+
+    let path = temp_path("review-multirpc-fatal");
+    let engine = engine(&path);
+    let mut client = connect(engine.clone()).await;
+    client.prelogin().await;
+    client.login("sa", "secret").await;
+
+    let mut body = sp_executesql_rpc("RAISERROR('die', 20, 1) WITH LOG");
+    body.push(0xff); // batch separator
+    body.extend(sp_executesql_rpc("SELECT 1 AS a"));
+    let tokens = client.rpc(&body).await;
+    assert!(
+        tokens
+            .iter()
+            .any(|t| matches!(t, Token::Error { number: 50000 })),
+        "the fatal error is delivered: {tokens:?}"
+    );
+    assert!(
+        !tokens.iter().any(|t| matches!(t, Token::Row(_))),
+        "the RPC after the fatal one never ran: {tokens:?}"
+    );
+    let mut byte = [0u8; 1];
+    let read = tokio::time::timeout(
+        std::time::Duration::from_secs(5),
+        client.stream.read(&mut byte),
+    )
+    .await
+    .expect("the server must close the connection after a fatal error")
+    .expect("read after fatal");
+    assert_eq!(read, 0, "closed after the fatal RPC's reply");
+
+    let _ = std::fs::remove_file(&path);
+}
+
+/// REVIEW probe (passes): a mid-batch RAISERROR <= 10 puts its INFO token
+/// between the preceding statement's DONE and the next result set's
+/// COLMETADATA — the stream-order rule the flush-before-RAISERROR exists
+/// for.
+#[tokio::test]
+async fn review_poc_info_token_orders_between_result_sets() {
+    let path = temp_path("review-info-order");
+    let engine = engine(&path);
+    let mut client = connect(engine.clone()).await;
+    client.prelogin().await;
+    client.login("sa", "secret").await;
+
+    let tokens = client
+        .batch("SELECT 1 AS a; RAISERROR('fyi', 5, 1); SELECT 2 AS b")
+        .await;
+    let info = tokens
+        .iter()
+        .position(|t| matches!(t, Token::Info { number: 50000 }))
+        .unwrap_or_else(|| panic!("an INFO token: {tokens:?}"));
+    let first_done = tokens
+        .iter()
+        .position(|t| matches!(t, Token::Done { .. }))
+        .unwrap_or_else(|| panic!("a DONE token: {tokens:?}"));
+    let second_colmeta = tokens
+        .iter()
+        .enumerate()
+        .filter(|(_, t)| matches!(t, Token::ColMetadata(_)))
+        .map(|(i, _)| i)
+        .nth(1)
+        .unwrap_or_else(|| panic!("a second COLMETADATA: {tokens:?}"));
+    assert!(
+        first_done < info,
+        "the first SELECT's DONE precedes the INFO: {tokens:?}"
+    );
+    assert!(
+        info < second_colmeta,
+        "the INFO precedes the second result set: {tokens:?}"
+    );
+    assert_eq!(row_ints(&tokens), [1, 2], "both SELECTs ran: {tokens:?}");
+
+    let _ = std::fs::remove_file(&path);
+}
+
 /// `SET NOCOUNT ON` drops DONE_COUNT from statement DONEs on the wire —
 /// results are untouched — and OFF restores it.
 #[tokio::test]


### PR DESCRIPTION
## Stage 15, part 1: the severity/abort truth table — THROW, RAISERROR, @@ERROR, fatal errors

The plan orders this first ("it's the subtle core"): the error-semantics rows that everything else in Stage 15 (procedures, triggers) will sit on.

### The truth table

| Raiser | Severity | Outside TRY | Inside TRY | Dooms the transaction? |
|---|---|---|---|---|
| RAISERROR | ≤ 10 | statement SUCCEEDS; INFO token on TDS | same | never |
| RAISERROR | 11–18 (19–25 need `WITH LOG`) | batch **continues** | CATCH fires | **never — exempt from XACT_ABORT** (SQL Server documents the exemption) |
| THROW | 16 (fixed; re-throw keeps the original) | batch **terminates** | CATCH fires | only under `XACT_ABORT ON` (or a re-thrown severity ≥ 17) |
| Engine errors | 11–16 / ≥ 17 | continue-in-txn / terminate | CATCH fires | `XACT_ABORT ON` or severity ≥ 17 (unchanged) |
| Any | ≥ 20 | batch terminates | **bypasses CATCH** | always; the TDS connection closes after delivery |

### The seam rule, applied again

Stage 13's lesson — a decision derived twice must be forced to agree — bit here immediately: the TRY boundary used to re-derive the doom decision, but it cannot see the failing statement's kind, so a RAISERROR under `XACT_ABORT ON` inside a TRY would have been wrongly doomed. The doom decision now has ONE site: the statement's own error arm in `run_block`, where the kind is known. `run_exec`'s own validation/depth errors get the rule applied at their creation (`doom_per_rule`), and the TRY and EXEC boundaries are pure transfer. Pinned by the seam test: `RAISERROR` inside `EXEC sp_executesql` inside `TRY` under `XACT_ABORT ON` reaches the CATCH with `XACT_STATE() = 1`, while the EXEC's own failure (unknown proc) under the same setup reads `-1`.

### What landed

- **THROW**: bare re-throw (original number/severity/state preserved; 10704 outside a CATCH), argument form (number ≥ 50000 else 35100, severity fixed at 16); always batch-terminating, dooming only per the standard rule.
- **RAISERROR**: printf subset (`%d %i %s %u %x %X %o %%`; 2786 type-mismatch/missing, 2787 unsupported), state 0→1, severity gates (out-of-range and the >18-needs-`WITH LOG` 2754), message-id form → 18054 (no `sys.messages`); `WITH LOG/NOWAIT/SETERROR` parsed, SETERROR stamps @@ERROR 50000 even at severity ≤ 10.
- **Severity classes**: ≤ 10 rides a new `BatchEvent::Info` → TDS INFO token in-stream (deferred DONEs flush first, same ordering rule as `USE`); ≥ 20 sets DONE_ERROR, then `stream_reply` returns "close" and the connection drops — pinned end-to-end (client reads the error, then EOF). Native protocol reports the error in the envelope and stays open (recorded divergence, like the NOCOUNT envelope).
- **@@ERROR**: maintained per statement (0 on success, the number on failure, visible to the CATCH's first statement, reset by the statement that reads it).

### Adversarial review outcome

The review confirmed the truth table's core (every fatal-completeness, ordering, and parse-ambiguity attack was refuted) and caught the commit's own principle being violated once more: the doom decision was single-sited, but the CONTINUATION decision was still derived twice, and the EXEC-arm fallback dropped THROW's batch termination — a THROW inside `EXEC sp_executesql`, in a transaction under `XACT_ABORT OFF`, let the outer batch keep running (HIGH, fixed). `run_exec` errors are now origin-tagged (`ExecError::Own` vs `Inner`): an error crossing out of the inner batch already terminated it and terminates the whole nest — nothing is re-derived from severity; only `run_exec`'s own validation errors take the statement-scope fallback. Mutation-pinned (collapsing the tag fails the review's PoC). Also fixed from the review: `%s`/`%d` with a NULL argument prints `(null)` as SQL Server does (was 2786), and the integer directives are 32-bit (`%x` of -1 is `ffffffff`, out-of-int-range arguments are 2786 — SQL Server's int-typed substitution). Four teeth gaps closed by importing the review's probes (state-0→1, nested bare-THROW re-throw depth, EXEC-arm @@ERROR, INFO flush ordering + wire order); 13 review tests landed in all. Record-only: the generic arm's durability check needs a failpoint that does not exist yet (follow-up); RAISERROR's own gate errors (2786/2754/…) take the lenient path — SQL Server's behavior there is undocumented, pinned so a change is deliberate; a top-level parse error does not stamp @@ERROR.

### Tests

Twelve engine truth-table tests (the XACT_ABORT × TRY × raiser matrix, the EXEC seam pair, @@ERROR tracking, printf, severity gates), two TDS e2e tests (INFO token; fatal close), `severity.slt`. Teeth-checked by mutation: the RAISERROR exemption, the CATCH fatal filter, `doom_per_rule`, @@ERROR maintenance, and the TDS fatal flag each make their pinning test fail when disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
