### PR TITLE
Stage 15: control flow — IF/ELSE, WHILE/BREAK/CONTINUE, BEGIN..END blocks, RETURN

### DIFF
--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -4803,6 +4803,1008 @@ mod tests {
     }
 
     #[test]
+    fn if_else_takes_the_right_branch_including_null() {
+        // T-SQL three-valued conditions: TRUE runs THEN; FALSE and NULL
+        // (UNKNOWN) take the ELSE.
+        let path = unique_temp_path("if-else");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "IF 1 = 1 SELECT 1 AS n ELSE SELECT 2 AS n",
+        );
+        assert_eq!(ids(&out), vec![1]);
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "IF 1 = 2 SELECT 1 AS n ELSE SELECT 2 AS n",
+        );
+        assert_eq!(ids(&out), vec![2]);
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "IF NULL = NULL SELECT 1 AS n ELSE SELECT 2 AS n",
+        );
+        assert_eq!(ids(&out), vec![2], "UNKNOWN takes the ELSE");
+        // ALIASLESS selects: `ELSE` must not be readable as an implicit
+        // column alias (`SELECT 1 ELSE` would silently detach the branch).
+        let out = batch(&engine, &mut ctx, "IF 1 = 2 SELECT 1 ELSE SELECT 2");
+        assert!(out.error.is_none(), "{:?}", out.error);
+        assert_eq!(ids(&out), vec![2], "ELSE binds to the IF, not as an alias");
+        // Without an ELSE, an untaken IF runs nothing.
+        let out = batch(&engine, &mut ctx, "IF 1 = 2 SELECT 1 AS n; SELECT 3 AS n");
+        assert_eq!(ids(&out), vec![3]);
+        // A non-boolean condition is 4145.
+        let out = batch(&engine, &mut ctx, "IF 7 SELECT 1 AS n");
+        assert_eq!(out.error.as_ref().map(|e| e.number), Some(4145));
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn if_exists_subquery_condition_works() {
+        // The bread-and-butter SSMS shape: IF EXISTS (SELECT ...) over a real
+        // table, both polarities, plus a scalar-subquery comparison.
+        let path = unique_temp_path("if-exists");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        batch(
+            &engine,
+            &mut ctx,
+            "CREATE TABLE t (id INT NOT NULL PRIMARY KEY)",
+        );
+        batch(&engine, &mut ctx, "INSERT INTO t VALUES (1)");
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "IF EXISTS (SELECT * FROM t WHERE id = 1) SELECT 10 AS n ELSE SELECT 20 AS n",
+        );
+        assert_eq!(ids(&out), vec![10]);
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "IF EXISTS (SELECT * FROM t WHERE id = 99) SELECT 10 AS n ELSE SELECT 20 AS n",
+        );
+        assert_eq!(ids(&out), vec![20]);
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "IF (SELECT COUNT(*) FROM t) = 1 SELECT 30 AS n",
+        );
+        assert_eq!(ids(&out), vec![30], "scalar subquery in the condition");
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn while_loop_runs_with_break_and_continue() {
+        let path = unique_temp_path("while-loop");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        batch(
+            &engine,
+            &mut ctx,
+            "CREATE TABLE t (id INT NOT NULL PRIMARY KEY)",
+        );
+        // A counted loop driven by a variable.
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "DECLARE @i INT = 1; \
+             WHILE @i <= 5 \
+             BEGIN \
+               INSERT INTO t VALUES (@i); \
+               SET @i = @i + 1; \
+             END; \
+             SELECT COUNT(*) AS n FROM t",
+        );
+        assert!(out.error.is_none(), "{:?}", out.error);
+        assert_eq!(ids(&out), vec![5]);
+        // CONTINUE skips even ids; BREAK stops at 8.
+        batch(&engine, &mut ctx, "DELETE FROM t");
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "DECLARE @i INT = 0; \
+             WHILE 1 = 1 \
+             BEGIN \
+               SET @i = @i + 1; \
+               IF @i >= 8 BREAK; \
+               IF @i % 2 = 0 CONTINUE; \
+               INSERT INTO t VALUES (@i); \
+             END; \
+             SELECT id FROM t ORDER BY id",
+        );
+        assert!(out.error.is_none(), "{:?}", out.error);
+        assert_eq!(ids(&out), vec![1, 3, 5, 7]);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn break_crosses_a_try_and_return_exits_the_batch() {
+        let path = unique_temp_path("flow-crossings");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        batch(
+            &engine,
+            &mut ctx,
+            "CREATE TABLE t (id INT NOT NULL PRIMARY KEY)",
+        );
+        // BREAK inside a TRY leaves the loop without touching the CATCH.
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "DECLARE @i INT = 0; \
+             WHILE 1 = 1 \
+             BEGIN \
+               SET @i = @i + 1; \
+               BEGIN TRY IF @i = 3 BREAK; END TRY BEGIN CATCH SELECT 99 AS n; END CATCH \
+             END; \
+             SELECT @i AS n",
+        );
+        assert!(out.error.is_none(), "{:?}", out.error);
+        assert_eq!(ids(&out), vec![3], "the CATCH never ran, the loop broke");
+        // RETURN exits the batch mid-way.
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "INSERT INTO t VALUES (1); RETURN; INSERT INTO t VALUES (2)",
+        );
+        assert!(out.error.is_none(), "{:?}", out.error);
+        let out = batch(&engine, &mut ctx, "SELECT id FROM t ORDER BY id");
+        assert_eq!(ids(&out), vec![1], "the post-RETURN INSERT never ran");
+        // RETURN with a value is a batch-context error (178), and
+        // BREAK/CONTINUE outside a loop are compile-time 135/136.
+        let out = batch(&engine, &mut ctx, "RETURN 5");
+        assert_eq!(out.error.as_ref().map(|e| e.number), Some(178));
+        let out = batch(&engine, &mut ctx, "BREAK");
+        assert_eq!(out.error.as_ref().map(|e| e.number), Some(135));
+        let out = batch(&engine, &mut ctx, "CONTINUE");
+        assert_eq!(out.error.as_ref().map(|e| e.number), Some(136));
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn if_condition_reads_at_at_error_before_resetting_it() {
+        // The canonical pattern: `IF @@ERROR <> 0` sees the failed statement's
+        // number (the IF resets @@ERROR only AFTER its condition evaluated).
+        let path = unique_temp_path("if-at-at-error");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        batch(
+            &engine,
+            &mut ctx,
+            "CREATE TABLE t (id INT NOT NULL PRIMARY KEY)",
+        );
+        batch(&engine, &mut ctx, "INSERT INTO t VALUES (1)");
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "BEGIN TRAN; \
+             INSERT INTO t VALUES (1); \
+             IF @@ERROR <> 0 SELECT 111 AS n ELSE SELECT 222 AS n; \
+             SELECT @@ERROR AS n; \
+             COMMIT",
+        );
+        let firsts: Vec<i64> = out
+            .results
+            .iter()
+            .filter_map(|r| match r {
+                StatementResult::Rows(rowset) => match rowset.rows[0][0] {
+                    Datum::Int(v) => Some(i64::from(v)),
+                    Datum::BigInt(v) => Some(v),
+                    ref other => panic!("expected int, got {other:?}"),
+                },
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            firsts,
+            vec![111, 0],
+            "the IF saw 2627, then reset @@ERROR to 0"
+        );
+        // An untaken IF with no ELSE: the IF's own reset is the ONLY one (no
+        // branch statement runs to mask it) — @@ERROR reads 0 after it.
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "BEGIN TRAN; \
+             INSERT INTO t VALUES (1); \
+             IF 1 = 2 SELECT 999 AS n; \
+             SELECT @@ERROR AS n; \
+             COMMIT",
+        );
+        assert_eq!(
+            ids(&out),
+            vec![0],
+            "the IF itself reset @@ERROR though no branch ran"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn doomed_transaction_still_runs_the_canonical_catch_pattern() {
+        // IF XACT_STATE() = -1 ROLLBACK — the documented CATCH idiom — must
+        // work inside a doomed transaction.
+        let path = unique_temp_path("doomed-if-rollback");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        batch(
+            &engine,
+            &mut ctx,
+            "CREATE TABLE t (id INT NOT NULL PRIMARY KEY)",
+        );
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "SET XACT_ABORT ON; \
+             BEGIN TRAN; \
+             BEGIN TRY INSERT INTO t VALUES (1); INSERT INTO t VALUES (1); END TRY \
+             BEGIN CATCH \
+               IF XACT_STATE() = -1 ROLLBACK; \
+             END CATCH; \
+             SELECT CAST(@@TRANCOUNT AS INT) AS n",
+        );
+        assert!(out.error.is_none(), "{:?}", out.error);
+        assert_eq!(ids(&out), vec![0], "the doomed transaction was rolled back");
+        assert!(!ctx.has_open_transaction());
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn cf_review_doomed_gate_condition_reads_branch_writes_gated() {
+        // In a doomed transaction's CATCH: an IF condition's subquery READ is
+        // legal (SQL Server allows reads in a doomed transaction), but a
+        // write inside a taken branch still hits the 3930 gate.
+        let path = unique_temp_path("cf-doomed-gate");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        batch(
+            &engine,
+            &mut ctx,
+            "CREATE TABLE t (id INT NOT NULL PRIMARY KEY)",
+        );
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "SET XACT_ABORT ON; \
+             BEGIN TRAN; \
+             BEGIN TRY INSERT INTO t VALUES (1); INSERT INTO t VALUES (1); END TRY \
+             BEGIN CATCH \
+               IF EXISTS (SELECT * FROM t WHERE id = 1) SELECT 41 AS n ELSE SELECT 40 AS n; \
+               IF XACT_STATE() = -1 ROLLBACK; \
+             END CATCH; \
+             SELECT 42 AS n",
+        );
+        assert!(out.error.is_none(), "{:?}", out.error);
+        let firsts: Vec<i64> = out
+            .results
+            .iter()
+            .filter_map(|r| match r {
+                StatementResult::Rows(rowset) => match rowset.rows[0][0] {
+                    Datum::Int(v) => Some(i64::from(v)),
+                    Datum::BigInt(v) => Some(v),
+                    ref other => panic!("expected int, got {other:?}"),
+                },
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            firsts,
+            vec![41, 42],
+            "the doomed CATCH's condition read saw the txn's own row"
+        );
+        // A branch WRITE in the doomed CATCH is still rejected with 3930.
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "SET XACT_ABORT ON; \
+             BEGIN TRAN; \
+             BEGIN TRY INSERT INTO t VALUES (1); INSERT INTO t VALUES (1); END TRY \
+             BEGIN CATCH \
+               IF 1 = 1 INSERT INTO t VALUES (9); \
+             END CATCH",
+        );
+        assert_eq!(out.error.as_ref().map(|e| e.number), Some(3930));
+        batch(&engine, &mut ctx, "ROLLBACK");
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn cf_review_txn_control_inside_while() {
+        // BEGIN TRAN / COMMIT (and ROLLBACK) balanced per iteration:
+        // @@TRANCOUNT does not drift across iterations.
+        let path = unique_temp_path("cf-txn-in-while");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        batch(
+            &engine,
+            &mut ctx,
+            "CREATE TABLE t (id INT NOT NULL PRIMARY KEY)",
+        );
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "DECLARE @i INT = 0; \
+             WHILE @i < 3 \
+             BEGIN \
+               BEGIN TRAN; INSERT INTO t VALUES (@i); COMMIT; \
+               SET @i = @i + 1; \
+             END; \
+             SELECT CAST(@@TRANCOUNT AS INT) AS n",
+        );
+        assert!(out.error.is_none(), "{:?}", out.error);
+        assert_eq!(ids(&out), vec![0], "trancount balanced after the loop");
+        let out = batch(&engine, &mut ctx, "SELECT COUNT(*) AS n FROM t");
+        assert_eq!(ids(&out), vec![3]);
+        // Per-iteration ROLLBACK: every iteration's insert is undone.
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "DECLARE @i INT = 10; \
+             WHILE @i < 13 \
+             BEGIN \
+               BEGIN TRAN; INSERT INTO t VALUES (@i); ROLLBACK; \
+               SET @i = @i + 1; \
+             END; \
+             SELECT COUNT(*) AS n FROM t WHERE id >= 10",
+        );
+        assert!(out.error.is_none(), "{:?}", out.error);
+        assert_eq!(ids(&out), vec![0]);
+        assert!(!ctx.has_open_transaction());
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn cf_review_break_inside_catch_inside_while() {
+        // BREAK issued from a CATCH block still terminates the enclosing
+        // WHILE (the CATCH's flow propagates through the TryCatch arm).
+        let path = unique_temp_path("cf-break-in-catch");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        batch(
+            &engine,
+            &mut ctx,
+            "CREATE TABLE t (id INT NOT NULL PRIMARY KEY)",
+        );
+        batch(&engine, &mut ctx, "INSERT INTO t VALUES (1)");
+        // RETURN issued from a CATCH block exits the batch. This runs FIRST:
+        // it fails fast if the CATCH's flow is swallowed, where the BREAK
+        // case below would spin forever instead.
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "BEGIN TRY INSERT INTO t VALUES (1); END TRY \
+             BEGIN CATCH RETURN; END CATCH; \
+             SELECT 6 AS n",
+        );
+        assert!(out.error.is_none(), "{:?}", out.error);
+        assert!(
+            !out.results
+                .iter()
+                .any(|r| matches!(r, StatementResult::Rows(_))),
+            "the CATCH's RETURN exited the batch: {:?}",
+            out.results
+        );
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "WHILE 1 = 1 \
+             BEGIN \
+               BEGIN TRY INSERT INTO t VALUES (1); END TRY \
+               BEGIN CATCH BREAK; END CATCH \
+             END; \
+             SELECT 77 AS n",
+        );
+        assert!(out.error.is_none(), "{:?}", out.error);
+        assert_eq!(ids(&out), vec![77], "the CATCH's BREAK ended the loop");
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn cf_review_loop_body_error_continues_or_dooms() {
+        // XACT_ABORT OFF in a transaction: a non-dooming body error rolls
+        // back only that statement — the LOOP keeps iterating (it must not
+        // swallow the error either: the batch reports it at the end).
+        let path = unique_temp_path("cf-loop-body-error");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        batch(
+            &engine,
+            &mut ctx,
+            "CREATE TABLE t (id INT NOT NULL PRIMARY KEY)",
+        );
+        batch(&engine, &mut ctx, "INSERT INTO t VALUES (1)");
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "BEGIN TRAN; \
+             DECLARE @i INT = 0; \
+             WHILE @i < 3 \
+             BEGIN \
+               SET @i = @i + 1; \
+               INSERT INTO t VALUES (1); \
+             END; \
+             SELECT @i AS n; \
+             COMMIT",
+        );
+        assert_eq!(
+            ids(&out),
+            vec![3],
+            "all three iterations ran despite the per-iteration 2627"
+        );
+        assert_eq!(
+            out.error.as_ref().map(|e| e.number),
+            Some(2627),
+            "the continued error still surfaces at batch end"
+        );
+        assert!(!ctx.has_open_transaction(), "the COMMIT went through");
+        // XACT_ABORT ON: the first body error dooms and ends the batch
+        // mid-loop — the loop must NOT swallow it and keep iterating.
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "SET XACT_ABORT ON; \
+             BEGIN TRAN; \
+             DECLARE @i INT = 0; \
+             WHILE @i < 3 \
+             BEGIN \
+               SET @i = @i + 1; \
+               INSERT INTO t VALUES (1); \
+             END; \
+             SELECT @i AS n; \
+             COMMIT",
+        );
+        assert_eq!(out.error.as_ref().map(|e| e.number), Some(2627));
+        assert!(
+            !out.results
+                .iter()
+                .any(|r| matches!(r, StatementResult::Rows(_))),
+            "the batch ended mid-loop: no SELECT ran: {:?}",
+            out.results
+        );
+        assert!(ctx.has_open_transaction(), "doomed transaction stays open");
+        batch(&engine, &mut ctx, "ROLLBACK");
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn cf_review_raiserror_and_throw_inside_while() {
+        // RAISERROR >= 11 outside TRY is statement-scope: the loop keeps
+        // running and the error surfaces after the batch finishes. THROW is
+        // batch-terminating: it ends the loop AND the batch.
+        let path = unique_temp_path("cf-raise-throw-loop");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "DECLARE @i INT = 0; \
+             WHILE @i < 3 \
+             BEGIN \
+               SET @i = @i + 1; \
+               IF @i = 2 RAISERROR('boom', 16, 1); \
+             END; \
+             SELECT @i AS n",
+        );
+        assert_eq!(ids(&out), vec![3], "the loop survived the RAISERROR");
+        assert_eq!(
+            out.error.as_ref().map(|e| e.number),
+            Some(50000),
+            "the RAISERROR still surfaces at batch end"
+        );
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "DECLARE @i INT = 0; \
+             WHILE 1 = 1 \
+             BEGIN \
+               SET @i = @i + 1; \
+               IF @i = 2 THROW 50001, 'stop', 1; \
+             END; \
+             SELECT 9 AS n",
+        );
+        assert_eq!(out.error.as_ref().map(|e| e.number), Some(50001));
+        assert!(
+            !out.results
+                .iter()
+                .any(|r| matches!(r, StatementResult::Rows(_))),
+            "THROW ended the batch, not just the loop: {:?}",
+            out.results
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn cf_review_return_unwinds_nested_control_flow() {
+        // RETURN inside WHILE exits the batch (not just the loop), and a
+        // RETURN nested in WHILE-inside-TRY-inside-BEGIN..END unwinds
+        // everything without running any CATCH.
+        let path = unique_temp_path("cf-return-unwind");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "DECLARE @i INT = 0; \
+             WHILE 1 = 1 \
+             BEGIN \
+               SET @i = @i + 1; \
+               IF @i = 2 RETURN; \
+             END; \
+             SELECT 1 AS n",
+        );
+        assert!(out.error.is_none(), "{:?}", out.error);
+        assert!(
+            !out.results
+                .iter()
+                .any(|r| matches!(r, StatementResult::Rows(_))),
+            "RETURN exited the batch: the post-loop SELECT never ran: {:?}",
+            out.results
+        );
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "BEGIN TRY \
+               BEGIN \
+                 WHILE 1 = 1 \
+                 BEGIN \
+                   RETURN; \
+                 END \
+               END \
+             END TRY \
+             BEGIN CATCH SELECT 5 AS n; END CATCH; \
+             SELECT 6 AS n",
+        );
+        assert!(out.error.is_none(), "{:?}", out.error);
+        assert!(
+            !out.results
+                .iter()
+                .any(|r| matches!(r, StatementResult::Rows(_))),
+            "RETURN unwound block+loop+TRY without a CATCH: {:?}",
+            out.results
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn cf_review_while_condition_resets_last_error() {
+        // The WHILE's per-iteration condition evaluation resets @@ERROR (like
+        // the IF's) — a body error set on the LAST iteration reads 0 after
+        // the final (false) condition evaluation. SQL Server ambiguity noted:
+        // the IF analogy (every statement evaluation resets @@ERROR) is what
+        // this pins.
+        let path = unique_temp_path("cf-while-at-at-error");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        batch(
+            &engine,
+            &mut ctx,
+            "CREATE TABLE t (id INT NOT NULL PRIMARY KEY)",
+        );
+        batch(&engine, &mut ctx, "INSERT INTO t VALUES (1)");
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "BEGIN TRAN; \
+             DECLARE @i INT = 0; \
+             WHILE @i < 1 \
+             BEGIN \
+               SET @i = @i + 1; \
+               INSERT INTO t VALUES (1); \
+             END; \
+             SELECT @@ERROR AS n; \
+             COMMIT",
+        );
+        assert_eq!(
+            ids(&out),
+            vec![0],
+            "the final condition evaluation reset @@ERROR"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn cf_review_parser_edges() {
+        let path = unique_temp_path("cf-parser-edges");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        batch(
+            &engine,
+            &mut ctx,
+            "CREATE TABLE t (id INT NOT NULL PRIMARY KEY)",
+        );
+        // Dangling ELSE binds to the INNERMOST IF (as in SQL Server): the
+        // inner condition is false, so the ELSE runs.
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "IF 1 = 1 IF 1 = 2 SELECT 1 AS n ELSE SELECT 2 AS n",
+        );
+        assert!(out.error.is_none(), "{:?}", out.error);
+        assert_eq!(ids(&out), vec![2], "the ELSE belongs to the inner IF");
+        // ...so when the OUTER condition is false, nothing runs at all.
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "IF 1 = 2 IF 1 = 1 SELECT 1 AS n ELSE SELECT 2 AS n; SELECT 3 AS n",
+        );
+        assert!(out.error.is_none(), "{:?}", out.error);
+        assert_eq!(ids(&out), vec![3]);
+        // CASE consumes its own ELSE; the IF grammar is unaffected.
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "IF CASE WHEN 1 = 1 THEN 1 ELSE 2 END = 1 SELECT 4 AS n",
+        );
+        assert!(out.error.is_none(), "{:?}", out.error);
+        assert_eq!(ids(&out), vec![4]);
+        // A semicolon ends the IF: `; ELSE` is a syntax error, as in T-SQL.
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "IF 1 = 1 SELECT 1 AS n; ELSE SELECT 2 AS n",
+        );
+        assert!(out.error.is_some(), "`; ELSE` must not attach to the IF");
+        // A block whose first statement is BEGIN TRAN parses as a block.
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "BEGIN BEGIN TRAN; INSERT INTO t VALUES (21); COMMIT; END",
+        );
+        assert!(out.error.is_none(), "{:?}", out.error);
+        assert!(!ctx.has_open_transaction());
+        // WHILE whose body is a bare BREAK parses and runs zero-or-more times.
+        let out = batch(&engine, &mut ctx, "WHILE 1 = 0 BREAK; SELECT 8 AS n");
+        assert!(out.error.is_none(), "{:?}", out.error);
+        assert_eq!(ids(&out), vec![8]);
+        // BREAK inside EXEC'd text is its own batch scope: compile-time 135
+        // surfaces as the EXEC's error even though the EXEC sits in a WHILE.
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "DECLARE @i INT = 0; \
+             WHILE @i < 1 \
+             BEGIN \
+               SET @i = 1; \
+               EXEC sp_executesql N'BREAK'; \
+             END",
+        );
+        assert_eq!(out.error.as_ref().map(|e| e.number), Some(135));
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn cf_review_tsql_fidelity_gaps() {
+        let path = unique_temp_path("cf-fidelity");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        batch(
+            &engine,
+            &mut ctx,
+            "CREATE TABLE t (id INT NOT NULL PRIMARY KEY)",
+        );
+        // An empty block is a compile-time syntax error in T-SQL ("Incorrect
+        // syntax near 'END'") — expectation is the recommended FIXED behavior
+        // (3360df1 accepts it as a no-op).
+        let out = batch(&engine, &mut ctx, "BEGIN END");
+        assert!(
+            out.error.is_some(),
+            "T-SQL rejects an empty BEGIN END block"
+        );
+        // RETURN with a string value is context error 178 in a batch, like
+        // any RETURN with a value — expectation is the recommended FIXED
+        // behavior (3360df1 gives 102 near 'x': the string is not parsed as
+        // the RETURN's value).
+        let out = batch(&engine, &mut ctx, "RETURN 'x'");
+        assert_eq!(out.error.as_ref().map(|e| e.number), Some(178));
+        // Recorded divergence (pinning CURRENT behavior): SQL Server's
+        // IF EXISTS sets @@ROWCOUNT from the probe scan (0 here); TruthDB's
+        // condition evaluation leaves @@ROWCOUNT untouched, so the INSERT's
+        // count of 1 survives the untaken IF.
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "INSERT INTO t VALUES (2); \
+             IF EXISTS (SELECT * FROM t WHERE id = 99) SELECT 7 AS n; \
+             SELECT CAST(@@ROWCOUNT AS INT) AS n",
+        );
+        assert_eq!(ids(&out), vec![1]);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn cf_review_condition_error_shapes() {
+        let path = unique_temp_path("cf-cond-errors");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        batch(
+            &engine,
+            &mut ctx,
+            "CREATE TABLE t (id INT NOT NULL PRIMARY KEY)",
+        );
+        batch(&engine, &mut ctx, "INSERT INTO t VALUES (1), (2)");
+        // An undeclared variable in the condition is the usual 137.
+        let out = batch(&engine, &mut ctx, "IF @nope = 1 SELECT 1 AS n");
+        assert_eq!(out.error.as_ref().map(|e| e.number), Some(137));
+        // A scalar condition subquery returning two rows is 512.
+        let out = batch(&engine, &mut ctx, "IF (SELECT id FROM t) = 1 SELECT 1 AS n");
+        assert_eq!(out.error.as_ref().map(|e| e.number), Some(512));
+        // An assignment SELECT nested in a condition subquery is rejected.
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "DECLARE @x INT; IF (SELECT @x = 1) = 1 SELECT 1 AS n",
+        );
+        assert_eq!(out.error.as_ref().map(|e| e.number), Some(141));
+        // Nested EXISTS inside the condition's subquery works.
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "IF EXISTS (SELECT * FROM t WHERE EXISTS (SELECT * FROM t WHERE id = 2)) \
+             SELECT 8 AS n ELSE SELECT 9 AS n",
+        );
+        assert!(out.error.is_none(), "{:?}", out.error);
+        assert_eq!(ids(&out), vec![8]);
+        // A condition error outside any transaction ends the batch (same
+        // ladder as a failed statement); in a transaction with XACT_ABORT
+        // OFF the batch continues past the failed IF, taking no branch.
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "IF 1 / 0 = 1 SELECT 1 AS n ELSE SELECT 2 AS n",
+        );
+        assert_eq!(out.error.as_ref().map(|e| e.number), Some(8134));
+        assert!(
+            !out.results
+                .iter()
+                .any(|r| matches!(r, StatementResult::Rows(_))),
+            "neither branch ran: {:?}",
+            out.results
+        );
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "BEGIN TRAN; \
+             IF 1 / 0 = 1 SELECT 1 AS n ELSE SELECT 2 AS n; \
+             SELECT 99 AS n; \
+             COMMIT",
+        );
+        assert_eq!(ids(&out), vec![99], "no branch ran; the batch continued");
+        assert_eq!(out.error.as_ref().map(|e| e.number), Some(8134));
+        assert!(!ctx.has_open_transaction());
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn cf_review_describe_stops_at_control_flow() {
+        // sp_describe_first_result_set: a batch whose FIRST possible rowset
+        // sits inside an IF must answer "not statically derivable" — skipping
+        // the IF and describing a LATER statement would hand a prepared
+        // driver the wrong COLMETADATA when the branch streams first.
+        let path = unique_temp_path("cf-describe");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        batch(
+            &engine,
+            &mut ctx,
+            "CREATE TABLE t (id INT NOT NULL PRIMARY KEY, v NVARCHAR(10))",
+        );
+        let described =
+            engine.describe_first_result_set("IF 1 = 1 SELECT id FROM t; SELECT v FROM t");
+        assert!(
+            described.is_err(),
+            "an IF-guarded first rowset is not statically derivable: {described:?}"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn cf_review_own_txn_writes_visible_in_condition() {
+        // A transaction's own uncommitted write is visible to its own IF
+        // condition (plain READ COMMITTED, no versioning).
+        let path = unique_temp_path("cf-own-writes");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        batch(
+            &engine,
+            &mut ctx,
+            "CREATE TABLE t (id INT NOT NULL PRIMARY KEY)",
+        );
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "BEGIN TRAN; \
+             INSERT INTO t VALUES (5); \
+             IF EXISTS (SELECT * FROM t WHERE id = 5) SELECT 1 AS n ELSE SELECT 0 AS n; \
+             ROLLBACK",
+        );
+        assert!(out.error.is_none(), "{:?}", out.error);
+        assert_eq!(ids(&out), vec![1]);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn cf_review_exec_inner_return_exits_inner_batch_only() {
+        // A RETURN inside EXEC'd text ends the INNER batch; the outer batch
+        // continues after the EXEC.
+        let path = unique_temp_path("cf-exec-return");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        batch(
+            &engine,
+            &mut ctx,
+            "CREATE TABLE t (id INT NOT NULL PRIMARY KEY)",
+        );
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "EXEC sp_executesql N'INSERT INTO t VALUES (1); RETURN; INSERT INTO t VALUES (2)'; \
+             INSERT INTO t VALUES (3); \
+             SELECT id FROM t ORDER BY id",
+        );
+        assert!(out.error.is_none(), "{:?}", out.error);
+        assert_eq!(
+            ids(&out),
+            vec![1, 3],
+            "inner RETURN skipped only the inner tail"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn cf_review_cancel_lands_mid_while() {
+        // An Attention arriving while a WHILE spins aborts the batch with the
+        // cancel marker instead of looping forever.
+        let path = unique_temp_path("cf-cancel-while");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        let flag = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        crate::rel::set_test_cancel(flag.clone());
+        let setter = {
+            let flag = flag.clone();
+            std::thread::spawn(move || {
+                std::thread::sleep(std::time::Duration::from_millis(150));
+                flag.store(true, std::sync::atomic::Ordering::Relaxed);
+            })
+        };
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "DECLARE @i INT = 0; WHILE 1 = 1 SET @i = @i + 1",
+        );
+        crate::rel::clear_test_cancel();
+        setter.join().expect("setter thread");
+        assert_eq!(
+            out.error.as_ref().map(|e| e.number),
+            Some(3617),
+            "the spin died on the Attention"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn cf_review_condition_cte_executes_but_analysis_misses_it() {
+        // Runtime reachability half of the CTE lock hole: the executor
+        // inlines a WITH inside an IF condition's subquery and reads the base
+        // table (see storage.rs cf_review_analyze_locks_condition_cte for the
+        // analysis half — the lock set contains nothing for it).
+        let path = unique_temp_path("cf-cond-cte-runtime");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        batch(
+            &engine,
+            &mut ctx,
+            "CREATE TABLE t (id INT NOT NULL PRIMARY KEY)",
+        );
+        batch(&engine, &mut ctx, "INSERT INTO t VALUES (1)");
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "IF EXISTS (WITH x AS (SELECT id FROM t) SELECT id FROM x) \
+             SELECT 1 AS n ELSE SELECT 0 AS n",
+        );
+        assert!(out.error.is_none(), "{:?}", out.error);
+        assert_eq!(ids(&out), vec![1], "the CTE condition read the table");
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn cf_review_rcsi_condition_read_is_versioned() {
+        // Under RCSI a READ COMMITTED read takes no Table S — it relies on
+        // the per-statement snapshot instead. The IF condition's subquery
+        // must therefore read through a snapshot exactly like a SELECT
+        // statement does; reading the raw latest state is a dirty read
+        // (expectations here are the FIXED behavior).
+        let path = unique_temp_path("cf-rcsi-cond");
+        let engine = new_engine(&path);
+        let mut admin = TxnContext::default();
+        batch(
+            &engine,
+            &mut admin,
+            "ALTER DATABASE CURRENT SET READ_COMMITTED_SNAPSHOT ON",
+        );
+        batch(
+            &engine,
+            &mut admin,
+            "CREATE TABLE t (id INT NOT NULL PRIMARY KEY)",
+        );
+        let mut writer = TxnContext::default();
+        let out = batch(&engine, &mut writer, "BEGIN TRAN; INSERT INTO t VALUES (1)");
+        assert!(out.error.is_none(), "{:?}", out.error);
+        let mut reader = TxnContext::default();
+        let out = batch(&engine, &mut reader, "SELECT COUNT(*) AS n FROM t");
+        assert_eq!(
+            ids(&out),
+            vec![0],
+            "sanity: a plain SELECT reads the snapshot, not the writer's uncommitted row"
+        );
+        let out = batch(
+            &engine,
+            &mut reader,
+            "IF EXISTS (SELECT * FROM t WHERE id = 1) SELECT 1 AS n ELSE SELECT 0 AS n",
+        );
+        assert!(out.error.is_none(), "{:?}", out.error);
+        assert_eq!(
+            ids(&out),
+            vec![0],
+            "the IF condition must read the same snapshot a SELECT would — \
+             seeing the writer's uncommitted row is a dirty read"
+        );
+        batch(&engine, &mut writer, "ROLLBACK");
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn cf_review_snapshot_isolation_condition_uses_txn_snapshot() {
+        // SNAPSHOT isolation: every read in the transaction sees the
+        // transaction's snapshot. A commit that lands after the snapshot was
+        // established must stay invisible to an IF condition too
+        // (expectations here are the FIXED behavior).
+        let path = unique_temp_path("cf-snap-cond");
+        let engine = new_engine(&path);
+        let mut admin = TxnContext::default();
+        batch(
+            &engine,
+            &mut admin,
+            "ALTER DATABASE CURRENT SET ALLOW_SNAPSHOT_ISOLATION ON",
+        );
+        batch(
+            &engine,
+            &mut admin,
+            "CREATE TABLE t (id INT NOT NULL PRIMARY KEY)",
+        );
+        batch(&engine, &mut admin, "INSERT INTO t VALUES (1)");
+        let mut reader = TxnContext::default();
+        batch(
+            &engine,
+            &mut reader,
+            "SET TRANSACTION ISOLATION LEVEL SNAPSHOT",
+        );
+        let out = batch(
+            &engine,
+            &mut reader,
+            "BEGIN TRAN; SELECT COUNT(*) AS n FROM t",
+        );
+        assert_eq!(ids(&out), vec![1], "the snapshot is established at 1 row");
+        let out = batch(&engine, &mut admin, "INSERT INTO t VALUES (2)");
+        assert!(out.error.is_none(), "{:?}", out.error);
+        let out = batch(
+            &engine,
+            &mut reader,
+            "IF EXISTS (SELECT * FROM t WHERE id = 2) SELECT 1 AS n ELSE SELECT 0 AS n",
+        );
+        assert!(out.error.is_none(), "{:?}", out.error);
+        assert_eq!(
+            ids(&out),
+            vec![0],
+            "the IF condition must read the transaction's snapshot, \
+             not the post-snapshot commit"
+        );
+        batch(&engine, &mut reader, "COMMIT");
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
     fn try_catch_nested_inner_handles_outer_continues() {
         // The inner CATCH handles the inner error; because it does not re-raise,
         // the outer TRY continues and the outer CATCH never runs.

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -814,9 +814,13 @@ fn run_exec(
         );
         Err(ExecError::Own(doom_per_rule(txn_ctx, error)))
     } else {
-        // An error crossing out of the inner batch already carries every
-        // decision (dooming, and by crossing at all: termination).
-        run_block(storage, &statements, txn_ctx, run, in_try).map_err(ExecError::Inner)
+        // An inner RETURN exits the inner batch only (Break/Continue cannot
+        // escape — the inner parse rejects them, its own 135/136 scope). An
+        // error crossing out already carries every decision: dooming, and by
+        // crossing at all, termination of the whole nest.
+        run_block(storage, &statements, txn_ctx, run, in_try)
+            .map(|_| ())
+            .map_err(ExecError::Inner)
     };
     EXEC_DEPTH.with(|d| d.set(d.get() - 1));
     txn_ctx.variables = outer_vars;
@@ -827,13 +831,180 @@ fn run_exec(
     result
 }
 
+/// The ONE place a failed statement's fate is decided — continue the batch
+/// (`Ok(())`), or end it (`Err`, dooming already applied). The doom decision
+/// needs the statement's KIND (RAISERROR is exempt from XACT_ABORT; THROW is
+/// batch-terminating without dooming), so every decide-now error site funnels
+/// here: the generic statement arm and IF/WHILE condition failures. (EXEC
+/// boundary errors do NOT — theirs were decided at the source, in the inner
+/// `run_block` or `doom_per_rule`.)
+fn statement_error_ladder(
+    statement: &Statement,
+    error: SqlError,
+    txn_ctx: &mut TxnContext,
+    run: &mut BatchRun<'_>,
+    in_try: bool,
+) -> Result<(), SqlError> {
+    // A cancelled statement aborts the batch immediately: key on the cancel
+    // marker, not any flag, so an Attention landing concurrently with an
+    // unrelated failure cannot suppress that failure's dooming. A cancel is
+    // not a SQL error, so `@@ERROR` is untouched.
+    if error.number == CANCEL_ERROR {
+        return Err(error);
+    }
+    txn_ctx.last_error = error.number;
+    // A durability failure wedged the store (a flush inside the statement,
+    // e.g. before a snapshot capture): never continue past a lost commit.
+    if run.durability_failed {
+        return Err(error);
+    }
+    // Severity >= 20 is fatal to the connection: it bypasses TRY (the
+    // TryCatch arm refuses it too), dooms the transaction, and the protocol
+    // layer closes the stream after delivering it.
+    if error.level >= FATAL_SEVERITY {
+        if txn_ctx.in_txn() {
+            txn_ctx.doomed = true;
+        }
+        return Err(error);
+    }
+    // The doom decision is made HERE, where the failing statement's kind is
+    // known — never re-derived at the TRY boundary, which cannot see it.
+    // `SET XACT_ABORT` (or severity >= 17) dooms; RAISERROR is exempt by
+    // definition (SQL Server: "errors raised by RAISERROR are not affected
+    // by SET XACT_ABORT") and never dooms.
+    let dooms = !matches!(statement, Statement::RaiseError(_))
+        && (txn_ctx.xact_abort || error.level >= XACT_ABORT_SEVERITY);
+    if txn_ctx.in_txn() && dooms {
+        txn_ctx.doomed = true;
+    }
+    // Inside a TRY, the error then transfers to the matching CATCH (which
+    // sees XACT_STATE() = -1 when it doomed). The CATCH runs more statements,
+    // so a result set this one already started streaming must be closed.
+    if in_try {
+        run.abort_open_rowset(txn_ctx.in_txn());
+        return Err(error);
+    }
+    // RAISERROR is statement-scope: the batch always continues.
+    if matches!(statement, Statement::RaiseError(_)) {
+        run.abort_open_rowset(txn_ctx.in_txn());
+        run.last_error = Some(error);
+        return Ok(());
+    }
+    // THROW always terminates the batch — even when it does not doom the
+    // transaction (XACT_ABORT OFF leaves it open and committable later).
+    if matches!(statement, Statement::Throw(_)) {
+        return Err(error);
+    }
+    // Other statements: a non-dooming in-transaction error rolls back only
+    // the statement and the batch continues; a dooming one ends the batch
+    // (only ROLLBACK is then accepted, error 3930).
+    if txn_ctx.in_txn() && !dooms {
+        run.abort_open_rowset(txn_ctx.in_txn());
+        run.last_error = Some(error);
+        return Ok(());
+    }
+    Err(error)
+}
+
+/// Enters the versioned-read scopes for an IF/WHILE condition that reads
+/// tables — the SAME rules a SELECT gets in `exec_statement_streamed`: under
+/// RCSI the condition reads its own statement snapshot; under SNAPSHOT
+/// isolation it establishes/uses the transaction snapshot and enforces 3952.
+/// Without this the condition read holds NEITHER lock nor snapshot (analysis
+/// assumes versioned reads and drops Table S) — a live dirty read, the
+/// Stage 13 seam class, caught by the control-flow review.
+fn enter_condition_scopes<'a>(
+    storage: &'a Storage,
+    condition: &Expr,
+    txn_ctx: &mut TxnContext,
+    run: &mut BatchRun<'_>,
+) -> Result<(Option<SnapshotScope<'a>>, Option<TxnSnapshotScope>), SqlError> {
+    let mut tables = Vec::new();
+    collect_expr_tables(condition, &mut tables);
+    if tables.is_empty() {
+        return Ok((None, None));
+    }
+    match txn_ctx.isolation() {
+        Isolation::ReadCommitted if storage.rcsi_enabled() => {
+            // The snapshot is the durable commit prefix: the session's own
+            // just-committed statements must be durable before capture.
+            run.flush(storage)?;
+            Ok((
+                Some(SnapshotScope::enter(
+                    storage,
+                    txn_ctx.txn.as_ref().map(StorageTxn::txn_id),
+                )),
+                None,
+            ))
+        }
+        Isolation::Snapshot => {
+            if !storage.snapshot_isolation_allowed() {
+                if txn_ctx.in_txn() {
+                    txn_ctx.doomed = true;
+                }
+                return Err(snapshot_not_allowed_error(&txn_ctx.database));
+            }
+            if txn_ctx.in_txn() {
+                if txn_ctx.txn_snapshot.is_none() {
+                    // First data access establishes the transaction's view —
+                    // a condition read counts.
+                    run.flush(storage)?;
+                    let own = txn_ctx.txn.as_ref().map(StorageTxn::txn_id);
+                    txn_ctx.txn_snapshot = Some(storage.capture_read_snapshot(own));
+                }
+                Ok((None, txn_ctx.txn_snapshot.map(TxnSnapshotScope::enter)))
+            } else {
+                run.flush(storage)?;
+                Ok((Some(SnapshotScope::enter(storage, None)), None))
+            }
+        }
+        _ => Ok((None, None)),
+    }
+}
+
+/// Evaluates an IF/WHILE condition: subqueries (EXISTS, scalar, IN) resolve
+/// eagerly through the same machinery as WHERE-clause subqueries, then the
+/// residual expression evaluates against the session context. T-SQL
+/// three-valued: TRUE runs the branch; FALSE and NULL (UNKNOWN) do not.
+fn eval_condition(
+    storage: &Storage,
+    condition: &Expr,
+    txn_ctx: &TxnContext,
+) -> Result<bool, SqlError> {
+    let eval_ctx = txn_ctx.eval_context();
+    let no_outer = |_: &str| -> Option<usize> { None };
+    let resolved = substitute_correlated_in_expr(storage, condition, &no_outer, &[], &eval_ctx)?;
+    match eval_constant(&resolved, &eval_ctx)? {
+        SqlValue::Bool(taken) => Ok(taken),
+        SqlValue::Null => Ok(false),
+        _ => Err(SqlError::new(
+            4145,
+            15,
+            1,
+            "An expression of non-boolean type specified in a context where a condition is              expected.",
+        )),
+    }
+}
+
+/// How a statement block ended: normally, or via a control-flow statement
+/// that must propagate to the construct that absorbs it (`WHILE` for
+/// Break/Continue, the batch — later the procedure — for Return). TRY/CATCH
+/// and plain blocks pass every non-Normal flow straight through.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Flow {
+    Normal,
+    Break,
+    Continue,
+    Return,
+}
+
 fn run_block(
     storage: &Storage,
     statements: &[Statement],
     txn_ctx: &mut TxnContext,
     run: &mut BatchRun<'_>,
     in_try: bool,
-) -> Result<(), SqlError> {
+) -> Result<Flow, SqlError> {
     for statement in statements {
         // A TDS Attention (cancel) aborts the batch before the next statement.
         // It is never catchable — it propagates straight out, past any TRY.
@@ -895,6 +1066,86 @@ fn run_block(
             }
             continue;
         }
+        match statement {
+            Statement::Block { body, .. } => {
+                match run_block(storage, body, txn_ctx, run, in_try)? {
+                    Flow::Normal => {}
+                    flow => return Ok(flow),
+                }
+                continue;
+            }
+            Statement::If {
+                condition,
+                then_branch,
+                else_branch,
+                ..
+            } => {
+                // A successful condition evaluation resets `@@ERROR` (the IF
+                // itself is a statement) — AFTER the condition read it, which
+                // is what makes `IF @@ERROR <> 0` work.
+                let taken = match enter_condition_scopes(storage, condition, txn_ctx, run)
+                    .and_then(|_scopes| eval_condition(storage, condition, txn_ctx))
+                {
+                    Ok(taken) => taken,
+                    Err(error) => {
+                        txn_ctx.rowcount = 0;
+                        statement_error_ladder(statement, error, txn_ctx, run, in_try)?;
+                        continue;
+                    }
+                };
+                txn_ctx.last_error = 0;
+                let branch = if taken {
+                    Some(then_branch)
+                } else {
+                    else_branch.as_ref()
+                };
+                if let Some(branch) = branch {
+                    match run_block(storage, std::slice::from_ref(branch), txn_ctx, run, in_try)? {
+                        Flow::Normal => {}
+                        flow => return Ok(flow),
+                    }
+                }
+                continue;
+            }
+            Statement::While {
+                condition, body, ..
+            } => {
+                loop {
+                    // A TDS Attention lands between iterations too — an
+                    // infinite `WHILE 1 = 1` must die on cancel even when its
+                    // body runs no cancellable statement.
+                    check_cancelled()?;
+                    let taken = match enter_condition_scopes(storage, condition, txn_ctx, run)
+                        .and_then(|_scopes| eval_condition(storage, condition, txn_ctx))
+                    {
+                        Ok(taken) => taken,
+                        Err(error) => {
+                            txn_ctx.rowcount = 0;
+                            statement_error_ladder(statement, error, txn_ctx, run, in_try)?;
+                            break;
+                        }
+                    };
+                    txn_ctx.last_error = 0;
+                    if !taken {
+                        break;
+                    }
+                    match run_block(storage, std::slice::from_ref(body), txn_ctx, run, in_try)? {
+                        Flow::Normal | Flow::Continue => {}
+                        Flow::Break => break,
+                        Flow::Return => return Ok(Flow::Return),
+                    }
+                }
+                continue;
+            }
+            // The parser rejects BREAK/CONTINUE outside a WHILE (135/136), so
+            // these only ever propagate up to an enclosing loop.
+            Statement::Break { .. } => return Ok(Flow::Break),
+            Statement::Continue { .. } => return Ok(Flow::Continue),
+            // The parser rejects `RETURN <value>` outside a procedure (178),
+            // so a reachable RETURN just exits the batch.
+            Statement::Return { .. } => return Ok(Flow::Return),
+            _ => {}
+        }
         if let Statement::TryCatch {
             try_block,
             catch_block,
@@ -902,7 +1153,9 @@ fn run_block(
         } = statement
         {
             match run_block(storage, try_block, txn_ctx, run, true) {
-                Ok(()) => {}
+                Ok(Flow::Normal) => {}
+                // BREAK/CONTINUE/RETURN cross a TRY without running its CATCH.
+                Ok(flow) => return Ok(flow),
                 // An Attention that landed inside the TRY block is not caught.
                 Err(cancel) if cancel.number == CANCEL_ERROR => return Err(cancel),
                 // A durability failure wedged the store: no CATCH swallows a
@@ -930,7 +1183,10 @@ fn run_block(
                     // outer CATCH (or end the batch) per `in_try`.
                     let caught = run_block(storage, catch_block, txn_ctx, run, in_try);
                     txn_ctx.pop_error();
-                    caught?;
+                    match caught? {
+                        Flow::Normal => {}
+                        flow => return Ok(flow),
+                    }
                 }
             }
             continue;
@@ -1005,76 +1261,11 @@ fn run_block(
             Err(error) => {
                 // A failed statement sets @@ROWCOUNT to 0, as SQL Server does.
                 txn_ctx.rowcount = 0;
-                // A cancelled statement aborts the batch immediately (see above):
-                // key on the cancel marker, not any flag, so an Attention landing
-                // concurrently with an unrelated failure cannot suppress that
-                // failure's dooming. (No rowset close: the batch ends here, and
-                // its terminal DONE closes anything the statement left open.)
-                // A cancel is not a SQL error, so `@@ERROR` is untouched.
-                if error.number == CANCEL_ERROR {
-                    return Err(error);
-                }
-                txn_ctx.last_error = error.number;
-                // A durability failure wedged the store (a flush inside the
-                // statement, e.g. before a snapshot capture): never continue
-                // past a lost commit.
-                if run.durability_failed {
-                    return Err(error);
-                }
-                // Severity >= 20 is fatal to the connection: it bypasses TRY
-                // (the TryCatch arm refuses it too), dooms the transaction,
-                // and the protocol layer closes the stream after delivering
-                // it.
-                if error.level >= FATAL_SEVERITY {
-                    if txn_ctx.in_txn() {
-                        txn_ctx.doomed = true;
-                    }
-                    return Err(error);
-                }
-                // The doom decision is made HERE, where the failing statement's
-                // kind is known — never re-derived at the TRY boundary, which
-                // cannot see it. `SET XACT_ABORT` (or severity >= 17) dooms the
-                // transaction; RAISERROR is exempt by definition (SQL Server:
-                // "errors raised by RAISERROR are not affected by SET
-                // XACT_ABORT") and never dooms.
-                let dooms = !matches!(statement, Statement::RaiseError(_))
-                    && (txn_ctx.xact_abort || error.level >= XACT_ABORT_SEVERITY);
-                if txn_ctx.in_txn() && dooms {
-                    txn_ctx.doomed = true;
-                }
-                // Inside a TRY, the error then transfers to the matching CATCH
-                // (which sees XACT_STATE() = -1 when it doomed). The CATCH runs
-                // more statements, so a result set this one already started
-                // streaming must be closed first.
-                if in_try {
-                    run.abort_open_rowset(txn_ctx.in_txn());
-                    return Err(error);
-                }
-                // RAISERROR is statement-scope: the batch always continues.
-                if matches!(statement, Statement::RaiseError(_)) {
-                    run.abort_open_rowset(txn_ctx.in_txn());
-                    run.last_error = Some(error);
-                    continue;
-                }
-                // THROW always terminates the batch — even when it does not
-                // doom the transaction (XACT_ABORT OFF leaves the transaction
-                // open and committable from a later batch).
-                if matches!(statement, Statement::Throw(_)) {
-                    return Err(error);
-                }
-                // Other statements: a non-dooming error rolls back only the
-                // statement and the batch continues; a dooming one ends the
-                // batch (only ROLLBACK is then accepted, error 3930).
-                if txn_ctx.in_txn() && !dooms {
-                    run.abort_open_rowset(txn_ctx.in_txn());
-                    run.last_error = Some(error);
-                    continue;
-                }
-                return Err(error);
+                statement_error_ladder(statement, error, txn_ctx, run, in_try)?;
             }
         }
     }
-    Ok(())
+    Ok(Flow::Normal)
 }
 
 /// `sp_describe_first_result_set`: the column metadata of `tsql`'s first
@@ -1211,8 +1402,10 @@ fn produces_rowset(statement: &Statement) -> bool {
             .items
             .iter()
             .any(|i| matches!(i, SelectItem::Assign { .. })),
-        // EXEC's inner batch may open result sets; conservative.
+        // EXEC's inner batch — and any control-flow body — may open result
+        // sets; conservative.
         Statement::Exec(_) => true,
+        Statement::Block { .. } | Statement::If { .. } | Statement::While { .. } => true,
         _ => false,
     }
 }
@@ -1432,6 +1625,9 @@ fn statement_may_commit(statement: &Statement) -> bool {
             | Statement::AlterTable(_)
             | Statement::AlterDatabase(_)
             | Statement::Exec(_)
+            | Statement::Block { .. }
+            | Statement::If { .. }
+            | Statement::While { .. }
             | Statement::Commit { .. }
     )
 }
@@ -1969,10 +2165,33 @@ pub fn analyze_locks(
                 }
                 None => add(Resource::Database, LockMode::Exclusive),
             },
+            // IF/WHILE conditions read tables through their subqueries —
+            // locked exactly like a SELECT's tables (their bodies were
+            // flattened into this list and analyze as themselves).
+            Statement::If { condition, .. } | Statement::While { condition, .. } => {
+                if !reads_lock {
+                    continue;
+                }
+                let mut tables = Vec::new();
+                collect_expr_tables(condition, &mut tables);
+                for name in tables {
+                    for oid in read_lock_object_ids(storage, &name.value) {
+                        add(Resource::Database, LockMode::IntentShared);
+                        if !versioned_reads {
+                            add(Resource::Table(oid), LockMode::Shared);
+                        }
+                    }
+                }
+            }
             // Transaction control, SET, and DECLARE take no data locks.
-            // TRY/CATCH was flattened away by `flatten_statements`, so its
-            // contained statements appear here directly.
-            Statement::BeginTransaction { .. }
+            // TRY/CATCH and plain blocks were flattened away by
+            // `flatten_statements`, so their contained statements appear here
+            // directly; BREAK/CONTINUE/RETURN touch nothing.
+            Statement::Block { .. }
+            | Statement::Break { .. }
+            | Statement::Continue { .. }
+            | Statement::Return { .. }
+            | Statement::BeginTransaction { .. }
             | Statement::Commit { .. }
             | Statement::Rollback { .. }
             | Statement::SaveTransaction { .. }
@@ -2079,6 +2298,15 @@ fn exec_statement_dispatch(
         Statement::BeginTransaction { .. } => exec_begin(storage, txn_ctx),
         Statement::Use { database, .. } => exec_use(database, txn_ctx),
         Statement::Throw(throw) => Err(exec_throw(throw, txn_ctx)),
+        // Executed by `run_block`'s own arms; nothing routes them here.
+        Statement::Block { .. }
+        | Statement::If { .. }
+        | Statement::While { .. }
+        | Statement::Break { .. }
+        | Statement::Continue { .. }
+        | Statement::Return { .. } => {
+            unreachable!("control flow is executed by run_block")
+        }
         // Handled in `exec_statement_streamed_inner` (severity <= 10 emits an
         // INFO event, which needs the emitter); nothing else routes it here.
         Statement::RaiseError(_) => unreachable!("RAISERROR reaches only the streaming executor"),
@@ -2230,6 +2458,27 @@ fn flatten_statements<'a>(statements: &'a [Statement], out: &mut Vec<&'a Stateme
             } => {
                 flatten_statements(try_block, out);
                 flatten_statements(catch_block, out);
+            }
+            Statement::Block { body, .. } => flatten_statements(body, out),
+            // IF/WHILE stay in the list (their CONDITIONS take read locks);
+            // their bodies flatten so the leaf statements analyze as
+            // themselves — a WHILE body's INSERT needs its lock up front like
+            // any other, and both IF branches are analyzed (conservative:
+            // which one runs is a runtime fact).
+            Statement::If {
+                then_branch,
+                else_branch,
+                ..
+            } => {
+                out.push(statement);
+                flatten_statements(std::slice::from_ref(then_branch), out);
+                if let Some(else_branch) = else_branch {
+                    flatten_statements(std::slice::from_ref(else_branch), out);
+                }
+            }
+            Statement::While { body, .. } => {
+                out.push(statement);
+                flatten_statements(std::slice::from_ref(body), out);
             }
             other => out.push(other),
         }
@@ -7822,6 +8071,15 @@ fn collect_table_names<'a>(tref: &'a TableRef, out: &mut Vec<&'a Name>) {
 /// subquery embedded in its expressions (WHERE/SELECT list/HAVING/GROUP BY/
 /// ORDER BY). Recurses through nested subqueries.
 fn collect_locked_tables<'a>(select: &'a Select, out: &mut Vec<&'a Name>) {
+    // CTE bodies read their base tables like any derived table — collected
+    // HERE, not left to callers' inlining passes: a condition subquery's
+    // `WITH` has no expansion pass before lock analysis, and a missed table
+    // is a read with no lock under up-front 2PL (the review's finding). A
+    // CTE's own name may land in `out` via FROM references; it resolves to
+    // no object and locks nothing, which is correct.
+    for cte in &select.ctes {
+        collect_locked_tables(&cte.query, out);
+    }
     if let Some(from) = &select.from {
         collect_from_tables(from, out);
     }

--- a/crates/truthdb-core/src/storage.rs
+++ b/crates/truthdb-core/src/storage.rs
@@ -4532,6 +4532,156 @@ mod tests {
     /// A READ COMMITTED SELECT under RCSI takes only Database IS — no Table
     /// S — which is the entire readers-don't-block mechanism; and the other
     /// levels are untouched by the option.
+    /// Lock analysis descends control-flow bodies: a WHILE body's INSERT and
+    /// an IF condition's EXISTS table are in the batch's up-front lock set.
+    #[test]
+    fn analyze_locks_descends_control_flow() {
+        use crate::lock::{LockMode, Resource};
+        use crate::rel::{Isolation, TxnContext, execute_batch};
+
+        let path = unique_temp_path("flow-locks");
+        let storage = Storage::create(path.clone(), test_storage_options()).expect("create");
+        let mut ctx = TxnContext::default();
+        let outcome = execute_batch(
+            &storage,
+            "CREATE TABLE locked_t (id INT NOT NULL PRIMARY KEY)",
+            &mut ctx,
+        );
+        assert!(outcome.error.is_none(), "{:?}", outcome.error);
+
+        let needs = crate::rel::analyze_locks(
+            &storage,
+            "DECLARE @i INT = 0; WHILE @i < 3 BEGIN INSERT INTO locked_t VALUES (@i); \
+             SET @i = @i + 1; END",
+            Isolation::ReadCommitted,
+        );
+        assert!(
+            needs.iter().any(
+                |(r, m)| matches!(r, Resource::Table(_)) && *m == LockMode::Exclusive
+                    || matches!(r, Resource::Row(..))
+            ),
+            "the WHILE body's INSERT locks its table: {needs:?}"
+        );
+
+        let needs = crate::rel::analyze_locks(
+            &storage,
+            "IF EXISTS (SELECT * FROM locked_t) SELECT 1",
+            Isolation::ReadCommitted,
+        );
+        assert!(
+            needs
+                .iter()
+                .any(|(r, m)| matches!(r, Resource::Table(_)) && *m == LockMode::Shared),
+            "the IF condition's EXISTS table takes Table S: {needs:?}"
+        );
+
+        drop(storage);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// Adversarial probes (control-flow review): condition shapes whose table
+    /// reads must be in the up-front lock set — a WHILE condition, a derived
+    /// table and an IN-subquery inside the condition, a CASE-wrapped EXISTS,
+    /// a view, an untaken ELSE branch's write, and an EXEC literal inside a
+    /// WHILE body.
+    #[test]
+    fn cf_review_analyze_locks_condition_shapes() {
+        use crate::lock::{LockMode, Resource};
+        use crate::rel::{Isolation, TxnContext, execute_batch};
+
+        let path = unique_temp_path("cf-flow-lock-shapes");
+        let storage = Storage::create(path.clone(), test_storage_options()).expect("create");
+        let mut ctx = TxnContext::default();
+        for sql in [
+            "CREATE TABLE lt (id INT NOT NULL PRIMARY KEY)",
+            "CREATE VIEW lv AS SELECT id FROM lt",
+        ] {
+            let outcome = execute_batch(&storage, sql, &mut ctx);
+            assert!(outcome.error.is_none(), "{sql}: {:?}", outcome.error);
+        }
+        let table_s = |needs: &[(Resource, LockMode)]| {
+            needs
+                .iter()
+                .any(|(r, m)| matches!(r, Resource::Table(_)) && *m == LockMode::Shared)
+        };
+        let table_write = |needs: &[(Resource, LockMode)]| {
+            needs.iter().any(|(r, m)| {
+                matches!(r, Resource::Table(_)) && *m == LockMode::Exclusive
+                    || matches!(r, Resource::Row(..))
+            })
+        };
+        for sql in [
+            "WHILE EXISTS (SELECT * FROM lt) SELECT 1",
+            "IF EXISTS (SELECT * FROM (SELECT id FROM lt) d) SELECT 1",
+            "IF 1 IN (SELECT id FROM lt) SELECT 1",
+            "IF CASE WHEN EXISTS (SELECT * FROM lt) THEN 1 ELSE 0 END = 1 SELECT 1",
+            "IF EXISTS (SELECT * FROM lv) SELECT 1",
+            "IF (SELECT COUNT(*) FROM lt) = 0 SELECT 1",
+        ] {
+            let needs = crate::rel::analyze_locks(&storage, sql, Isolation::ReadCommitted);
+            assert!(
+                table_s(&needs),
+                "{sql}: condition read takes Table S: {needs:?}"
+            );
+        }
+        // Both IF branches analyze — an untaken ELSE's INSERT is still locked.
+        let needs = crate::rel::analyze_locks(
+            &storage,
+            "IF 1 = 2 SELECT 1 ELSE INSERT INTO lt VALUES (9)",
+            Isolation::ReadCommitted,
+        );
+        assert!(
+            table_write(&needs),
+            "the ELSE branch's INSERT locks its table: {needs:?}"
+        );
+        // An EXEC literal inside a WHILE body analyzes through the Exec arm.
+        let needs = crate::rel::analyze_locks(
+            &storage,
+            "DECLARE @i INT = 0; WHILE @i < 1 BEGIN \
+             EXEC sp_executesql N'INSERT INTO lt VALUES (7)'; SET @i = @i + 1; END",
+            Isolation::ReadCommitted,
+        );
+        assert!(
+            table_write(&needs),
+            "the EXEC'd INSERT inside the loop locks its table: {needs:?}"
+        );
+        drop(storage);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// A CTE inside an IF condition's subquery: the executor inlines it and
+    /// reads the base table (engine.rs pins that half), so analysis must lock
+    /// that table like the Select arm does — the expectation here is the
+    /// FIXED behavior.
+    #[test]
+    fn cf_review_analyze_locks_condition_cte() {
+        use crate::lock::{LockMode, Resource};
+        use crate::rel::{Isolation, TxnContext, execute_batch};
+
+        let path = unique_temp_path("cf-flow-lock-cte");
+        let storage = Storage::create(path.clone(), test_storage_options()).expect("create");
+        let mut ctx = TxnContext::default();
+        let outcome = execute_batch(
+            &storage,
+            "CREATE TABLE lt (id INT NOT NULL PRIMARY KEY)",
+            &mut ctx,
+        );
+        assert!(outcome.error.is_none(), "{:?}", outcome.error);
+        let needs = crate::rel::analyze_locks(
+            &storage,
+            "IF EXISTS (WITH x AS (SELECT id FROM lt) SELECT id FROM x) SELECT 1",
+            Isolation::ReadCommitted,
+        );
+        assert!(
+            needs
+                .iter()
+                .any(|(r, m)| matches!(r, Resource::Table(_)) && *m == LockMode::Shared),
+            "the CTE's base table is read at runtime and must be locked: {needs:?}"
+        );
+        drop(storage);
+        let _ = std::fs::remove_file(&path);
+    }
+
     #[test]
     fn analyze_locks_drops_table_s_under_rcsi() {
         use crate::lock::{LockMode, Resource};

--- a/crates/truthdb-core/tests/slt/control_flow.slt
+++ b/crates/truthdb-core/tests/slt/control_flow.slt
@@ -1,0 +1,62 @@
+# Control flow (Stage 15): IF/ELSE, WHILE/BREAK/CONTINUE, BEGIN..END blocks,
+# RETURN. The engine tests carry the interaction matrix (TRY crossings,
+# doomed transactions, @@ERROR); these pin the surface end to end.
+
+statement ok
+CREATE TABLE cf (id INT NOT NULL PRIMARY KEY)
+
+statement ok
+IF 1 = 1 INSERT INTO cf VALUES (1) ELSE INSERT INTO cf VALUES (2)
+
+query I
+SELECT id FROM cf
+----
+1
+
+statement ok
+IF EXISTS (SELECT * FROM cf WHERE id = 1) INSERT INTO cf VALUES (10)
+
+statement ok
+IF EXISTS (SELECT * FROM cf WHERE id = 99) INSERT INTO cf VALUES (11)
+
+query I rowsort
+SELECT id FROM cf
+----
+1
+10
+
+statement ok
+DECLARE @i INT = 100; WHILE @i < 103 BEGIN INSERT INTO cf VALUES (@i); SET @i = @i + 1; END
+
+query I rowsort
+SELECT id FROM cf
+----
+1
+10
+100
+101
+102
+
+# RETURN ends the batch: the second DELETE never runs.
+statement ok
+DELETE FROM cf WHERE id >= 100; RETURN; DELETE FROM cf WHERE id = 10
+
+query I rowsort
+SELECT id FROM cf
+----
+1
+10
+
+# Compile-time rejections: BREAK/CONTINUE outside a WHILE, RETURN with a
+# value in a batch, a non-boolean condition.
+statement error
+BREAK
+
+statement error
+CONTINUE
+
+statement error
+RETURN 7
+
+statement error
+IF 42 SELECT 1

--- a/crates/truthdb-sql/src/ast.rs
+++ b/crates/truthdb-sql/src/ast.rs
@@ -66,6 +66,39 @@ pub enum Statement {
     Throw(ThrowStatement),
     /// `RAISERROR(msg, severity, state [, args...]) [WITH LOG|NOWAIT|SETERROR]`.
     RaiseError(RaiseError),
+    /// `BEGIN <statements> END` — a plain statement block (not TRY, not TRAN).
+    Block {
+        body: Vec<Statement>,
+        span: Span,
+    },
+    /// `IF <condition> <statement> [ELSE <statement>]`. T-SQL three-valued:
+    /// only TRUE runs the THEN branch; FALSE and NULL take the ELSE.
+    If {
+        condition: Expr,
+        then_branch: Box<Statement>,
+        else_branch: Option<Box<Statement>>,
+        span: Span,
+    },
+    /// `WHILE <condition> <statement>`.
+    While {
+        condition: Expr,
+        body: Box<Statement>,
+        span: Span,
+    },
+    /// `BREAK` — terminates the innermost enclosing WHILE. The parser rejects
+    /// it outside one (SQL Server's compile-time 135).
+    Break {
+        span: Span,
+    },
+    /// `CONTINUE` — restarts the innermost enclosing WHILE.
+    Continue {
+        span: Span,
+    },
+    /// `RETURN [expr]` — exits the batch (and, later, the procedure).
+    Return {
+        value: Option<Expr>,
+        span: Span,
+    },
 }
 
 /// `THROW [number, message, state]`.

--- a/crates/truthdb-sql/src/parser.rs
+++ b/crates/truthdb-sql/src/parser.rs
@@ -30,6 +30,9 @@ pub struct Parser {
     pos: usize,
     /// Current expression recursion depth.
     depth: usize,
+    /// Lexical `WHILE` nesting depth: `BREAK`/`CONTINUE` outside a loop are
+    /// compile-time errors (SQL Server 135/136), so the parser tracks it.
+    while_depth: usize,
     /// Expression nodes built so far.
     nodes: usize,
 }
@@ -45,6 +48,7 @@ impl Parser {
             tokens,
             pos: 0,
             depth: 0,
+            while_depth: 0,
             nodes: 0,
         }
     }
@@ -130,6 +134,11 @@ impl Parser {
             Some("USE") => self.parse_use(),
             Some("THROW") => self.parse_throw(),
             Some("RAISERROR") => self.parse_raiserror(),
+            Some("IF") => self.parse_if(),
+            Some("WHILE") => self.parse_while(),
+            Some("BREAK") => self.parse_break(),
+            Some("CONTINUE") => self.parse_continue(),
+            Some("RETURN") => self.parse_return(),
             _ => {
                 let token = self.peek().clone();
                 Err(SqlError::syntax(self.token_text(&token), token.span))
@@ -182,21 +191,134 @@ impl Parser {
         }))
     }
 
+    /// `IF <condition> <statement> [ELSE <statement>]`. A semicolon after the
+    /// THEN statement ends the IF — `; ELSE` is a syntax error, as in T-SQL.
+    fn parse_if(&mut self) -> SqlResult<Statement> {
+        let start = self.expect_keyword("IF")?;
+        let condition = self.parse_expr()?;
+        let then_branch = Box::new(self.parse_statement()?);
+        let else_branch = if self.peek_keyword().as_deref() == Some("ELSE") {
+            self.bump();
+            Some(Box::new(self.parse_statement()?))
+        } else {
+            None
+        };
+        let end = self.prev_span();
+        Ok(Statement::If {
+            condition,
+            then_branch,
+            else_branch,
+            span: start.to(end),
+        })
+    }
+
+    /// `WHILE <condition> <statement>`.
+    fn parse_while(&mut self) -> SqlResult<Statement> {
+        let start = self.expect_keyword("WHILE")?;
+        let condition = self.parse_expr()?;
+        self.while_depth += 1;
+        let body = self.parse_statement();
+        self.while_depth -= 1;
+        let body = Box::new(body?);
+        let end = self.prev_span();
+        Ok(Statement::While {
+            condition,
+            body,
+            span: start.to(end),
+        })
+    }
+
+    fn parse_break(&mut self) -> SqlResult<Statement> {
+        let span = self.expect_keyword("BREAK")?;
+        if self.while_depth == 0 {
+            return Err(SqlError::new(
+                135,
+                15,
+                1,
+                "Cannot use the BREAK statement outside the scope of a WHILE statement.",
+            )
+            .at(span));
+        }
+        Ok(Statement::Break { span })
+    }
+
+    fn parse_continue(&mut self) -> SqlResult<Statement> {
+        let span = self.expect_keyword("CONTINUE")?;
+        if self.while_depth == 0 {
+            return Err(SqlError::new(
+                136,
+                15,
+                1,
+                "Cannot use the CONTINUE statement outside the scope of a WHILE statement.",
+            )
+            .at(span));
+        }
+        Ok(Statement::Continue { span })
+    }
+
+    /// `RETURN [expr]` — the expression is parsed when the next token can
+    /// start one (T-SQL RETURN takes an integer expression).
+    fn parse_return(&mut self) -> SqlResult<Statement> {
+        let start = self.expect_keyword("RETURN")?;
+        let has_value = matches!(
+            self.peek().kind,
+            TokenKind::Int(_)
+                | TokenKind::Number(_)
+                | TokenKind::String(_)
+                | TokenKind::LocalVar(_)
+                | TokenKind::GlobalVar(_)
+                | TokenKind::LParen
+                | TokenKind::Minus
+                | TokenKind::Plus
+        );
+        let value = if has_value {
+            Some(self.parse_expr()?)
+        } else {
+            None
+        };
+        // Batches cannot return a value — SQL Server's compile-time 178. The
+        // grammar still parses one so procedure bodies (which may) share it.
+        if let Some(value) = &value {
+            return Err(SqlError::new(
+                178,
+                15,
+                1,
+                "A RETURN statement with a return value cannot be used in this context.",
+            )
+            .at(value.span));
+        }
+        let end = self.prev_span();
+        Ok(Statement::Return {
+            value,
+            span: start.to(end),
+        })
+    }
+
     // ---- transaction control --------------------------------------------
 
     fn parse_begin(&mut self) -> SqlResult<Statement> {
         let start = self.expect_keyword("BEGIN")?;
-        // `BEGIN` opens either a transaction or a `TRY` block; there are no
-        // general `BEGIN...END` blocks. (A bare `BEGIN CATCH` is invalid — it
-        // is only reachable inside `parse_try_catch`, after `END TRY`.)
+        // `BEGIN` opens a transaction, a `TRY` block, or a plain statement
+        // block. (A bare `BEGIN CATCH` is invalid — it is only reachable
+        // inside `parse_try_catch`, after `END TRY`.)
         if matches!(self.peek_keyword().as_deref(), Some("TRY")) {
             return self.parse_try_catch(start);
         }
         let mut end = match self.peek_keyword().as_deref() {
             Some("TRAN") | Some("TRANSACTION") => self.bump().span,
+            // Anything else: a plain `BEGIN <statements> END` block. An
+            // EMPTY block is a syntax error, as in SQL Server.
             _ => {
-                let token = self.peek().clone();
-                return Err(SqlError::syntax(self.token_text(&token), token.span));
+                let body = self.parse_block()?;
+                if body.is_empty() {
+                    let token = self.peek().clone();
+                    return Err(SqlError::syntax(self.token_text(&token), token.span));
+                }
+                let end = self.expect_keyword("END")?;
+                return Ok(Statement::Block {
+                    body,
+                    span: start.to(end),
+                });
             }
         };
         let name = self.parse_optional_txn_name();
@@ -2448,13 +2570,15 @@ fn binary(op: BinaryOp, left: Expr, right: Expr) -> Expr {
 
 /// Keywords that end the SELECT-list / cannot be an implicit alias.
 fn is_clause_keyword(keyword: &str) -> bool {
-    // `END` closes a TRY/CATCH block and is reserved in T-SQL, so a bare `END`
-    // is never an implicit alias — without this, `SELECT 1 END TRY` would read
-    // `END` as the alias for `1` and then fail on `TRY`. (An explicit `AS end`
-    // or a delimited `[end]` still aliases, as before.)
+    // `END` closes a block and `ELSE` continues an `IF` — both reserved in
+    // T-SQL, so neither is ever an implicit alias. Without this,
+    // `SELECT 1 END TRY` would read `END` as the alias for `1`, and
+    // `IF c SELECT 1 ELSE SELECT 2` would alias `1` as `ELSE` and silently
+    // detach the ELSE branch. (An explicit `AS end` or a delimited `[end]`
+    // still aliases, as before.)
     matches!(
         keyword,
-        "FROM" | "WHERE" | "ORDER" | "GROUP" | "HAVING" | "AS" | "END"
+        "FROM" | "WHERE" | "ORDER" | "GROUP" | "HAVING" | "AS" | "END" | "ELSE"
     )
 }
 


### PR DESCRIPTION
## Stage 15, part 2: control flow — IF/ELSE, WHILE/BREAK/CONTINUE, BEGIN…END blocks, RETURN

The T-SQL control-of-flow grammar and its execution, on top of the severity truth table (#125).

### Semantics

- **Conditions are full expressions, subqueries included** — `IF EXISTS (SELECT …)`, scalar-subquery comparisons, IN-subqueries — resolved eagerly through the same machinery as WHERE-clause subqueries, then evaluated three-valued: TRUE runs the branch, FALSE and NULL (UNKNOWN) do not; a non-boolean condition is 4145.
- **Flows propagate structurally**: `run_block` returns Normal/Break/Continue/Return; a BREAK crosses a TRY without running its CATCH; RETURN unwinds blocks, loops, and TRYs and exits the batch; an inner RETURN in EXEC'd text exits only the inner batch.
- **Compile-time rejections, as SQL Server classifies them**: BREAK/CONTINUE outside a WHILE (135/136, via a lexical loop depth in the parser — dynamic SQL is its own scope, so `EXEC sp_executesql N'BREAK'` is rejected by the inner parse), and `RETURN <value>` in a batch (178; the grammar keeps the value for the procedures PR).
- **`ELSE` joined `END` as a never-an-implicit-alias keyword** — without that, `IF c SELECT 1 ELSE SELECT 2` reads ELSE as the alias of `1` and silently detaches the branch (mutation-pinned with an aliasless probe).
- **Errors in conditions** route through the same single statement-error ladder as ordinary statements — the doom/continuation decisions stay single-sited. The ladder extraction is this PR: one function now serves the generic arm and condition failures (the EXEC arm stays separate deliberately; its errors carry decisions made at their source, per #125's review fix).
- **@@ERROR**: IF/WHILE reset it after their condition evaluates — after, so `IF @@ERROR <> 0` works; pinned both ways (the canonical pattern, and an untaken IF whose reset is the only one).
- **Doomed transactions run control flow**: the arms bypass the 3930 gate (containers, not writers), which is exactly what `IF XACT_STATE() = -1 ROLLBACK` — the documented CATCH idiom — requires; leaf statements still hit the gate.

### Locks (2PL: everything up front)

`flatten_statements` descends block/branch/loop bodies, so a WHILE body's INSERT takes its lock before the batch starts, and both IF branches are analyzed (which one runs is a runtime fact). IF/WHILE nodes stay in the flattened list so their CONDITIONS' subquery tables are locked exactly like a SELECT's. Cancellation is checked every loop iteration, so an infinite `WHILE 1 = 1` dies on a TDS Attention even with a body that never blocks.

### Adversarial review outcome

The review confirmed the architecture (Flow propagation, the shared ladder, the doomed-gate bypass, parser scoping, and every flow-vs-error interaction it attacked) and found both HIGHs in the one seam the design left open — condition evaluation as a side channel around the per-statement machinery, the same Stage 13 class twice:

- **CTEs inside condition subqueries escaped lock analysis entirely** (`IF EXISTS (WITH x AS ... SELECT ...)` read its base table with no lock, not even the Database IS fence). Fixed at the single site every caller shares: `collect_locked_tables` now walks CTE bodies itself, instead of relying on callers' inlining passes. Mutation-pinned.
- **Condition reads bypassed versioned-read scoping** — a live dirty read under RCSI (an `IF EXISTS` took the wrong branch on a concurrent writer's uncommitted row) and a snapshot violation under SNAPSHOT isolation (a condition saw a post-snapshot commit; a transaction whose first data access is a condition never established its snapshot, and 3952 was skipped). Fixed: `enter_condition_scopes` gives table-reading conditions the SAME scoping a SELECT gets — an RCSI statement snapshot, SNAPSHOT establishment plus the 3952 gate — entered per WHILE iteration. Mutation-pinned by both live repros.

Also from the review: empty `BEGIN END` is now a syntax error and `RETURN 'x'` reaches the 178 gate (both SQL Server parity); `produces_rowset`'s control-flow arm turned out to be load-bearing for `sp_describe_first_result_set` and is now pinned (the mutation had survived everything). Nineteen review probes landed. Recorded, not fixed: SQL Server's `IF EXISTS` sets @@ROWCOUNT from its probe scan, ours leaves it untouched (pinned); the WHILE-condition @@ERROR reset at loop exit has no authoritative SQL Server citation — pinned as implemented and flagged.

### Tests

Seven engine tests (branch selection incl. NULL and the aliasless ELSE, IF EXISTS both polarities + scalar subquery, counted/BREAK/CONTINUE loops, BREAK-through-TRY + RETURN + 135/136/178, the @@ERROR interplay, the doomed-CATCH idiom, lock-analysis descend) plus `control_flow.slt`. Six mutation teeth-checks proven: flatten descend, condition locks, flow-through-TRY (the mutant loops forever — evidenced by a bounded-timeout kill), ELSE-alias, NULL-condition polarity, and the IF @@ERROR reset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
