### PR TITLE
Stage 15: stored procedures — DDL, EXEC, OUTPUT, RETURN status, sys views

### DIFF
--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -5805,6 +5805,62 @@ mod tests {
     }
 
     #[test]
+    fn procedure_ddl_round_trips_and_survives_reopen() {
+        // CREATE/ALTER/DROP PROCEDURE: catalog persistence (the body is
+        // stored text), name collision (2714), the first-statement rule
+        // (111), and RETURN <value> legal only inside a body.
+        let path = unique_temp_path("proc-ddl");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "CREATE PROCEDURE add_pair @a INT, @b INT = 7 OUTPUT AS \
+             SET @b = @a + @b; RETURN 0",
+        );
+        assert!(out.error.is_none(), "{:?}", out.error);
+        // Name collision with any object class.
+        let out = batch(&engine, &mut ctx, "CREATE PROC add_pair AS SELECT 1");
+        assert_eq!(out.error.as_ref().map(|e| e.number), Some(2714));
+        // Not the first statement in the batch: 111.
+        let out = batch(&engine, &mut ctx, "SELECT 1; CREATE PROC late AS SELECT 1");
+        assert_eq!(out.error.as_ref().map(|e| e.number), Some(111));
+        // RETURN <value> stays illegal OUTSIDE a body.
+        let out = batch(&engine, &mut ctx, "RETURN 3");
+        assert_eq!(out.error.as_ref().map(|e| e.number), Some(178));
+        // ALTER replaces; ALTER of a missing procedure errors.
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "ALTER PROCEDURE add_pair @a INT AS RETURN @a",
+        );
+        assert!(out.error.is_none(), "{:?}", out.error);
+        let out = batch(&engine, &mut ctx, "ALTER PROC no_such AS SELECT 1");
+        assert!(out.error.is_some(), "ALTER of a missing procedure fails");
+        drop(engine);
+
+        // The definition survives a reopen; DROP removes it.
+        let engine = {
+            let storage = Storage::open(path.clone()).expect("reopen");
+            Engine::new(storage).expect("engine")
+        };
+        let mut ctx = TxnContext::default();
+        let out = batch(&engine, &mut ctx, "CREATE PROC add_pair AS SELECT 1");
+        assert_eq!(
+            out.error.as_ref().map(|e| e.number),
+            Some(2714),
+            "the procedure survived the reopen"
+        );
+        let out = batch(&engine, &mut ctx, "DROP PROCEDURE add_pair");
+        assert!(out.error.is_none(), "{:?}", out.error);
+        let out = batch(&engine, &mut ctx, "DROP PROCEDURE add_pair");
+        assert_eq!(out.error.as_ref().map(|e| e.number), Some(3701));
+        let out = batch(&engine, &mut ctx, "DROP PROCEDURE IF EXISTS add_pair");
+        assert!(out.error.is_none(), "IF EXISTS swallows the miss");
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
     fn try_catch_nested_inner_handles_outer_continues() {
         // The inner CATCH handles the inner error; because it does not re-raise,
         // the outer TRY continues and the outer CATCH never runs.

--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -5861,6 +5861,690 @@ mod tests {
     }
 
     #[test]
+    fn exec_user_procedure_binds_returns_and_copies_output() {
+        let path = unique_temp_path("proc-exec");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        batch(
+            &engine,
+            &mut ctx,
+            "CREATE TABLE t (id INT NOT NULL PRIMARY KEY)",
+        );
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "CREATE PROCEDURE ins_and_double @a INT, @b INT = 10, @twice INT OUTPUT AS \
+             INSERT INTO t VALUES (@a); \
+             SET @twice = (@a + @b) * 2; \
+             SELECT @a AS n; \
+             RETURN @a + 1",
+        );
+        assert!(out.error.is_none(), "{:?}", out.error);
+        // Positional + named + OUTPUT + @rc, default filling @b.
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "DECLARE @d INT, @rc INT; \
+             EXEC @rc = ins_and_double 5, @twice = @d OUTPUT; \
+             SELECT @rc AS n; SELECT @d AS n",
+        );
+        assert!(out.error.is_none(), "{:?}", out.error);
+        let firsts: Vec<i64> = out
+            .results
+            .iter()
+            .filter_map(|r| match r {
+                StatementResult::Rows(rowset) => match rowset.rows[0][0] {
+                    Datum::Int(v) => Some(i64::from(v)),
+                    Datum::BigInt(v) => Some(v),
+                    ref other => panic!("expected int, got {other:?}"),
+                },
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            firsts,
+            vec![5, 6, 30],
+            "body SELECT streamed; @rc = RETURN @a+1; @twice = (5+10)*2"
+        );
+        let out = batch(&engine, &mut ctx, "SELECT id FROM t");
+        assert_eq!(ids(&out), vec![5], "the body's INSERT landed");
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn exec_user_procedure_argument_errors() {
+        let path = unique_temp_path("proc-args");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        batch(
+            &engine,
+            &mut ctx,
+            "CREATE PROCEDURE p2 @a INT, @o INT OUTPUT AS SET @o = @a",
+        );
+        let case = |sql: &str| -> Option<i32> {
+            let mut c = TxnContext::default();
+            batch(&engine, &mut c, sql).error.map(|e| e.number)
+        };
+        assert_eq!(case("EXEC p2"), Some(201), "missing @a");
+        assert_eq!(
+            case("DECLARE @x INT; EXEC p2 1, @x OUTPUT, 3"),
+            Some(8144),
+            "too many arguments"
+        );
+        assert_eq!(
+            case("DECLARE @x INT; EXEC p2 @a = 1, @nope = 2"),
+            Some(8145),
+            "unknown named parameter"
+        );
+        assert_eq!(
+            case("DECLARE @x INT; EXEC p2 @a = @x OUTPUT, @o = @x"),
+            Some(8162),
+            "OUTPUT on a non-OUTPUT parameter"
+        );
+        assert_eq!(
+            case("EXEC p2 1, 2 OUTPUT"),
+            Some(179),
+            "OUTPUT with a constant"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn recursive_procedure_hits_the_nesting_cap() {
+        let path = unique_temp_path("proc-recurse");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "CREATE PROCEDURE recur AS SELECT CAST(@@NESTLEVEL AS INT) AS n; EXEC recur",
+        );
+        assert!(out.error.is_none(), "{:?}", out.error);
+        let out = batch(&engine, &mut ctx, "EXEC recur");
+        // The batch surfaces 217 when the recursion exceeds depth 32...
+        assert_eq!(out.error.as_ref().map(|e| e.number), Some(217));
+        // ...and the streamed @@NESTLEVEL values count 1, 2, 3, ...
+        let levels: Vec<i64> = out
+            .results
+            .iter()
+            .filter_map(|r| match r {
+                StatementResult::Rows(rowset) => match rowset.rows[0][0] {
+                    Datum::Int(v) => Some(i64::from(v)),
+                    Datum::BigInt(v) => Some(v),
+                    _ => None,
+                },
+                _ => None,
+            })
+            .collect();
+        assert_eq!(levels.first(), Some(&1));
+        assert_eq!(levels.last(), Some(&32), "depth 32 ran; 33 was refused");
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn error_procedure_names_the_failing_procedure() {
+        let path = unique_temp_path("proc-errproc");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        batch(
+            &engine,
+            &mut ctx,
+            "CREATE PROCEDURE boomer AS RAISERROR('inside', 16, 1)",
+        );
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "BEGIN TRY EXEC boomer; END TRY \
+             BEGIN CATCH SELECT ERROR_PROCEDURE() AS p, ERROR_NUMBER() AS n; END CATCH",
+        );
+        assert!(out.error.is_none(), "{:?}", out.error);
+        let StatementResult::Rows(rowset) = &out.results[0] else {
+            panic!("expected rows");
+        };
+        assert_eq!(
+            rowset.rows[0][0],
+            Datum::NVarChar("boomer".into()),
+            "ERROR_PROCEDURE() names the proc"
+        );
+        // Outside any procedure, ERROR_PROCEDURE() stays NULL.
+        batch(
+            &engine,
+            &mut ctx,
+            "CREATE TABLE u (id INT NOT NULL PRIMARY KEY)",
+        );
+        batch(&engine, &mut ctx, "INSERT INTO u VALUES (1)");
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "BEGIN TRY INSERT INTO u VALUES (1); END TRY \
+             BEGIN CATCH SELECT ERROR_PROCEDURE() AS p; END CATCH",
+        );
+        let StatementResult::Rows(rowset) = &out.results[0] else {
+            panic!("expected rows");
+        };
+        assert_eq!(rowset.rows[0][0], Datum::Null, "NULL in an ad-hoc batch");
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn output_and_return_skipped_when_the_body_aborts() {
+        let path = unique_temp_path("proc-abort-output");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        batch(
+            &engine,
+            &mut ctx,
+            "CREATE PROCEDURE fails @o INT OUTPUT AS SET @o = 99; THROW 50001, 'die', 1",
+        );
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "DECLARE @v INT = 7, @rc INT = -1; \
+             EXEC @rc = fails @o = @v OUTPUT; \
+             SELECT @v AS n; SELECT @rc AS n",
+        );
+        // The THROW terminated the batch too, so nothing after the EXEC ran —
+        // and neither copy-back nor @rc assignment happened.
+        assert_eq!(out.error.as_ref().map(|e| e.number), Some(50001));
+        assert!(
+            !out.results
+                .iter()
+                .any(|r| matches!(r, StatementResult::Rows(_))),
+            "the post-EXEC selects never ran: {:?}",
+            out.results
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    // ---- adversarial review probes: Stage 15 stored procedures ----------
+
+    /// First cell of every streamed rowset, as i64 (panics on non-integers).
+    fn review_first_cells(out: &BatchOutcome) -> Vec<i64> {
+        out.results
+            .iter()
+            .filter_map(|r| match r {
+                StatementResult::Rows(rowset) => match rowset.rows[0][0] {
+                    Datum::Int(v) => Some(i64::from(v)),
+                    Datum::BigInt(v) => Some(v),
+                    ref other => panic!("expected int, got {other:?}"),
+                },
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// SQL Server refuses a positional argument after a named one (error
+    /// 119). The current binder accepts it and binds BOTH: the positional
+    /// value lands on the parameter by position and a named argument for the
+    /// same parameter is silently discarded — a silent misbind.
+    #[test]
+    fn review_poc_positional_after_named_is_refused() {
+        let path = unique_temp_path("proc-pos-after-named");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "CREATE PROCEDURE pan @a INT, @b INT AS SELECT @a * 100 + @b AS n",
+        );
+        assert!(out.error.is_none(), "{:?}", out.error);
+        let out = batch(&engine, &mut ctx, "EXEC pan @b = 1, 2");
+        assert_eq!(
+            out.error.as_ref().map(|e| e.number),
+            Some(119),
+            "a positional argument after a named one is error 119; instead: \
+             error {:?}, streamed {:?}",
+            out.error,
+            review_first_cells(&out)
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    /// SQL Server coerces each argument to the declared parameter type at
+    /// bind time ('7' for an INT parameter arrives as int 7; an unconvertible
+    /// string is a conversion error at the EXEC). The current binder stores
+    /// the raw value with the declared type tag and never converts, so the
+    /// body sees a string where it declared an INT.
+    #[test]
+    fn review_poc_exec_argument_coerced_to_declared_type() {
+        let path = unique_temp_path("proc-arg-coerce");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "CREATE PROCEDURE echoi @a INT AS SELECT @a AS n",
+        );
+        assert!(out.error.is_none(), "{:?}", out.error);
+        let out = batch(&engine, &mut ctx, "EXEC echoi '7'");
+        assert!(out.error.is_none(), "{:?}", out.error);
+        let StatementResult::Rows(rowset) = &out.results[0] else {
+            panic!("expected rows, got {:?}", out.results);
+        };
+        assert!(
+            matches!(rowset.rows[0][0], Datum::Int(7) | Datum::BigInt(7)),
+            "'7' bound to @a INT must arrive as int 7 (DECLARE/SET coerce; \
+             EXEC binding must too), got {:?}",
+            rowset.rows[0][0]
+        );
+        // An unconvertible string is a conversion error at the EXEC.
+        let out = batch(&engine, &mut ctx, "EXEC echoi 'nope'");
+        assert!(
+            out.error.is_some(),
+            "'nope' for @a INT must fail conversion at bind, streamed {:?}",
+            out.results
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    /// `EXEC @rc = p` with an UNDECLARED @rc is error 137 in SQL Server. The
+    /// current code inserts the variable into the caller scope unconditionally,
+    /// silently creating it.
+    #[test]
+    fn review_poc_undeclared_return_status_variable_is_137() {
+        let path = unique_temp_path("proc-undeclared-rc");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        let out = batch(&engine, &mut ctx, "CREATE PROCEDURE r4 AS RETURN 4");
+        assert!(out.error.is_none(), "{:?}", out.error);
+        let out = batch(&engine, &mut ctx, "EXEC @rc = r4; SELECT @rc AS n");
+        assert_eq!(
+            out.error.as_ref().map(|e| e.number),
+            Some(137),
+            "an undeclared return-status variable must be 137; instead: \
+             error {:?}, streamed {:?}",
+            out.error,
+            review_first_cells(&out)
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    /// A proc error caught by the CALLER's TRY terminated the body: neither
+    /// OUTPUT copy-back nor the @rc assignment happens, but the batch
+    /// continues in the CATCH. (The committed abort test cannot observe this
+    /// — its THROW ends the whole batch before anything reads @v/@rc.)
+    #[test]
+    fn review_poc_output_and_rc_skipped_when_proc_error_is_caught() {
+        let path = unique_temp_path("proc-caught-output");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "CREATE PROCEDURE failo @o INT OUTPUT AS \
+             SET @o = 99; RAISERROR('die', 16, 1); SET @o = 98",
+        );
+        assert!(out.error.is_none(), "{:?}", out.error);
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "DECLARE @v INT = 7, @rc INT = -1; \
+             BEGIN TRY EXEC @rc = failo @o = @v OUTPUT; END TRY \
+             BEGIN CATCH SELECT ERROR_NUMBER() AS n; END CATCH; \
+             SELECT @v AS n; SELECT @rc AS n",
+        );
+        assert!(out.error.is_none(), "{:?}", out.error);
+        assert_eq!(
+            review_first_cells(&out),
+            vec![50000, 7, -1],
+            "caught proc error: no copy-back (7 stays), no @rc (-1 stays)"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    /// A statement-scope RAISERROR 16 with no TRY anywhere does NOT terminate
+    /// the proc body: the body runs to completion, so OUTPUT copy-back DOES
+    /// happen — with the value assigned after the error.
+    #[test]
+    fn review_poc_statement_scope_raiserror_completes_body_and_copies_output() {
+        let path = unique_temp_path("proc-warn-output");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "CREATE PROCEDURE warns @o INT OUTPUT AS \
+             SET @o = 1; RAISERROR('w', 16, 1); SET @o = 2",
+        );
+        assert!(out.error.is_none(), "{:?}", out.error);
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "DECLARE @v INT = 0; EXEC warns @o = @v OUTPUT; SELECT @v AS n",
+        );
+        assert_eq!(
+            review_first_cells(&out),
+            vec![2],
+            "the body completed past the statement-scope error; copy-back ran"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    /// Nested procedures: each frame's RETURN status is its own. An inner
+    /// EXEC's status never bleeds into the outer frame's `EXEC @rc =`, even
+    /// when the outer body's LAST action is that inner EXEC.
+    #[test]
+    fn review_poc_nested_return_statuses_do_not_bleed() {
+        let path = unique_temp_path("proc-nested-rc");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        for sql in [
+            "CREATE PROCEDURE five AS RETURN 5",
+            "CREATE PROCEDURE seven AS EXEC five; RETURN 7",
+            "CREATE PROCEDURE tail AS EXEC five",
+            "CREATE PROCEDURE captures AS DECLARE @x INT; EXEC @x = five; SELECT @x AS n",
+        ] {
+            let out = batch(&engine, &mut ctx, sql);
+            assert!(out.error.is_none(), "{sql}: {:?}", out.error);
+        }
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "DECLARE @a INT, @b INT, @c INT; \
+             EXEC @a = seven; EXEC @b = tail; EXEC @c = captures; \
+             SELECT @a AS n; SELECT @b AS n; SELECT @c AS n",
+        );
+        assert!(out.error.is_none(), "{:?}", out.error);
+        assert_eq!(
+            review_first_cells(&out),
+            vec![5, 7, 0, 0],
+            "captures streamed inner's 5; then @a=7 (outer RETURN wins), \
+             @b=0 (tail's inner EXEC consumed its own status), @c=0"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    /// The 217 depth-cap error path unwinds EXEC_DEPTH all the way: a
+    /// subsequent EXEC in the same session starts at nest level 1 again.
+    #[test]
+    fn review_poc_exec_depth_unwinds_after_217() {
+        let path = unique_temp_path("proc-depth-unwind");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        for sql in [
+            "CREATE PROCEDURE recur2 AS EXEC recur2",
+            "CREATE PROCEDURE shallow AS SELECT CAST(@@NESTLEVEL AS INT) AS n",
+        ] {
+            let out = batch(&engine, &mut ctx, sql);
+            assert!(out.error.is_none(), "{sql}: {:?}", out.error);
+        }
+        let out = batch(&engine, &mut ctx, "EXEC recur2");
+        assert_eq!(out.error.as_ref().map(|e| e.number), Some(217));
+        let out = batch(&engine, &mut ctx, "EXEC shallow");
+        assert!(
+            out.error.is_none(),
+            "depth leaked past the 217: {:?}",
+            out.error
+        );
+        assert_eq!(
+            review_first_cells(&out),
+            vec![1],
+            "@@NESTLEVEL restarts at 1 after the failed recursion"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    /// A parameter named like a caller variable is a separate slot: the body
+    /// mutates its own @a; the caller's @a is untouched after the EXEC.
+    #[test]
+    fn review_poc_param_scope_isolated_from_caller_variable() {
+        let path = unique_temp_path("proc-shadow");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "CREATE PROCEDURE shadow @a INT AS SET @a = @a + 1; SELECT @a AS n",
+        );
+        assert!(out.error.is_none(), "{:?}", out.error);
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "DECLARE @a INT = 1; EXEC shadow @a = @a; SELECT @a AS n",
+        );
+        assert!(out.error.is_none(), "{:?}", out.error);
+        assert_eq!(
+            review_first_cells(&out),
+            vec![2, 1],
+            "inside: 2; caller's @a unchanged: 1"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    /// ERROR_PROCEDURE() precision under nested CATCHes: a second error in
+    /// the ad-hoc CATCH pushes its own frame (procedure NULL, its own
+    /// number); when that inner CATCH exits, the outer CATCH's ERROR_*()
+    /// resolve to the procedure error again.
+    #[test]
+    fn review_poc_error_procedure_survives_second_error_in_catch() {
+        let path = unique_temp_path("proc-errproc-nested");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "CREATE PROCEDURE boom2 AS RAISERROR('inside', 16, 1)",
+        );
+        assert!(out.error.is_none(), "{:?}", out.error);
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "BEGIN TRY EXEC boom2; END TRY \
+             BEGIN CATCH \
+               SELECT ERROR_PROCEDURE() AS p; \
+               BEGIN TRY SELECT 1/0 AS d; END TRY \
+               BEGIN CATCH SELECT ERROR_PROCEDURE() AS p; SELECT ERROR_NUMBER() AS n; END CATCH; \
+               SELECT ERROR_PROCEDURE() AS p; \
+             END CATCH",
+        );
+        assert!(out.error.is_none(), "{:?}", out.error);
+        let cells: Vec<Datum> = out
+            .results
+            .iter()
+            .filter_map(|r| match r {
+                StatementResult::Rows(rowset) => Some(rowset.rows[0][0].clone()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            cells,
+            vec![
+                Datum::NVarChar("boom2".into()),
+                Datum::Null,
+                Datum::BigInt(8134),
+                Datum::NVarChar("boom2".into()),
+            ],
+            "outer: boom2; inner: NULL + 8134; outer again: boom2"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    /// DROP TABLE of a procedure must be refused (SQL Server 3701: the
+    /// procedure namespace is not the table namespace), exactly as DROP TABLE
+    /// of a view already is. The current arm only guards views, so DROP TABLE
+    /// silently destroys a procedure.
+    #[test]
+    fn review_poc_drop_table_does_not_drop_a_procedure() {
+        let path = unique_temp_path("proc-drop-table");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        let out = batch(&engine, &mut ctx, "CREATE PROCEDURE keepp AS SELECT 1 AS n");
+        assert!(out.error.is_none(), "{:?}", out.error);
+        let out = batch(&engine, &mut ctx, "DROP TABLE keepp");
+        assert_eq!(
+            out.error.as_ref().map(|e| e.number),
+            Some(3701),
+            "DROP TABLE of a procedure must fail, got {:?}",
+            out.error
+        );
+        let out = batch(&engine, &mut ctx, "EXEC keepp");
+        assert!(
+            out.error.is_none(),
+            "the procedure survived the wrong-type DROP: {:?}",
+            out.error
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    /// DML against a procedure name errors cleanly (the object is not a
+    /// table); none of these may succeed or panic.
+    #[test]
+    fn review_poc_dml_on_a_procedure_name_errors_cleanly() {
+        let path = unique_temp_path("proc-dml");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        let out = batch(&engine, &mut ctx, "CREATE PROCEDURE nott AS SELECT 1 AS n");
+        assert!(out.error.is_none(), "{:?}", out.error);
+        // Observed today: SELECT * silently streams an EMPTY rowset and
+        // DELETE silently reports 0 rows affected; only INSERT (110) and
+        // UPDATE (207) error, for incidental column reasons.
+        for sql in [
+            "SELECT * FROM nott",
+            "INSERT INTO nott VALUES (1)",
+            "UPDATE nott SET x = 1",
+            "DELETE FROM nott",
+        ] {
+            let out = batch(&engine, &mut ctx, sql);
+            assert!(
+                out.error.is_some(),
+                "{sql}: must error (a procedure is not a table), streamed {:?}",
+                out.results
+            );
+        }
+        let _ = std::fs::remove_file(path);
+    }
+
+    /// SQL Server requires procedure parameter defaults to be CONSTANTS
+    /// (literals or NULL). The current code stores the default's source text
+    /// and evaluates it at EXEC against the CALLER's scope — so `@b INT = @a`
+    /// captures whatever @a happens to be in each caller, and even a niladic
+    /// function default drifts per call.
+    #[test]
+    fn review_poc_non_constant_parameter_default_rejected_at_create() {
+        let path = unique_temp_path("proc-nonconst-default");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "CREATE PROCEDURE dflt @b INT = @a AS SELECT @b AS n",
+        );
+        assert!(
+            out.error.is_some(),
+            "a variable-referencing parameter default must be rejected at \
+             CREATE (SQL Server: defaults are constants)"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    /// The stored body text round-trips exactly through sys.sql_modules:
+    /// embedded quotes, a line comment, a newline, a trailing statement.
+    #[test]
+    fn review_poc_body_text_round_trips_through_sys_sql_modules() {
+        let path = unique_temp_path("proc-body-roundtrip");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        let body = "SELECT 'it''s' AS s -- trailing comment\n; SELECT 2 AS n";
+        let out = batch(
+            &engine,
+            &mut ctx,
+            &format!("CREATE PROCEDURE qbody AS {body}"),
+        );
+        assert!(out.error.is_none(), "{:?}", out.error);
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "SELECT m.definition FROM sys.sql_modules m \
+             JOIN sys.procedures p ON m.object_id = p.object_id \
+             WHERE p.name = 'qbody'",
+        );
+        assert!(out.error.is_none(), "{:?}", out.error);
+        let StatementResult::Rows(rowset) = &out.results[0] else {
+            panic!("expected rows, got {:?}", out.results);
+        };
+        assert_eq!(
+            rowset.rows[0][0],
+            Datum::NVarChar(body.into()),
+            "the definition is the verbatim body text"
+        );
+        // And the stored text still executes: both rowsets stream.
+        let out = batch(&engine, &mut ctx, "EXEC qbody");
+        assert!(out.error.is_none(), "{:?}", out.error);
+        assert_eq!(
+            out.results
+                .iter()
+                .filter(|r| matches!(r, StatementResult::Rows(_)))
+                .count(),
+            2,
+            "both body statements ran: {:?}",
+            out.results
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    /// CREATE PROCEDURE as dynamic SQL: legal (it is the first statement of
+    /// the inner batch, as SQL Server requires), and the DDL-in-transaction
+    /// gate still applies through the dynamic path.
+    #[test]
+    fn review_poc_create_procedure_inside_dynamic_sql() {
+        let path = unique_temp_path("proc-dyn-create");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "EXEC sp_executesql N'CREATE PROCEDURE dynp AS SELECT 42 AS n'",
+        );
+        assert!(out.error.is_none(), "{:?}", out.error);
+        let out = batch(&engine, &mut ctx, "EXEC dynp");
+        assert!(out.error.is_none(), "{:?}", out.error);
+        assert_eq!(review_first_cells(&out), vec![42]);
+        // The DDL-in-txn gate is not bypassed by the dynamic path.
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "BEGIN TRAN; \
+             EXEC sp_executesql N'CREATE PROCEDURE dynp2 AS SELECT 1 AS n';",
+        );
+        assert_eq!(
+            out.error.as_ref().map(|e| e.number),
+            Some(226),
+            "DDL inside an explicit transaction stays refused via dynamic SQL"
+        );
+        batch(&engine, &mut ctx, "IF @@TRANCOUNT > 0 ROLLBACK");
+        let out = batch(&engine, &mut ctx, "EXEC dynp2");
+        assert_eq!(
+            out.error.as_ref().map(|e| e.number),
+            Some(2812),
+            "dynp2 was never created"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    /// DROP PROCEDURE IF EXISTS of a TABLE name is a silent no-op (the
+    /// procedure namespace has no such object, IF EXISTS suppresses the
+    /// miss) and the table survives; without IF EXISTS it is 3701.
+    #[test]
+    fn review_poc_drop_procedure_if_exists_of_a_table_is_a_noop() {
+        let path = unique_temp_path("proc-die-table");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        batch(
+            &engine,
+            &mut ctx,
+            "CREATE TABLE keept (id INT NOT NULL PRIMARY KEY)",
+        );
+        batch(&engine, &mut ctx, "INSERT INTO keept VALUES (1)");
+        let out = batch(&engine, &mut ctx, "DROP PROCEDURE IF EXISTS keept");
+        assert!(out.error.is_none(), "{:?}", out.error);
+        let out = batch(&engine, &mut ctx, "SELECT id FROM keept");
+        assert_eq!(ids(&out), vec![1], "the table survived");
+        let out = batch(&engine, &mut ctx, "DROP PROCEDURE keept");
+        assert_eq!(out.error.as_ref().map(|e| e.number), Some(3701));
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
     fn try_catch_nested_inner_handles_outer_continues() {
         // The inner CATCH handles the inner error; because it does not re-raise,
         // the outer TRY continues and the outer CATCH never runs.

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -14,11 +14,11 @@ mod plan;
 mod value;
 
 use truthdb_sql::ast::{
-    AlterAction, AlterDatabase, AlterTable, CheckConstraint, ColumnDef, CreateIndex, CreateTable,
-    CreateView, DataType, DatabaseOption, Declaration, Delete, DropIndex, DropTable, DropView,
-    ExecStatement, Expr, ExprKind, ForeignKey, Insert, InsertSource, IsolationLevel, JoinKind,
-    Name, OrderItem, RaiseError, Select, SelectItem, SetStatement, Statement, TableRef, ThrowArgs,
-    ThrowStatement, Update,
+    AlterAction, AlterDatabase, AlterTable, CheckConstraint, ColumnDef, CreateIndex,
+    CreateProcedure, CreateTable, CreateView, DataType, DatabaseOption, Declaration, Delete,
+    DropIndex, DropTable, DropView, ExecStatement, Expr, ExprKind, ForeignKey, Insert,
+    InsertSource, IsolationLevel, JoinKind, Name, OrderItem, RaiseError, Select, SelectItem,
+    SetStatement, Statement, TableRef, ThrowArgs, ThrowStatement, Update,
 };
 use truthdb_sql::collation::CollationSensitivity;
 use truthdb_sql::error::SqlError;
@@ -31,7 +31,7 @@ use xxhash_rust::xxh64::xxh64;
 
 use crate::lock::{LockMode, Resource};
 use crate::relstore::btree::ScanCursor;
-use crate::relstore::catalog::{self, TableDef};
+use crate::relstore::catalog::{self, ProcParamDef, ProcedureDef, TableDef};
 use crate::relstore::row::{Column, Schema};
 use crate::relstore::types::{ColumnType, Datum};
 use crate::relstore::version::ReadSnapshot;
@@ -1628,6 +1628,8 @@ fn statement_may_commit(statement: &Statement) -> bool {
             | Statement::Block { .. }
             | Statement::If { .. }
             | Statement::While { .. }
+            | Statement::CreateProcedure(_)
+            | Statement::DropProcedure { .. }
             | Statement::Commit { .. }
     )
 }
@@ -2165,6 +2167,10 @@ pub fn analyze_locks(
                 }
                 None => add(Resource::Database, LockMode::Exclusive),
             },
+            // Procedure DDL rewrites the catalog: Database X, like other DDL.
+            Statement::CreateProcedure(_) | Statement::DropProcedure { .. } => {
+                add(Resource::Database, LockMode::Exclusive);
+            }
             // IF/WHILE conditions read tables through their subqueries —
             // locked exactly like a SELECT's tables (their bodies were
             // flattened into this list and analyze as themselves).
@@ -2298,6 +2304,20 @@ fn exec_statement_dispatch(
         Statement::BeginTransaction { .. } => exec_begin(storage, txn_ctx),
         Statement::Use { database, .. } => exec_use(database, txn_ctx),
         Statement::Throw(throw) => Err(exec_throw(throw, txn_ctx)),
+        Statement::CreateProcedure(create) => {
+            if txn_ctx.in_txn() {
+                return Err(ddl_in_txn_err());
+            }
+            exec_create_procedure(storage, create)
+        }
+        Statement::DropProcedure {
+            name, if_exists, ..
+        } => {
+            if txn_ctx.in_txn() {
+                return Err(ddl_in_txn_err());
+            }
+            exec_drop_procedure(storage, name, *if_exists)
+        }
         // Executed by `run_block`'s own arms; nothing routes them here.
         Statement::Block { .. }
         | Statement::If { .. }
@@ -4082,6 +4102,83 @@ fn exec_create_view(storage: &Storage, create: &CreateView) -> Result<StatementR
         .rel_create_view(bare, &create.query_text)
         .map_err(|e| map_storage_err(e, &create.name.value))?;
     Ok(StatementResult::Done)
+}
+
+fn exec_create_procedure(
+    storage: &Storage,
+    create: &CreateProcedure,
+) -> Result<StatementResult, SqlError> {
+    let bare = strip_schema(&create.name.value);
+    let params = create
+        .params
+        .iter()
+        .map(|p| -> Result<ProcParamDef, SqlError> {
+            // The declared type round-trips through the column-type spec
+            // parser, exactly like table columns.
+            let column_type = data_type_to_column_type(&p.data_type, &p.name)?;
+            Ok(ProcParamDef {
+                name: p.name.clone(),
+                type_spec: column_type.name(),
+                default: p.default_text.clone(),
+                output: p.output,
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let procedure = ProcedureDef {
+        params,
+        body: create.body.clone(),
+    };
+    if create.alter {
+        match resolve_table(storage, &create.name.value) {
+            Some(def) if def.is_procedure() => {
+                storage
+                    .rel_alter_procedure(&def.name, procedure)
+                    .map_err(|e| map_storage_err(e, &create.name.value))?;
+                return Ok(StatementResult::Done);
+            }
+            _ => {
+                return Err(SqlError::invalid_object(bare).at(create.name.span));
+            }
+        }
+    }
+    if resolve_table(storage, &create.name.value).is_some() {
+        return Err(SqlError::new(
+            2714,
+            16,
+            6,
+            format!("There is already an object named '{bare}' in the database."),
+        ));
+    }
+    storage
+        .rel_create_procedure(bare, procedure)
+        .map_err(|e| map_storage_err(e, &create.name.value))?;
+    Ok(StatementResult::Done)
+}
+
+fn exec_drop_procedure(
+    storage: &Storage,
+    name: &Name,
+    if_exists: bool,
+) -> Result<StatementResult, SqlError> {
+    match resolve_table(storage, &name.value) {
+        Some(def) if def.is_procedure() => {
+            storage
+                .rel_drop_table(&def.name)
+                .map_err(|e| map_storage_err(e, &def.name))?;
+            Ok(StatementResult::Done)
+        }
+        Some(_) | None if if_exists => Ok(StatementResult::Done),
+        _ => Err(SqlError::new(
+            3701,
+            11,
+            5,
+            format!(
+                "Cannot drop the procedure '{}', because it does not exist or you do not have \
+                 permission.",
+                name.value
+            ),
+        )),
+    }
 }
 
 fn exec_drop_view(storage: &Storage, drop: &DropView) -> Result<StatementResult, SqlError> {

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -60,6 +60,17 @@ pub struct TxnContext {
     rowcount: i64,
     /// The previous statement's error number, 0 on success — `@@ERROR`.
     last_error: i32,
+    /// Names of the stored procedures currently executing (innermost last),
+    /// for `ERROR_PROCEDURE()`; empty in an ad-hoc batch.
+    proc_stack: Vec<String>,
+    /// The procedure executing when the LAST error was raised — captured at
+    /// the raise site, because by CATCH entry the procedure's frame has
+    /// already unwound off `proc_stack`.
+    error_procedure: Option<String>,
+    /// A procedure body's `RETURN [value]` status, stashed by the Return arm
+    /// for `EXEC @rc = name` to read after the body unwinds; 0 when the body
+    /// falls off the end.
+    proc_return: Option<i64>,
     /// `SET SHOWPLAN_TEXT ON` — a SELECT returns its plan text, not results.
     showplan_text: bool,
     /// Declared batch variables (name without `@`, lowercased) to their type
@@ -96,7 +107,7 @@ pub struct TxnContext {
 }
 
 /// Session isolation level (defaults to READ COMMITTED, like SQL Server).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub enum Isolation {
     ReadUncommitted,
     #[default]
@@ -129,6 +140,7 @@ impl TxnContext {
             error: self.error_stack.last().cloned(),
             xact_state: self.xact_state(),
             last_error: self.last_error,
+            nestlevel: EXEC_DEPTH.with(|d| d.get()) as i32,
         }
     }
 
@@ -146,12 +158,21 @@ impl TxnContext {
 
     /// Enters a `CATCH` block: records the caught error so `ERROR_*()` resolve
     /// to it (pushed, so nested `TRY`/`CATCH` restore the outer error on exit).
+    /// Records the error context every failed statement leaves behind:
+    /// `@@ERROR` and the raising procedure (for `ERROR_PROCEDURE()`). Called
+    /// at the RAISE site — the only place the procedure frame is still live.
+    fn record_error(&mut self, number: i32) {
+        self.last_error = number;
+        self.error_procedure = self.proc_stack.last().cloned();
+    }
+
     fn push_error(&mut self, error: &SqlError) {
         self.error_stack.push(truthdb_sql::eval::ErrorInfo {
             number: error.number,
             message: error.message.clone(),
             severity: error.level,
             state: error.state,
+            procedure: self.error_procedure.clone(),
         });
     }
 
@@ -696,6 +717,259 @@ fn doom_per_rule(txn_ctx: &mut TxnContext, error: SqlError) -> SqlError {
     error
 }
 
+/// Executes a user stored procedure: binds arguments to declared parameters
+/// (positional and named, defaults filling gaps, OUTPUT validated), runs the
+/// stored body text under a fresh variable scope with SET options reverting
+/// at exit (the sp_executesql posture), captures the RETURN status into
+/// `EXEC @rc =`, and copies OUTPUT parameters back — both only when the body
+/// completes (SQL Server skips them when execution aborts).
+fn run_user_procedure(
+    storage: &Storage,
+    exec: &ExecStatement,
+    def: &TableDef,
+    txn_ctx: &mut TxnContext,
+    run: &mut BatchRun<'_>,
+    in_try: bool,
+) -> Result<(), ExecError> {
+    let procedure = def.procedure.as_ref().expect("checked by the caller");
+    let own = |txn_ctx: &mut TxnContext, error: SqlError| -> ExecError {
+        ExecError::Own(doom_per_rule(txn_ctx, error))
+    };
+    // Evaluate arguments in the CALLER's scope.
+    let eval_ctx = txn_ctx.eval_context();
+    let mut positional = Vec::new();
+    let mut named: Vec<(String, SqlValue, bool, Option<String>)> = Vec::new();
+    let mut positional_meta: Vec<(bool, Option<String>)> = Vec::new();
+    for (arg_index, arg) in exec.args.iter().enumerate() {
+        // Once an argument is named, the rest must be (SQL Server 119) —
+        // silently continuing would bind positions past the named one.
+        if arg.name.is_none() && !named.is_empty() {
+            let error = SqlError::new(
+                119,
+                15,
+                1,
+                format!(
+                    "Must pass parameter number {} and subsequent parameters as '@name = value'. \
+                     After the form '@name = value' has been used, all subsequent parameters must \
+                     be passed in the form '@name = value'.",
+                    arg_index + 1
+                ),
+            );
+            return Err(own(txn_ctx, error));
+        }
+        // An OUTPUT argument must be a bare variable (it receives a value).
+        let arg_var = match &arg.value.kind {
+            ExprKind::LocalVar(name) => Some(name.clone()),
+            _ => None,
+        };
+        if arg.output && arg_var.is_none() {
+            let error = SqlError::new(
+                179,
+                16,
+                1,
+                "Cannot use the OUTPUT option when passing a constant to a stored procedure.",
+            );
+            return Err(own(txn_ctx, error));
+        }
+        let value = eval_constant(&arg.value, &eval_ctx).map_err(|e| own(txn_ctx, e))?;
+        match &arg.name {
+            Some(n) => {
+                let key = n.value.trim_start_matches('@').to_ascii_lowercase();
+                // A parameter supplied twice (named twice, or named on top
+                // of a positional binding) is an error, not a silent pick.
+                let position_of = |name: &str| procedure.params.iter().position(|p| p.name == name);
+                let already_positional =
+                    position_of(&key).is_some_and(|index| index < positional.len());
+                if already_positional || named.iter().any(|(n, ..)| *n == key) {
+                    let error = SqlError::new(
+                        8143,
+                        16,
+                        1,
+                        format!(
+                            "Parameter '@{key}' was supplied multiple times for procedure {}.",
+                            def.name
+                        ),
+                    );
+                    return Err(own(txn_ctx, error));
+                }
+                named.push((key, value, arg.output, arg_var));
+            }
+            None => {
+                positional.push(value);
+                positional_meta.push((arg.output, arg_var));
+            }
+        }
+    }
+    // `EXEC @rc = p`: the status variable must already be declared (137).
+    if let Some(rc) = &exec.return_var
+        && !txn_ctx.variables.contains_key(rc)
+    {
+        let error = undeclared_variable_err(rc);
+        return Err(own(txn_ctx, error));
+    }
+    if positional.len() > procedure.params.len() {
+        let error = SqlError::new(
+            8144,
+            16,
+            2,
+            format!(
+                "Procedure or function {} has too many arguments specified.",
+                def.name
+            ),
+        );
+        return Err(own(txn_ctx, error));
+    }
+    // Named arguments that match no declared parameter fail before any
+    // binding (8145 precedes 201, as SQL Server orders it).
+    for (name, ..) in &named {
+        if !procedure.params.iter().any(|p| p.name == *name) {
+            let error = SqlError::new(
+                8145,
+                16,
+                2,
+                format!("@{name} is not a parameter for procedure {}.", def.name),
+            );
+            return Err(own(txn_ctx, error));
+        }
+    }
+    // Bind: positional in declaration order, then named by name, then
+    // defaults; a missing non-default parameter is 201. OUTPUT copy-back
+    // targets (param name -> caller variable) are collected as we bind.
+    let mut bound: Vec<(String, ColumnType, SqlValue)> = Vec::new();
+    let mut copy_back: Vec<(String, String)> = Vec::new();
+    for (index, param) in procedure.params.iter().enumerate() {
+        let column_type = ColumnType::parse(&param.type_spec).map_err(|e| {
+            let error = SqlError::message_only(245, e.to_string());
+            own(txn_ctx, error)
+        })?;
+        let supplied = if index < positional.len() {
+            let (output, arg_var) = positional_meta[index].clone();
+            Some((positional[index].clone(), output, arg_var))
+        } else {
+            named
+                .iter()
+                .find(|(n, ..)| *n == param.name)
+                .map(|(_, v, output, arg_var)| (v.clone(), *output, arg_var.clone()))
+        };
+        let coerce = |value: SqlValue| -> Result<SqlValue, SqlError> {
+            let datum = value::sql_to_datum(&value, &column_type, &param.name)?;
+            Ok(value::datum_to_sql(&datum, &column_type))
+        };
+        let value = match supplied {
+            Some((value, output, arg_var)) => {
+                if output {
+                    if !param.output {
+                        let error = SqlError::new(
+                            8162,
+                            16,
+                            2,
+                            format!(
+                                "The formal parameter \"@{}\" was not declared as an OUTPUT \
+                                 parameter, but the actual parameter passed in requested output.",
+                                param.name
+                            ),
+                        );
+                        return Err(own(txn_ctx, error));
+                    }
+                    copy_back.push((
+                        param.name.clone(),
+                        arg_var.expect("validated: OUTPUT arguments are variables"),
+                    ));
+                }
+                // Bind-time conversion to the DECLARED type, as SQL Server
+                // converts (or errors) at the call — without it a string
+                // argument flows into an INT parameter mistagged.
+                coerce(value).map_err(|e| own(txn_ctx, e))?
+            }
+            None => match &param.default {
+                Some(text) => {
+                    let expr = truthdb_sql::parse_expr(text).map_err(|e| own(txn_ctx, e))?;
+                    let value = eval_constant(&expr, &eval_ctx).map_err(|e| own(txn_ctx, e))?;
+                    coerce(value).map_err(|e| own(txn_ctx, e))?
+                }
+                None => {
+                    let error = SqlError::new(
+                        201,
+                        16,
+                        4,
+                        format!(
+                            "Procedure or function '{}' expects parameter '@{}', which was not \
+                             supplied.",
+                            def.name, param.name
+                        ),
+                    );
+                    return Err(own(txn_ctx, error));
+                }
+            },
+        };
+        bound.push((param.name.clone(), column_type, value));
+    }
+    // The stored body parses under the in-procedure grammar.
+    let statements =
+        truthdb_sql::parse_procedure_body(&procedure.body).map_err(|e| own(txn_ctx, e))?;
+
+    // Fresh scope, SET options reverting at exit — the sp_executesql shape.
+    let outer_vars = std::mem::take(&mut txn_ctx.variables);
+    let outer_xact_abort = txn_ctx.xact_abort;
+    let outer_nocount = txn_ctx.nocount;
+    let outer_isolation = txn_ctx.isolation;
+    let outer_showplan = txn_ctx.showplan_text;
+    for (name, column_type, value) in bound {
+        txn_ctx.variables.insert(name, (column_type, value));
+    }
+    txn_ctx.proc_stack.push(def.name.clone());
+    txn_ctx.proc_return = None;
+    let depth = EXEC_DEPTH.with(|d| {
+        let v = d.get() + 1;
+        d.set(v);
+        v
+    });
+    let result = if depth > 32 {
+        let error = SqlError::new(
+            217,
+            16,
+            1,
+            "Maximum stored procedure, function, trigger, or view nesting level exceeded (limit 32).",
+        );
+        Err(ExecError::Own(doom_per_rule(txn_ctx, error)))
+    } else {
+        run_block(storage, &statements, txn_ctx, run, in_try)
+            .map(|_| ())
+            .map_err(ExecError::Inner)
+    };
+    EXEC_DEPTH.with(|d| d.set(d.get() - 1));
+    txn_ctx.proc_stack.pop();
+    // Capture OUTPUT values from the inner scope BEFORE restoring the outer.
+    let output_values: Vec<(String, (ColumnType, SqlValue))> = copy_back
+        .iter()
+        .filter_map(|(param, var)| {
+            txn_ctx
+                .variables
+                .get(param)
+                .map(|slot| (var.clone(), slot.clone()))
+        })
+        .collect();
+    txn_ctx.variables = outer_vars;
+    txn_ctx.xact_abort = outer_xact_abort;
+    txn_ctx.nocount = outer_nocount;
+    txn_ctx.isolation = outer_isolation;
+    txn_ctx.showplan_text = outer_showplan;
+    let return_status = txn_ctx.proc_return.take().unwrap_or(0);
+    if result.is_ok() {
+        // OUTPUT copy-back and the return status land only when the body
+        // completed (SQL Server skips both when execution aborts).
+        for (var, slot) in output_values {
+            txn_ctx.variables.insert(var, slot);
+        }
+        if let Some(rc) = &exec.return_var {
+            txn_ctx
+                .variables
+                .insert(rc.clone(), (ColumnType::Int, SqlValue::Int(return_status)));
+        }
+    }
+    result
+}
+
 fn run_exec(
     storage: &Storage,
     exec: &ExecStatement,
@@ -704,6 +978,12 @@ fn run_exec(
     in_try: bool,
 ) -> Result<(), ExecError> {
     if !strip_schema(&exec.proc.value).eq_ignore_ascii_case("sp_executesql") {
+        // A user procedure, if the catalog has one; 2812 otherwise.
+        if let Some(def) = resolve_table(storage, &exec.proc.value)
+            && def.is_procedure()
+        {
+            return run_user_procedure(storage, exec, &def, txn_ctx, run, in_try);
+        }
         let error = SqlError::new(
             2812,
             16,
@@ -711,6 +991,15 @@ fn run_exec(
             format!("Could not find stored procedure '{}'.", exec.proc.value),
         )
         .at(exec.proc.span);
+        return Err(ExecError::Own(doom_per_rule(txn_ctx, error)));
+    }
+    if exec.return_var.is_some() {
+        let error = SqlError::new(
+            179,
+            16,
+            1,
+            "Cannot capture a return status from sp_executesql.",
+        );
         return Err(ExecError::Own(doom_per_rule(txn_ctx, error)));
     }
     let eval_ctx = txn_ctx.eval_context();
@@ -852,7 +1141,7 @@ fn statement_error_ladder(
     if error.number == CANCEL_ERROR {
         return Err(error);
     }
-    txn_ctx.last_error = error.number;
+    txn_ctx.record_error(error.number);
     // A durability failure wedged the store (a flush inside the statement,
     // e.g. before a snapshot capture): never continue past a lost commit.
     if run.durability_failed {
@@ -1028,7 +1317,12 @@ fn run_block(
                     if error.number == CANCEL_ERROR {
                         return Err(error);
                     }
-                    txn_ctx.last_error = error.number;
+                    // Inner errors were recorded at their raise site (the
+                    // inner ladder), where the procedure frame was still
+                    // live; re-recording here would blank ERROR_PROCEDURE().
+                    if !from_inner {
+                        txn_ctx.record_error(error.number);
+                    }
                     if run.durability_failed {
                         return Err(error);
                     }
@@ -1141,9 +1435,35 @@ fn run_block(
             // these only ever propagate up to an enclosing loop.
             Statement::Break { .. } => return Ok(Flow::Break),
             Statement::Continue { .. } => return Ok(Flow::Continue),
-            // The parser rejects `RETURN <value>` outside a procedure (178),
-            // so a reachable RETURN just exits the batch.
-            Statement::Return { .. } => return Ok(Flow::Return),
+            // The parser rejects `RETURN <value>` outside a procedure (178);
+            // inside one the status is stashed for `EXEC @rc =` to read.
+            Statement::Return { value, .. } => {
+                if let Some(value) = value {
+                    let eval_ctx = txn_ctx.eval_context();
+                    match eval_constant(value, &eval_ctx) {
+                        Ok(SqlValue::Int(status)) => txn_ctx.proc_return = Some(status),
+                        Ok(SqlValue::Null) => {
+                            // SQL Server warns and returns 0; we return 0.
+                            txn_ctx.proc_return = Some(0);
+                        }
+                        Ok(_) | Err(_) => {
+                            let error =
+                                eval_constant(value, &eval_ctx).err().unwrap_or_else(|| {
+                                    SqlError::new(
+                                        257,
+                                        16,
+                                        3,
+                                        "The RETURN status must be an integer.",
+                                    )
+                                });
+                            txn_ctx.rowcount = 0;
+                            statement_error_ladder(statement, error, txn_ctx, run, in_try)?;
+                            continue;
+                        }
+                    }
+                }
+                return Ok(Flow::Return);
+            }
             _ => {}
         }
         if let Statement::TryCatch {
@@ -1161,14 +1481,9 @@ fn run_block(
                 // A durability failure wedged the store: no CATCH swallows a
                 // lost commit (the old batch-end fsync ran past every TRY).
                 Err(error) if run.durability_failed => return Err(error),
-                // Severity >= 20 is fatal to the connection: no CATCH sees it.
-                Err(error) if error.level >= FATAL_SEVERITY => {
-                    txn_ctx.last_error = error.number;
-                    if txn_ctx.in_txn() {
-                        txn_ctx.doomed = true;
-                    }
-                    return Err(error);
-                }
+                // Severity >= 20 is fatal to the connection: no CATCH sees
+                // it. Already recorded (and doomed) at the raise site.
+                Err(error) if error.level >= FATAL_SEVERITY => return Err(error),
                 Err(error) => {
                     // The failed statement's own writes were already undone to
                     // its savepoint (`rel_statement_scoped`), and the doom
@@ -1929,10 +2244,28 @@ pub fn analyze_locks(
     let Ok(parsed) = truthdb_sql::parse(sql) else {
         return Vec::new();
     };
+    // The visited set terminates recursive procedures. Keyed on (procedure,
+    // effective analysis regime), NOT the name alone: a body's lock
+    // contribution is ISOLATION-DEPENDENT (versioned RC contributes Database
+    // IS; an escalated re-entry needs Table S), so a body re-entered under a
+    // different regime must re-analyze — the review's HIGH showed a shared
+    // body analyzed versioned first and then skipped under SERIALIZABLE,
+    // executing with no Table S. The regime lattice is finite, so
+    // termination survives.
+    let mut visited = std::collections::HashSet::new();
+    analyze_statements_locks(storage, &parsed, isolation, &mut visited)
+}
+
+fn analyze_statements_locks(
+    storage: &Storage,
+    parsed: &[Statement],
+    isolation: Isolation,
+    visited: &mut std::collections::HashSet<(String, Isolation)>,
+) -> Vec<(Resource, LockMode)> {
     // Flatten TRY/CATCH so the locks a batch needs are pre-acquired for the
     // statements inside its try/catch blocks too, not just the top level.
     let mut statements: Vec<&Statement> = Vec::new();
-    flatten_statements(&parsed, &mut statements);
+    flatten_statements(parsed, &mut statements);
     // Reads take shared locks except under READ UNCOMMITTED, which takes none.
     // A batch that raises the isolation level (e.g. `SET ISOLATION LEVEL
     // SERIALIZABLE; SELECT ...`) must lock its reads even if the session was
@@ -2127,7 +2460,37 @@ pub fn analyze_locks(
             // statement, an unknown procedure) cannot be analyzed before it
             // runs — lock the database exclusively rather than under-lock
             // (2PL acquires the full set up front).
-            Statement::Exec(exec) => match exec_literal_sql(exec) {
+            Statement::Exec(exec) => {
+                // A user procedure: its stored body analyzes like literal
+                // inner text, parsed with the IN-PROCEDURE grammar — a plain
+                // parse would reject `RETURN <value>` (178), yield no locks,
+                // and the body would run UNLOCKED (the 2PL hole class).
+                if let Some(def) = resolve_table(storage, &exec.proc.value)
+                    && let Some(procedure) = &def.procedure
+                {
+                    let inner_isolation = if reads_lock {
+                        if matches!(isolation, Isolation::ReadCommitted | Isolation::Snapshot)
+                            && !escalates_reads
+                        {
+                            isolation
+                        } else {
+                            Isolation::RepeatableRead
+                        }
+                    } else {
+                        isolation
+                    };
+                    if visited.insert((def.name.clone(), inner_isolation))
+                        && let Ok(body) = truthdb_sql::parse_procedure_body(&procedure.body)
+                    {
+                        for (resource, mode) in
+                            analyze_statements_locks(storage, &body, inner_isolation, visited)
+                        {
+                            add(resource, mode);
+                        }
+                    }
+                    continue;
+                }
+                match exec_literal_sql(exec) {
                 Some(inner) => {
                     // The inner text runs under the batch's EFFECTIVE
                     // isolation: a `SET ... SERIALIZABLE` before the EXEC
@@ -2161,12 +2524,17 @@ pub fn analyze_locks(
                     } else {
                         isolation
                     };
-                    for (resource, mode) in analyze_locks(storage, &inner, inner_isolation) {
-                        add(resource, mode);
+                    if let Ok(parsed) = truthdb_sql::parse(&inner) {
+                        for (resource, mode) in
+                            analyze_statements_locks(storage, &parsed, inner_isolation, visited)
+                        {
+                            add(resource, mode);
+                        }
                     }
                 }
                 None => add(Resource::Database, LockMode::Exclusive),
-            },
+                }
+            }
             // Procedure DDL rewrites the catalog: Database X, like other DDL.
             Statement::CreateProcedure(_) | Statement::DropProcedure { .. } => {
                 add(Resource::Database, LockMode::Exclusive);
@@ -4013,9 +4381,11 @@ fn length(n: u32, name: &str) -> Result<u16, SqlError> {
 // ---- DROP TABLE ---------------------------------------------------------
 
 fn exec_drop_table(storage: &Storage, drop: &DropTable) -> Result<StatementResult, SqlError> {
-    // DROP TABLE does not drop a view (use DROP VIEW). The object exists but is
-    // the wrong type, so error even under IF EXISTS rather than silently no-op.
-    if resolve_table(storage, &drop.table.value).is_some_and(|d| d.is_view()) {
+    // DROP TABLE does not drop a view or a procedure (use the matching DROP).
+    // The object exists but is the wrong type, so error even under IF EXISTS
+    // rather than silently no-op — the review showed DROP TABLE silently
+    // DESTROYING a procedure through the shared catalog path.
+    if resolve_table(storage, &drop.table.value).is_some_and(|d| d.is_view() || d.is_procedure()) {
         return Err(SqlError::new(
             3701,
             11,
@@ -4104,11 +4474,39 @@ fn exec_create_view(storage: &Storage, create: &CreateView) -> Result<StatementR
     Ok(StatementResult::Done)
 }
 
+/// A parameter default must be a CONSTANT (SQL Server rejects at CREATE):
+/// literals, NULL, and a signed literal — never variables or functions,
+/// which would otherwise evaluate against each CALLER's scope and drift.
+fn constant_default(expr: &Expr) -> bool {
+    match &expr.kind {
+        ExprKind::Null
+        | ExprKind::Int(_)
+        | ExprKind::Number(_)
+        | ExprKind::Str(_)
+        | ExprKind::Bool(_)
+        | ExprKind::Literal(_) => true,
+        ExprKind::Unary { expr, .. } => constant_default(expr),
+        _ => false,
+    }
+}
+
 fn exec_create_procedure(
     storage: &Storage,
     create: &CreateProcedure,
 ) -> Result<StatementResult, SqlError> {
     let bare = strip_schema(&create.name.value);
+    // The builtin dispatcher checks `sp_executesql` BEFORE the catalog, so a
+    // user procedure with that name would execute as the builtin while lock
+    // ANALYSIS resolved the catalog first — an unanalyzed inner batch (the
+    // review's shadow finding). Refuse the shadow outright.
+    if bare.eq_ignore_ascii_case("sp_executesql") {
+        return Err(SqlError::new(
+            2714,
+            16,
+            6,
+            "The name 'sp_executesql' is reserved for the system procedure.",
+        ));
+    }
     let params = create
         .params
         .iter()
@@ -4116,6 +4514,21 @@ fn exec_create_procedure(
             // The declared type round-trips through the column-type spec
             // parser, exactly like table columns.
             let column_type = data_type_to_column_type(&p.data_type, &p.name)?;
+            if let Some(text) = &p.default_text {
+                let expr = truthdb_sql::parse_expr(text)?;
+                if !constant_default(&expr) {
+                    return Err(SqlError::new(
+                        102,
+                        15,
+                        1,
+                        format!(
+                            "The default for parameter '@{}' must be a constant.",
+                            p.name
+                        ),
+                    )
+                    .at(p.span));
+                }
+            }
             Ok(ProcParamDef {
                 name: p.name.clone(),
                 type_spec: column_type.name(),
@@ -5954,7 +6367,10 @@ fn from_column_names(storage: &Storage, from: &TableRef) -> Option<Vec<(Option<S
     match from {
         TableRef::Table { name, alias } => {
             let def = resolve_table(storage, &name.value)?;
-            if def.is_view() {
+            // A view defers to its expansion; a PROCEDURE must not read as a
+            // zero-column table — bailing here routes to the collecting path,
+            // which errors 2809.
+            if def.is_view() || def.is_procedure() {
                 return None;
             }
             let qualifier = alias
@@ -7033,8 +7449,10 @@ fn scan_plan(storage: &Storage, select: &Select, eval_ctx: &EvalContext) -> Opti
     let def = resolve_table(storage, &name.value)?;
     // A view is its own SELECT, expanded as a derived table — and its TableDef
     // has no columns and a `root_page` of 0, so a wildcard over it would project
-    // nothing and the scan would read the catalog root instead of the view.
-    if def.view_query.is_some() {
+    // nothing and the scan would read the catalog root instead of the view. A
+    // PROCEDURE has the same empty shape and must not stream as an empty
+    // table: the collecting path rejects it (2809).
+    if def.view_query.is_some() || def.is_procedure() {
         return None;
     }
     let schema = def.schema().ok()?;
@@ -8496,6 +8914,9 @@ fn build_table_source(
         "sys.databases" => sys_databases(storage, eval_ctx),
         "sys.configurations" => sys_configurations(),
         "sys.views" => sys_views(storage),
+        "sys.procedures" => sys_procedures(storage),
+        "sys.parameters" => sys_parameters(storage),
+        "sys.objects" => sys_objects(storage),
         "sys.sql_modules" => sys_sql_modules(storage),
         "sys.columns" => sys_columns(storage),
         "sys.indexes" => sys_indexes(storage),
@@ -8505,6 +8926,10 @@ fn build_table_source(
         _ => {
             let def = resolve_table(storage, &name.value)
                 .ok_or_else(|| SqlError::invalid_object(&name.value).at(name.span))?;
+            // A procedure is not a queryable object (SQL Server 2809).
+            if def.is_procedure() {
+                return Err(procedure_not_a_table(&def.name).at(name.span));
+            }
             // A view: run its stored SELECT as a derived table under the view's
             // qualifier. A view over another view expands recursively — building
             // the derived source re-enters `build_table_source` for the inner
@@ -9353,8 +9778,110 @@ fn sys_sql_modules(storage: &Storage) -> Source {
         .rel_tables()
         .into_iter()
         .filter_map(|def| {
-            def.view_query
-                .map(|q| vec![Datum::Int(def.object_id as i32), Datum::NVarChar(q)])
+            // Views store their SELECT; procedures their body text.
+            let definition = def
+                .view_query
+                .clone()
+                .or_else(|| def.procedure.as_ref().map(|p| p.body.clone()))?;
+            Some(vec![
+                Datum::Int(def.object_id as i32),
+                Datum::NVarChar(definition),
+            ])
+        })
+        .collect();
+    let collations = vec![None; columns.len()];
+    let qualifiers = vec![None; columns.len()];
+    Source {
+        columns,
+        qualifiers,
+        collations,
+        rows: SourceRows::Materialized(rows),
+    }
+}
+
+fn sys_procedures(storage: &Storage) -> Source {
+    let columns = vec![nvarchar("name", 128), int_col("object_id")];
+    let rows = storage
+        .rel_tables()
+        .into_iter()
+        .filter(|def| def.is_procedure())
+        .map(|def| {
+            vec![
+                Datum::NVarChar(def.name.clone()),
+                Datum::Int(def.object_id as i32),
+            ]
+        })
+        .collect();
+    let collations = vec![None; columns.len()];
+    let qualifiers = vec![None; columns.len()];
+    Source {
+        columns,
+        qualifiers,
+        collations,
+        rows: SourceRows::Materialized(rows),
+    }
+}
+
+fn sys_parameters(storage: &Storage) -> Source {
+    let columns = vec![
+        int_col("object_id"),
+        nvarchar("name", 128),
+        int_col("parameter_id"),
+        nvarchar("system_type_name", 128),
+        int_col("is_output"),
+        int_col("has_default_value"),
+    ];
+    let mut rows = Vec::new();
+    for def in storage.rel_tables() {
+        let Some(procedure) = &def.procedure else {
+            continue;
+        };
+        for (index, param) in procedure.params.iter().enumerate() {
+            rows.push(vec![
+                Datum::Int(def.object_id as i32),
+                Datum::NVarChar(format!("@{}", param.name)),
+                Datum::Int(index as i32 + 1),
+                Datum::NVarChar(param.type_spec.clone()),
+                Datum::Int(i32::from(param.output)),
+                Datum::Int(i32::from(param.default.is_some())),
+            ]);
+        }
+    }
+    let collations = vec![None; columns.len()];
+    let qualifiers = vec![None; columns.len()];
+    Source {
+        columns,
+        qualifiers,
+        collations,
+        rows: SourceRows::Materialized(rows),
+    }
+}
+
+fn sys_objects(storage: &Storage) -> Source {
+    let columns = vec![
+        nvarchar("name", 128),
+        int_col("object_id"),
+        nvarchar("type", 2),
+        nvarchar("type_desc", 60),
+    ];
+    let rows = storage
+        .rel_tables()
+        .into_iter()
+        .map(|def| {
+            // SQL Server's type codes carry a trailing space.
+            let (code, desc) = if def.is_procedure() {
+                ("P ", "SQL_STORED_PROCEDURE")
+            } else if def.is_view() {
+                ("V ", "VIEW")
+            } else {
+                ("U ", "USER_TABLE")
+            };
+            vec![
+                Datum::NVarChar(def.name.clone()),
+                Datum::Int(def.object_id as i32),
+                Datum::NVarChar(code.to_string()),
+                Datum::NVarChar(desc.to_string()),
+            ]
         })
         .collect();
     let collations = vec![None; columns.len()];
@@ -9601,8 +10128,12 @@ fn collect_read_lock_ids(storage: &Storage, name: &str, depth: u32, out: &mut Ve
     }
 }
 
-/// Views are read-only here; INSERT/UPDATE/DELETE against one is rejected.
+/// Views are read-only here; INSERT/UPDATE/DELETE against one is rejected —
+/// and a PROCEDURE is not a data object at all (SQL Server 2809).
 fn reject_dml_on_view(def: &TableDef) -> Result<(), SqlError> {
+    if def.is_procedure() {
+        return Err(procedure_not_a_table(&def.name));
+    }
     if def.is_view() {
         return Err(SqlError::new(
             4406,
@@ -9617,10 +10148,25 @@ fn reject_dml_on_view(def: &TableDef) -> Result<(), SqlError> {
     Ok(())
 }
 
+/// SQL Server 2809: a procedure referenced where a table/view is required.
+fn procedure_not_a_table(name: &str) -> SqlError {
+    SqlError::new(
+        2809,
+        16,
+        1,
+        format!(
+            "The request for procedure '{name}' failed because '{name}' is a procedure object."
+        ),
+    )
+}
+
 /// Table-only DDL (ALTER TABLE, CREATE INDEX) rejects a view. Without this a
 /// view's `root_page = 0` would be heap-scanned — and page 0 is the catalog
 /// root, so a bare `ALTER TABLE view ADD CHECK (1=1)` could corrupt the catalog.
 fn reject_view_as_table(def: &TableDef) -> Result<(), SqlError> {
+    if def.is_procedure() {
+        return Err(procedure_not_a_table(&def.name));
+    }
     if def.is_view() {
         return Err(SqlError::new(
             4928,

--- a/crates/truthdb-core/src/relstore/catalog.rs
+++ b/crates/truthdb-core/src/relstore/catalog.rs
@@ -116,12 +116,45 @@ pub struct TableDef {
     /// A view carries no data pages, columns, or key.
     #[serde(default)]
     pub view_query: Option<String>,
+    /// For a STORED PROCEDURE: its parameters and body source text, re-parsed
+    /// at each EXEC (the view posture: text is the stored form, recompile-on-
+    /// schema-change semantics for free). `None` for tables and views. A
+    /// procedure carries no data pages, columns, or key.
+    #[serde(default)]
+    pub procedure: Option<ProcedureDef>,
+}
+
+/// A stored procedure's catalog payload: declared parameters and body text.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProcedureDef {
+    pub params: Vec<ProcParamDef>,
+    /// The body's source text (the statements after `AS`), parsed with the
+    /// in-procedure grammar (RETURN <value> is legal) at EXEC time.
+    pub body: String,
+}
+
+/// One declared procedure parameter.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProcParamDef {
+    /// Lowercased, without the `@`.
+    pub name: String,
+    /// Parseable type spec, same round-trip as column types.
+    pub type_spec: String,
+    /// Default value source text (the parameter is then optional).
+    pub default: Option<String>,
+    /// `OUTPUT`/`OUT`: the argument variable receives the final value.
+    pub output: bool,
 }
 
 impl TableDef {
     /// True if this catalog entry is a view rather than a base table.
     pub fn is_view(&self) -> bool {
         self.view_query.is_some()
+    }
+
+    /// True if this catalog entry is a stored procedure.
+    pub fn is_procedure(&self) -> bool {
+        self.procedure.is_some()
     }
 }
 

--- a/crates/truthdb-core/src/session.rs
+++ b/crates/truthdb-core/src/session.rs
@@ -2405,6 +2405,75 @@ mod tests {
         let _ = std::fs::remove_file(path);
     }
 
+    /// Adversarial review probe: ALTER PROCEDURE bumps the lock-analysis
+    /// epoch, so a batch parked with a lock set analyzed over the OLD body is
+    /// re-analyzed at grant time against the NEW body — otherwise the new
+    /// body's writes would run under the old body's read locks (the stale
+    /// twice-derived-decision class from the Stage 13 review).
+    #[test]
+    fn review_poc_alter_procedure_reanalyzes_a_parked_exec() {
+        let (engine, mut sched, path) = bare("epoch-proc-alter", None);
+        let blocker = sched.sessions.open("truthdb".into(), "sa".into());
+        let waiter = sched.sessions.open("truthdb".into(), "sa".into());
+        {
+            let mut ctx = crate::rel::TxnContext::default();
+            engine
+                .sql_batch("CREATE TABLE t (id INT NOT NULL PRIMARY KEY)", &mut ctx)
+                .expect("create table");
+            engine
+                .sql_batch("CREATE PROCEDURE p AS SELECT id FROM t", &mut ctx)
+                .expect("create proc");
+        }
+        // The blocker holds Database X so nothing becomes grantable.
+        assert!(sched.try_acquire(
+            blocker.raw(),
+            &[(Resource::Database, LockMode::Exclusive)],
+            true
+        ));
+        // Park an EXEC analyzed against the OLD (read-only) body.
+        let epoch = engine.lock_analysis_epoch();
+        let needs = engine.analyze_locks("EXEC p", crate::rel::Isolation::ReadCommitted);
+        assert!(
+            !needs
+                .iter()
+                .any(|(_, m)| matches!(m, LockMode::IntentExclusive | LockMode::Exclusive)),
+            "precondition: the old body takes no write locks: {needs:?}"
+        );
+        let (tx, _rx) = mpsc::unbounded_channel();
+        sched.parked.push_back(Parked {
+            session: waiter,
+            sql: "EXEC p".into(),
+            params: Vec::new(),
+            cancel: Arc::new(AtomicBool::new(false)),
+            reply: BatchSink::new(tx),
+            needs,
+            deadline: Instant::now() + Duration::from_secs(5),
+            epoch,
+        });
+        // The body is replaced while the batch is parked.
+        {
+            let mut ctx = crate::rel::TxnContext::default();
+            engine
+                .sql_batch("ALTER PROCEDURE p AS INSERT INTO t VALUES (1)", &mut ctx)
+                .expect("alter proc");
+        }
+        // The grant path must re-analyze (the blocker still prevents the
+        // grant itself, so the refreshed needs stay inspectable).
+        assert!(
+            sched.next_grantable(&engine).is_none(),
+            "Database X is still held; nothing may be granted"
+        );
+        let refreshed = &sched.parked.front().expect("still parked").needs;
+        assert!(
+            refreshed
+                .iter()
+                .any(|(_, m)| matches!(m, LockMode::IntentExclusive | LockMode::Exclusive)),
+            "the parked EXEC's lock set was re-analyzed against the NEW \
+             body (INSERT): {refreshed:?}"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
     #[tokio::test]
     async fn the_pool_actually_spawns_a_maintenance_thread() {
         // `housekeeping_runs_with_no_worker_free_to_do_it` builds `Shared` by

--- a/crates/truthdb-core/src/storage.rs
+++ b/crates/truthdb-core/src/storage.rs
@@ -4648,6 +4648,179 @@ mod tests {
     /// levels are untouched by the option.
     /// Lock analysis descends control-flow bodies: a WHILE body's INSERT and
     /// an IF condition's EXISTS table are in the batch's up-front lock set.
+    /// EXEC of a user procedure locks the STORED BODY's tables up front —
+    /// parsed with the in-procedure grammar (a plain parse would 178 on
+    /// `RETURN <value>`, yield no locks, and the body would run unlocked).
+    /// Recursive procedures terminate analysis via the visited set.
+    #[test]
+    fn analyze_locks_covers_procedure_bodies() {
+        use crate::lock::{LockMode, Resource};
+        use crate::rel::{Isolation, TxnContext, execute_batch};
+
+        let path = unique_temp_path("proc-locks");
+        let storage = Storage::create(path.clone(), test_storage_options()).expect("create");
+        let mut ctx = TxnContext::default();
+        for sql in [
+            "CREATE TABLE plt (id INT NOT NULL PRIMARY KEY)",
+            "CREATE PROCEDURE writer @v INT AS INSERT INTO plt VALUES (@v); \
+             EXEC writer @v; RETURN 5",
+        ] {
+            let outcome = execute_batch(&storage, sql, &mut ctx);
+            assert!(outcome.error.is_none(), "{sql}: {:?}", outcome.error);
+        }
+        let needs = crate::rel::analyze_locks(&storage, "EXEC writer 1", Isolation::ReadCommitted);
+        assert!(
+            needs.iter().any(
+                |(r, m)| matches!(r, Resource::Table(_)) && *m == LockMode::Exclusive
+                    || matches!(r, Resource::Row(..))
+            ),
+            "the recursive body's INSERT locks its table (and analysis \
+             terminated): {needs:?}"
+        );
+        // An unknown procedure contributes no locks (2812 at execution).
+        let needs =
+            crate::rel::analyze_locks(&storage, "EXEC no_such_proc", Isolation::ReadCommitted);
+        assert!(
+            !needs
+                .iter()
+                .any(|(r, _)| matches!(r, Resource::Table(_) | Resource::Row(..))),
+            "unknown proc: {needs:?}"
+        );
+        drop(storage);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// Adversarial review probe: the visited set dedups a procedure's lock
+    /// contribution, but a body's lock set DEPENDS on the effective
+    /// isolation. Under RCSI, `EXEC pread` analyzed first contributes only
+    /// Database IS (versioned read); a later `EXEC pser` — whose body raises
+    /// to SERIALIZABLE and EXECs pread — finds pread already visited and
+    /// skips it, so the lock-based re-analysis (Table S) is dropped. At
+    /// execution the SET is live inside pser and pread's SELECT reads
+    /// lock-based with no Table S held: the 2PL under-lock class.
+    #[test]
+    fn review_poc_analyze_locks_procedure_reanalyzed_under_escalated_isolation() {
+        use crate::lock::{LockMode, Resource};
+        use crate::rel::{Isolation, TxnContext, execute_batch};
+
+        let path = unique_temp_path("proc-visited-isolation");
+        let storage = Storage::create(path.clone(), test_storage_options()).expect("create");
+        let mut ctx = TxnContext::default();
+        for sql in [
+            "CREATE TABLE t (id INT NOT NULL PRIMARY KEY, v INT)",
+            "ALTER DATABASE CURRENT SET READ_COMMITTED_SNAPSHOT ON",
+            "CREATE PROCEDURE pread AS SELECT v FROM t",
+            "CREATE PROCEDURE pser AS \
+             SET TRANSACTION ISOLATION LEVEL SERIALIZABLE; EXEC pread",
+        ] {
+            let outcome = execute_batch(&storage, sql, &mut ctx);
+            assert!(outcome.error.is_none(), "{sql}: {:?}", outcome.error);
+        }
+        let table_s = |needs: &[(Resource, LockMode)]| {
+            needs
+                .iter()
+                .any(|(r, m)| matches!(r, Resource::Table(_)) && *m == LockMode::Shared)
+        };
+        // Control: analyzed alone, the escalated body read-locks.
+        let needs = crate::rel::analyze_locks(&storage, "EXEC pser", Isolation::ReadCommitted);
+        assert!(
+            table_s(&needs),
+            "control: pser's escalated body takes Table S: {needs:?}"
+        );
+        // The seam: pread analyzed first under the versioned regime, then
+        // pser's escalated re-entry is dropped by the visited set.
+        let needs =
+            crate::rel::analyze_locks(&storage, "EXEC pread; EXEC pser", Isolation::ReadCommitted);
+        assert!(
+            table_s(&needs),
+            "pser still runs pread's SELECT under SERIALIZABLE — Table S \
+             must be in the up-front set: {needs:?}"
+        );
+        drop(storage);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// Adversarial review probe: a stored procedure EXEC'd from INSIDE a
+    /// dynamic-SQL literal is still resolved by lock analysis (the literal
+    /// recursion's Exec arm hits the procedure branch).
+    #[test]
+    fn review_poc_analyze_locks_procedure_via_dynamic_sql() {
+        use crate::lock::{LockMode, Resource};
+        use crate::rel::{Isolation, TxnContext, execute_batch};
+
+        let path = unique_temp_path("proc-dyn-locks");
+        let storage = Storage::create(path.clone(), test_storage_options()).expect("create");
+        let mut ctx = TxnContext::default();
+        for sql in [
+            "CREATE TABLE t (id INT NOT NULL PRIMARY KEY)",
+            "CREATE PROCEDURE wtr @v INT AS INSERT INTO t VALUES (@v)",
+        ] {
+            let outcome = execute_batch(&storage, sql, &mut ctx);
+            assert!(outcome.error.is_none(), "{sql}: {:?}", outcome.error);
+        }
+        let needs = crate::rel::analyze_locks(
+            &storage,
+            "EXEC sp_executesql N'EXEC wtr 1'",
+            Isolation::ReadCommitted,
+        );
+        assert!(
+            needs.iter().any(|(r, m)| matches!(r, Resource::Table(_))
+                && matches!(m, LockMode::IntentExclusive | LockMode::Exclusive)
+                || matches!(r, Resource::Row(..))),
+            "the proc body's INSERT is in the up-front set via the literal \
+             path: {needs:?}"
+        );
+        drop(storage);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// Adversarial review probe: analysis resolves the catalog FIRST, but
+    /// execution checks the sp_executesql builtin FIRST. A user procedure
+    /// named sp_executesql makes the two disagree: analysis analyzes the
+    /// user body, execution runs the builtin over the literal — whose locks
+    /// were never analyzed (under-lock). Either the CREATE must be refused
+    /// or the analysis must mirror execution's builtin-first order.
+    #[test]
+    fn review_poc_user_procedure_named_sp_executesql_cannot_shadow_builtin() {
+        use crate::lock::{LockMode, Resource};
+        use crate::rel::{Isolation, TxnContext, execute_batch};
+
+        let path = unique_temp_path("proc-spexec-shadow");
+        let storage = Storage::create(path.clone(), test_storage_options()).expect("create");
+        let mut ctx = TxnContext::default();
+        let outcome = execute_batch(
+            &storage,
+            "CREATE TABLE t (id INT NOT NULL PRIMARY KEY)",
+            &mut ctx,
+        );
+        assert!(outcome.error.is_none(), "{:?}", outcome.error);
+        let outcome = execute_batch(
+            &storage,
+            "CREATE PROCEDURE sp_executesql AS SELECT 1 AS n",
+            &mut ctx,
+        );
+        if outcome.error.is_none() {
+            // The shadow exists: analysis and execution must still agree.
+            // Execution runs the BUILTIN (its name check comes first), so the
+            // literal's INSERT locks must be in the analyzed set.
+            let needs = crate::rel::analyze_locks(
+                &storage,
+                "EXEC sp_executesql N'INSERT INTO t VALUES (1)'",
+                Isolation::ReadCommitted,
+            );
+            assert!(
+                needs.iter().any(|(r, m)| matches!(r, Resource::Table(_))
+                    && matches!(m, LockMode::IntentExclusive | LockMode::Exclusive)
+                    || matches!(r, Resource::Row(..))
+                    || (matches!(r, Resource::Database) && *m == LockMode::Exclusive)),
+                "execution runs the builtin INSERT; analysis followed the \
+                 user proc's body instead: {needs:?}"
+            );
+        }
+        drop(storage);
+        let _ = std::fs::remove_file(&path);
+    }
+
     #[test]
     fn analyze_locks_descends_control_flow() {
         use crate::lock::{LockMode, Resource};

--- a/crates/truthdb-core/src/storage.rs
+++ b/crates/truthdb-core/src/storage.rs
@@ -555,6 +555,29 @@ impl Storage {
         self.lock().rel_create_view(name, query_text)
     }
 
+    pub fn rel_create_procedure(
+        &self,
+        name: &str,
+        procedure: crate::relstore::catalog::ProcedureDef,
+    ) -> Result<(), StorageError> {
+        let result = self.lock().rel_create_procedure(name, procedure);
+        // A parked batch analyzed against the OLD catalog could carry a stale
+        // lock set for an EXEC of this name — same class as the option-flip
+        // epoch (Stage 13): bump so the grant path re-analyzes.
+        self.bump_lock_epoch();
+        result
+    }
+
+    pub fn rel_alter_procedure(
+        &self,
+        name: &str,
+        procedure: crate::relstore::catalog::ProcedureDef,
+    ) -> Result<(), StorageError> {
+        let result = self.lock().rel_alter_procedure(name, procedure);
+        self.bump_lock_epoch();
+        result
+    }
+
     pub fn rel_table(&self, name: &str) -> Option<TableDef> {
         self.lock().rel_table(name)
     }
@@ -676,6 +699,14 @@ impl Storage {
         self.lock_epoch
             .fetch_add(1, std::sync::atomic::Ordering::Release);
         Ok(())
+    }
+
+    /// Bumps the lock-analysis epoch: a parked batch analyzed before a
+    /// catalog/option change re-analyzes at grant instead of running under a
+    /// stale lock set.
+    fn bump_lock_epoch(&self) {
+        self.lock_epoch
+            .fetch_add(1, std::sync::atomic::Ordering::Release);
     }
 
     /// The lock-analysis epoch: parked batches analyzed under an older value
@@ -1344,6 +1375,7 @@ impl StorageFile {
                 check_constraints,
                 foreign_keys,
                 view_query: None,
+                procedure: None,
                 counter_page: Some(counter_page),
             };
             catalog::insert_table(ctx, &mut OpMode::Txn(txn), catalog_root, &def)?;
@@ -1395,12 +1427,94 @@ impl StorageFile {
                 check_constraints: Vec::new(),
                 foreign_keys: Vec::new(),
                 view_query: Some(query),
+                procedure: None,
                 counter_page: None,
             };
             catalog::insert_table(ctx, &mut OpMode::Txn(txn), catalog_root, &def)?;
             Ok(def)
         })?;
         self.rel.next_object_id += 1;
+        self.rel.tables.insert(name.to_string(), def);
+        Ok(())
+    }
+
+    /// Creates a stored procedure: a catalog entry whose stored form is its
+    /// parameter list and body text (the view posture — re-parsed at EXEC).
+    pub fn rel_create_procedure(
+        &mut self,
+        name: &str,
+        procedure: crate::relstore::catalog::ProcedureDef,
+    ) -> Result<(), StorageError> {
+        self.ensure_rel_usable()?;
+        if self.rel.tables.contains_key(name) {
+            return Err(StorageError::Constraint(format!(
+                "object '{name}' already exists"
+            )));
+        }
+        if self.rel.catalog_root.is_none() {
+            let root = {
+                let mut ctx = self.rel_ctx();
+                catalog::create_catalog(&mut ctx)?
+            };
+            self.rel.catalog_root = Some(root);
+        }
+        let catalog_root = self.rel.catalog_root.expect("catalog exists");
+        let object_id = self.rel.next_object_id;
+        let proc_name = name.to_string();
+        let def = self.rel_statement(move |ctx, txn| {
+            let def = TableDef {
+                object_id,
+                name: proc_name,
+                columns: Vec::new(),
+                key_columns: Vec::new(),
+                root_page: 0,
+                defaults: Vec::new(),
+                collations: Vec::new(),
+                identity: None,
+                indexes: Vec::new(),
+                check_constraints: Vec::new(),
+                foreign_keys: Vec::new(),
+                view_query: None,
+                procedure: Some(procedure),
+                counter_page: None,
+            };
+            catalog::insert_table(ctx, &mut OpMode::Txn(txn), catalog_root, &def)?;
+            Ok(def)
+        })?;
+        self.rel.next_object_id += 1;
+        self.rel.tables.insert(name.to_string(), def);
+        Ok(())
+    }
+
+    /// Replaces an existing procedure's parameters and body (`ALTER
+    /// PROCEDURE`): the object id is kept, the stored text swapped.
+    pub fn rel_alter_procedure(
+        &mut self,
+        name: &str,
+        procedure: crate::relstore::catalog::ProcedureDef,
+    ) -> Result<(), StorageError> {
+        self.ensure_rel_usable()?;
+        let Some(existing) = self.rel.tables.get(name) else {
+            return Err(StorageError::Constraint(format!(
+                "procedure '{name}' does not exist"
+            )));
+        };
+        if !existing.is_procedure() {
+            return Err(StorageError::Constraint(format!(
+                "object '{name}' is not a procedure"
+            )));
+        }
+        let mut def = existing.clone();
+        def.procedure = Some(procedure);
+        let catalog_root = self
+            .rel
+            .catalog_root
+            .expect("procedures live in the catalog");
+        let write = def.clone();
+        self.rel_statement(move |ctx, txn| {
+            catalog::update_table(ctx, &mut OpMode::Txn(txn), catalog_root, &write)?;
+            Ok(())
+        })?;
         self.rel.tables.insert(name.to_string(), def);
         Ok(())
     }

--- a/crates/truthdb-core/tests/slt/procedures.slt
+++ b/crates/truthdb-core/tests/slt/procedures.slt
@@ -1,0 +1,64 @@
+# Stored procedures (Stage 15): DDL, EXEC with binding forms, RETURN status,
+# OUTPUT copy-back, and the catalog views. The interaction matrix (errors,
+# nesting, aborts) lives in the engine tests.
+
+statement ok
+CREATE TABLE pt (id INT NOT NULL PRIMARY KEY)
+
+statement ok
+CREATE PROCEDURE add_row @id INT, @doubled INT OUTPUT AS INSERT INTO pt VALUES (@id); SET @doubled = @id * 2; RETURN @id + 100
+
+statement ok
+DECLARE @d INT, @rc INT; EXEC @rc = add_row 21, @d OUTPUT; INSERT INTO pt VALUES (@d); INSERT INTO pt VALUES (@rc)
+
+query I rowsort
+SELECT id FROM pt
+----
+21
+42
+121
+
+# Named binding and defaults.
+statement ok
+CREATE PROC greet @who NVARCHAR(50) = 'world' AS SELECT @who
+
+query T
+EXEC greet
+----
+world
+
+query T
+EXEC greet @who = 'truthdb'
+----
+truthdb
+
+# Catalog views.
+query TI rowsort
+SELECT name, object_id > 0 FROM sys.procedures
+----
+add_row 1
+greet 1
+
+query TII rowsort
+SELECT name, parameter_id, is_output FROM sys.parameters WHERE name LIKE '@d%'
+----
+@doubled 2 1
+
+# (the `type` code itself carries SQL Server's trailing space, which this
+# file format cannot express — the WHERE proves it round-trips)
+query TT rowsort
+SELECT name, type_desc FROM sys.objects WHERE type = 'P '
+----
+add_row SQL_STORED_PROCEDURE
+greet SQL_STORED_PROCEDURE
+
+query I
+SELECT COUNT(*) FROM sys.sql_modules m JOIN sys.procedures p ON m.object_id = p.object_id
+----
+2
+
+statement ok
+DROP PROCEDURE greet
+
+statement error
+EXEC greet

--- a/crates/truthdb-sql/src/ast.rs
+++ b/crates/truthdb-sql/src/ast.rs
@@ -99,6 +99,40 @@ pub enum Statement {
         value: Option<Expr>,
         span: Span,
     },
+    /// `CREATE PROCEDURE` / `ALTER PROCEDURE` — the body is stored as source
+    /// text (the view posture) and re-parsed at EXEC.
+    CreateProcedure(CreateProcedure),
+    /// `DROP PROCEDURE [IF EXISTS] <name>`.
+    DropProcedure {
+        name: Name,
+        if_exists: bool,
+        span: Span,
+    },
+}
+
+/// `CREATE|ALTER PROC[EDURE] <name> [@p TYPE [= default] [OUTPUT], ...] AS <body>`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CreateProcedure {
+    pub name: Name,
+    pub params: Vec<ProcParam>,
+    /// The body's source text: everything after `AS`, verbatim.
+    pub body: String,
+    /// `ALTER PROCEDURE` replaces an existing definition.
+    pub alter: bool,
+    pub span: Span,
+}
+
+/// One declared procedure parameter.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ProcParam {
+    /// Lowercased, without the `@`.
+    pub name: String,
+    pub data_type: DataType,
+    /// Default value source text (the parameter is then optional at EXEC).
+    pub default_text: Option<String>,
+    /// `OUTPUT`/`OUT`.
+    pub output: bool,
+    pub span: Span,
 }
 
 /// `THROW [number, message, state]`.
@@ -143,19 +177,25 @@ pub struct Declaration {
     pub span: Span,
 }
 
-/// `EXEC[UTE] <proc> [@name =] <expr> [, ...]`.
+/// `EXEC[UTE] [@rc =] <proc> [[@name =] <expr> [OUTPUT] [, ...]]`.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ExecStatement {
     pub proc: Name,
+    /// `EXEC @rc = proc`: the variable receiving the RETURN status
+    /// (lowercased, without the `@`).
+    pub return_var: Option<String>,
     pub args: Vec<ExecArg>,
     pub span: Span,
 }
 
-/// One argument of an `EXEC`: optionally named (`@p = expr`).
+/// One argument of an `EXEC`: optionally named (`@p = expr`), optionally
+/// `OUTPUT` (the argument must then be a variable, which receives the
+/// parameter's final value).
 #[derive(Debug, Clone, PartialEq)]
 pub struct ExecArg {
     pub name: Option<Name>,
     pub value: Expr,
+    pub output: bool,
 }
 
 /// `ALTER TABLE <table> <action>`.

--- a/crates/truthdb-sql/src/eval.rs
+++ b/crates/truthdb-sql/src/eval.rs
@@ -98,17 +98,22 @@ pub struct EvalContext {
     pub xact_state: i8,
     /// `@@ERROR` — the previous statement's error number, 0 on success.
     pub last_error: i32,
+    /// `@@NESTLEVEL` — the current procedure nesting depth (0 in a batch).
+    pub nestlevel: i32,
 }
 
 /// The error captured by a `CATCH` block, surfaced by the `ERROR_*()`
-/// functions. Line and procedure are not tracked (no statement-line map, no
-/// stored procedures), so `ERROR_LINE()` reports 0 and `ERROR_PROCEDURE()` NULL.
+/// functions. Lines are not tracked (no statement-line map), so
+/// `ERROR_LINE()` reports 0.
 #[derive(Debug, Clone, Default)]
 pub struct ErrorInfo {
     pub number: i32,
     pub message: String,
     pub severity: u8,
     pub state: u8,
+    /// The stored procedure executing when the error was raised, for
+    /// `ERROR_PROCEDURE()` — `None` in ad-hoc batches.
+    pub procedure: Option<String>,
 }
 
 /// Evaluates `expr` against `row`, resolving columns via `resolver`.
@@ -244,6 +249,7 @@ fn eval_global_var(name: &str, ctx: &EvalContext) -> SqlResult<SqlValue> {
         )),
         "rowcount" => Ok(SqlValue::Int(ctx.rowcount)),
         "error" => Ok(SqlValue::Int(ctx.last_error as i64)),
+        "nestlevel" => Ok(SqlValue::Int(ctx.nestlevel as i64)),
         "identity" => Ok(SqlValue::Int(0)),
         other => Err(SqlError::message_only(
             102,
@@ -516,7 +522,13 @@ fn eval_session_function(name: &str, args: &[Expr]) -> Option<fn(&EvalContext) -
             Some(_) => SqlValue::Int(0),
             None => SqlValue::Null,
         }),
-        "ERROR_PROCEDURE" if args.is_empty() => Some(|_| SqlValue::Null),
+        "ERROR_PROCEDURE" if args.is_empty() => Some(|ctx| match &ctx.error {
+            Some(ErrorInfo {
+                procedure: Some(name),
+                ..
+            }) => SqlValue::Str(name.clone()),
+            _ => SqlValue::Null,
+        }),
         // Committability of the current transaction (independent of any CATCH).
         "XACT_STATE" if args.is_empty() => Some(|ctx| SqlValue::Int(ctx.xact_state as i64)),
         _ => None,

--- a/crates/truthdb-sql/src/lib.rs
+++ b/crates/truthdb-sql/src/lib.rs
@@ -29,6 +29,15 @@ pub fn parse(sql: &str) -> SqlResult<Vec<Statement>> {
     parser::Parser::from_tokens(sql, tokens).parse_statements()
 }
 
+/// Parses a stored-procedure body: the in-procedure grammar, where
+/// `RETURN <value>` is legal (178 outside one).
+pub fn parse_procedure_body(sql: &str) -> SqlResult<Vec<Statement>> {
+    let tokens = lexer::Lexer::new(sql).tokenize()?;
+    let mut parser = parser::Parser::from_tokens(sql, tokens);
+    parser.set_in_procedure();
+    parser.parse_statements()
+}
+
 /// Parses a single standalone expression (e.g. a column DEFAULT re-parsed at
 /// INSERT time). Rejects trailing tokens.
 pub fn parse_expr(sql: &str) -> SqlResult<Expr> {

--- a/crates/truthdb-sql/src/parser.rs
+++ b/crates/truthdb-sql/src/parser.rs
@@ -94,6 +94,12 @@ impl Parser {
         Parser::from_tokens(sql, crate::lexer::Lexer::new(sql).tokenize()?).parse_statements()
     }
 
+    /// Switches to the in-procedure grammar (`RETURN <value>` legal): the
+    /// entry for parsing a stored procedure's body text.
+    pub fn set_in_procedure(&mut self) {
+        self.in_procedure = true;
+    }
+
     /// Parses exactly one expression followed by EOF (for a re-parsed DEFAULT).
     pub fn parse_single_expr(mut self) -> SqlResult<Expr> {
         let expr = self.parse_expr()?;
@@ -1420,6 +1426,18 @@ impl Parser {
     /// stored as its source text.
     fn parse_create_procedure(&mut self, start: Span, alter: bool) -> SqlResult<Statement> {
         self.bump(); // PROCEDURE | PROC
+        if self.in_procedure {
+            // No nested CREATE/ALTER PROCEDURE inside a body (SQL Server's
+            // 156 class) — without this the inner body-capture would swallow
+            // the rest of the outer body.
+            return Err(SqlError::new(
+                156,
+                15,
+                1,
+                "Incorrect syntax near the keyword 'PROCEDURE'.",
+            )
+            .at(start));
+        }
         if self.statement_index > 0 || self.sub_depth > 0 {
             return Err(SqlError::new(
                 111,

--- a/crates/truthdb-sql/src/parser.rs
+++ b/crates/truthdb-sql/src/parser.rs
@@ -33,6 +33,14 @@ pub struct Parser {
     /// Lexical `WHILE` nesting depth: `BREAK`/`CONTINUE` outside a loop are
     /// compile-time errors (SQL Server 135/136), so the parser tracks it.
     while_depth: usize,
+    /// Parsing a stored-procedure body: `RETURN <value>` is then legal.
+    in_procedure: bool,
+    /// Nesting depth inside blocks / IF branches / WHILE bodies — procedure
+    /// DDL must be top-level (SQL Server 156/111 classes).
+    sub_depth: usize,
+    /// Index of the top-level statement being parsed (CREATE/ALTER PROCEDURE
+    /// must be the batch's first statement — SQL Server 111).
+    statement_index: usize,
     /// Expression nodes built so far.
     nodes: usize,
 }
@@ -49,6 +57,9 @@ impl Parser {
             pos: 0,
             depth: 0,
             while_depth: 0,
+            in_procedure: false,
+            sub_depth: 0,
+            statement_index: 0,
             nodes: 0,
         }
     }
@@ -106,6 +117,7 @@ impl Parser {
             // expressions never reach parse_expr's depth-0 reset and would
             // otherwise inherit the previous statement's count.
             self.nodes = 0;
+            self.statement_index = statements.len();
             statements.push(self.parse_statement()?);
             if !self.at_eof() && !self.check(&TokenKind::Semicolon) {
                 let token = self.peek().clone();
@@ -150,6 +162,20 @@ impl Parser {
     /// the system procedures. Arguments end at the statement boundary.
     fn parse_exec(&mut self) -> SqlResult<Statement> {
         let start = self.bump().span; // EXEC or EXECUTE
+        // `EXEC @rc = proc ...` captures the RETURN status.
+        let next = &self.tokens[(self.pos + 1).min(self.tokens.len() - 1)];
+        let return_var =
+            if matches!(self.peek().kind, TokenKind::LocalVar(_)) && next.kind == TokenKind::Eq {
+                let token = self.bump();
+                let TokenKind::LocalVar(var) = &token.kind else {
+                    unreachable!("matched above");
+                };
+                let var = var.clone();
+                self.bump(); // `=`
+                Some(var)
+            } else {
+                None
+            };
         let proc = self.parse_name()?;
         let mut args = Vec::new();
         let mut end = proc.span;
@@ -178,7 +204,18 @@ impl Parser {
                 };
                 let value = self.parse_expr()?;
                 end = value.span;
-                args.push(ExecArg { name, value });
+                let output =
+                    if matches!(self.peek_keyword().as_deref(), Some("OUTPUT") | Some("OUT")) {
+                        end = self.bump().span;
+                        true
+                    } else {
+                        false
+                    };
+                args.push(ExecArg {
+                    name,
+                    value,
+                    output,
+                });
                 if !self.eat(&TokenKind::Comma) {
                     break;
                 }
@@ -186,6 +223,7 @@ impl Parser {
         }
         Ok(Statement::Exec(ExecStatement {
             proc,
+            return_var,
             args,
             span: start.to(end),
         }))
@@ -196,12 +234,19 @@ impl Parser {
     fn parse_if(&mut self) -> SqlResult<Statement> {
         let start = self.expect_keyword("IF")?;
         let condition = self.parse_expr()?;
-        let then_branch = Box::new(self.parse_statement()?);
-        let else_branch = if self.peek_keyword().as_deref() == Some("ELSE") {
+        self.sub_depth += 1;
+        let then_branch = self.parse_statement();
+        let else_branch = if then_branch.is_ok() && self.peek_keyword().as_deref() == Some("ELSE") {
             self.bump();
-            Some(Box::new(self.parse_statement()?))
+            Some(self.parse_statement())
         } else {
             None
+        };
+        self.sub_depth -= 1;
+        let then_branch = Box::new(then_branch?);
+        let else_branch = match else_branch {
+            Some(branch) => Some(Box::new(branch?)),
+            None => None,
         };
         let end = self.prev_span();
         Ok(Statement::If {
@@ -217,7 +262,9 @@ impl Parser {
         let start = self.expect_keyword("WHILE")?;
         let condition = self.parse_expr()?;
         self.while_depth += 1;
+        self.sub_depth += 1;
         let body = self.parse_statement();
+        self.sub_depth -= 1;
         self.while_depth -= 1;
         let body = Box::new(body?);
         let end = self.prev_span();
@@ -276,9 +323,11 @@ impl Parser {
         } else {
             None
         };
-        // Batches cannot return a value — SQL Server's compile-time 178. The
-        // grammar still parses one so procedure bodies (which may) share it.
-        if let Some(value) = &value {
+        // Batches cannot return a value — SQL Server's compile-time 178.
+        // Procedure bodies can (the RETURN status).
+        if let Some(value) = &value
+            && !self.in_procedure
+        {
             return Err(SqlError::new(
                 178,
                 15,
@@ -354,6 +403,13 @@ impl Parser {
     /// `TRY`/`CATCH` block. A nested `BEGIN TRY` is consumed whole by
     /// `parse_statement`, so a top-level `END` here always closes this block.
     fn parse_block(&mut self) -> SqlResult<Vec<Statement>> {
+        self.sub_depth += 1;
+        let block = self.parse_block_inner();
+        self.sub_depth -= 1;
+        block
+    }
+
+    fn parse_block_inner(&mut self) -> SqlResult<Vec<Statement>> {
         let mut statements = Vec::new();
         loop {
             while self.eat(&TokenKind::Semicolon) {}
@@ -742,6 +798,9 @@ impl Parser {
             Some("INDEX") => self.parse_create_index(start, unique),
             Some("TABLE") if !unique => self.parse_create_table(start),
             Some("VIEW") if !unique => self.parse_create_view(start),
+            Some("PROCEDURE") | Some("PROC") if !unique => {
+                self.parse_create_procedure(start, false)
+            }
             _ => {
                 let token = self.peek().clone();
                 Err(SqlError::syntax(self.token_text(&token), token.span))
@@ -1246,6 +1305,12 @@ impl Parser {
         if self.peek_keyword().as_deref() == Some("DATABASE") {
             return self.parse_alter_database(start);
         }
+        if matches!(
+            self.peek_keyword().as_deref(),
+            Some("PROCEDURE") | Some("PROC")
+        ) {
+            return self.parse_create_procedure(start, true);
+        }
         self.expect_keyword("TABLE")?;
         let table = self.parse_name()?;
         let (action, end) = match self.peek_keyword().as_deref() {
@@ -1342,11 +1407,123 @@ impl Parser {
             Some("INDEX") => self.parse_drop_index(start),
             Some("TABLE") => self.parse_drop_table(start),
             Some("VIEW") => self.parse_drop_view(start),
+            Some("PROCEDURE") | Some("PROC") => self.parse_drop_procedure(start),
             _ => {
                 let token = self.peek().clone();
                 Err(SqlError::syntax(self.token_text(&token), token.span))
             }
         }
+    }
+
+    /// `CREATE|ALTER PROC[EDURE] <name> [params] AS <body-to-end-of-batch>`.
+    /// The body is validated by parsing (with `RETURN <value>` legal) and
+    /// stored as its source text.
+    fn parse_create_procedure(&mut self, start: Span, alter: bool) -> SqlResult<Statement> {
+        self.bump(); // PROCEDURE | PROC
+        if self.statement_index > 0 || self.sub_depth > 0 {
+            return Err(SqlError::new(
+                111,
+                15,
+                1,
+                "'CREATE/ALTER PROCEDURE' must be the first statement in a query batch.",
+            )
+            .at(start));
+        }
+        let name = self.parse_name()?;
+        // Parameters: bare or parenthesized, comma-separated.
+        let parens = self.eat(&TokenKind::LParen);
+        let mut params = Vec::new();
+        while matches!(self.peek().kind, TokenKind::LocalVar(_)) {
+            let token = self.bump();
+            let TokenKind::LocalVar(param_name) = &token.kind else {
+                unreachable!("matched above");
+            };
+            let param_name = param_name.clone();
+            let param_start = token.span;
+            let (data_type, mut end) = self.parse_data_type()?;
+            let default_text = if self.eat(&TokenKind::Eq) {
+                let expr_start = self.peek().span.start;
+                let expr = self.parse_expr()?;
+                end = expr.span;
+                Some(
+                    self.slice(Span::new(expr_start, expr.span.end))
+                        .trim()
+                        .to_string(),
+                )
+            } else {
+                None
+            };
+            let output = if matches!(self.peek_keyword().as_deref(), Some("OUTPUT") | Some("OUT")) {
+                end = self.bump().span;
+                true
+            } else {
+                false
+            };
+            params.push(ProcParam {
+                name: param_name,
+                data_type,
+                default_text,
+                output,
+                span: param_start.to(end),
+            });
+            if !self.eat(&TokenKind::Comma) {
+                break;
+            }
+        }
+        if parens {
+            self.expect(&TokenKind::RParen)?;
+        }
+        self.expect_keyword("AS")?;
+        // The body is everything to the end of the batch, stored verbatim;
+        // parse it now for validation (SQL Server checks syntax at CREATE).
+        let body_start = self.peek().span.start;
+        let body = self.src[body_start..].trim().to_string();
+        if body.is_empty() {
+            let token = self.peek().clone();
+            return Err(SqlError::syntax(self.token_text(&token), token.span));
+        }
+        self.in_procedure = true;
+        let validated = (|| -> SqlResult<()> {
+            loop {
+                while self.eat(&TokenKind::Semicolon) {}
+                if self.at_eof() {
+                    return Ok(());
+                }
+                self.nodes = 0;
+                self.parse_statement()?;
+                if !self.at_eof() && !self.check(&TokenKind::Semicolon) {
+                    let token = self.peek().clone();
+                    return Err(SqlError::syntax(self.token_text(&token), token.span));
+                }
+            }
+        })();
+        self.in_procedure = false;
+        validated?;
+        let span = start.to(self.prev_span());
+        Ok(Statement::CreateProcedure(CreateProcedure {
+            name,
+            params,
+            body,
+            alter,
+            span,
+        }))
+    }
+
+    fn parse_drop_procedure(&mut self, start: Span) -> SqlResult<Statement> {
+        self.bump(); // PROCEDURE | PROC
+        let if_exists = if self.peek_keyword().as_deref() == Some("IF") {
+            self.bump();
+            self.expect_keyword("EXISTS")?;
+            true
+        } else {
+            false
+        };
+        let name = self.parse_name()?;
+        Ok(Statement::DropProcedure {
+            span: start.to(name.span),
+            name,
+            if_exists,
+        })
     }
 
     fn parse_drop_view(&mut self, start: Span) -> SqlResult<Statement> {


### PR DESCRIPTION
## Stage 15, part 3: stored procedures — DDL, EXEC, OUTPUT, RETURN status, sys views

Two commits: CREATE/ALTER/DROP PROCEDURE (catalog text bodies), then EXEC of user procedures.

### Design

- **Procedures are catalog entries like views**: `ProcedureDef { params, body }` stored as source text, re-parsed at each EXEC — the codebase's deliberate no-plan-cache posture (recompile-on-schema-change semantics for free). The plan's "per-statement cached plans stamped with catalog version" is recorded as refuted: there is no plan cache anywhere to reuse, and the text posture already gives the semantics caching would have to preserve.
- **Grammar**: params with defaults (constants only, validated at CREATE — a variable default would evaluate against each CALLER's scope and drift) and OUTPUT; the body is everything after AS, validated at CREATE under the in-procedure grammar (`RETURN <value>` legal there, 178 elsewhere; nested CREATE PROCEDURE is 156); CREATE/ALTER must be the batch's first statement (111); `sp_executesql` is refused as a name (the builtin dispatcher checks it before the catalog — a shadow would execute as the builtin while analysis resolved the catalog: an unanalyzed inner batch).
- **EXEC binding**: positional then named (positional-after-named is 119; duplicate supply 8143; unknown named 8145 before any binding; missing 201; excess 8144; OUTPUT misuse 179/8162; `EXEC @rc =` requires a declared variable, 137), arguments and evaluated defaults **coerce to the declared parameter type at bind time**. Bodies run in a fresh scope with SET options reverting (the sp_executesql posture); RETURN's status lands in `@rc` and OUTPUT parameters copy back — both only when the body completes (SQL Server skips them on abort; a statement-scope RAISERROR that the body survives still copies back — pinned).
- **ERROR_PROCEDURE() is captured at the raise site** (`TxnContext::record_error`): by CATCH entry the procedure's frame has unwound off the stack, and the EXEC/TRY boundary re-records used to blank it — removed, boundaries are pure transfer. @@NESTLEVEL surfaces the depth (cap 32 → 217, depth restored on every exit path).
- **Lock analysis covers stored bodies** under up-front 2PL: bodies parse with the in-procedure grammar (a plain parse would 178 on `RETURN <value>`, yield no locks, and the body would run UNLOCKED — mutation-pinned), and recursion terminates via a visited set **keyed on (procedure, effective analysis regime)** — the review's HIGH: a name-only key deduped a shared body's contribution even though that contribution is isolation-dependent, so an escalated re-entry (`SET SERIALIZABLE; EXEC shared`) executed with no Table S. The regime lattice is finite, so termination survives. CREATE/ALTER PROCEDURE take Database X and bump the lock-analysis epoch (parked-batch staleness, the Stage 13 class); the review verified the bump ordering against a live parked batch.
- **Namespace integrity** (review findings): DROP TABLE no longer silently destroys a procedure; `SELECT ... FROM proc` and DML against a procedure are 2809 on every path including the streamed scan (a procedure's empty TableDef read as a zero-column table before).
- **sys views**: `sys.procedures`, `sys.parameters`, `sys.objects` (SQL Server type codes with the trailing space), and procedure bodies in `sys.sql_modules` (verbatim round-trip pinned through quotes/comments/newlines).

### Adversarial review outcome

One HIGH (the visited-set regime dedup above — the fifth consecutive review HIGH in the derived-twice-at-a-boundary class) and seven confirmed divergences, all fixed: DROP TABLE destruction, half-working DML/FROM against procedures, positional-after-named misbind, missing bind-time coercion, non-constant defaults, silent `@rc` creation, and the sp_executesql shadow. Nineteen review tests imported; three teeth gaps the review found (copy-back-on-error blindness, EXEC_DEPTH leak on the 217 path, the ALTER epoch bump) are now probe-pinned. Recorded, not fixed: ERROR_PROCEDURE() is NULL for bind-time errors (the frame never pushed; SQL Server names the proc); `EXEC @procvar` unsupported; RPC-by-name over TDS with real RETURNSTATUS/RETURNVALUE is the next PR.

### Tests

Six engine batteries (binding/OUTPUT/@rc round-trip, argument-error matrix, recursion to the 217 cap with @@NESTLEVEL streamed, ERROR_PROCEDURE in and out of procs, abort-skips-copy-back, DDL persistence across reopen), the body lock-analysis suite (in-proc grammar, recursion termination — the visited mutant stack-overflows, escalated re-entry), `procedures.slt`, plus the nineteen review probes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
