### PR TITLE
Stage 15 (RPC-by-name): real RETURNSTATUS and typed RETURNVALUEs for user procedures

### DIFF
--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -428,6 +428,13 @@ pub trait BatchEmitter {
     /// An informational message (RAISERROR severity <= 10): TDS renders an
     /// INFO token in-stream, not an error. Emitters with no wire ignore it.
     fn info(&mut self, _error: &SqlError) {}
+
+    /// A procedure's RETURN status (RPC-by-name): the RETURNSTATUS value.
+    fn return_status(&mut self, _status: i32) {}
+
+    /// A procedure OUTPUT parameter's final value (RPC-by-name): a typed
+    /// RETURNVALUE token.
+    fn return_value(&mut self, _name: &str, _column_type: &ColumnType, _value: &Datum) {}
 }
 
 /// Reassembles emitted results into the whole-batch [`BatchOutcome`] for the

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -441,13 +441,6 @@ pub trait BatchEmitter {
     /// An informational message (RAISERROR severity <= 10): TDS renders an
     /// INFO token in-stream, not an error. Emitters with no wire ignore it.
     fn info(&mut self, _error: &SqlError) {}
-
-    /// A procedure's RETURN status (RPC-by-name): the RETURNSTATUS value.
-    fn return_status(&mut self, _status: i32) {}
-
-    /// A procedure OUTPUT parameter's final value (RPC-by-name): a typed
-    /// RETURNVALUE token.
-    fn return_value(&mut self, _name: &str, _column_type: &ColumnType, _value: &Datum) {}
 }
 
 /// Reassembles emitted results into the whole-batch [`BatchOutcome`] for the
@@ -1461,7 +1454,27 @@ fn run_block(
                 if let Some(value) = value {
                     let eval_ctx = txn_ctx.eval_context();
                     match eval_constant(value, &eval_ctx) {
-                        Ok(SqlValue::Int(status)) => txn_ctx.proc_return = Some(status),
+                        Ok(SqlValue::Int(status))
+                            if (i32::MIN as i64..=i32::MAX as i64).contains(&status) =>
+                        {
+                            txn_ctx.proc_return = Some(status)
+                        }
+                        // A RETURN value outside int range overflows, as SQL
+                        // Server does (8115) — the status is an int. Without this
+                        // the out-of-range value would be stashed and later fail
+                        // to encode (and, on the RPC path, read back as NULL and
+                        // be mistaken for a procedure that never completed).
+                        Ok(SqlValue::Int(_)) => {
+                            let error = SqlError::new(
+                                8115,
+                                16,
+                                2,
+                                "Arithmetic overflow error converting expression to data type int.",
+                            );
+                            txn_ctx.rowcount = 0;
+                            statement_error_ladder(statement, error, txn_ctx, run, in_try)?;
+                            continue;
+                        }
                         Ok(SqlValue::Null) => {
                             // SQL Server warns and returns 0; we return 0.
                             txn_ctx.proc_return = Some(0);

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -194,6 +194,19 @@ impl TxnContext {
         self.variables.clear();
     }
 
+    /// The final value and type of a batch variable, as a `Datum`, for the
+    /// RPC-by-name response tail: after the synthesized `EXEC` batch completes
+    /// the session reads the OUTPUT parameters (copied back into caller-scope
+    /// variables) and the seeded return-status variable back off the context.
+    /// `name` may carry a leading `@`; lookup is case-insensitive, matching how
+    /// variables are keyed.
+    pub fn variable_datum(&self, name: &str) -> Option<(ColumnType, Datum)> {
+        let key = name.trim_start_matches('@').to_ascii_lowercase();
+        let (column_type, value) = self.variables.get(&key)?;
+        let datum = value::sql_to_datum(value, column_type, &key).ok()?;
+        Some((*column_type, datum))
+    }
+
     /// True if a transaction is open (used by the session to decide whether a
     /// disconnect must roll back).
     pub fn has_open_transaction(&self) -> bool {

--- a/crates/truthdb-core/src/session.rs
+++ b/crates/truthdb-core/src/session.rs
@@ -122,6 +122,16 @@ pub enum BatchEvent {
     /// An informational message (RAISERROR severity <= 10): TDS renders an
     /// INFO token in-stream; it is not an error and stops nothing.
     Info(SqlError),
+    /// A procedure's RETURN status for an RPC-by-name call: the RETURNSTATUS
+    /// token's value (hardcoded 0 before this event existed).
+    ReturnStatus(i32),
+    /// A procedure OUTPUT parameter's final value for an RPC-by-name call,
+    /// rendered as a typed RETURNVALUE token after RETURNSTATUS.
+    ReturnValue {
+        name: String,
+        column_type: crate::relstore::types::ColumnType,
+        value: Datum,
+    },
     /// The handle `sp_prepare`/`sp_prepexec` allocated, reported to the client
     /// as a RETURNVALUE token. Sent after every statement's events, just
     /// before `Complete` — where SQL Server puts return values.
@@ -326,6 +336,23 @@ impl crate::rel::BatchEmitter for BatchSink {
     fn info(&mut self, error: &truthdb_sql::error::SqlError) {
         self.send(BatchEvent::Info(error.clone()));
     }
+
+    fn return_status(&mut self, status: i32) {
+        self.send(BatchEvent::ReturnStatus(status));
+    }
+
+    fn return_value(
+        &mut self,
+        name: &str,
+        column_type: &crate::relstore::types::ColumnType,
+        value: &Datum,
+    ) {
+        self.send(BatchEvent::ReturnValue {
+            name: name.to_string(),
+            column_type: column_type.clone(),
+            value: value.clone(),
+        });
+    }
 }
 
 /// Reassembles an event stream into a whole [`BatchReply`] — the shape every
@@ -370,6 +397,8 @@ async fn collect_reply(
             // An informational message (RAISERROR <= 10) is wire-only too:
             // it is not an error and carries no result.
             BatchEvent::Info(_) => {}
+            // Return status/values are wire-only (RETURNSTATUS/RETURNVALUE).
+            BatchEvent::ReturnStatus(_) | BatchEvent::ReturnValue { .. } => {}
             BatchEvent::Error(err) => error = Some(err),
             BatchEvent::Complete { in_transaction } => {
                 return Ok(BatchReply {

--- a/crates/truthdb-core/src/session.rs
+++ b/crates/truthdb-core/src/session.rs
@@ -818,6 +818,35 @@ impl EngineHandle {
         rx
     }
 
+    /// Runs an RPC-by-name call of a USER procedure: synthesizes the
+    /// equivalent `EXEC` batch with the wire parameters seeded as variables
+    /// (named binding, OUTPUT flags carried), and streams the reply like any
+    /// batch. Lock analysis resolves the procedure body through the EXEC
+    /// arm. TODO(next commit): emit ReturnStatus/ReturnValue from the
+    /// session's variables at batch end — the wire tail currently reports
+    /// status 0 and no OUTPUT values.
+    pub fn stream_proc_rpc(
+        &self,
+        session: SessionId,
+        name: String,
+        params: Vec<crate::rel::RpcParam>,
+        outputs: Vec<bool>,
+        cancel: Arc<AtomicBool>,
+    ) -> mpsc::UnboundedReceiver<BatchEvent> {
+        let mut sql = format!("EXEC [{}]", name.replace(']', "]]"));
+        for (index, param) in params.iter().enumerate() {
+            let sep = if index == 0 { " " } else { ", " };
+            let bare = param.name.trim_start_matches('@');
+            let output = if outputs.get(index).copied().unwrap_or(false) {
+                " OUTPUT"
+            } else {
+                ""
+            };
+            sql.push_str(&format!("{sep}@{bare} = @{bare}{output}"));
+        }
+        self.stream_rpc(session, sql, String::new(), params, cancel)
+    }
+
     /// Runs a prepared-statement RPC (the `sp_prepare` handle family),
     /// streaming its reply exactly like [`Self::stream_rpc`].
     pub fn stream_prepared(

--- a/crates/truthdb-core/src/session.rs
+++ b/crates/truthdb-core/src/session.rs
@@ -126,8 +126,11 @@ pub enum BatchEvent {
     /// token's value (hardcoded 0 before this event existed).
     ReturnStatus(i32),
     /// A procedure OUTPUT parameter's final value for an RPC-by-name call,
-    /// rendered as a typed RETURNVALUE token after RETURNSTATUS.
+    /// rendered as a typed RETURNVALUE token after RETURNSTATUS. `ordinal` is
+    /// the parameter's 0-based position in the RPC call (ordinal-keyed drivers
+    /// place the value there).
     ReturnValue {
+        ordinal: u16,
         name: String,
         column_type: crate::relstore::types::ColumnType,
         value: Datum,
@@ -336,23 +339,6 @@ impl crate::rel::BatchEmitter for BatchSink {
     fn info(&mut self, error: &truthdb_sql::error::SqlError) {
         self.send(BatchEvent::Info(error.clone()));
     }
-
-    fn return_status(&mut self, status: i32) {
-        self.send(BatchEvent::ReturnStatus(status));
-    }
-
-    fn return_value(
-        &mut self,
-        name: &str,
-        column_type: &crate::relstore::types::ColumnType,
-        value: &Datum,
-    ) {
-        self.send(BatchEvent::ReturnValue {
-            name: name.to_string(),
-            column_type: *column_type,
-            value: value.clone(),
-        });
-    }
 }
 
 /// Reassembles an event stream into a whole [`BatchReply`] — the shape every
@@ -551,14 +537,18 @@ impl SessionManager {
 /// exactly when the copy-back and status assignment happened.
 #[derive(Clone)]
 struct ProcRpcTail {
-    /// The seeded variable holding the RETURN status.
+    /// The seeded variable holding the RETURN status. It is seeded NULL and the
+    /// procedure overwrites it with an Int only if it completes; a still-NULL
+    /// value at read time means the procedure aborted, so no tail is emitted.
     status_var: String,
     /// One entry per OUTPUT parameter, in call order: the caller-scope variable
-    /// to read the final value back from, and the name the RETURNVALUE token
-    /// carries. For a named argument both are the wire name (`@out`); for a
+    /// to read the final value back from, the name the RETURNVALUE token
+    /// carries, and the parameter's 0-based position in the RPC call (the
+    /// RETURNVALUE ParamOrdinal — ordinal-keyed drivers place values by it). For
+    /// a named argument the read/token names are the wire name (`@out`); for a
     /// positional one (JDBC `{call p(?)}`) the read variable is a synthetic seed
-    /// and the token name is empty, which drivers match by ordinal.
-    output_vars: Vec<(String, String)>,
+    /// and the token name is empty.
+    output_vars: Vec<(String, String, u16)>,
 }
 
 enum EngineCall {
@@ -875,6 +865,7 @@ impl EngineHandle {
             let sep = if index == 0 { " " } else { ", " };
             let is_output = outputs.get(index).copied().unwrap_or(false);
             let output_kw = if is_output { " OUTPUT" } else { "" };
+            let ordinal = index as u16;
             if param.name.trim_start_matches('@').is_empty() {
                 // Positional (unnamed) argument — a JDBC `{call p(?, ?)}` shape.
                 // Seed under a synthetic variable and pass it positionally; the
@@ -882,23 +873,26 @@ impl EngineHandle {
                 let var = format!("__truthdb_arg{index}");
                 sql.push_str(&format!("{sep}@{var}{output_kw}"));
                 if is_output {
-                    output_vars.push((format!("@{var}"), String::new()));
+                    output_vars.push((format!("@{var}"), String::new(), ordinal));
                 }
                 param.name = format!("@{var}");
             } else {
                 let bare = param.name.trim_start_matches('@').to_string();
                 sql.push_str(&format!("{sep}@{bare} = @{bare}{output_kw}"));
                 if is_output {
-                    output_vars.push((param.name.clone(), param.name.clone()));
+                    output_vars.push((param.name.clone(), param.name.clone(), ordinal));
                 }
             }
             seeded.push(param);
         }
-        // Seed the return-status variable as an ordinary batch variable.
+        // Seed the return-status variable NULL: the procedure overwrites it with
+        // an Int only on completion, so a still-NULL read means it aborted (see
+        // read_proc_tail). Seeding it also satisfies `EXEC @rc =`'s declared-var
+        // requirement (137).
         seeded.push(crate::rel::RpcParam {
             name: format!("@{status_var}"),
             column_type: crate::relstore::types::ColumnType::Int,
-            value: Datum::Int(0),
+            value: Datum::Null,
         });
         let proc_tail = ProcRpcTail {
             status_var,
@@ -1489,11 +1483,15 @@ fn run_and_finish(shared: &Arc<Shared>, work: Runnable) {
         .engine
         .sql_batch_streamed(&sql, &mut txn_ctx, &params, &mut reply);
     // RPC-by-name tail: a procedure copies its OUTPUT parameters back and stores
-    // its RETURN status only when it completed, so the tokens are emitted only
-    // when the batch ran clean (`Ok(None)`). Read the values off the context now,
-    // before `finish` hands it back to the scheduler.
+    // its RETURN status only when it *completed* — which is not the same as the
+    // *batch* running clean. A procedure that raises a continued (non-dooming)
+    // error and then returns completes, yet the batch surfaces that error
+    // (`Ok(Some(err))`); SQL Server still sends the tail there. So read the tail
+    // on any `Ok` outcome and let `read_proc_tail` decide from the completion
+    // signal (the status variable is non-NULL only if the procedure completed).
+    // Read it now, before `finish` hands the context back to the scheduler.
     let tail_events = match (&proc_tail, &outcome) {
-        (Some(tail), Ok(None)) => Some(read_proc_tail(&txn_ctx, tail)),
+        (Some(tail), Ok(_)) => Some(read_proc_tail(&txn_ctx, tail)),
         _ => None,
     };
     let in_transaction = {
@@ -1520,20 +1518,27 @@ fn run_and_finish(shared: &Arc<Shared>, work: Runnable) {
 }
 
 /// Reads an RPC-by-name call's response tail off the finished context: the
-/// RETURN status (always emitted — SQL Server sends RETURNSTATUS for every proc
-/// RPC, defaulting to 0), then each OUTPUT parameter as a typed RETURNVALUE. The
-/// renderer orders the tokens (RETURNSTATUS before RETURNVALUEs) regardless of
-/// event order, but they are produced status-first to match.
+/// RETURN status, then each OUTPUT parameter as a typed RETURNVALUE.
+///
+/// The status variable is the completion signal. It was seeded NULL, and
+/// `run_user_procedure` overwrites it with an Int (and copies OUTPUT parameters
+/// back) only when the body completes — both under the one `result.is_ok()`
+/// gate. So a NULL status here means the procedure aborted: emit nothing, which
+/// is what SQL Server does for a failed procedure. A non-NULL Int status means
+/// it completed (possibly after a continued, non-dooming error), and the OUTPUT
+/// copy-back happened too, so the whole tail is emitted. This single observable
+/// keeps the emission decision in agreement with the copy-back decision.
 fn read_proc_tail(txn_ctx: &TxnContext, tail: &ProcRpcTail) -> Vec<BatchEvent> {
-    let mut events = Vec::with_capacity(tail.output_vars.len() + 1);
     let status = match txn_ctx.variable_datum(&tail.status_var) {
         Some((_, Datum::Int(status))) => status,
-        _ => 0,
+        _ => return Vec::new(),
     };
+    let mut events = Vec::with_capacity(tail.output_vars.len() + 1);
     events.push(BatchEvent::ReturnStatus(status));
-    for (read_var, wire_name) in &tail.output_vars {
+    for (read_var, wire_name, ordinal) in &tail.output_vars {
         if let Some((column_type, value)) = txn_ctx.variable_datum(read_var) {
             events.push(BatchEvent::ReturnValue {
+                ordinal: *ordinal,
                 name: wire_name.clone(),
                 column_type,
                 value,

--- a/crates/truthdb-core/src/session.rs
+++ b/crates/truthdb-core/src/session.rs
@@ -349,7 +349,7 @@ impl crate::rel::BatchEmitter for BatchSink {
     ) {
         self.send(BatchEvent::ReturnValue {
             name: name.to_string(),
-            column_type: column_type.clone(),
+            column_type: *column_type,
             value: value.clone(),
         });
     }
@@ -539,6 +539,28 @@ impl SessionManager {
 
 /// A message to the engine thread. Each carries a one-shot reply channel the
 /// async caller awaits.
+/// The response-tail descriptor for an RPC-by-name call of a user procedure.
+///
+/// The call is executed as a synthesized `EXEC @<status_var> = [proc] @p = @p
+/// [OUTPUT]…` batch: the wire parameters are seeded as batch variables, so once
+/// the batch completes the procedure's OUTPUT parameters have been copied back
+/// into their caller-scope variables and the RETURN status into `status_var`.
+/// The worker reads them off the context (before it is handed back to the
+/// scheduler) and emits the RETURNSTATUS / RETURNVALUE events the wire renderer
+/// turns into tokens — but only when the batch completed without error, which is
+/// exactly when the copy-back and status assignment happened.
+#[derive(Clone)]
+struct ProcRpcTail {
+    /// The seeded variable holding the RETURN status.
+    status_var: String,
+    /// One entry per OUTPUT parameter, in call order: the caller-scope variable
+    /// to read the final value back from, and the name the RETURNVALUE token
+    /// carries. For a named argument both are the wire name (`@out`); for a
+    /// positional one (JDBC `{call p(?)}`) the read variable is a synthetic seed
+    /// and the token name is empty, which drivers match by ordinal.
+    output_vars: Vec<(String, String)>,
+}
+
 enum EngineCall {
     OpenSession {
         database: String,
@@ -552,6 +574,10 @@ enum EngineCall {
         session: SessionId,
         sql: String,
         params: Vec<crate::rel::RpcParam>,
+        /// For an RPC-by-name call of a user procedure: the OUTPUT parameters
+        /// and return-status variable to read back off the context once the
+        /// synthesized `EXEC` batch completes. `None` for an ordinary batch.
+        proc_tail: Option<ProcRpcTail>,
         /// Set by the connection on a TDS Attention to abort the batch mid-flight.
         cancel: Arc<AtomicBool>,
         reply: BatchSink,
@@ -809,6 +835,7 @@ impl EngineHandle {
             session,
             sql,
             params,
+            proc_tail: None,
             cancel,
             reply: BatchSink::new(tx),
         });
@@ -818,13 +845,17 @@ impl EngineHandle {
         rx
     }
 
-    /// Runs an RPC-by-name call of a USER procedure: synthesizes the
-    /// equivalent `EXEC` batch with the wire parameters seeded as variables
-    /// (named binding, OUTPUT flags carried), and streams the reply like any
-    /// batch. Lock analysis resolves the procedure body through the EXEC
-    /// arm. TODO(next commit): emit ReturnStatus/ReturnValue from the
-    /// session's variables at batch end — the wire tail currently reports
-    /// status 0 and no OUTPUT values.
+    /// Runs an RPC-by-name call of a USER procedure: synthesizes the equivalent
+    /// `EXEC` batch with the wire parameters seeded as variables (named binding,
+    /// OUTPUT flags carried) and streams the reply like any batch. Lock analysis
+    /// resolves the procedure body through the EXEC arm.
+    ///
+    /// The RETURN status is captured with `EXEC @<rc> = …` into a synthetic
+    /// variable seeded from an extra Int parameter — no wire token, no extra
+    /// statement — and the OUTPUT parameters land back in their caller-scope
+    /// variables. A [`ProcRpcTail`] tells the worker which variables to read off
+    /// the context once the batch completes, so it can emit the real RETURNSTATUS
+    /// and typed RETURNVALUEs.
     pub fn stream_proc_rpc(
         &self,
         session: SessionId,
@@ -833,18 +864,56 @@ impl EngineHandle {
         outputs: Vec<bool>,
         cancel: Arc<AtomicBool>,
     ) -> mpsc::UnboundedReceiver<BatchEvent> {
-        let mut sql = format!("EXEC [{}]", name.replace(']', "]]"));
-        for (index, param) in params.iter().enumerate() {
+        // `@__truthdb_rc` is seeded (not a proc argument), so `EXEC @__truthdb_rc
+        // = …` finds it declared and stores the RETURN status there. The name is
+        // one no user variable would collide with in the synthesized batch.
+        let status_var = "__truthdb_rc".to_string();
+        let mut sql = format!("EXEC @{status_var} = [{}]", name.replace(']', "]]"));
+        let mut output_vars = Vec::new();
+        let mut seeded: Vec<crate::rel::RpcParam> = Vec::with_capacity(params.len() + 1);
+        for (index, mut param) in params.into_iter().enumerate() {
             let sep = if index == 0 { " " } else { ", " };
-            let bare = param.name.trim_start_matches('@');
-            let output = if outputs.get(index).copied().unwrap_or(false) {
-                " OUTPUT"
+            let is_output = outputs.get(index).copied().unwrap_or(false);
+            let output_kw = if is_output { " OUTPUT" } else { "" };
+            if param.name.trim_start_matches('@').is_empty() {
+                // Positional (unnamed) argument — a JDBC `{call p(?, ?)}` shape.
+                // Seed under a synthetic variable and pass it positionally; the
+                // RETURNVALUE carries no name, which drivers match by ordinal.
+                let var = format!("__truthdb_arg{index}");
+                sql.push_str(&format!("{sep}@{var}{output_kw}"));
+                if is_output {
+                    output_vars.push((format!("@{var}"), String::new()));
+                }
+                param.name = format!("@{var}");
             } else {
-                ""
-            };
-            sql.push_str(&format!("{sep}@{bare} = @{bare}{output}"));
+                let bare = param.name.trim_start_matches('@').to_string();
+                sql.push_str(&format!("{sep}@{bare} = @{bare}{output_kw}"));
+                if is_output {
+                    output_vars.push((param.name.clone(), param.name.clone()));
+                }
+            }
+            seeded.push(param);
         }
-        self.stream_rpc(session, sql, String::new(), params, cancel)
+        // Seed the return-status variable as an ordinary batch variable.
+        seeded.push(crate::rel::RpcParam {
+            name: format!("@{status_var}"),
+            column_type: crate::relstore::types::ColumnType::Int,
+            value: Datum::Int(0),
+        });
+        let proc_tail = ProcRpcTail {
+            status_var,
+            output_vars,
+        };
+        let (tx, rx) = mpsc::unbounded_channel();
+        self.inbox.send(EngineCall::RunBatch {
+            session,
+            sql,
+            params: seeded,
+            proc_tail: Some(proc_tail),
+            cancel,
+            reply: BatchSink::new(tx),
+        });
+        rx
     }
 
     /// Runs a prepared-statement RPC (the `sp_prepare` handle family),
@@ -1031,6 +1100,7 @@ struct Runnable {
     session: SessionId,
     sql: String,
     params: Vec<crate::rel::RpcParam>,
+    proc_tail: Option<ProcRpcTail>,
     cancel: Arc<AtomicBool>,
     reply: BatchSink,
     txn_ctx: TxnContext,
@@ -1160,9 +1230,10 @@ fn worker_loop(shared: &Arc<Shared>) {
                 session,
                 sql,
                 params,
+                proc_tail,
                 cancel,
                 reply,
-            }) => dispatch_batch(shared, session, sql, params, cancel, reply),
+            }) => dispatch_batch(shared, session, sql, params, proc_tail, cancel, reply),
             Work::Call(EngineCall::RunRpc {
                 session,
                 command,
@@ -1276,7 +1347,7 @@ fn dispatch_rpc(
                     return;
                 }
             };
-            dispatch_batch(shared, session, text, values, cancel, reply);
+            dispatch_batch(shared, session, text, values, None, cancel, reply);
         }
         PreparedRpc::PrepExec {
             decls,
@@ -1299,7 +1370,7 @@ fn dispatch_rpc(
                     return;
                 }
             };
-            dispatch_batch(shared, session, stmt, values, cancel, reply);
+            dispatch_batch(shared, session, stmt, values, None, cancel, reply);
         }
     }
 }
@@ -1345,6 +1416,7 @@ fn dispatch_batch(
     session: SessionId,
     sql: String,
     params: Vec<crate::rel::RpcParam>,
+    proc_tail: Option<ProcRpcTail>,
     cancel: Arc<AtomicBool>,
     reply: BatchSink,
 ) {
@@ -1362,6 +1434,7 @@ fn dispatch_batch(
                 session,
                 sql,
                 params,
+                proc_tail,
                 cancel,
                 reply,
                 txn_ctx,
@@ -1372,6 +1445,7 @@ fn dispatch_batch(
                 session,
                 sql,
                 params,
+                proc_tail,
                 cancel,
                 reply,
                 needs,
@@ -1399,6 +1473,7 @@ fn run_and_finish(shared: &Arc<Shared>, work: Runnable) {
         session,
         sql,
         params,
+        proc_tail,
         cancel,
         reply,
         mut txn_ctx,
@@ -1413,6 +1488,14 @@ fn run_and_finish(shared: &Arc<Shared>, work: Runnable) {
     let outcome = shared
         .engine
         .sql_batch_streamed(&sql, &mut txn_ctx, &params, &mut reply);
+    // RPC-by-name tail: a procedure copies its OUTPUT parameters back and stores
+    // its RETURN status only when it completed, so the tokens are emitted only
+    // when the batch ran clean (`Ok(None)`). Read the values off the context now,
+    // before `finish` hands it back to the scheduler.
+    let tail_events = match (&proc_tail, &outcome) {
+        (Some(tail), Ok(None)) => Some(read_proc_tail(&txn_ctx, tail)),
+        _ => None,
+    };
     let in_transaction = {
         let mut sched = shared.scheduler.lock().expect("scheduler poisoned");
         sched.finish(&shared.engine, session, txn_ctx)
@@ -1420,11 +1503,44 @@ fn run_and_finish(shared: &Arc<Shared>, work: Runnable) {
     // The terminal events wait for the locks to settle: `Complete` carries the
     // post-batch transaction state, which only `finish` knows.
     match outcome {
-        Ok(error) => reply.send_tail(error, in_transaction),
+        Ok(error) => {
+            if let Some(events) = tail_events {
+                for event in events {
+                    if !reply.send(event) {
+                        return;
+                    }
+                }
+            }
+            reply.send_tail(error, in_transaction);
+        }
         Err(err) => {
             reply.send(BatchEvent::Failed(err));
         }
     }
+}
+
+/// Reads an RPC-by-name call's response tail off the finished context: the
+/// RETURN status (always emitted — SQL Server sends RETURNSTATUS for every proc
+/// RPC, defaulting to 0), then each OUTPUT parameter as a typed RETURNVALUE. The
+/// renderer orders the tokens (RETURNSTATUS before RETURNVALUEs) regardless of
+/// event order, but they are produced status-first to match.
+fn read_proc_tail(txn_ctx: &TxnContext, tail: &ProcRpcTail) -> Vec<BatchEvent> {
+    let mut events = Vec::with_capacity(tail.output_vars.len() + 1);
+    let status = match txn_ctx.variable_datum(&tail.status_var) {
+        Some((_, Datum::Int(status))) => status,
+        _ => 0,
+    };
+    events.push(BatchEvent::ReturnStatus(status));
+    for (read_var, wire_name) in &tail.output_vars {
+        if let Some((column_type, value)) = txn_ctx.variable_datum(read_var) {
+            events.push(BatchEvent::ReturnValue {
+                name: wire_name.clone(),
+                column_type,
+                value,
+            });
+        }
+    }
+    events
 }
 
 /// Runs every parked batch whose locks are now grantable, in FIFO order, until
@@ -1449,6 +1565,7 @@ struct Parked {
     session: SessionId,
     sql: String,
     params: Vec<crate::rel::RpcParam>,
+    proc_tail: Option<ProcRpcTail>,
     cancel: Arc<AtomicBool>,
     reply: BatchSink,
     needs: Vec<(Resource, LockMode)>,
@@ -1661,6 +1778,7 @@ impl Scheduler {
                     session: parked.session,
                     sql: parked.sql,
                     params: parked.params,
+                    proc_tail: parked.proc_tail,
                     cancel: parked.cancel,
                     reply: parked.reply,
                     txn_ctx,
@@ -2442,6 +2560,7 @@ mod tests {
             session: id,
             sql: "SELECT id FROM t".into(),
             params: Vec::new(),
+            proc_tail: None,
             cancel: Arc::new(AtomicBool::new(false)),
             reply,
             needs: Vec::new(),
@@ -2502,6 +2621,7 @@ mod tests {
             session: waiter,
             sql: "EXEC p".into(),
             params: Vec::new(),
+            proc_tail: None,
             cancel: Arc::new(AtomicBool::new(false)),
             reply: BatchSink::new(tx),
             needs,
@@ -2623,6 +2743,7 @@ mod tests {
             session: id,
             sql: "SELECT 1".into(),
             params: Vec::new(),
+            proc_tail: None,
             cancel: Arc::new(AtomicBool::new(false)),
             reply,
             needs: vec![(Resource::Table(1), LockMode::Shared)],
@@ -2749,6 +2870,7 @@ mod tests {
             session: id,
             sql: "SELECT 1".into(),
             params: Vec::new(),
+            proc_tail: None,
             cancel: Arc::new(AtomicBool::new(false)),
             reply,
             needs: vec![(Resource::Table(1), LockMode::Shared)],

--- a/crates/truthdb-tds/src/rpc.rs
+++ b/crates/truthdb-tds/src/rpc.rs
@@ -83,6 +83,9 @@ pub enum RpcProc {
 pub struct RpcRequest {
     pub proc: RpcProc,
     pub params: Vec<RpcParam>,
+    /// Parallel to `params`: fByRefValue — the caller wants the parameter
+    /// back as a RETURNVALUE (an OUTPUT argument).
+    pub outputs: Vec<bool>,
 }
 
 /// Decodes an RPC request body (the bytes *after* the ALL_HEADERS block).
@@ -147,6 +150,7 @@ fn parse_one_rpc(c: &mut Cursor) -> io::Result<RpcRequest> {
     let _option_flags = c.u16()?;
 
     let mut params = Vec::new();
+    let mut outputs = Vec::new();
     while c.remaining() > 0 {
         // A batch flag (0x80 = old-style / 0xFF = separator) begins the next
         // RPC in a multi-RPC request; the caller consumes it and loops.
@@ -156,15 +160,22 @@ fn parse_one_rpc(c: &mut Cursor) -> io::Result<RpcRequest> {
         }
         let name_len = c.u8()? as usize;
         let name = c.utf16(name_len * 2)?;
-        let _status = c.u8()?; // StatusFlags: fByRefValue / fDefaultValue.
+        // StatusFlags: bit 0 = fByRefValue (an OUTPUT parameter the caller
+        // wants back as a RETURNVALUE); bit 1 = fDefaultValue.
+        let status = c.u8()?;
         let (column_type, value) = decode_param(c)?;
         params.push(RpcParam {
             name,
             column_type,
             value,
         });
+        outputs.push(status & 0x01 != 0);
     }
-    Ok(RpcRequest { proc, params })
+    Ok(RpcRequest {
+        proc,
+        params,
+        outputs,
+    })
 }
 
 /// Decodes a body expected to hold exactly one RPC (tests' shorthand).

--- a/crates/truthdb-tds/src/server.rs
+++ b/crates/truthdb-tds/src/server.rs
@@ -767,6 +767,16 @@ struct BatchRender {
     /// A prepared handle to report as a RETURNVALUE just before the final
     /// DONEPROC — held so RETURNSTATUS precedes it, SQL Server's order.
     pending_handle: Option<i32>,
+    /// The procedure's real RETURN status (RPC-by-name); None keeps the
+    /// legacy 0.
+    return_status: Option<i32>,
+    /// OUTPUT parameter values, held for the response tail after
+    /// RETURNSTATUS, before DONEPROC — SQL Server's order.
+    return_values: Vec<(
+        String,
+        truthdb_core::relstore::types::ColumnType,
+        truthdb_core::relstore::types::Datum,
+    )>,
     /// More replies follow this one in the same response (a multi-RPC
     /// request): the final DONEPROC keeps `DONE_MORE` instead of `DONE_FINAL`.
     more_responses: bool,
@@ -872,6 +882,16 @@ impl BatchRender {
                 // RETURNVALUE, which precedes the final DONEPROC.
                 self.pending_handle = Some(handle);
             }
+            BatchEvent::ReturnStatus(status) => {
+                self.return_status = Some(status);
+            }
+            BatchEvent::ReturnValue {
+                name,
+                column_type,
+                value,
+            } => {
+                self.return_values.push((name, column_type, value));
+            }
             BatchEvent::Info(info) => {
                 // RAISERROR severity <= 10: an INFO token, not an error — the
                 // batch continues and no DONE flag changes. Pending DONEs go
@@ -915,10 +935,15 @@ impl BatchRender {
                     self.buf.clear();
                     if !self.errored {
                         // A failed procedure returns no status.
-                        token::return_status(&mut self.buf, 0);
+                        token::return_status(&mut self.buf, self.return_status.unwrap_or(0));
                     }
                     if let Some(handle) = self.pending_handle.take() {
                         token::return_value_int(&mut self.buf, "handle", handle);
+                    }
+                    if !self.errored {
+                        for (name, column_type, value) in self.return_values.drain(..) {
+                            token::return_value(&mut self.buf, &name, &column_type, &value);
+                        }
                     }
                     out.write(&self.buf).await?;
                     self.final_done(out, self.errored, in_transaction).await?;

--- a/crates/truthdb-tds/src/server.rs
+++ b/crates/truthdb-tds/src/server.rs
@@ -735,7 +735,12 @@ fn start_rpc(
             ),
         )),
         // Error 2812 is SQL Server's "Could not find stored procedure".
-        RpcProc::Other(name) => Err((2812, format!("Could not find stored procedure '{name}'."))),
+        // A user procedure: the engine resolves the name (2812 if absent),
+        // binds the named params, and emits the real RETURNSTATUS and typed
+        // RETURNVALUEs for OUTPUT parameters.
+        RpcProc::Other(name) => {
+            Ok(engine.stream_proc_rpc(session, name, request.params, request.outputs, cancel))
+        }
     }
 }
 

--- a/crates/truthdb-tds/src/server.rs
+++ b/crates/truthdb-tds/src/server.rs
@@ -775,9 +775,10 @@ struct BatchRender {
     /// The procedure's real RETURN status (RPC-by-name); None keeps the
     /// legacy 0.
     return_status: Option<i32>,
-    /// OUTPUT parameter values, held for the response tail after
-    /// RETURNSTATUS, before DONEPROC — SQL Server's order.
+    /// OUTPUT parameter values (ParamOrdinal, name, type, value), held for the
+    /// response tail after RETURNSTATUS, before DONEPROC — SQL Server's order.
     return_values: Vec<(
+        u16,
         String,
         truthdb_core::relstore::types::ColumnType,
         truthdb_core::relstore::types::Datum,
@@ -891,11 +892,12 @@ impl BatchRender {
                 self.return_status = Some(status);
             }
             BatchEvent::ReturnValue {
+                ordinal,
                 name,
                 column_type,
                 value,
             } => {
-                self.return_values.push((name, column_type, value));
+                self.return_values.push((ordinal, name, column_type, value));
             }
             BatchEvent::Info(info) => {
                 // RAISERROR severity <= 10: an INFO token, not an error — the
@@ -938,17 +940,25 @@ impl BatchRender {
                     // RETURNSTATUS/RETURNVALUE/DONEPROC tail always follows.
                     self.flush_pending(out, true).await?;
                     self.buf.clear();
-                    if !self.errored {
-                        // A failed procedure returns no status.
-                        token::return_status(&mut self.buf, self.return_status.unwrap_or(0));
+                    // RETURNSTATUS: a procedure that completed reports its real
+                    // status — the engine sends the event only on completion,
+                    // even under a continued error, so a warned-but-completed
+                    // proc still reports it. Any other clean RPC reply
+                    // (sp_executesql, a prepared handle) keeps the status-0
+                    // default. An aborted procedure or a failed RPC sends no
+                    // status event and is errored, so nothing is emitted.
+                    if let Some(status) = self.return_status {
+                        token::return_status(&mut self.buf, status);
+                    } else if !self.errored {
+                        token::return_status(&mut self.buf, 0);
                     }
                     if let Some(handle) = self.pending_handle.take() {
                         token::return_value_int(&mut self.buf, "handle", handle);
                     }
-                    if !self.errored {
-                        for (name, column_type, value) in self.return_values.drain(..) {
-                            token::return_value(&mut self.buf, &name, &column_type, &value);
-                        }
+                    // OUTPUT parameters: populated only when the procedure
+                    // completed, so emit whatever the engine sent.
+                    for (ordinal, name, column_type, value) in self.return_values.drain(..) {
+                        token::return_value(&mut self.buf, ordinal, &name, &column_type, &value);
                     }
                     out.write(&self.buf).await?;
                     self.final_done(out, self.errored, in_transaction).await?;

--- a/crates/truthdb-tds/src/token.rs
+++ b/crates/truthdb-tds/src/token.rs
@@ -197,7 +197,7 @@ const TOKEN_RETURNVALUE: u8 = 0xac;
 /// Flags, TYPE_INFO (INTN, 4), value.
 pub fn return_value_int(out: &mut Vec<u8>, name: &str, value: i32) {
     out.push(TOKEN_RETURNVALUE);
-    out.extend_from_slice(&0u16.to_le_bytes()); // ParamOrdinal
+    out.extend_from_slice(&0u16.to_le_bytes()); // ParamOrdinal (the handle is param 0)
     push_b_varchar(out, name);
     out.push(0x01); // Status: output parameter
     out.extend_from_slice(&0u32.to_le_bytes()); // UserType
@@ -212,12 +212,17 @@ pub fn return_value_int(out: &mut Vec<u8>, name: &str, value: i32) {
 /// TYPE_INFO then the value in that type's wire encoding.
 pub fn return_value(
     out: &mut Vec<u8>,
+    ordinal: u16,
     name: &str,
     column_type: &truthdb_core::relstore::types::ColumnType,
     value: &Datum,
 ) {
     out.push(TOKEN_RETURNVALUE);
-    out.extend_from_slice(&0u16.to_le_bytes()); // ParamOrdinal
+    // ParamOrdinal: the parameter's 0-based position in the RPC call. pytds
+    // (TDS 7.2+) places each OUTPUT value into the caller's list at this index,
+    // so a wrong ordinal misplaces or collides values; go-mssqldb/mssql-jdbc
+    // match by name/order and ignore it.
+    out.extend_from_slice(&ordinal.to_le_bytes());
     push_b_varchar(out, name);
     out.push(0x01); // Status: output parameter
     out.extend_from_slice(&0u32.to_le_bytes()); // UserType

--- a/crates/truthdb-tds/src/token.rs
+++ b/crates/truthdb-tds/src/token.rs
@@ -208,6 +208,24 @@ pub fn return_value_int(out: &mut Vec<u8>, name: &str, value: i32) {
     out.extend_from_slice(&value.to_le_bytes());
 }
 
+/// RETURNVALUE for a procedure's OUTPUT parameter, typed like a row cell:
+/// TYPE_INFO then the value in that type's wire encoding.
+pub fn return_value(
+    out: &mut Vec<u8>,
+    name: &str,
+    column_type: &truthdb_core::relstore::types::ColumnType,
+    value: &Datum,
+) {
+    out.push(TOKEN_RETURNVALUE);
+    out.extend_from_slice(&0u16.to_le_bytes()); // ParamOrdinal
+    push_b_varchar(out, name);
+    out.push(0x01); // Status: output parameter
+    out.extend_from_slice(&0u32.to_le_bytes()); // UserType
+    out.extend_from_slice(&0u16.to_le_bytes()); // Flags
+    out.extend_from_slice(&typeinfo::encode_type_info(column_type));
+    out.extend_from_slice(&typeinfo::encode_value(value, column_type));
+}
+
 /// COLMETADATA for a result set's columns.
 pub fn colmetadata(out: &mut Vec<u8>, columns: &[ResultColumn]) {
     out.push(TOKEN_COLMETADATA);

--- a/crates/truthdb-tds/tests/tds_client.rs
+++ b/crates/truthdb-tds/tests/tds_client.rs
@@ -324,7 +324,10 @@ enum Token {
         cmd: u16,
     },
     ReturnStatus(i32),
-    ReturnValue,
+    ReturnValue {
+        name: String,
+        value: Cell,
+    },
     Other(u8),
 }
 
@@ -426,15 +429,26 @@ fn parse_tokens(payload: &[u8]) -> Vec<Token> {
             }
             0xac => {
                 // RETURNVALUE: ordinal u16, B_VARCHAR name, status u8,
-                // usertype u32, flags u16, TYPE_INFO(INTN,4), value.
-                i += 2;
+                // usertype u32, flags u16, TYPE_INFO, then the value in that
+                // type's row encoding.
+                i += 2; // ParamOrdinal
                 let name_chars = payload[i] as usize;
-                i += 1 + name_chars * 2;
+                i += 1;
+                let units: Vec<u16> = payload[i..i + name_chars * 2]
+                    .chunks_exact(2)
+                    .map(|c| u16::from_le_bytes([c[0], c[1]]))
+                    .collect();
+                let name = String::from_utf16(&units).unwrap();
+                i += name_chars * 2;
                 i += 1 + 4 + 2; // status, usertype, flags
-                i += 2; // INTN + max len
-                let len = payload[i] as usize;
-                i += 1 + len;
-                tokens.push(Token::ReturnValue);
+                let (col_type, consumed) = parse_type_info(&payload[i..]);
+                i += consumed;
+                let (cells, consumed) = parse_row(&payload[i..], &[col_type]);
+                i += consumed;
+                tokens.push(Token::ReturnValue {
+                    name,
+                    value: cells.into_iter().next().unwrap(),
+                });
             }
             other => {
                 tokens.push(Token::Other(other));
@@ -445,6 +459,38 @@ fn parse_tokens(payload: &[u8]) -> Vec<Token> {
     tokens
 }
 
+/// Parses one TYPE_INFO (the type token and its type-specific bytes), shared by
+/// COLMETADATA columns and the RETURNVALUE token. Returns the type and the
+/// number of bytes consumed.
+fn parse_type_info(bytes: &[u8]) -> (ColType, usize) {
+    let type_token = bytes[0];
+    let mut i = 1;
+    let col_type = match type_token {
+        0x26 => {
+            i += 1; // max len byte
+            ColType::Int
+        }
+        0x68 => {
+            i += 1;
+            ColType::Bit
+        }
+        0x6d => {
+            i += 1;
+            ColType::Float
+        }
+        0xe7 => {
+            i += 2 + 5; // max len u16 + collation
+            ColType::NVarChar
+        }
+        0xa7 => {
+            i += 2 + 5;
+            ColType::VarChar
+        }
+        other => panic!("unhandled type token {other:#x}"),
+    };
+    (col_type, i)
+}
+
 fn parse_colmetadata(bytes: &[u8]) -> (Vec<ColType>, usize) {
     let count = u16::from_le_bytes([bytes[0], bytes[1]]) as usize;
     let mut i = 2;
@@ -452,31 +498,8 @@ fn parse_colmetadata(bytes: &[u8]) -> (Vec<ColType>, usize) {
     for _ in 0..count {
         i += 4; // usertype
         i += 2; // flags
-        let type_token = bytes[i];
-        i += 1;
-        let col_type = match type_token {
-            0x26 => {
-                i += 1; // max len byte
-                ColType::Int
-            }
-            0x68 => {
-                i += 1;
-                ColType::Bit
-            }
-            0x6d => {
-                i += 1;
-                ColType::Float
-            }
-            0xe7 => {
-                i += 2 + 5; // max len u16 + collation
-                ColType::NVarChar
-            }
-            0xa7 => {
-                i += 2 + 5;
-                ColType::VarChar
-            }
-            other => panic!("unhandled type token {other:#x}"),
-        };
+        let (col_type, consumed) = parse_type_info(&bytes[i..]);
+        i += consumed;
         // ColName: b_varchar (char count then UCS-2).
         let name_len = bytes[i] as usize;
         i += 1 + name_len * 2;
@@ -776,6 +799,58 @@ const TM_BEGIN_XACT: u16 = 5;
 const TM_COMMIT_XACT: u16 = 7;
 const TM_ROLLBACK_XACT: u16 = 8;
 
+/// An RPC argument value, encoded as an input parameter (TYPE_INFO + value).
+enum RpcArg {
+    Int(i32),
+    IntNull,
+    NVarChar(String),
+}
+
+impl RpcArg {
+    fn encode(&self, b: &mut Vec<u8>) {
+        match self {
+            RpcArg::Int(v) => {
+                b.push(0x26); // INTN
+                b.push(4); // max len
+                b.push(4); // value len
+                b.extend_from_slice(&v.to_le_bytes());
+            }
+            RpcArg::IntNull => {
+                b.push(0x26);
+                b.push(4);
+                b.push(0); // NULL: zero-length value
+            }
+            RpcArg::NVarChar(s) => {
+                b.push(0xe7); // NVARCHAR
+                b.extend_from_slice(&8000u16.to_le_bytes());
+                b.extend_from_slice(&[0x09, 0x04, 0xd0, 0x00, 0x34]); // collation
+                let bytes = ucs2le(s);
+                b.extend_from_slice(&(bytes.len() as u16).to_le_bytes());
+                b.extend_from_slice(&bytes);
+            }
+        }
+    }
+}
+
+/// One RPC-by-name call of a user procedure. Each parameter is (name, value,
+/// output): an empty name is a positional argument; `output` sets the
+/// fByRefValue status bit (an OUTPUT argument returned as a RETURNVALUE).
+fn proc_rpc(name: &str, params: &[(&str, RpcArg, bool)]) -> Vec<u8> {
+    let mut b = Vec::new();
+    let name_units = ucs2le(name);
+    b.extend_from_slice(&((name_units.len() / 2) as u16).to_le_bytes()); // NameLen (chars)
+    b.extend_from_slice(&name_units);
+    b.extend_from_slice(&0u16.to_le_bytes()); // option flags
+    for (pname, value, output) in params {
+        let pn = ucs2le(pname);
+        b.push((pn.len() / 2) as u8); // param-name char count (0 = positional)
+        b.extend_from_slice(&pn);
+        b.push(if *output { 0x01 } else { 0x00 }); // StatusFlags: fByRefValue
+        value.encode(&mut b);
+    }
+    b
+}
+
 /// One sp_executesql RPC (by ProcID) with a single unnamed @stmt param.
 fn sp_executesql_rpc(sql: &str) -> Vec<u8> {
     let mut b = Vec::new();
@@ -877,6 +952,235 @@ async fn a_multi_rpc_request_answers_each_rpc_in_one_response() {
     );
     assert_eq!(row_ints(&tokens), [4], "tokens: {tokens:?}");
 
+    let _ = std::fs::remove_file(&path);
+}
+
+/// Extracts the (name, value) of every RETURNVALUE token in order.
+fn return_values(tokens: &[Token]) -> Vec<(String, Cell)> {
+    tokens
+        .iter()
+        .filter_map(|t| match t {
+            Token::ReturnValue { name, value } => Some((name.clone(), value.clone())),
+            _ => None,
+        })
+        .collect()
+}
+
+/// The one RETURNSTATUS value in a reply.
+fn return_status(tokens: &[Token]) -> Option<i32> {
+    tokens.iter().find_map(|t| match t {
+        Token::ReturnStatus(v) => Some(*v),
+        _ => None,
+    })
+}
+
+/// An RPC-by-name call of a user procedure with a named OUTPUT parameter and a
+/// RETURN carries the real status and the OUTPUT value back as RETURNSTATUS and
+/// a typed RETURNVALUE.
+#[tokio::test]
+async fn rpc_by_name_returns_status_and_named_output() {
+    let path = temp_path("rpc-named-output");
+    let engine = engine(&path);
+    let mut client = connect(engine.clone()).await;
+    client.prelogin().await;
+    client.login("sa", "secret").await;
+    client
+        .batch("CREATE PROCEDURE addone @x INT, @out INT OUTPUT AS BEGIN SET @out = @x + 1; RETURN 7; END")
+        .await;
+
+    let body = proc_rpc(
+        "addone",
+        &[
+            ("@x", RpcArg::Int(10), false),
+            ("@out", RpcArg::IntNull, true),
+        ],
+    );
+    let tokens = client.rpc(&body).await;
+
+    assert_eq!(return_status(&tokens), Some(7), "tokens: {tokens:?}");
+    assert_eq!(
+        return_values(&tokens),
+        vec![("@out".to_string(), Cell::Int(11))],
+        "tokens: {tokens:?}"
+    );
+    // The reply frames as a procedure reply and ends clean.
+    assert!(
+        tokens
+            .iter()
+            .any(|t| matches!(t, Token::DoneProc { error: false, .. })),
+        "tokens: {tokens:?}"
+    );
+    let _ = std::fs::remove_file(&path);
+}
+
+/// A positional (unnamed-parameter) call — the JDBC `{call p(?, ?)}` shape —
+/// binds by position and returns the OUTPUT value as a nameless RETURNVALUE the
+/// driver matches by ordinal.
+#[tokio::test]
+async fn rpc_by_name_positional_output() {
+    let path = temp_path("rpc-positional");
+    let engine = engine(&path);
+    let mut client = connect(engine.clone()).await;
+    client.prelogin().await;
+    client.login("sa", "secret").await;
+    client
+        .batch("CREATE PROCEDURE double2 @a INT, @b INT OUTPUT AS BEGIN SET @b = @a * 2; RETURN 3; END")
+        .await;
+
+    let body = proc_rpc(
+        "double2",
+        &[("", RpcArg::Int(21), false), ("", RpcArg::IntNull, true)],
+    );
+    let tokens = client.rpc(&body).await;
+
+    assert_eq!(return_status(&tokens), Some(3), "tokens: {tokens:?}");
+    assert_eq!(
+        return_values(&tokens),
+        vec![(String::new(), Cell::Int(42))],
+        "tokens: {tokens:?}"
+    );
+    let _ = std::fs::remove_file(&path);
+}
+
+/// A typed OUTPUT parameter other than INT round-trips through the RETURNVALUE
+/// encoder (exercises the TYPE_INFO path for a variable-length string).
+#[tokio::test]
+async fn rpc_by_name_nvarchar_output() {
+    let path = temp_path("rpc-nvarchar");
+    let engine = engine(&path);
+    let mut client = connect(engine.clone()).await;
+    client.prelogin().await;
+    client.login("sa", "secret").await;
+    client
+        .batch(
+            "CREATE PROCEDURE greet @who NVARCHAR(50), @msg NVARCHAR(80) OUTPUT AS \
+             BEGIN SET @msg = N'hello ' + @who; END",
+        )
+        .await;
+
+    let body = proc_rpc(
+        "greet",
+        &[
+            ("@who", RpcArg::NVarChar("world".to_string()), false),
+            ("@msg", RpcArg::NVarChar(String::new()), true),
+        ],
+    );
+    let tokens = client.rpc(&body).await;
+
+    // No RETURN: the status defaults to 0, still emitted.
+    assert_eq!(return_status(&tokens), Some(0), "tokens: {tokens:?}");
+    assert_eq!(
+        return_values(&tokens),
+        vec![("@msg".to_string(), Cell::Str("hello world".to_string()))],
+        "tokens: {tokens:?}"
+    );
+    let _ = std::fs::remove_file(&path);
+}
+
+/// A NULL result in an OUTPUT parameter is returned as a NULL RETURNVALUE.
+#[tokio::test]
+async fn rpc_by_name_null_output() {
+    let path = temp_path("rpc-null-output");
+    let engine = engine(&path);
+    let mut client = connect(engine.clone()).await;
+    client.prelogin().await;
+    client.login("sa", "secret").await;
+    client
+        .batch("CREATE PROCEDURE clear1 @out INT OUTPUT AS BEGIN SET @out = NULL; END")
+        .await;
+
+    let body = proc_rpc("clear1", &[("@out", RpcArg::Int(5), true)]);
+    let tokens = client.rpc(&body).await;
+
+    assert_eq!(
+        return_values(&tokens),
+        vec![("@out".to_string(), Cell::Null)],
+        "tokens: {tokens:?}"
+    );
+    let _ = std::fs::remove_file(&path);
+}
+
+/// An RPC-by-name call of a procedure that does not exist is error 2812, the
+/// same as SQL Server, and no RETURNSTATUS or RETURNVALUE is emitted.
+#[tokio::test]
+async fn rpc_by_name_unknown_proc_is_2812() {
+    let path = temp_path("rpc-unknown");
+    let engine = engine(&path);
+    let mut client = connect(engine.clone()).await;
+    client.prelogin().await;
+    client.login("sa", "secret").await;
+
+    let body = proc_rpc("no_such_proc", &[("@x", RpcArg::Int(1), false)]);
+    let tokens = client.rpc(&body).await;
+
+    assert!(
+        tokens
+            .iter()
+            .any(|t| matches!(t, Token::Error { number: 2812 })),
+        "tokens: {tokens:?}"
+    );
+    assert!(
+        return_values(&tokens).is_empty(),
+        "a failed procedure returns no OUTPUT values: {tokens:?}"
+    );
+    let _ = std::fs::remove_file(&path);
+}
+
+/// Two procedure RPCs in one request each carry their own RETURNSTATUS and
+/// RETURNVALUE tail — the tails do not bleed across the multi-RPC boundary.
+#[tokio::test]
+async fn multi_rpc_proc_calls_each_carry_their_own_tail() {
+    let path = temp_path("rpc-multi-tail");
+    let engine = engine(&path);
+    let mut client = connect(engine.clone()).await;
+    client.prelogin().await;
+    client.login("sa", "secret").await;
+    client
+        .batch("CREATE PROCEDURE addk @x INT, @out INT OUTPUT AS BEGIN SET @out = @x + 100; RETURN @x; END")
+        .await;
+
+    let mut body = proc_rpc(
+        "addk",
+        &[
+            ("@x", RpcArg::Int(1), false),
+            ("@out", RpcArg::IntNull, true),
+        ],
+    );
+    body.push(0xff); // batch separator
+    body.extend(proc_rpc(
+        "addk",
+        &[
+            ("@x", RpcArg::Int(2), false),
+            ("@out", RpcArg::IntNull, true),
+        ],
+    ));
+    let tokens = client.rpc(&body).await;
+
+    let statuses: Vec<i32> = tokens
+        .iter()
+        .filter_map(|t| match t {
+            Token::ReturnStatus(v) => Some(*v),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(statuses, [1, 2], "one status per RPC, in order: {tokens:?}");
+    assert_eq!(
+        return_values(&tokens),
+        vec![
+            ("@out".to_string(), Cell::Int(101)),
+            ("@out".to_string(), Cell::Int(102)),
+        ],
+        "each RPC's OUTPUT in order: {tokens:?}"
+    );
+    // Every DONEPROC but the last carries DONE_MORE.
+    let procs: Vec<(bool, bool)> = tokens
+        .iter()
+        .filter_map(|t| match t {
+            Token::DoneProc { more, error, .. } => Some((*more, *error)),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(procs, [(true, false), (false, false)], "tokens: {tokens:?}");
     let _ = std::fs::remove_file(&path);
 }
 

--- a/crates/truthdb-tds/tests/tds_client.rs
+++ b/crates/truthdb-tds/tests/tds_client.rs
@@ -325,6 +325,7 @@ enum Token {
     },
     ReturnStatus(i32),
     ReturnValue {
+        ordinal: u16,
         name: String,
         value: Cell,
     },
@@ -431,6 +432,7 @@ fn parse_tokens(payload: &[u8]) -> Vec<Token> {
                 // RETURNVALUE: ordinal u16, B_VARCHAR name, status u8,
                 // usertype u32, flags u16, TYPE_INFO, then the value in that
                 // type's row encoding.
+                let ordinal = u16::from_le_bytes([payload[i], payload[i + 1]]);
                 i += 2; // ParamOrdinal
                 let name_chars = payload[i] as usize;
                 i += 1;
@@ -446,6 +448,7 @@ fn parse_tokens(payload: &[u8]) -> Vec<Token> {
                 let (cells, consumed) = parse_row(&payload[i..], &[col_type]);
                 i += consumed;
                 tokens.push(Token::ReturnValue {
+                    ordinal,
                     name,
                     value: cells.into_iter().next().unwrap(),
                 });
@@ -955,12 +958,16 @@ async fn a_multi_rpc_request_answers_each_rpc_in_one_response() {
     let _ = std::fs::remove_file(&path);
 }
 
-/// Extracts the (name, value) of every RETURNVALUE token in order.
-fn return_values(tokens: &[Token]) -> Vec<(String, Cell)> {
+/// Extracts the (ordinal, name, value) of every RETURNVALUE token in order.
+fn return_values(tokens: &[Token]) -> Vec<(u16, String, Cell)> {
     tokens
         .iter()
         .filter_map(|t| match t {
-            Token::ReturnValue { name, value } => Some((name.clone(), value.clone())),
+            Token::ReturnValue {
+                ordinal,
+                name,
+                value,
+            } => Some((*ordinal, name.clone(), value.clone())),
             _ => None,
         })
         .collect()
@@ -1000,7 +1007,7 @@ async fn rpc_by_name_returns_status_and_named_output() {
     assert_eq!(return_status(&tokens), Some(7), "tokens: {tokens:?}");
     assert_eq!(
         return_values(&tokens),
-        vec![("@out".to_string(), Cell::Int(11))],
+        vec![(1, "@out".to_string(), Cell::Int(11))],
         "tokens: {tokens:?}"
     );
     // The reply frames as a procedure reply and ends clean.
@@ -1036,7 +1043,7 @@ async fn rpc_by_name_positional_output() {
     assert_eq!(return_status(&tokens), Some(3), "tokens: {tokens:?}");
     assert_eq!(
         return_values(&tokens),
-        vec![(String::new(), Cell::Int(42))],
+        vec![(1, String::new(), Cell::Int(42))],
         "tokens: {tokens:?}"
     );
     let _ = std::fs::remove_file(&path);
@@ -1071,7 +1078,7 @@ async fn rpc_by_name_nvarchar_output() {
     assert_eq!(return_status(&tokens), Some(0), "tokens: {tokens:?}");
     assert_eq!(
         return_values(&tokens),
-        vec![("@msg".to_string(), Cell::Str("hello world".to_string()))],
+        vec![(1, "@msg".to_string(), Cell::Str("hello world".to_string()))],
         "tokens: {tokens:?}"
     );
     let _ = std::fs::remove_file(&path);
@@ -1094,7 +1101,7 @@ async fn rpc_by_name_null_output() {
 
     assert_eq!(
         return_values(&tokens),
-        vec![("@out".to_string(), Cell::Null)],
+        vec![(0, "@out".to_string(), Cell::Null)],
         "tokens: {tokens:?}"
     );
     let _ = std::fs::remove_file(&path);
@@ -1167,8 +1174,8 @@ async fn multi_rpc_proc_calls_each_carry_their_own_tail() {
     assert_eq!(
         return_values(&tokens),
         vec![
-            ("@out".to_string(), Cell::Int(101)),
-            ("@out".to_string(), Cell::Int(102)),
+            (1, "@out".to_string(), Cell::Int(101)),
+            (1, "@out".to_string(), Cell::Int(102)),
         ],
         "each RPC's OUTPUT in order: {tokens:?}"
     );
@@ -1181,6 +1188,115 @@ async fn multi_rpc_proc_calls_each_carry_their_own_tail() {
         })
         .collect();
     assert_eq!(procs, [(true, false), (false, false)], "tokens: {tokens:?}");
+    let _ = std::fs::remove_file(&path);
+}
+
+/// A procedure that raises a non-fatal error (severity 11-16) and then RETURNs
+/// still *completes*, so its RETURN status and OUTPUT parameters are transmitted
+/// alongside the error — as SQL Server does. The batch surfacing a continued
+/// error must not suppress the tail (the emission gate and the copy-back gate
+/// have to agree; they are unified on the procedure-completion signal).
+#[tokio::test]
+async fn rpc_by_name_completed_proc_with_warning_still_returns_tail() {
+    let path = temp_path("rpc-warn-tail");
+    let engine = engine(&path);
+    let mut client = connect(engine.clone()).await;
+    client.prelogin().await;
+    client.login("sa", "secret").await;
+    client
+        .batch(
+            "CREATE PROCEDURE warnproc @x INT, @out INT OUTPUT AS \
+             BEGIN SET @out = @x + 1; RAISERROR('warn', 16, 1); RETURN 7; END",
+        )
+        .await;
+
+    let body = proc_rpc(
+        "warnproc",
+        &[
+            ("@x", RpcArg::Int(10), false),
+            ("@out", RpcArg::IntNull, true),
+        ],
+    );
+    let tokens = client.rpc(&body).await;
+
+    // The warning is delivered as an ERROR token and DONEPROC keeps DONE_ERROR,
+    assert!(
+        tokens
+            .iter()
+            .any(|t| matches!(t, Token::Error { number: 50000 })),
+        "tokens: {tokens:?}"
+    );
+    assert!(
+        tokens
+            .iter()
+            .any(|t| matches!(t, Token::DoneProc { error: true, .. })),
+        "tokens: {tokens:?}"
+    );
+    // ...yet the completed procedure's status and OUTPUT are still returned.
+    assert_eq!(return_status(&tokens), Some(7), "tokens: {tokens:?}");
+    assert_eq!(
+        return_values(&tokens),
+        vec![(1, "@out".to_string(), Cell::Int(11))],
+        "tokens: {tokens:?}"
+    );
+    let _ = std::fs::remove_file(&path);
+}
+
+/// Two OUTPUT parameters each carry their own 0-based ParamOrdinal — pytds
+/// places OUTPUT values into the caller's list by this field, so a hardcoded 0
+/// would collide both at index 0 and lose the first. Positional call.
+#[tokio::test]
+async fn rpc_by_name_multiple_outputs_carry_distinct_ordinals() {
+    let path = temp_path("rpc-ordinals");
+    let engine = engine(&path);
+    let mut client = connect(engine.clone()).await;
+    client.prelogin().await;
+    client.login("sa", "secret").await;
+    client
+        .batch("CREATE PROCEDURE two @x INT OUTPUT, @y INT OUTPUT AS BEGIN SET @x = 1; SET @y = 2; END")
+        .await;
+
+    let body = proc_rpc(
+        "two",
+        &[("", RpcArg::IntNull, true), ("", RpcArg::IntNull, true)],
+    );
+    let tokens = client.rpc(&body).await;
+
+    assert_eq!(
+        return_values(&tokens),
+        vec![
+            (0, String::new(), Cell::Int(1)),
+            (1, String::new(), Cell::Int(2)),
+        ],
+        "each OUTPUT carries its 0-based position, not a shared 0: {tokens:?}"
+    );
+    let _ = std::fs::remove_file(&path);
+}
+
+/// A RETURN value outside the int32 range overflows (error 8115) like SQL
+/// Server, rather than being silently reported as a clean status 0.
+#[tokio::test]
+async fn rpc_by_name_out_of_range_return_is_8115() {
+    let path = temp_path("rpc-bigrc");
+    let engine = engine(&path);
+    let mut client = connect(engine.clone()).await;
+    client.prelogin().await;
+    client.login("sa", "secret").await;
+    client
+        .batch("CREATE PROCEDURE bigrc AS BEGIN RETURN 3000000000; END")
+        .await;
+
+    let tokens = client.rpc(&proc_rpc("bigrc", &[])).await;
+
+    assert!(
+        tokens
+            .iter()
+            .any(|t| matches!(t, Token::Error { number: 8115 })),
+        "tokens: {tokens:?}"
+    );
+    // The procedure aborted, so no clean status and no OUTPUT are reported.
+    assert_eq!(return_status(&tokens), None, "tokens: {tokens:?}");
+    assert!(return_values(&tokens).is_empty(), "tokens: {tokens:?}");
     let _ = std::fs::remove_file(&path);
 }
 


### PR DESCRIPTION
# Stage 15 (RPC-by-name): real RETURNSTATUS and typed RETURNVALUEs for user procedures

Completes the TDS **RPC-by-name** path — the last piece of Stage 15's catalog bullet. When a
driver calls a user stored procedure by name over the wire (a real RPC, not `sp_executesql`
text), the server now returns the procedure's RETURN status as a RETURNSTATUS token and its
OUTPUT parameters as typed RETURNVALUE tokens. The prior three commits on this branch landed
the plumbing (BatchEvents, the typed `token::return_value`, `fByRefValue` decode, the renderer
tail order); the values were still stubbed at `0` / none. This commit produces the real values.

## How

`EngineHandle::stream_proc_rpc` synthesizes an `EXEC @__truthdb_rc = [proc] @p = @p [OUTPUT], …`
batch, seeds the wire parameters as batch variables, and seeds one synthetic Int variable
`@__truthdb_rc` so the RETURN status lands somewhere readable — no extra wire token, no extra
statement. A `ProcRpcTail { status_var, output_vars }` is threaded through
`EngineCall::RunBatch → Runnable`/`Parked → run_and_finish`. Once the batch completes,
`run_and_finish` reads the status variable and each OUTPUT variable off `txn_ctx`
(`TxnContext::variable_datum`, typed `Datum`) and emits `ReturnStatus` + `ReturnValue` **before**
`finish` reclaims the context and **before** `Complete` — so a parked batch is handled at real
completion, not at dispatch.

The tokens are emitted only when the batch ran clean (`Ok(None)`), which is exactly when the
procedure copied its OUTPUT parameters back and stored its status (`run_user_procedure` does both
only on `result.is_ok()`); a failed procedure returns no status, matching the renderer's existing
`errored` gate and SQL Server.

Positional (unnamed-parameter) calls — the JDBC `{call p(?, ?)}` shape — bind by position through
synthetic `@__truthdb_argN` seeds and return nameless RETURNVALUEs that drivers match by ordinal.

## Tests (`truthdb-tds/tests/tds_client.rs`, +6)

- named OUTPUT + `RETURN 7` → RETURNSTATUS 7, RETURNVALUE `@out`=11
- positional OUTPUT (JDBC shape) → nameless RETURNVALUE matched by ordinal
- NVARCHAR OUTPUT → exercises the typed TYPE_INFO encoder
- NULL OUTPUT → NULL RETURNVALUE
- unknown proc → 2812, no status/values
- two proc RPCs in one request → each carries its own tail (no bleed across the multi-RPC boundary)

The RETURNVALUE test-parser now decodes the ParamName and the typed value (shared TYPE_INFO decode
with COLMETADATA).

Full workspace suite green; clippy clean on touched files.

## Adversarial review

A five-lens review (continuation-gate seam, parked-completion, injection/collision, driver-conformance, silent-drop/types) with refute-by-default verification confirmed three findings; each fix is teeth-checked by mutation:

- **HIGH** — the tail was gated on the batch running clean, so a procedure that raised a continued (non-dooming) RAISERROR sev 11-16 and then RETURNed lost its OUTPUT value and status on the wire even though it completed. Fixed by unifying the emission gate with the copy-back gate on the procedure-completion signal (status variable seeded NULL, overwritten with an Int only on completion).
- **HIGH** — the RETURNVALUE ParamOrdinal was hardcoded 0, so pytds (which places OUTPUT values by ordinal) misplaced/lost non-first or multiple OUTPUT parameters. Fixed by threading each parameter's 0-based RPC position through to the token.
- **LOW** — a RETURN value outside int32 range was read back as a clean status 0; now overflows (8115) as SQL Server does (also required for the completion signal to stay valid).

Refuted (not defects in this change): a TIME-type OUTPUT would be mis-encoded (a pre-existing `typeinfo` gap, not this path), and param-name interpolation is only reachable by a self-authenticated client that could already run any SQL (no privilege boundary).
