### PR TITLE
Stage 15: scalar user-defined functions (CREATE/ALTER/DROP FUNCTION)

### DIFF
--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -5666,6 +5666,107 @@ mod tests {
     }
 
     #[test]
+    fn scalar_function_snapshot_scope_covers_body_reads() {
+        // The snapshot-scope determination must recurse into a called UDF's
+        // body exactly as lock analysis does: under SNAPSHOT isolation with
+        // snapshot isolation NOT allowed, a statement whose ONLY table access is
+        // inside a UDF body must still raise 3952 (the body IS a data access).
+        // Before the fix these silently succeeded and read live/unlocked — the
+        // "neither lock nor snapshot" seam.
+        let path = unique_temp_path("udf-snapshot-scope");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        batch(
+            &engine,
+            &mut ctx,
+            "CREATE TABLE t (id INT NOT NULL PRIMARY KEY)",
+        );
+        batch(
+            &engine,
+            &mut ctx,
+            "CREATE FUNCTION dbo.cnt () RETURNS INT AS BEGIN RETURN (SELECT COUNT(*) FROM t) END",
+        );
+        batch(
+            &engine,
+            &mut ctx,
+            "SET TRANSACTION ISOLATION LEVEL SNAPSHOT",
+        );
+        // A SELECT whose only table read is inside the UDF body.
+        let out = batch(&engine, &mut ctx, "SELECT dbo.cnt() AS n");
+        assert_eq!(
+            out.error.as_ref().map(|e| e.number),
+            Some(3952),
+            "a UDF-only SELECT must arm the snapshot scope: {:?}",
+            out.error
+        );
+        // An IF condition whose only table read is inside the UDF body.
+        let out = batch(&engine, &mut ctx, "IF dbo.cnt() > 0 SELECT 1 AS n");
+        assert_eq!(
+            out.error.as_ref().map(|e| e.number),
+            Some(3952),
+            "a UDF-only IF condition must arm the snapshot scope: {:?}",
+            out.error
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn scalar_function_in_view_body_is_lock_analyzed() {
+        use crate::lock::{LockMode, Resource};
+        use crate::rel::Isolation;
+        let path = unique_temp_path("udf-view-lock");
+        let engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE base (x INT NOT NULL PRIMARY KEY)")
+            .expect("base");
+        engine
+            .execute("CREATE TABLE secret (z INT NOT NULL PRIMARY KEY)")
+            .expect("secret");
+        engine
+            .execute(
+                "CREATE FUNCTION dbo.secret_count () RETURNS INT AS \
+                 BEGIN RETURN (SELECT COUNT(*) FROM secret) END",
+            )
+            .expect("fn");
+        engine
+            .execute("CREATE VIEW v AS SELECT x, dbo.secret_count() AS sc FROM base")
+            .expect("view");
+        let secret = table_object_id(&engine, "secret");
+        // A UDF reached THROUGH a view must still have its body's table Shared-
+        // locked — else the view-nested UDF reads secret unlocked under 2PL.
+        let locks = engine.analyze_locks("SELECT * FROM v", Isolation::ReadCommitted);
+        assert!(
+            locks.contains(&(Resource::Table(secret), LockMode::Shared)),
+            "a view-nested UDF's body table must be Shared-locked: {locks:?}"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn scalar_function_does_not_shadow_builtin() {
+        let path = unique_temp_path("udf-builtin-shadow");
+        let engine = new_engine(&path);
+        engine
+            .execute("CREATE FUNCTION dbo.abs (@x INT) RETURNS INT AS BEGIN RETURN 0 END")
+            .expect("fn");
+        // A bare call binds to the built-in ABS (5), not the same-named UDF (0).
+        let (_, rows) = sql_rows(&engine, "SELECT abs(-5) AS n");
+        assert_eq!(
+            rows,
+            vec![vec![Some("5".into())]],
+            "bare abs() must be the built-in"
+        );
+        // The schema-qualified name still reaches the UDF.
+        let (_, rows) = sql_rows(&engine, "SELECT dbo.abs(-5) AS n");
+        assert_eq!(
+            rows,
+            vec![vec![Some("0".into())]],
+            "dbo.abs() must be the UDF"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
     fn cf_review_describe_stops_at_control_flow() {
         // sp_describe_first_result_set: a batch whose FIRST possible rowset
         // sits inside an IF must answer "not statically derivable" — skipping

--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -5576,6 +5576,96 @@ mod tests {
     }
 
     #[test]
+    fn scalar_function_body_tables_locked_up_front() {
+        use crate::lock::{LockMode, Resource};
+        use crate::rel::Isolation;
+        let path = unique_temp_path("udf-lock-seam");
+        let engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE secret (id INT NOT NULL PRIMARY KEY)")
+            .expect("secret");
+        engine
+            .execute("CREATE TABLE t2 (id INT NOT NULL PRIMARY KEY)")
+            .expect("t2");
+        engine
+            .execute(
+                "CREATE FUNCTION dbo.secret_count () RETURNS INT AS \
+                 BEGIN RETURN (SELECT COUNT(*) FROM secret) END",
+            )
+            .expect("fn");
+        let secret = table_object_id(&engine, "secret");
+        // A query that calls the function must Shared-lock the table its body
+        // reads, up front — otherwise the body would read it with no lock held
+        // under 2PL (the seam-defect class). Checked in the SELECT list, the
+        // WHERE clause, and an IF condition.
+        for sql in [
+            "SELECT id, dbo.secret_count() FROM t2",
+            "SELECT id FROM t2 WHERE dbo.secret_count() > 0",
+            "IF dbo.secret_count() > 0 SELECT 1 AS n",
+        ] {
+            let locks = engine.analyze_locks(sql, Isolation::ReadCommitted);
+            assert!(
+                locks.contains(&(Resource::Table(secret), LockMode::Shared)),
+                "the function's inner-read table must be Shared-locked for `{sql}`: {locks:?}"
+            );
+        }
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn scalar_function_isolation_error_and_nesting() {
+        let path = unique_temp_path("udf-isolation");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        // A function does not see caller locals: a body reference to `@outer`
+        // is undeclared inside the function scope (137), never the caller's
+        // value.
+        batch(
+            &engine,
+            &mut ctx,
+            "CREATE FUNCTION dbo.leak () RETURNS INT AS BEGIN RETURN @outer END",
+        );
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "DECLARE @outer INT = 5; SELECT dbo.leak() AS n",
+        );
+        assert_eq!(
+            out.error.as_ref().map(|e| e.number),
+            Some(137),
+            "a function must not see caller locals: {:?}",
+            out.error
+        );
+        // An error inside the body aborts the calling statement.
+        batch(
+            &engine,
+            &mut ctx,
+            "CREATE FUNCTION dbo.divzero (@x INT) RETURNS INT AS BEGIN RETURN 1 / @x END",
+        );
+        let out = batch(&engine, &mut ctx, "SELECT dbo.divzero(0) AS n");
+        assert_eq!(
+            out.error.as_ref().map(|e| e.number),
+            Some(8134),
+            "divide-by-zero in a function aborts the query: {:?}",
+            out.error
+        );
+        // Unbounded recursion hits the shared nesting cap (217), and unwinds.
+        batch(
+            &engine,
+            &mut ctx,
+            "CREATE FUNCTION dbo.recur (@x INT) RETURNS INT AS BEGIN RETURN dbo.recur(@x) END",
+        );
+        let out = batch(&engine, &mut ctx, "SELECT dbo.recur(1) AS n");
+        assert_eq!(
+            out.error.as_ref().map(|e| e.number),
+            Some(217),
+            "recursion must hit the nesting cap: {:?}",
+            out.error
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
     fn cf_review_describe_stops_at_control_flow() {
         // sp_describe_first_result_set: a batch whose FIRST possible rowset
         // sits inside an IF must answer "not statically derivable" — skipping

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -1587,7 +1587,7 @@ fn run_block(
                 // the caller. Nested user functions and subqueries in the RETURN
                 // expression are rewritten to literals first, exactly like an
                 // IF/WHILE condition.
-                if let Some(return_type) = run.function_return_type.clone() {
+                if let Some(return_type) = run.function_return_type {
                     let value = value
                         .as_ref()
                         .expect("a scalar function RETURN carries a value (parser-enforced)");

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -14,11 +14,11 @@ mod plan;
 mod value;
 
 use truthdb_sql::ast::{
-    AlterAction, AlterDatabase, AlterTable, CheckConstraint, ColumnDef, CreateIndex,
-    CreateProcedure, CreateTable, CreateView, DataType, DatabaseOption, Declaration, Delete,
-    DropIndex, DropTable, DropView, ExecStatement, Expr, ExprKind, ForeignKey, Insert,
-    InsertSource, IsolationLevel, JoinKind, Name, OrderItem, RaiseError, Select, SelectItem,
-    SetStatement, Statement, TableRef, ThrowArgs, ThrowStatement, Update,
+    AlterAction, AlterDatabase, AlterTable, CheckConstraint, ColumnDef, CreateFunction,
+    CreateIndex, CreateProcedure, CreateTable, CreateView, DataType, DatabaseOption, Declaration,
+    Delete, DropIndex, DropTable, DropView, ExecStatement, Expr, ExprKind, ForeignKey, Insert,
+    InsertSource, IsolationLevel, JoinKind, Name, OrderItem, RaiseError, ReturnsClause, Select,
+    SelectItem, SetStatement, Statement, TableRef, ThrowArgs, ThrowStatement, Update,
 };
 use truthdb_sql::collation::CollationSensitivity;
 use truthdb_sql::error::SqlError;
@@ -31,7 +31,9 @@ use xxhash_rust::xxh64::xxh64;
 
 use crate::lock::{LockMode, Resource};
 use crate::relstore::btree::ScanCursor;
-use crate::relstore::catalog::{self, ProcParamDef, ProcedureDef, TableDef};
+use crate::relstore::catalog::{
+    self, FunctionDef, FunctionReturns, ProcParamDef, ProcedureDef, TableDef,
+};
 use crate::relstore::row::{Column, Schema};
 use crate::relstore::types::{ColumnType, Datum};
 use crate::relstore::version::ReadSnapshot;
@@ -71,6 +73,10 @@ pub struct TxnContext {
     /// for `EXEC @rc = name` to read after the body unwinds; 0 when the body
     /// falls off the end.
     proc_return: Option<i64>,
+    /// A scalar function body's `RETURN <expr>` value, coerced to the declared
+    /// return type and stashed by the Return arm for the caller to read. Only
+    /// set while a function body runs (see [`run_user_scalar_function`]).
+    func_return: Option<SqlValue>,
     /// `SET SHOWPLAN_TEXT ON` — a SELECT returns its plan text, not results.
     showplan_text: bool,
     /// Declared batch variables (name without `@`, lowercased) to their type
@@ -401,6 +407,7 @@ pub fn execute_batch_streamed(
         durability_failed: false,
         committed: false,
         last_error: None,
+        function_return_type: None,
     };
     // `run_block` returns Err only when the batch must terminate (a cancel, or a
     // dooming/uncaught error outside any TRY); a non-dooming error under
@@ -441,6 +448,24 @@ pub trait BatchEmitter {
     /// An informational message (RAISERROR severity <= 10): TDS renders an
     /// INFO token in-stream, not an error. Emitters with no wire ignore it.
     fn info(&mut self, _error: &SqlError) {}
+}
+
+/// A [`BatchEmitter`] that drops everything: a scalar function body produces no
+/// result sets (a data-returning SELECT is rejected at CREATE, 444), so its
+/// per-statement DONE events have nowhere to go.
+struct DiscardEmitter;
+
+impl BatchEmitter for DiscardEmitter {
+    fn columns(&mut self, _columns: Vec<ResultColumn>) {}
+    fn rows(&mut self, _rows: Vec<Vec<Datum>>) {}
+    fn statement_done(
+        &mut self,
+        _count: Option<u64>,
+        _in_transaction: bool,
+        _command: DoneCommand,
+    ) {
+    }
+    fn statement_aborted(&mut self, _in_transaction: bool) {}
 }
 
 /// Reassembles emitted results into the whole-batch [`BatchOutcome`] for the
@@ -516,6 +541,11 @@ struct BatchRun<'a> {
     /// any TRY) — the batch continues past it (SQL Server default) and it is
     /// reported alongside the results rather than terminating the batch.
     last_error: Option<SqlError>,
+    /// Set while running a scalar function body: the declared return type. The
+    /// `RETURN <expr>` arm then evaluates its value, coerces it to this type,
+    /// and stashes it in `TxnContext::func_return` (rather than the procedure
+    /// int-status path).
+    function_return_type: Option<ColumnType>,
 }
 
 /// A statement's DONE, parked until the next durability point.
@@ -981,6 +1011,103 @@ fn run_user_procedure(
         }
     }
     result
+}
+
+/// Runs a scalar user-defined function's body once with `arg_values` bound to
+/// its parameters, returning the value its `RETURN` produced, coerced to the
+/// declared return type.
+///
+/// The body runs in an isolated throwaway context — only the parameters are
+/// visible (SQL Server functions do not see caller locals), no transaction is
+/// open (functions are side-effect-free), and any table reads observe the
+/// caller's ambient snapshot on this thread. Nesting shares the `EXEC_DEPTH`
+/// budget (217 at depth 32). Because the context has no transaction, an error in
+/// the body always terminates the function (there is no XACT_ABORT-OFF continue
+/// path), which is exactly the SQL Server posture: a function error aborts the
+/// statement that called it.
+fn run_user_scalar_function(
+    storage: &Storage,
+    def: &TableDef,
+    arg_values: &[SqlValue],
+    caller: &EvalContext,
+) -> Result<SqlValue, SqlError> {
+    let function = def.function.as_ref().expect("checked by the caller");
+    let FunctionReturns::Scalar { type_spec, body } = &function.returns;
+    if arg_values.len() < function.params.len() {
+        return Err(SqlError::new(
+            313,
+            16,
+            3,
+            format!(
+                "An insufficient number of arguments were supplied for the procedure or function {}.",
+                def.name
+            ),
+        ));
+    }
+    if arg_values.len() > function.params.len() {
+        return Err(SqlError::new(
+            8144,
+            16,
+            2,
+            format!(
+                "Procedure or function {} has too many arguments specified.",
+                def.name
+            ),
+        ));
+    }
+    let return_type =
+        ColumnType::parse(type_spec).map_err(|e| SqlError::message_only(245, e.to_string()))?;
+    // Fresh scope with only the parameters; the caller's session identity is
+    // carried so DB_NAME()/SUSER_SNAME()/@@SPID resolve inside the body.
+    let mut txn_ctx = TxnContext::default();
+    txn_ctx.set_session_identity(caller.database.clone(), caller.login.clone(), caller.spid);
+    for (param, value) in function.params.iter().zip(arg_values) {
+        let column_type = ColumnType::parse(&param.type_spec)
+            .map_err(|e| SqlError::message_only(245, e.to_string()))?;
+        let datum = value::sql_to_datum(value, &column_type, &param.name)?;
+        let coerced = value::datum_to_sql(&datum, &column_type);
+        txn_ctx
+            .variables
+            .insert(param.name.clone(), (column_type, coerced));
+    }
+    let statements = truthdb_sql::parse_function_body(body)?;
+    let depth = EXEC_DEPTH.with(|d| {
+        let v = d.get() + 1;
+        d.set(v);
+        v
+    });
+    let result = if depth > 32 {
+        Err(SqlError::new(
+            217,
+            16,
+            1,
+            "Maximum stored procedure, function, trigger, or view nesting level exceeded (limit 32).",
+        ))
+    } else {
+        let mut emitter = DiscardEmitter;
+        let mut run = BatchRun {
+            emitter: &mut emitter,
+            deferred: Vec::new(),
+            rowset_open: false,
+            durability_failed: false,
+            committed: false,
+            last_error: None,
+            function_return_type: Some(return_type),
+        };
+        run_block(storage, &statements, &mut txn_ctx, &mut run, false).map(|_| ())
+    };
+    EXEC_DEPTH.with(|d| d.set(d.get() - 1));
+    result?;
+    // The body ends in `RETURN <expr>` (enforced at CREATE, 455), so a completed
+    // body always set `func_return`.
+    txn_ctx.func_return.take().ok_or_else(|| {
+        SqlError::new(
+            455,
+            16,
+            2,
+            "The last statement included within a function must be a return statement.",
+        )
+    })
 }
 
 fn run_exec(
@@ -1451,6 +1578,37 @@ fn run_block(
             // The parser rejects `RETURN <value>` outside a procedure (178);
             // inside one the status is stashed for `EXEC @rc =` to read.
             Statement::Return { value, .. } => {
+                // A scalar function body's RETURN: evaluate its (mandatory)
+                // value, coerce it to the declared return type, and stash it for
+                // the caller. Nested user functions and subqueries in the RETURN
+                // expression are rewritten to literals first, exactly like an
+                // IF/WHILE condition.
+                if let Some(return_type) = run.function_return_type.clone() {
+                    let value = value
+                        .as_ref()
+                        .expect("a scalar function RETURN carries a value (parser-enforced)");
+                    let eval_ctx = txn_ctx.eval_context();
+                    let no_outer = |_: &str| -> Option<usize> { None };
+                    let coerced =
+                        substitute_correlated_in_expr(storage, value, &no_outer, &[], &eval_ctx)
+                            .and_then(|bound| eval_constant(&bound, &eval_ctx))
+                            .and_then(|raw| {
+                                let datum =
+                                    value::sql_to_datum(&raw, &return_type, "return value")?;
+                                Ok(value::datum_to_sql(&datum, &return_type))
+                            });
+                    match coerced {
+                        Ok(coerced) => {
+                            txn_ctx.func_return = Some(coerced);
+                            return Ok(Flow::Return);
+                        }
+                        Err(error) => {
+                            txn_ctx.rowcount = 0;
+                            statement_error_ladder(statement, error, txn_ctx, run, in_try)?;
+                            continue;
+                        }
+                    }
+                }
                 if let Some(value) = value {
                     let eval_ctx = txn_ctx.eval_context();
                     match eval_constant(value, &eval_ctx) {
@@ -1978,6 +2136,8 @@ fn statement_may_commit(statement: &Statement) -> bool {
             | Statement::While { .. }
             | Statement::CreateProcedure(_)
             | Statement::DropProcedure { .. }
+            | Statement::CreateFunction(_)
+            | Statement::DropFunction { .. }
             | Statement::Commit { .. }
     )
 }
@@ -2361,6 +2521,15 @@ fn analyze_statements_locks(
                         }
                     }
                 }
+                // A scalar function the query calls reads tables through its
+                // body; lock those up front too (2PL), or the body would read
+                // with no lock held. read_lock_object_ids recurses the body.
+                for oid in select_function_read_ids(storage, &expanded) {
+                    add(Resource::Database, LockMode::IntentShared);
+                    if !versioned_reads {
+                        add(Resource::Table(oid), LockMode::Shared);
+                    }
+                }
             }
             Statement::Insert(insert) => {
                 if let Some(def) = resolve_table(storage, &insert.table.value) {
@@ -2409,6 +2578,10 @@ fn analyze_statements_locks(
                             add(Resource::Database, LockMode::IntentShared);
                             add(Resource::Table(oid), LockMode::Shared);
                         }
+                    }
+                    for oid in select_function_read_ids(storage, &expanded) {
+                        add(Resource::Database, LockMode::IntentShared);
+                        add(Resource::Table(oid), LockMode::Shared);
                     }
                 }
             }
@@ -2569,7 +2742,10 @@ fn analyze_statements_locks(
                 }
             }
             // Procedure DDL rewrites the catalog: Database X, like other DDL.
-            Statement::CreateProcedure(_) | Statement::DropProcedure { .. } => {
+            Statement::CreateProcedure(_)
+            | Statement::DropProcedure { .. }
+            | Statement::CreateFunction(_)
+            | Statement::DropFunction { .. } => {
                 add(Resource::Database, LockMode::Exclusive);
             }
             // IF/WHILE conditions read tables through their subqueries —
@@ -2587,6 +2763,12 @@ fn analyze_statements_locks(
                         if !versioned_reads {
                             add(Resource::Table(oid), LockMode::Shared);
                         }
+                    }
+                }
+                for oid in expr_function_read_ids(storage, condition) {
+                    add(Resource::Database, LockMode::IntentShared);
+                    if !versioned_reads {
+                        add(Resource::Table(oid), LockMode::Shared);
                     }
                 }
             }
@@ -2718,6 +2900,20 @@ fn exec_statement_dispatch(
                 return Err(ddl_in_txn_err());
             }
             exec_drop_procedure(storage, name, *if_exists)
+        }
+        Statement::CreateFunction(create) => {
+            if txn_ctx.in_txn() {
+                return Err(ddl_in_txn_err());
+            }
+            exec_create_function(storage, create)
+        }
+        Statement::DropFunction {
+            name, if_exists, ..
+        } => {
+            if txn_ctx.in_txn() {
+                return Err(ddl_in_txn_err());
+            }
+            exec_drop_function(storage, name, *if_exists)
         }
         // Executed by `run_block`'s own arms; nothing routes them here.
         Statement::Block { .. }
@@ -4418,7 +4614,9 @@ fn exec_drop_table(storage: &Storage, drop: &DropTable) -> Result<StatementResul
     // The object exists but is the wrong type, so error even under IF EXISTS
     // rather than silently no-op — the review showed DROP TABLE silently
     // DESTROYING a procedure through the shared catalog path.
-    if resolve_table(storage, &drop.table.value).is_some_and(|d| d.is_view() || d.is_procedure()) {
+    if resolve_table(storage, &drop.table.value)
+        .is_some_and(|d| d.is_view() || d.is_procedure() || d.is_function())
+    {
         return Err(SqlError::new(
             3701,
             11,
@@ -4620,6 +4818,185 @@ fn exec_drop_procedure(
             5,
             format!(
                 "Cannot drop the procedure '{}', because it does not exist or you do not have \
+                 permission.",
+                name.value
+            ),
+        )),
+    }
+}
+
+fn exec_create_function(
+    storage: &Storage,
+    create: &CreateFunction,
+) -> Result<StatementResult, SqlError> {
+    let bare = strip_schema(&create.name.value);
+    let params = create
+        .params
+        .iter()
+        .map(|p| -> Result<ProcParamDef, SqlError> {
+            let column_type = data_type_to_column_type(&p.data_type, &p.name)?;
+            if let Some(text) = &p.default_text {
+                let expr = truthdb_sql::parse_expr(text)?;
+                if !constant_default(&expr) {
+                    return Err(SqlError::new(
+                        102,
+                        15,
+                        1,
+                        format!(
+                            "The default for parameter '@{}' must be a constant.",
+                            p.name
+                        ),
+                    )
+                    .at(p.span));
+                }
+            }
+            Ok(ProcParamDef {
+                name: p.name.clone(),
+                type_spec: column_type.name(),
+                default: p.default_text.clone(),
+                output: false,
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let ReturnsClause::Scalar(return_type) = &create.returns;
+    let return_type = data_type_to_column_type(return_type, bare)?;
+    // Validate the body: it must be side-effect-free and end in RETURN <expr>
+    // (SQL Server's function-body rules). Re-parse under the function grammar.
+    let body = truthdb_sql::parse_function_body(&create.body)?;
+    validate_scalar_function_body(&body)?;
+    let function = FunctionDef {
+        params,
+        returns: FunctionReturns::Scalar {
+            type_spec: return_type.name(),
+            body: create.body.clone(),
+        },
+    };
+    if create.alter {
+        match resolve_table(storage, &create.name.value) {
+            Some(def) if def.is_function() => {
+                storage
+                    .rel_alter_function(&def.name, function)
+                    .map_err(|e| map_storage_err(e, &create.name.value))?;
+                return Ok(StatementResult::Done);
+            }
+            _ => {
+                return Err(SqlError::invalid_object(bare).at(create.name.span));
+            }
+        }
+    }
+    if resolve_table(storage, &create.name.value).is_some() {
+        return Err(SqlError::new(
+            2714,
+            16,
+            6,
+            format!("There is already an object named '{bare}' in the database."),
+        ));
+    }
+    storage
+        .rel_create_function(bare, function)
+        .map_err(|e| map_storage_err(e, &create.name.value))?;
+    Ok(StatementResult::Done)
+}
+
+/// Validates a scalar function's body against SQL Server's rules: every
+/// statement must be side-effect-free (443 otherwise; a data-returning SELECT is
+/// 444), and the last statement must be a `RETURN <expr>` (455).
+fn validate_scalar_function_body(statements: &[Statement]) -> Result<(), SqlError> {
+    for statement in statements {
+        check_function_statement(statement)?;
+    }
+    match last_effective_statement(statements) {
+        Some(Statement::Return { value: Some(_), .. }) => Ok(()),
+        _ => Err(SqlError::new(
+            455,
+            16,
+            2,
+            "The last statement included within a function must be a return statement.",
+        )),
+    }
+}
+
+/// The body's terminal statement, unwrapping a trailing `BEGIN...END` block —
+/// SQL Server's 455 check looks at the last statement of the body block.
+fn last_effective_statement(statements: &[Statement]) -> Option<&Statement> {
+    match statements.last() {
+        Some(Statement::Block { body, .. }) => last_effective_statement(body),
+        other => other,
+    }
+}
+
+/// Rejects a statement a function body may not contain. Side-effecting
+/// statements (DML, DDL, EXEC, transaction control, THROW/RAISERROR) are 443; a
+/// data-returning SELECT is 444; control flow recurses.
+fn check_function_statement(statement: &Statement) -> Result<(), SqlError> {
+    match statement {
+        Statement::Declare(_)
+        | Statement::Set(_)
+        | Statement::Return { .. }
+        | Statement::Break { .. }
+        | Statement::Continue { .. } => Ok(()),
+        Statement::Block { body, .. } => {
+            for inner in body {
+                check_function_statement(inner)?;
+            }
+            Ok(())
+        }
+        Statement::If {
+            then_branch,
+            else_branch,
+            ..
+        } => {
+            check_function_statement(then_branch)?;
+            if let Some(else_branch) = else_branch {
+                check_function_statement(else_branch)?;
+            }
+            Ok(())
+        }
+        Statement::While { body, .. } => check_function_statement(body),
+        // An assignment SELECT (`SELECT @x = …`) is allowed — it returns no
+        // rows. A SELECT that produces a result set cannot (444).
+        Statement::Select(select)
+            if select
+                .items
+                .iter()
+                .all(|i| matches!(i, SelectItem::Assign { .. })) =>
+        {
+            Ok(())
+        }
+        Statement::Select(_) => Err(SqlError::new(
+            444,
+            16,
+            2,
+            "Select statements included within a function cannot return data to a client.",
+        )),
+        _ => Err(SqlError::new(
+            443,
+            16,
+            1,
+            "Invalid use of a side-effecting operator within a function.",
+        )),
+    }
+}
+
+fn exec_drop_function(
+    storage: &Storage,
+    name: &Name,
+    if_exists: bool,
+) -> Result<StatementResult, SqlError> {
+    match resolve_table(storage, &name.value) {
+        Some(def) if def.is_function() => {
+            storage
+                .rel_drop_table(&def.name)
+                .map_err(|e| map_storage_err(e, &def.name))?;
+            Ok(StatementResult::Done)
+        }
+        Some(_) | None if if_exists => Ok(StatementResult::Done),
+        _ => Err(SqlError::new(
+            3701,
+            11,
+            5,
+            format!(
+                "Cannot drop the function '{}', because it does not exist or you do not have \
                  permission.",
                 name.value
             ),
@@ -6403,7 +6780,7 @@ fn from_column_names(storage: &Storage, from: &TableRef) -> Option<Vec<(Option<S
             // A view defers to its expansion; a PROCEDURE must not read as a
             // zero-column table — bailing here routes to the collecting path,
             // which errors 2809.
-            if def.is_view() || def.is_procedure() {
+            if def.is_view() || def.is_procedure() || def.is_function() {
                 return None;
             }
             let qualifier = alias
@@ -6982,6 +7359,80 @@ fn substitute_from_outer_refs(
 /// Evaluates each correlated subquery in `expr` against `outer_row` (binding the
 /// enclosing query's columns per `outer`) and replaces it with a literal —
 /// producing a subquery-free predicate for that outer row.
+/// A [`ColumnResolver`] over a bare name→index closure (the `outer` resolver the
+/// correlated-substitution pass carries), so a user scalar function's arguments
+/// can be evaluated against the current row.
+struct FnResolver<'a>(&'a dyn Fn(&str) -> Option<usize>);
+
+impl truthdb_sql::eval::ColumnResolver for FnResolver<'_> {
+    fn resolve(&self, name: &str) -> Option<usize> {
+        (self.0)(name)
+    }
+}
+
+/// Resolves a function-call name to a user-defined SCALAR function, or `None`
+/// (an unknown name, a built-in, or a table-valued function). Schema-qualified
+/// (`dbo.f`) and bare names both resolve; a bare name that shadows a built-in
+/// takes the user function (a documented minor divergence from SQL Server, which
+/// requires schema-qualified UDF calls).
+fn resolve_scalar_function(storage: &Storage, name: &str) -> Option<TableDef> {
+    let def = resolve_table(storage, name)?;
+    match def.function.as_ref()?.returns {
+        FunctionReturns::Scalar { .. } => Some(def),
+    }
+}
+
+/// True if an expression contains a call to a user-defined scalar function —
+/// which, like a subquery, cannot be evaluated by the pure eval crate and must
+/// be rewritten to a literal per row first.
+fn expr_has_user_function(storage: &Storage, expr: &Expr) -> bool {
+    let has = |e: &Expr| expr_has_user_function(storage, e);
+    match &expr.kind {
+        ExprKind::Function { name, args } => {
+            resolve_scalar_function(storage, name).is_some() || args.iter().any(has)
+        }
+        ExprKind::Null
+        | ExprKind::Int(_)
+        | ExprKind::Number(_)
+        | ExprKind::Str(_)
+        | ExprKind::Bool(_)
+        | ExprKind::Literal(_)
+        | ExprKind::Column(_)
+        | ExprKind::GlobalVar(_)
+        | ExprKind::LocalVar(_)
+        | ExprKind::Subquery(_)
+        | ExprKind::Exists(_)
+        | ExprKind::InSubquery { .. } => false,
+        ExprKind::Unary { expr: e, .. }
+        | ExprKind::IsNull { expr: e, .. }
+        | ExprKind::Cast { expr: e, .. } => has(e),
+        ExprKind::Binary { left, right, .. } => has(left) || has(right),
+        ExprKind::Like {
+            expr: e, pattern, ..
+        } => has(e) || has(pattern),
+        ExprKind::InList { expr: e, list, .. } => has(e) || list.iter().any(has),
+        ExprKind::Between {
+            expr: e, low, high, ..
+        } => has(e) || has(low) || has(high),
+        ExprKind::Aggregate { arg, .. } => arg.as_deref().is_some_and(has),
+        ExprKind::Case {
+            operand,
+            branches,
+            else_result,
+        } => {
+            operand.as_deref().is_some_and(has)
+                || branches.iter().any(|(w, r)| has(w) || has(r))
+                || else_result.as_deref().is_some_and(has)
+        }
+    }
+}
+
+/// True if an expression needs the per-row storage-aware rewrite (a subquery or
+/// a user scalar function) before the pure evaluator can run on it.
+fn expr_needs_binding(storage: &Storage, expr: &Expr) -> bool {
+    expr_has_subquery(expr) || expr_has_user_function(storage, expr)
+}
+
 fn substitute_correlated_in_expr(
     storage: &Storage,
     expr: &Expr,
@@ -7078,10 +7529,26 @@ fn substitute_correlated_in_expr(
             high: recur_box(high)?,
             negated: *negated,
         },
-        ExprKind::Function { name, args } => ExprKind::Function {
-            name: name.clone(),
-            args: args.iter().map(&recur).collect::<Result<_, _>>()?,
-        },
+        ExprKind::Function { name, args } => {
+            let args = args.iter().map(&recur).collect::<Result<Vec<_>, _>>()?;
+            // A call that resolves to a user scalar function runs its body once
+            // for this row (its arguments evaluated against the row) and folds to
+            // the returned value — the same rewrite-to-literal discipline
+            // subqueries use, keeping scalar evaluation free of storage access.
+            if let Some(def) = resolve_scalar_function(storage, name) {
+                let resolver = FnResolver(outer);
+                let values = args
+                    .iter()
+                    .map(|a| eval::eval(a, outer_row, &resolver, eval_ctx))
+                    .collect::<Result<Vec<_>, _>>()?;
+                ExprKind::Literal(run_user_scalar_function(storage, &def, &values, eval_ctx)?)
+            } else {
+                ExprKind::Function {
+                    name: name.clone(),
+                    args,
+                }
+            }
+        }
         ExprKind::Aggregate {
             func,
             distinct,
@@ -7193,7 +7660,10 @@ fn exec_select(
     // numeric/string expression is rejected rather than silently coerced. Any
     // subquery left in the (already-rewritten) predicate is correlated: bind the
     // outer row into it and evaluate per row.
-    let where_correlated = select.where_clause.as_ref().is_some_and(expr_has_subquery);
+    let where_correlated = select
+        .where_clause
+        .as_ref()
+        .is_some_and(|w| expr_needs_binding(storage, w));
     let mut rows: Vec<Vec<Datum>> = Vec::new();
     // One row: filter it into `rows` or drop it. Shared by both input shapes.
     let take = |row: Vec<Datum>, rows: &mut Vec<Vec<Datum>>| -> Result<(), SqlError> {
@@ -7444,8 +7914,13 @@ fn scan_plan(storage: &Storage, select: &Select, eval_ctx: &EvalContext) -> Opti
     }
     // An uncorrelated subquery is executed by the rewrite this path skips; a
     // correlated one runs a query per row. (A subquery in the SELECT list is
-    // already excluded: it is not a bare column.)
-    if select.where_clause.as_ref().is_some_and(expr_has_subquery) {
+    // already excluded: it is not a bare column.) A user scalar function in the
+    // WHERE needs the same rewrite, so decline it here too.
+    if select
+        .where_clause
+        .as_ref()
+        .is_some_and(|w| expr_needs_binding(storage, w))
+    {
         return None;
     }
     // Whether every output column *could* be a source column, which is a
@@ -7485,7 +7960,7 @@ fn scan_plan(storage: &Storage, select: &Select, eval_ctx: &EvalContext) -> Opti
     // nothing and the scan would read the catalog root instead of the view. A
     // PROCEDURE has the same empty shape and must not stream as an empty
     // table: the collecting path rejects it (2809).
-    if def.view_query.is_some() || def.is_procedure() {
+    if def.view_query.is_some() || def.is_procedure() || def.is_function() {
         return None;
     }
     let schema = def.schema().ok()?;
@@ -8544,7 +9019,7 @@ fn project(
                 // subquery still present here is correlated (the rewrite pass
                 // left it for the per-row bind): substitute the outer row's
                 // values in, making it uncorrelated for that row.
-                let correlated = expr_has_subquery(expr);
+                let correlated = expr_needs_binding(storage, expr);
                 let mut values = Vec::with_capacity(rows.len());
                 for row in &row_sql {
                     let bound;
@@ -8815,6 +9290,175 @@ fn collect_expr_tables<'a>(expr: &'a Expr, out: &mut Vec<&'a Name>) {
     }
 }
 
+/// Collects, as OWNED names, the read-lock targets an expression reaches: the
+/// tables its subqueries reference and the (user or built-in) functions it
+/// calls. Unlike [`collect_expr_tables`], the results do not borrow the input,
+/// so they can be gathered from a separately-parsed scalar-function body — the
+/// key to locking a table-reading function's inner reads up front under 2PL.
+/// Built-in function names collected here resolve to nothing and are harmless.
+fn collect_expr_read_names(expr: &Expr, tables: &mut Vec<String>, funcs: &mut Vec<String>) {
+    match &expr.kind {
+        ExprKind::Function { name, args } => {
+            funcs.push(name.clone());
+            args.iter()
+                .for_each(|a| collect_expr_read_names(a, tables, funcs));
+        }
+        ExprKind::Subquery(select) | ExprKind::Exists(select) => {
+            collect_select_read_names(select, tables, funcs)
+        }
+        ExprKind::InSubquery { expr, subquery, .. } => {
+            collect_expr_read_names(expr, tables, funcs);
+            collect_select_read_names(subquery, tables, funcs);
+        }
+        ExprKind::Unary { expr, .. }
+        | ExprKind::IsNull { expr, .. }
+        | ExprKind::Cast { expr, .. } => collect_expr_read_names(expr, tables, funcs),
+        ExprKind::Binary { left, right, .. } => {
+            collect_expr_read_names(left, tables, funcs);
+            collect_expr_read_names(right, tables, funcs);
+        }
+        ExprKind::Like { expr, pattern, .. } => {
+            collect_expr_read_names(expr, tables, funcs);
+            collect_expr_read_names(pattern, tables, funcs);
+        }
+        ExprKind::InList { expr, list, .. } => {
+            collect_expr_read_names(expr, tables, funcs);
+            list.iter()
+                .for_each(|e| collect_expr_read_names(e, tables, funcs));
+        }
+        ExprKind::Between {
+            expr, low, high, ..
+        } => {
+            collect_expr_read_names(expr, tables, funcs);
+            collect_expr_read_names(low, tables, funcs);
+            collect_expr_read_names(high, tables, funcs);
+        }
+        ExprKind::Aggregate { arg, .. } => {
+            if let Some(a) = arg {
+                collect_expr_read_names(a, tables, funcs);
+            }
+        }
+        ExprKind::Case {
+            operand,
+            branches,
+            else_result,
+        } => {
+            if let Some(o) = operand {
+                collect_expr_read_names(o, tables, funcs);
+            }
+            for (w, r) in branches {
+                collect_expr_read_names(w, tables, funcs);
+                collect_expr_read_names(r, tables, funcs);
+            }
+            if let Some(e) = else_result {
+                collect_expr_read_names(e, tables, funcs);
+            }
+        }
+        ExprKind::Null
+        | ExprKind::Int(_)
+        | ExprKind::Number(_)
+        | ExprKind::Str(_)
+        | ExprKind::Bool(_)
+        | ExprKind::Literal(_)
+        | ExprKind::Column(_)
+        | ExprKind::GlobalVar(_)
+        | ExprKind::LocalVar(_) => {}
+    }
+}
+
+/// Owned read-name collection over a SELECT (see [`collect_expr_read_names`]).
+fn collect_select_read_names(select: &Select, tables: &mut Vec<String>, funcs: &mut Vec<String>) {
+    for cte in &select.ctes {
+        collect_select_read_names(&cte.query, tables, funcs);
+    }
+    if let Some(from) = &select.from {
+        collect_from_read_names(from, tables, funcs);
+    }
+    for item in &select.items {
+        if let SelectItem::Expr { expr, .. } | SelectItem::Assign { value: expr, .. } = item {
+            collect_expr_read_names(expr, tables, funcs);
+        }
+    }
+    for expr in select
+        .where_clause
+        .iter()
+        .chain(select.having.iter())
+        .chain(select.group_by.iter())
+    {
+        collect_expr_read_names(expr, tables, funcs);
+    }
+    for item in &select.order_by {
+        collect_expr_read_names(&item.expr, tables, funcs);
+    }
+}
+
+fn collect_from_read_names(tref: &TableRef, tables: &mut Vec<String>, funcs: &mut Vec<String>) {
+    match tref {
+        TableRef::Table { name, .. } => tables.push(name.value.clone()),
+        TableRef::Join {
+            left, right, on, ..
+        } => {
+            collect_from_read_names(left, tables, funcs);
+            collect_from_read_names(right, tables, funcs);
+            if let Some(on) = on {
+                collect_expr_read_names(on, tables, funcs);
+            }
+        }
+        TableRef::Derived { subquery, .. } => collect_select_read_names(subquery, tables, funcs),
+    }
+}
+
+/// Owned read-name collection over a scalar function body's statement (its
+/// reads come only from expressions — a data-returning statement is rejected at
+/// CREATE, 444).
+fn collect_statement_read_names(
+    statement: &Statement,
+    tables: &mut Vec<String>,
+    funcs: &mut Vec<String>,
+) {
+    match statement {
+        Statement::Return {
+            value: Some(expr), ..
+        } => collect_expr_read_names(expr, tables, funcs),
+        Statement::Set(SetStatement::Variable { value, .. }) => {
+            collect_expr_read_names(value, tables, funcs)
+        }
+        // An assignment SELECT in a function body reads its FROM tables.
+        Statement::Select(select) => collect_select_read_names(select, tables, funcs),
+        Statement::Declare(declarations) => {
+            for decl in declarations {
+                if let Some(init) = &decl.initializer {
+                    collect_expr_read_names(init, tables, funcs);
+                }
+            }
+        }
+        Statement::If {
+            condition,
+            then_branch,
+            else_branch,
+            ..
+        } => {
+            collect_expr_read_names(condition, tables, funcs);
+            collect_statement_read_names(then_branch, tables, funcs);
+            if let Some(e) = else_branch {
+                collect_statement_read_names(e, tables, funcs);
+            }
+        }
+        Statement::While {
+            condition, body, ..
+        } => {
+            collect_expr_read_names(condition, tables, funcs);
+            collect_statement_read_names(body, tables, funcs);
+        }
+        Statement::Block { body, .. } => {
+            for inner in body {
+                collect_statement_read_names(inner, tables, funcs);
+            }
+        }
+        _ => {}
+    }
+}
+
 /// A table's exposed name: its alias, else its (schema-stripped) name.
 fn exposed_name(name: &Name, alias: Option<&Name>) -> String {
     alias
@@ -8962,6 +9606,11 @@ fn build_table_source(
             // A procedure is not a queryable object (SQL Server 2809).
             if def.is_procedure() {
                 return Err(procedure_not_a_table(&def.name).at(name.span));
+            }
+            // A scalar function is not a rowset — it cannot appear in FROM.
+            // (Table-valued functions, added later, expand here instead.)
+            if def.is_function() {
+                return Err(function_not_a_table(&def.name).at(name.span));
             }
             // A view: run its stored SELECT as a derived table under the view's
             // qualifier. A view over another view expands recursively — building
@@ -9657,7 +10306,9 @@ fn sys_tables(storage: &Storage) -> Source {
     let rows = storage
         .rel_tables()
         .into_iter()
-        .filter(|def| !def.is_view())
+        // Only base tables. (The `!is_view()` filter alone let procedures leak
+        // in — a pre-existing gap — so exclude every non-table object kind.)
+        .filter(|def| !def.is_view() && !def.is_procedure() && !def.is_function())
         .map(|def| vec![Datum::Int(def.object_id as i32), Datum::NVarChar(def.name)])
         .collect();
     let collations = vec![None; columns.len()];
@@ -9811,11 +10462,16 @@ fn sys_sql_modules(storage: &Storage) -> Source {
         .rel_tables()
         .into_iter()
         .filter_map(|def| {
-            // Views store their SELECT; procedures their body text.
+            // Views store their SELECT; procedures and functions their body.
             let definition = def
                 .view_query
                 .clone()
-                .or_else(|| def.procedure.as_ref().map(|p| p.body.clone()))?;
+                .or_else(|| def.procedure.as_ref().map(|p| p.body.clone()))
+                .or_else(|| {
+                    def.function.as_ref().map(|f| match &f.returns {
+                        FunctionReturns::Scalar { body, .. } => body.clone(),
+                    })
+                })?;
             Some(vec![
                 Datum::Int(def.object_id as i32),
                 Datum::NVarChar(definition),
@@ -9865,19 +10521,55 @@ fn sys_parameters(storage: &Storage) -> Source {
         int_col("has_default_value"),
     ];
     let mut rows = Vec::new();
+    let mut push_param = |object_id: u32,
+                          name: String,
+                          id: i32,
+                          type_spec: String,
+                          output: bool,
+                          has_default: bool| {
+        rows.push(vec![
+            Datum::Int(object_id as i32),
+            Datum::NVarChar(name),
+            Datum::Int(id),
+            Datum::NVarChar(type_spec),
+            Datum::Int(i32::from(output)),
+            Datum::Int(i32::from(has_default)),
+        ]);
+    };
     for def in storage.rel_tables() {
-        let Some(procedure) = &def.procedure else {
-            continue;
-        };
-        for (index, param) in procedure.params.iter().enumerate() {
-            rows.push(vec![
-                Datum::Int(def.object_id as i32),
-                Datum::NVarChar(format!("@{}", param.name)),
-                Datum::Int(index as i32 + 1),
-                Datum::NVarChar(param.type_spec.clone()),
-                Datum::Int(i32::from(param.output)),
-                Datum::Int(i32::from(param.default.is_some())),
-            ]);
+        if let Some(procedure) = &def.procedure {
+            for (index, param) in procedure.params.iter().enumerate() {
+                push_param(
+                    def.object_id,
+                    format!("@{}", param.name),
+                    index as i32 + 1,
+                    param.type_spec.clone(),
+                    param.output,
+                    param.default.is_some(),
+                );
+            }
+        } else if let Some(function) = &def.function {
+            // A scalar function's return value is parameter_id 0 with an empty
+            // name and is_output set (SQL Server's convention).
+            let FunctionReturns::Scalar { type_spec, .. } = &function.returns;
+            push_param(
+                def.object_id,
+                String::new(),
+                0,
+                type_spec.clone(),
+                true,
+                false,
+            );
+            for (index, param) in function.params.iter().enumerate() {
+                push_param(
+                    def.object_id,
+                    format!("@{}", param.name),
+                    index as i32 + 1,
+                    param.type_spec.clone(),
+                    false,
+                    param.default.is_some(),
+                );
+            }
         }
     }
     let collations = vec![None; columns.len()];
@@ -9901,8 +10593,13 @@ fn sys_objects(storage: &Storage) -> Source {
         .rel_tables()
         .into_iter()
         .map(|def| {
-            // SQL Server's type codes carry a trailing space.
-            let (code, desc) = if def.is_procedure() {
+            // SQL Server's single-letter codes carry a trailing space; the
+            // two-letter function codes fill CHAR(2) exactly.
+            let (code, desc) = if let Some(function) = &def.function {
+                match function.returns {
+                    FunctionReturns::Scalar { .. } => ("FN", "SQL_SCALAR_FUNCTION"),
+                }
+            } else if def.is_procedure() {
                 ("P ", "SQL_STORED_PROCEDURE")
             } else if def.is_view() {
                 ("V ", "VIEW")
@@ -10131,6 +10828,33 @@ fn read_lock_object_ids(storage: &Storage, name: &str) -> Vec<u32> {
     out
 }
 
+/// The base-table object ids the scalar functions called in a SELECT read
+/// through their bodies (deduped). Non-function names collected along the way
+/// resolve to nothing.
+fn select_function_read_ids(storage: &Storage, select: &Select) -> Vec<u32> {
+    let mut tables = Vec::new();
+    let mut funcs = Vec::new();
+    collect_select_read_names(select, &mut tables, &mut funcs);
+    let mut out = Vec::new();
+    for func in &funcs {
+        collect_read_lock_ids(storage, func, 0, &mut out);
+    }
+    out
+}
+
+/// Like [`select_function_read_ids`] but for a bare expression (an IF/WHILE
+/// condition).
+fn expr_function_read_ids(storage: &Storage, expr: &Expr) -> Vec<u32> {
+    let mut tables = Vec::new();
+    let mut funcs = Vec::new();
+    collect_expr_read_names(expr, &mut tables, &mut funcs);
+    let mut out = Vec::new();
+    for func in &funcs {
+        collect_read_lock_ids(storage, func, 0, &mut out);
+    }
+    out
+}
+
 /// Resolves `name` to the base-table object ids the executor will read,
 /// recursing through nested views (so a view over a view locks the inner view's
 /// base tables). Bounded by [`MAX_VIEW_NESTING`] so a view cycle terminates.
@@ -10141,6 +10865,24 @@ fn collect_read_lock_ids(storage: &Storage, name: &str, depth: u32, out: &mut Ve
     let Some(def) = resolve_table(storage, name) else {
         return;
     };
+    // A scalar function: its inner reads (subqueries in its body, nested
+    // function calls) must be locked up front, or the body would read tables
+    // with no lock held under 2PL — the seam-defect class. Recurse into the
+    // body's read targets, bounded by the same depth guard.
+    if let Some(function) = &def.function {
+        let FunctionReturns::Scalar { body, .. } = &function.returns;
+        if let Ok(statements) = truthdb_sql::parse_function_body(body) {
+            let mut tables = Vec::new();
+            let mut funcs = Vec::new();
+            for statement in &statements {
+                collect_statement_read_names(statement, &mut tables, &mut funcs);
+            }
+            for referenced in tables.iter().chain(funcs.iter()) {
+                collect_read_lock_ids(storage, referenced, depth + 1, out);
+            }
+        }
+        return;
+    }
     let Some(text) = &def.view_query else {
         // A base table.
         if !out.contains(&def.object_id) {
@@ -10166,6 +10908,9 @@ fn collect_read_lock_ids(storage: &Storage, name: &str, depth: u32, out: &mut Ve
 fn reject_dml_on_view(def: &TableDef) -> Result<(), SqlError> {
     if def.is_procedure() {
         return Err(procedure_not_a_table(&def.name));
+    }
+    if def.is_function() {
+        return Err(function_not_a_table(&def.name));
     }
     if def.is_view() {
         return Err(SqlError::new(
@@ -10193,12 +10938,29 @@ fn procedure_not_a_table(name: &str) -> SqlError {
     )
 }
 
+/// A scalar function used where a table is required (`FROM`, DML target,
+/// table-only DDL). A scalar function is not a rowset; SQL Server 4121-class.
+fn function_not_a_table(name: &str) -> SqlError {
+    SqlError::new(
+        4121,
+        16,
+        1,
+        format!(
+            "Cannot find the user-defined function '{name}', or the name refers to a scalar \
+             function that cannot be used where a table is expected."
+        ),
+    )
+}
+
 /// Table-only DDL (ALTER TABLE, CREATE INDEX) rejects a view. Without this a
 /// view's `root_page = 0` would be heap-scanned — and page 0 is the catalog
 /// root, so a bare `ALTER TABLE view ADD CHECK (1=1)` could corrupt the catalog.
 fn reject_view_as_table(def: &TableDef) -> Result<(), SqlError> {
     if def.is_procedure() {
         return Err(procedure_not_a_table(&def.name));
+    }
+    if def.is_function() {
+        return Err(function_not_a_table(&def.name));
     }
     if def.is_view() {
         return Err(SqlError::new(

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -1350,7 +1350,11 @@ fn enter_condition_scopes<'a>(
 ) -> Result<(Option<SnapshotScope<'a>>, Option<TxnSnapshotScope>), SqlError> {
     let mut tables = Vec::new();
     collect_expr_tables(condition, &mut tables);
-    if tables.is_empty() {
+    // A scalar function the condition calls may read tables through its body;
+    // those reads must observe the same snapshot as a direct read (the lock
+    // analysis already resolved them), so arm the scope when the condition
+    // reaches any table directly OR through a called function.
+    if tables.is_empty() && expr_function_read_ids(storage, condition).is_empty() {
         return Ok((None, None));
     }
     match txn_ctx.isolation() {
@@ -1946,41 +1950,52 @@ fn current_snapshot() -> Option<ReadSnapshot> {
 struct SnapshotScope<'a> {
     storage: &'a Storage,
     seq: u64,
+    /// The snapshot that was current when this scope was entered, restored on
+    /// exit. Scopes can nest — a scalar function's body statement runs under the
+    /// caller's active statement/transaction snapshot — so a nested scope must
+    /// restore the caller's snapshot on drop, not erase it.
+    prev: Option<ReadSnapshot>,
 }
 
 impl<'a> SnapshotScope<'a> {
     fn enter(storage: &'a Storage, own_txn: Option<u64>) -> Self {
+        let prev = CURRENT_SNAPSHOT.get();
         let snap = storage.capture_read_snapshot(own_txn);
         CURRENT_SNAPSHOT.set(Some(snap));
         SnapshotScope {
             storage,
             seq: snap.seq,
+            prev,
         }
     }
 }
 
 impl Drop for SnapshotScope<'_> {
     fn drop(&mut self) {
-        CURRENT_SNAPSHOT.set(None);
+        CURRENT_SNAPSHOT.set(self.prev);
         self.storage.release_read_snapshot(self.seq);
     }
 }
 
 /// Statement-scoped view of a TRANSACTION's snapshot (SNAPSHOT isolation):
-/// sets the thread-local for this statement and clears it on exit, but the
-/// registration lives with the transaction, not the statement.
-struct TxnSnapshotScope;
+/// sets the thread-local for this statement and restores the prior one on exit
+/// (see [`SnapshotScope::prev`]), but the registration lives with the
+/// transaction, not the statement.
+struct TxnSnapshotScope {
+    prev: Option<ReadSnapshot>,
+}
 
 impl TxnSnapshotScope {
     fn enter(snap: ReadSnapshot) -> Self {
+        let prev = CURRENT_SNAPSHOT.get();
         CURRENT_SNAPSHOT.set(Some(snap));
-        TxnSnapshotScope
+        TxnSnapshotScope { prev }
     }
 }
 
 impl Drop for TxnSnapshotScope {
     fn drop(&mut self) {
-        CURRENT_SNAPSHOT.set(None);
+        CURRENT_SNAPSHOT.set(self.prev);
     }
 }
 
@@ -1988,13 +2003,17 @@ impl Drop for TxnSnapshotScope {
 /// only when its FROM/subqueries name one. `SELECT 1` under SNAPSHOT must
 /// neither raise 3952 nor establish the transaction's snapshot — SQL Server
 /// defers both to the first read of an actual object.
-fn statement_reads_tables(statement: &Statement) -> bool {
+fn statement_reads_tables(storage: &Storage, statement: &Statement) -> bool {
     match statement {
         Statement::Select(select) => {
             let expanded = expand_ctes(select);
             let mut tables = Vec::new();
             collect_locked_tables(&expanded, &mut tables);
-            !tables.is_empty()
+            // A scalar function the SELECT calls reads tables through its body;
+            // that read must observe the statement/transaction snapshot too, so
+            // it counts as a table access (matching the lock analysis, which
+            // resolves the same function bodies).
+            !tables.is_empty() || !select_function_read_ids(storage, &expanded).is_empty()
         }
         _ => true,
     }
@@ -2055,7 +2074,7 @@ fn exec_statement_streamed(
                 txn_ctx.txn.as_ref().map(StorageTxn::txn_id),
             ));
         }
-        Isolation::Snapshot if data_access && statement_reads_tables(statement) => {
+        Isolation::Snapshot if data_access && statement_reads_tables(storage, statement) => {
             if !storage.snapshot_isolation_allowed() {
                 if txn_ctx.in_txn() {
                     txn_ctx.doomed = true;
@@ -7376,6 +7395,13 @@ impl truthdb_sql::eval::ColumnResolver for FnResolver<'_> {
 /// takes the user function (a documented minor divergence from SQL Server, which
 /// requires schema-qualified UDF calls).
 fn resolve_scalar_function(storage: &Storage, name: &str) -> Option<TableDef> {
+    // A bare (unqualified) name that matches a built-in always binds to the
+    // built-in — a same-named UDF is reached only by its schema-qualified name
+    // (`dbo.abs`), as SQL Server requires. Without this a UDF named like a
+    // built-in would silently hijack every unqualified call to that name.
+    if !name.contains('.') && truthdb_sql::functions::is_builtin_function(name) {
+        return None;
+    }
     let def = resolve_table(storage, name)?;
     match def.function.as_ref()?.returns {
         FunctionReturns::Scalar { .. } => Some(def),
@@ -10890,16 +10916,19 @@ fn collect_read_lock_ids(storage: &Storage, name: &str, depth: u32, out: &mut Ve
         }
         return;
     };
-    // A view: recurse into every table its body references. Inline the body's
-    // own CTEs so a base table reached only through a CTE is still locked.
+    // A view: recurse into every table its body references — and every scalar
+    // function it calls, whose body may read further tables (else a UDF reached
+    // through a view would read unlocked). Inline the body's own CTEs so a base
+    // table reached only through a CTE is still locked.
     let Ok(body) = parse_view_query(text, &def.name) else {
         return;
     };
     let expanded = expand_ctes(&body);
-    let mut names = Vec::new();
-    collect_locked_tables(&expanded, &mut names);
-    for referenced in names {
-        collect_read_lock_ids(storage, &referenced.value, depth + 1, out);
+    let mut tables = Vec::new();
+    let mut funcs = Vec::new();
+    collect_select_read_names(&expanded, &mut tables, &mut funcs);
+    for referenced in tables.iter().chain(funcs.iter()) {
+        collect_read_lock_ids(storage, referenced, depth + 1, out);
     }
 }
 

--- a/crates/truthdb-core/src/relstore/catalog.rs
+++ b/crates/truthdb-core/src/relstore/catalog.rs
@@ -122,6 +122,12 @@ pub struct TableDef {
     /// procedure carries no data pages, columns, or key.
     #[serde(default)]
     pub procedure: Option<ProcedureDef>,
+    /// For a user-defined FUNCTION: its parameters, return shape, and body
+    /// source text, re-parsed at each call (the same view posture as a
+    /// procedure). `None` for every other object kind. A function carries no
+    /// data pages, columns, or key.
+    #[serde(default)]
+    pub function: Option<FunctionDef>,
 }
 
 /// A stored procedure's catalog payload: declared parameters and body text.
@@ -146,6 +152,26 @@ pub struct ProcParamDef {
     pub output: bool,
 }
 
+/// A user-defined function's catalog payload: its declared parameters (reusing
+/// [`ProcParamDef`], with `output` always false — functions have no OUTPUT
+/// parameters) and its return shape.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FunctionDef {
+    pub params: Vec<ProcParamDef>,
+    pub returns: FunctionReturns,
+}
+
+/// A function's return shape. Only the scalar form exists today; the inline and
+/// multi-statement table-valued forms are added by later work (the enum is
+/// forward-compatible — an old catalog only ever holds `Scalar`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum FunctionReturns {
+    /// `RETURNS <type> AS BEGIN … RETURN <expr>; END`: a scalar UDF. `type_spec`
+    /// is the declared return type (same round-trip as a column type); `body` is
+    /// the source text after `AS`, re-parsed per call.
+    Scalar { type_spec: String, body: String },
+}
+
 impl TableDef {
     /// True if this catalog entry is a view rather than a base table.
     pub fn is_view(&self) -> bool {
@@ -155,6 +181,11 @@ impl TableDef {
     /// True if this catalog entry is a stored procedure.
     pub fn is_procedure(&self) -> bool {
         self.procedure.is_some()
+    }
+
+    /// True if this catalog entry is a user-defined function.
+    pub fn is_function(&self) -> bool {
+        self.function.is_some()
     }
 }
 

--- a/crates/truthdb-core/src/storage.rs
+++ b/crates/truthdb-core/src/storage.rs
@@ -578,6 +578,30 @@ impl Storage {
         result
     }
 
+    pub fn rel_create_function(
+        &self,
+        name: &str,
+        function: crate::relstore::catalog::FunctionDef,
+    ) -> Result<(), StorageError> {
+        let result = self.lock().rel_create_function(name, function);
+        // Like a procedure: a table-reading function changes which locks a batch
+        // that references it must hold, so a parked batch analyzed against the
+        // old catalog carries a stale lock set — bump so the grant path
+        // re-analyzes.
+        self.bump_lock_epoch();
+        result
+    }
+
+    pub fn rel_alter_function(
+        &self,
+        name: &str,
+        function: crate::relstore::catalog::FunctionDef,
+    ) -> Result<(), StorageError> {
+        let result = self.lock().rel_alter_function(name, function);
+        self.bump_lock_epoch();
+        result
+    }
+
     pub fn rel_table(&self, name: &str) -> Option<TableDef> {
         self.lock().rel_table(name)
     }
@@ -1376,6 +1400,7 @@ impl StorageFile {
                 foreign_keys,
                 view_query: None,
                 procedure: None,
+                function: None,
                 counter_page: Some(counter_page),
             };
             catalog::insert_table(ctx, &mut OpMode::Txn(txn), catalog_root, &def)?;
@@ -1428,6 +1453,7 @@ impl StorageFile {
                 foreign_keys: Vec::new(),
                 view_query: Some(query),
                 procedure: None,
+                function: None,
                 counter_page: None,
             };
             catalog::insert_table(ctx, &mut OpMode::Txn(txn), catalog_root, &def)?;
@@ -1476,12 +1502,96 @@ impl StorageFile {
                 foreign_keys: Vec::new(),
                 view_query: None,
                 procedure: Some(procedure),
+                function: None,
                 counter_page: None,
             };
             catalog::insert_table(ctx, &mut OpMode::Txn(txn), catalog_root, &def)?;
             Ok(def)
         })?;
         self.rel.next_object_id += 1;
+        self.rel.tables.insert(name.to_string(), def);
+        Ok(())
+    }
+
+    /// Records a user-defined function in the catalog (`CREATE FUNCTION`): its
+    /// parameters, return shape, and body text (the view posture — re-parsed at
+    /// each call).
+    pub fn rel_create_function(
+        &mut self,
+        name: &str,
+        function: crate::relstore::catalog::FunctionDef,
+    ) -> Result<(), StorageError> {
+        self.ensure_rel_usable()?;
+        if self.rel.tables.contains_key(name) {
+            return Err(StorageError::Constraint(format!(
+                "object '{name}' already exists"
+            )));
+        }
+        if self.rel.catalog_root.is_none() {
+            let root = {
+                let mut ctx = self.rel_ctx();
+                catalog::create_catalog(&mut ctx)?
+            };
+            self.rel.catalog_root = Some(root);
+        }
+        let catalog_root = self.rel.catalog_root.expect("catalog exists");
+        let object_id = self.rel.next_object_id;
+        let func_name = name.to_string();
+        let def = self.rel_statement(move |ctx, txn| {
+            let def = TableDef {
+                object_id,
+                name: func_name,
+                columns: Vec::new(),
+                key_columns: Vec::new(),
+                root_page: 0,
+                defaults: Vec::new(),
+                collations: Vec::new(),
+                identity: None,
+                indexes: Vec::new(),
+                check_constraints: Vec::new(),
+                foreign_keys: Vec::new(),
+                view_query: None,
+                procedure: None,
+                function: Some(function),
+                counter_page: None,
+            };
+            catalog::insert_table(ctx, &mut OpMode::Txn(txn), catalog_root, &def)?;
+            Ok(def)
+        })?;
+        self.rel.next_object_id += 1;
+        self.rel.tables.insert(name.to_string(), def);
+        Ok(())
+    }
+
+    /// Replaces an existing function's definition (`ALTER FUNCTION`): the object
+    /// id is kept, the stored definition swapped.
+    pub fn rel_alter_function(
+        &mut self,
+        name: &str,
+        function: crate::relstore::catalog::FunctionDef,
+    ) -> Result<(), StorageError> {
+        self.ensure_rel_usable()?;
+        let Some(existing) = self.rel.tables.get(name) else {
+            return Err(StorageError::Constraint(format!(
+                "function '{name}' does not exist"
+            )));
+        };
+        if !existing.is_function() {
+            return Err(StorageError::Constraint(format!(
+                "object '{name}' is not a function"
+            )));
+        }
+        let mut def = existing.clone();
+        def.function = Some(function);
+        let catalog_root = self
+            .rel
+            .catalog_root
+            .expect("functions live in the catalog");
+        let write = def.clone();
+        self.rel_statement(move |ctx, txn| {
+            catalog::update_table(ctx, &mut OpMode::Txn(txn), catalog_root, &write)?;
+            Ok(())
+        })?;
         self.rel.tables.insert(name.to_string(), def);
         Ok(())
     }

--- a/crates/truthdb-core/tests/slt/functions.slt
+++ b/crates/truthdb-core/tests/slt/functions.slt
@@ -1,0 +1,192 @@
+# Scalar user-defined functions (Stage 15): CREATE/ALTER/DROP FUNCTION, per-row
+# evaluation in SELECT/WHERE, nested calls, table-reading bodies, side-effect
+# restrictions, and the catalog views.
+
+statement ok
+CREATE FUNCTION dbo.addone (@x INT) RETURNS INT AS BEGIN RETURN @x + 1 END
+
+# A scalar call folds to its returned value (schema-qualified and bare).
+query I
+SELECT dbo.addone(5)
+----
+6
+
+query I
+SELECT addone(41)
+----
+42
+
+# Per-row over a table, in the SELECT list and the WHERE clause.
+statement ok
+CREATE TABLE ft (id INT NOT NULL PRIMARY KEY)
+
+statement ok
+INSERT INTO ft VALUES (1), (2), (3)
+
+query I rowsort
+SELECT dbo.addone(id) FROM ft
+----
+2
+3
+4
+
+query I rowsort
+SELECT id FROM ft WHERE dbo.addone(id) > 3
+----
+3
+
+# Control flow in the body.
+statement ok
+CREATE FUNCTION dbo.absval (@x INT) RETURNS INT AS BEGIN IF @x < 0 RETURN -@x; RETURN @x END
+
+query II
+SELECT dbo.absval(-7), dbo.absval(7)
+----
+7 7
+
+# One function calling another (nested); shares the nesting budget.
+statement ok
+CREATE FUNCTION dbo.addtwo (@x INT) RETURNS INT AS BEGIN RETURN dbo.addone(dbo.addone(@x)) END
+
+query I
+SELECT dbo.addtwo(10)
+----
+12
+
+# A body that reads a table (its inner reads are locked up front).
+statement ok
+CREATE FUNCTION dbo.rowcount () RETURNS INT AS BEGIN RETURN (SELECT COUNT(*) FROM ft) END
+
+query I
+SELECT dbo.rowcount()
+----
+3
+
+# An assignment SELECT (returns no rows) is allowed and reads its FROM table.
+statement ok
+CREATE FUNCTION dbo.rowcount2 () RETURNS INT AS BEGIN DECLARE @c INT; SELECT @c = COUNT(*) FROM ft; RETURN @c END
+
+query I
+SELECT dbo.rowcount2()
+----
+3
+
+# A non-INT return type.
+statement ok
+CREATE FUNCTION dbo.greet (@who NVARCHAR(50)) RETURNS NVARCHAR(80) AS BEGIN RETURN N'hello ' + @who END
+
+query T
+SELECT dbo.greet(N'world')
+----
+hello world
+
+# NULL flows through.
+query I
+SELECT dbo.addone(NULL)
+----
+NULL
+
+# ALTER FUNCTION replaces the definition.
+statement ok
+ALTER FUNCTION dbo.addone (@x INT) RETURNS INT AS BEGIN RETURN @x + 10 END
+
+query I
+SELECT dbo.addone(5)
+----
+15
+
+# DROP FUNCTION.
+statement ok
+DROP FUNCTION dbo.addtwo
+
+statement error
+SELECT dbo.addtwo(1)
+
+# --- Side-effect restrictions (function bodies must be side-effect-free) ---
+
+# INSERT/UPDATE/DELETE in a function body is rejected (443).
+statement error
+CREATE FUNCTION dbo.bad_dml (@x INT) RETURNS INT AS BEGIN INSERT INTO ft VALUES (@x); RETURN @x END
+
+# A data-returning SELECT is rejected (444).
+statement error
+CREATE FUNCTION dbo.bad_select () RETURNS INT AS BEGIN SELECT id FROM ft; RETURN 1 END
+
+# The last statement must be a RETURN (455).
+statement error
+CREATE FUNCTION dbo.no_return (@x INT) RETURNS INT AS BEGIN SET @x = @x + 1 END
+
+# EXEC of a procedure in a function body is rejected (443).
+statement error
+CREATE FUNCTION dbo.bad_exec () RETURNS INT AS BEGIN EXEC sp_executesql N'SELECT 1'; RETURN 1 END
+
+# Transaction control in a function body is rejected (443).
+statement error
+CREATE FUNCTION dbo.bad_txn () RETURNS INT AS BEGIN BEGIN TRANSACTION; RETURN 1 END
+
+# A function parameter cannot be OUTPUT.
+statement error
+CREATE FUNCTION dbo.bad_output (@x INT OUTPUT) RETURNS INT AS BEGIN RETURN @x END
+
+# --- Namespace classification (a scalar function is not a table) ---
+
+statement ok
+CREATE FUNCTION dbo.two () RETURNS INT AS BEGIN RETURN 2 END
+
+# A scalar function cannot appear in FROM.
+statement error
+SELECT * FROM dbo.two
+
+# It is not a DML target.
+statement error
+INSERT INTO dbo.two VALUES (1)
+
+# DROP TABLE must not destroy a function.
+statement error
+DROP TABLE dbo.two
+
+# EXEC of a function is not a procedure call (2812).
+statement error
+EXEC dbo.two
+
+# A name already used by a table cannot be a function, and vice versa.
+statement error
+CREATE FUNCTION ft () RETURNS INT AS BEGIN RETURN 1 END
+
+# --- Catalog views ---
+
+query T
+SELECT type FROM sys.objects WHERE name = 'two'
+----
+FN
+
+query T
+SELECT type_desc FROM sys.objects WHERE name = 'greet'
+----
+SQL_SCALAR_FUNCTION
+
+# sys.parameters: the return value is parameter_id 0 (is_output 1), then the
+# declared parameters (1-based).
+query III rowsort
+SELECT parameter_id, is_output, has_default_value FROM sys.parameters WHERE object_id = (SELECT object_id FROM sys.objects WHERE name = 'greet')
+----
+0 1 0
+1 0 0
+
+# The declared parameter keeps its @-prefixed name.
+query T
+SELECT name FROM sys.parameters WHERE object_id = (SELECT object_id FROM sys.objects WHERE name = 'greet') AND parameter_id = 1
+----
+@who
+
+# sys.sql_modules carries the body text.
+query T
+SELECT definition FROM sys.sql_modules WHERE object_id = (SELECT object_id FROM sys.objects WHERE name = 'two')
+----
+BEGIN RETURN 2 END
+
+# A function does not appear in sys.tables (only base tables do).
+query I
+SELECT COUNT(*) FROM sys.tables WHERE name = 'two'
+----
+0

--- a/crates/truthdb-sql/src/ast.rs
+++ b/crates/truthdb-sql/src/ast.rs
@@ -108,6 +108,15 @@ pub enum Statement {
         if_exists: bool,
         span: Span,
     },
+    /// `CREATE FUNCTION` / `ALTER FUNCTION` — the body is stored as source text
+    /// (the view posture) and re-parsed at each call.
+    CreateFunction(CreateFunction),
+    /// `DROP FUNCTION [IF EXISTS] <name>`.
+    DropFunction {
+        name: Name,
+        if_exists: bool,
+        span: Span,
+    },
 }
 
 /// `CREATE|ALTER PROC[EDURE] <name> [@p TYPE [= default] [OUTPUT], ...] AS <body>`.
@@ -120,6 +129,27 @@ pub struct CreateProcedure {
     /// `ALTER PROCEDURE` replaces an existing definition.
     pub alter: bool,
     pub span: Span,
+}
+
+/// `CREATE|ALTER FUNCTION <name> ( [@p TYPE [= default], ...] ) RETURNS <ret> AS <body>`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CreateFunction {
+    pub name: Name,
+    pub params: Vec<ProcParam>,
+    pub returns: ReturnsClause,
+    /// The body's source text: everything after `AS`, verbatim (scalar form).
+    pub body: String,
+    /// `ALTER FUNCTION` replaces an existing definition.
+    pub alter: bool,
+    pub span: Span,
+}
+
+/// A function's declared return shape. Only the scalar form exists today; the
+/// table-valued forms are added by later work.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ReturnsClause {
+    /// `RETURNS <scalar type>`: a scalar UDF.
+    Scalar(DataType),
 }
 
 /// One declared procedure parameter.

--- a/crates/truthdb-sql/src/functions.rs
+++ b/crates/truthdb-sql/src/functions.rs
@@ -7,6 +7,65 @@ use crate::error::{SqlError, SqlResult};
 use crate::temporal;
 use crate::value::SqlValue;
 
+/// The built-in scalar and session function names (case-insensitive), used to
+/// keep a same-named user-defined function from hijacking a built-in when called
+/// by its bare (unqualified) name — SQL Server binds a one-part function name to
+/// the built-in and requires a two-part name (`dbo.f`) for a UDF.
+pub fn is_builtin_function(name: &str) -> bool {
+    const BUILTINS: &[&str] = &[
+        // Scalar built-ins (eval_function, below).
+        "ISNULL",
+        "COALESCE",
+        "IIF",
+        "NULLIF",
+        "LEN",
+        "DATALENGTH",
+        "UPPER",
+        "LOWER",
+        "LTRIM",
+        "RTRIM",
+        "TRIM",
+        "REVERSE",
+        "LEFT",
+        "RIGHT",
+        "SUBSTRING",
+        "CHARINDEX",
+        "REPLACE",
+        "REPLICATE",
+        "CONCAT",
+        "ABS",
+        "CEILING",
+        "FLOOR",
+        "SIGN",
+        "SQRT",
+        "ROUND",
+        "POWER",
+        "YEAR",
+        "MONTH",
+        "DAY",
+        "DATEPART",
+        "DATEADD",
+        "DATEDIFF",
+        "CAST",
+        "CONVERT",
+        // Session / niladic functions (eval::eval_session_function, SERVERPROPERTY).
+        "DB_NAME",
+        "SUSER_SNAME",
+        "SUSER_NAME",
+        "SCOPE_IDENTITY",
+        "ERROR_NUMBER",
+        "ERROR_MESSAGE",
+        "ERROR_SEVERITY",
+        "ERROR_STATE",
+        "ERROR_LINE",
+        "ERROR_PROCEDURE",
+        "XACT_STATE",
+        "SERVERPROPERTY",
+    ];
+    let upper = name.to_ascii_uppercase();
+    BUILTINS.contains(&upper.as_str())
+}
+
 pub fn eval_function(name: &str, args: Vec<SqlValue>) -> SqlResult<SqlValue> {
     let upper = name.to_ascii_uppercase();
     match upper.as_str() {

--- a/crates/truthdb-sql/src/lib.rs
+++ b/crates/truthdb-sql/src/lib.rs
@@ -38,6 +38,15 @@ pub fn parse_procedure_body(sql: &str) -> SqlResult<Vec<Statement>> {
     parser.parse_statements()
 }
 
+/// Parses a scalar-function body: the in-function grammar, where `RETURN <expr>`
+/// yields the function's mandatory typed result.
+pub fn parse_function_body(sql: &str) -> SqlResult<Vec<Statement>> {
+    let tokens = lexer::Lexer::new(sql).tokenize()?;
+    let mut parser = parser::Parser::from_tokens(sql, tokens);
+    parser.set_in_function();
+    parser.parse_statements()
+}
+
 /// Parses a single standalone expression (e.g. a column DEFAULT re-parsed at
 /// INSERT time). Rejects trailing tokens.
 pub fn parse_expr(sql: &str) -> SqlResult<Expr> {

--- a/crates/truthdb-sql/src/parser.rs
+++ b/crates/truthdb-sql/src/parser.rs
@@ -35,6 +35,10 @@ pub struct Parser {
     while_depth: usize,
     /// Parsing a stored-procedure body: `RETURN <value>` is then legal.
     in_procedure: bool,
+    /// Parsing a scalar-function body: `RETURN <expr>` is mandatory and yields
+    /// the function's typed result, so the value is always parsed (not gated on
+    /// a leading-token whitelist) and the 178 batch-return check does not apply.
+    in_function: bool,
     /// Nesting depth inside blocks / IF branches / WHILE bodies — procedure
     /// DDL must be top-level (SQL Server 156/111 classes).
     sub_depth: usize,
@@ -58,6 +62,7 @@ impl Parser {
             depth: 0,
             while_depth: 0,
             in_procedure: false,
+            in_function: false,
             sub_depth: 0,
             statement_index: 0,
             nodes: 0,
@@ -98,6 +103,12 @@ impl Parser {
     /// entry for parsing a stored procedure's body text.
     pub fn set_in_procedure(&mut self) {
         self.in_procedure = true;
+    }
+
+    /// Switches to the in-function grammar (`RETURN <expr>` mandatory): the
+    /// entry for parsing a scalar function's body text.
+    pub fn set_in_function(&mut self) {
+        self.in_function = true;
     }
 
     /// Parses exactly one expression followed by EOF (for a re-parsed DEFAULT).
@@ -313,6 +324,18 @@ impl Parser {
     /// start one (T-SQL RETURN takes an integer expression).
     fn parse_return(&mut self) -> SqlResult<Statement> {
         let start = self.expect_keyword("RETURN")?;
+        // A scalar function's RETURN yields its mandatory typed result, so the
+        // expression is always parsed (it commonly begins with a word — a
+        // column, CASE, CAST, NULL, or a nested call — which the batch/procedure
+        // whitelist below deliberately excludes).
+        if self.in_function {
+            let value = self.parse_expr()?;
+            let end = self.prev_span();
+            return Ok(Statement::Return {
+                span: start.to(end),
+                value: Some(value),
+            });
+        }
         let has_value = matches!(
             self.peek().kind,
             TokenKind::Int(_)
@@ -807,6 +830,7 @@ impl Parser {
             Some("PROCEDURE") | Some("PROC") if !unique => {
                 self.parse_create_procedure(start, false)
             }
+            Some("FUNCTION") if !unique => self.parse_create_function(start, false),
             _ => {
                 let token = self.peek().clone();
                 Err(SqlError::syntax(self.token_text(&token), token.span))
@@ -1317,6 +1341,9 @@ impl Parser {
         ) {
             return self.parse_create_procedure(start, true);
         }
+        if self.peek_keyword().as_deref() == Some("FUNCTION") {
+            return self.parse_create_function(start, true);
+        }
         self.expect_keyword("TABLE")?;
         let table = self.parse_name()?;
         let (action, end) = match self.peek_keyword().as_deref() {
@@ -1414,6 +1441,7 @@ impl Parser {
             Some("TABLE") => self.parse_drop_table(start),
             Some("VIEW") => self.parse_drop_view(start),
             Some("PROCEDURE") | Some("PROC") => self.parse_drop_procedure(start),
+            Some("FUNCTION") => self.parse_drop_function(start),
             _ => {
                 let token = self.peek().clone();
                 Err(SqlError::syntax(self.token_text(&token), token.span))
@@ -1538,6 +1566,127 @@ impl Parser {
         };
         let name = self.parse_name()?;
         Ok(Statement::DropProcedure {
+            span: start.to(name.span),
+            name,
+            if_exists,
+        })
+    }
+
+    /// `CREATE|ALTER FUNCTION <name> ( [params] ) RETURNS <type> AS <body>`.
+    /// Only the scalar form is parsed here; the body is validated by parsing it
+    /// (with `RETURN <expr>` mandatory) and stored as source text.
+    fn parse_create_function(&mut self, start: Span, alter: bool) -> SqlResult<Statement> {
+        self.bump(); // FUNCTION
+        if self.in_procedure || self.in_function {
+            return Err(
+                SqlError::new(156, 15, 1, "Incorrect syntax near the keyword 'FUNCTION'.")
+                    .at(start),
+            );
+        }
+        if self.statement_index > 0 || self.sub_depth > 0 {
+            return Err(SqlError::new(
+                111,
+                15,
+                1,
+                "'CREATE/ALTER FUNCTION' must be the first statement in a query batch.",
+            )
+            .at(start));
+        }
+        let name = self.parse_name()?;
+        // Function parameter lists are always parenthesized (SQL Server requires
+        // the parentheses even for a zero-parameter function).
+        self.expect(&TokenKind::LParen)?;
+        let mut params = Vec::new();
+        while matches!(self.peek().kind, TokenKind::LocalVar(_)) {
+            let token = self.bump();
+            let TokenKind::LocalVar(param_name) = &token.kind else {
+                unreachable!("matched above");
+            };
+            let param_name = param_name.clone();
+            let param_start = token.span;
+            let (data_type, mut end) = self.parse_data_type()?;
+            let default_text = if self.eat(&TokenKind::Eq) {
+                let expr_start = self.peek().span.start;
+                let expr = self.parse_expr()?;
+                end = expr.span;
+                Some(
+                    self.slice(Span::new(expr_start, expr.span.end))
+                        .trim()
+                        .to_string(),
+                )
+            } else {
+                None
+            };
+            // A function parameter cannot be OUTPUT (SQL Server 156-class); the
+            // executor re-checks, but reject the keyword early for a clear error.
+            if matches!(self.peek_keyword().as_deref(), Some("OUTPUT") | Some("OUT")) {
+                let token = self.peek().clone();
+                return Err(SqlError::syntax(self.token_text(&token), token.span));
+            }
+            params.push(ProcParam {
+                name: param_name,
+                data_type,
+                default_text,
+                output: false,
+                span: param_start.to(end),
+            });
+            if !self.eat(&TokenKind::Comma) {
+                break;
+            }
+        }
+        self.expect(&TokenKind::RParen)?;
+        self.expect_keyword("RETURNS")?;
+        // Scalar form only: the return is a system type. (RETURNS TABLE / @t
+        // TABLE — the table-valued forms — are added by later work; a TABLE
+        // return type falls through to parse_data_type's 243.)
+        let (return_type, _) = self.parse_data_type()?;
+        let returns = ReturnsClause::Scalar(return_type);
+        self.expect_keyword("AS")?;
+        let body_start = self.peek().span.start;
+        let body = self.src[body_start..].trim().to_string();
+        if body.is_empty() {
+            let token = self.peek().clone();
+            return Err(SqlError::syntax(self.token_text(&token), token.span));
+        }
+        self.in_function = true;
+        let validated = (|| -> SqlResult<()> {
+            loop {
+                while self.eat(&TokenKind::Semicolon) {}
+                if self.at_eof() {
+                    return Ok(());
+                }
+                self.nodes = 0;
+                self.parse_statement()?;
+                if !self.at_eof() && !self.check(&TokenKind::Semicolon) {
+                    let token = self.peek().clone();
+                    return Err(SqlError::syntax(self.token_text(&token), token.span));
+                }
+            }
+        })();
+        self.in_function = false;
+        validated?;
+        let span = start.to(self.prev_span());
+        Ok(Statement::CreateFunction(CreateFunction {
+            name,
+            params,
+            returns,
+            body,
+            alter,
+            span,
+        }))
+    }
+
+    fn parse_drop_function(&mut self, start: Span) -> SqlResult<Statement> {
+        self.bump(); // FUNCTION
+        let if_exists = if self.peek_keyword().as_deref() == Some("IF") {
+            self.bump();
+            self.expect_keyword("EXISTS")?;
+            true
+        } else {
+            false
+        };
+        let name = self.parse_name()?;
+        Ok(Statement::DropFunction {
             span: start.to(name.span),
             name,
             if_exists,
@@ -2587,8 +2736,11 @@ impl Parser {
                     }
                     _ => {
                         let name = self.parse_name()?;
-                        // A single identifier followed by `(` is a function call.
-                        if !name.value.contains('.') && self.check(&TokenKind::LParen) {
+                        // A name followed by `(` is a function call — including a
+                        // schema-qualified one (`dbo.f(@x)`), the canonical way to
+                        // call a user-defined function. A column reference is
+                        // never followed by `(`, so this never misreads one.
+                        if self.check(&TokenKind::LParen) {
                             self.parse_function(name)
                         } else {
                             Ok(Expr {


### PR DESCRIPTION
# Stage 15: scalar user-defined functions (CREATE/ALTER/DROP FUNCTION)

The first of Stage 15's `CREATE FUNCTION` forms. A scalar UDF is stored as a catalog entry
(`FunctionDef` on `TableDef`, the view/procedure posture — body text re-parsed per call, so
`ALTER FUNCTION` between calls is recompile-on-schema-change for free) and invoked per-row inside
expressions.

## Parser
- `CREATE/ALTER/DROP FUNCTION` dispatched alongside `PROCEDURE`; a `RETURNS <type>` clause; a
  function-body grammar where `RETURN <expr>` is mandatory and yields the typed result (the
  batch/procedure `RETURN` whitelist deliberately excludes word-initial expressions — a column,
  `CASE`, `CAST`, `NULL`, a nested call).
- `dbo.f(@x)` — the canonical schema-qualified UDF call — now parses: the dot-guard on a
  name-before-`(` is relaxed (a column is never followed by `(`, so this never misreads one).

## Execution
A scalar call can't be resolved in the pure eval crate, so — exactly like a subquery — the executor
rewrites `f(args)` to a literal per row before evaluating (`substitute_correlated_in_expr`'s
`Function` arm → `resolve_scalar_function` → `run_user_scalar_function`), gated by
`expr_needs_binding` at the same sites subqueries use: SELECT list, WHERE, IF/WHILE conditions; the
scan fast path declines a UDF-bearing WHERE. The body runs in an isolated throwaway `TxnContext`
(only parameters visible, no transaction, table reads observe the caller's ambient snapshot), and
`RETURN` coerces to the declared type via a new `func_return` channel. Nesting shares the
`EXEC_DEPTH` budget (217); because the context has no transaction, a body error always aborts the
calling statement.

## Lock seam (2PL)
A table-reading function's inner reads are locked up front: `analyze_locks` resolves a called
function's name and recurses into its body's read targets (subqueries, nested calls) — the
expression-level analog of the EXEC recursion. Without this, a function body would read tables with
no lock held (the seam-defect class). Covered for SELECT, INSERT…SELECT, and IF/WHILE.

## Restrictions (validated at CREATE)
The body must be side-effect-free — DML, EXEC, DDL, transaction control → 443; a data-returning
SELECT → 444 (an assignment `SELECT @x = …` is allowed); the last statement must be `RETURN` → 455.
A function parameter cannot be OUTPUT.

## Catalog / namespace
`sys.objects` FN/SQL_SCALAR_FUNCTION; `sys.parameters` emits the return value as parameter_id 0 then
the parameters; `sys.sql_modules` carries the body. A scalar function is rejected where a table is
required (FROM, DML target, table-only DDL), `DROP TABLE` won't destroy it, and it no longer leaks
into `sys.tables` (which also excludes procedures now — a pre-existing gap fixed in passing).

## Tests
`functions.slt` (per-row eval in SELECT/WHERE, nested + table-reading bodies, control flow,
NVARCHAR/NULL, assignment-SELECT bodies, ALTER/DROP, the restriction and classification errors,
catalog views) and two engine tests: the lock seam across SELECT/WHERE/IF, and caller-local
isolation (137) + body-error propagation (8134) + recursion cap (217).

## Not yet (documented scope)
Table-valued functions (`RETURNS TABLE` / `@t TABLE`); UDFs in ORDER BY / GROUP BY / HAVING / CHECK /
aggregate-arg / join-ON positions — the same scope as subqueries today, and a clean 195 error there.

## Adversarial review

A five-lens review (lock seam, eval coverage, context isolation, validation bypass, catalog/coercion) with refute-by-default verification confirmed six defects, all fixed and mutation-teeth-checked. The lock analysis had been taught to recurse into UDF bodies, but four other table-read decision sites re-derived that decision syntactically and didn't — the "decisions derived twice must agree" seam:

- **HIGH** — a table-reading UDF read with neither a lock nor a snapshot when the calling statement/condition names no base table (RCSI/SNAPSHOT drops Table-S expecting a versioned read, but `statement_reads_tables` / `enter_condition_scopes` didn't arm the snapshot for a UDF-only read → dirty read). Both now recurse into called-function bodies, matching the lock analysis.
- **HIGH** — a UDF reached *through a view* wasn't lock-analyzed (the view-branch collector was tables-only). Now collects functions in the view body too.
- **MEDIUM** — nested `SnapshotScope::drop` clobbered the caller's ambient snapshot to `None`; now saves/restores the prior snapshot.
- **MEDIUM** — a UDF named like a built-in silently hijacked it for unqualified calls; a bare built-in name now binds to the built-in (the UDF is reached only by `dbo.name`).

Refuted: UDF result-column type inference is a pre-existing engine-wide behavior, not UDF-specific.
