### PR TITLE
Stage 15: inline table-valued functions (RETURNS TABLE AS RETURN(select))

### DIFF
--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -5767,6 +5767,46 @@ mod tests {
     }
 
     #[test]
+    fn inline_tvf_body_tables_locked_and_snapshotted() {
+        use crate::lock::{LockMode, Resource};
+        use crate::rel::Isolation;
+        let path = unique_temp_path("tvf-seam");
+        let engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE secret (z INT NOT NULL PRIMARY KEY)")
+            .expect("secret");
+        engine
+            .execute(
+                "CREATE FUNCTION dbo.rows_of (@x INT) RETURNS TABLE AS \
+                 RETURN (SELECT z FROM secret WHERE z >= @x)",
+            )
+            .expect("tvf");
+        let secret = table_object_id(&engine, "secret");
+        // A TVF in FROM must Shared-lock the table its body reads, up front.
+        let locks = engine.analyze_locks("SELECT z FROM dbo.rows_of(1)", Isolation::ReadCommitted);
+        assert!(
+            locks.contains(&(Resource::Table(secret), LockMode::Shared)),
+            "a TVF's body table must be Shared-locked: {locks:?}"
+        );
+        // And it must arm the snapshot scope: under SNAPSHOT-not-allowed a TVF
+        // whose body reads a table raises 3952 (the body IS a data access).
+        let mut ctx = TxnContext::default();
+        batch(
+            &engine,
+            &mut ctx,
+            "SET TRANSACTION ISOLATION LEVEL SNAPSHOT",
+        );
+        let out = batch(&engine, &mut ctx, "SELECT z FROM dbo.rows_of(1)");
+        assert_eq!(
+            out.error.as_ref().map(|e| e.number),
+            Some(3952),
+            "a TVF-reading SELECT must arm the snapshot scope: {:?}",
+            out.error
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
     fn cf_review_describe_stops_at_control_flow() {
         // sp_describe_first_result_set: a batch whose FIRST possible rowset
         // sits inside an IF must answer "not statically derivable" — skipping

--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -5807,6 +5807,64 @@ mod tests {
     }
 
     #[test]
+    fn recursive_function_lock_analysis_terminates() {
+        use crate::rel::Isolation;
+        let path = unique_temp_path("udf-recursion-bomb");
+        let engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE t (id INT NOT NULL PRIMARY KEY)")
+            .expect("t");
+        // A self-referencing TVF whose body references itself TWICE (fan-out 2):
+        // without the visited-set memoization in collect_read_lock_ids this
+        // recurses ~2^32 times and hangs analysis (and, under the scheduler
+        // mutex, the whole server). Run in a thread so a regression FAILS
+        // cleanly on the timeout rather than hanging the test binary.
+        engine
+            .execute(
+                "CREATE FUNCTION dbo.bomb (@x INT) RETURNS TABLE AS \
+                 RETURN (SELECT a.id FROM dbo.bomb(@x) AS a JOIN dbo.bomb(@x) AS b ON a.id = b.id)",
+            )
+            .expect("bomb");
+        let (tx, rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let _ = engine.analyze_locks("SELECT id FROM dbo.bomb(1)", Isolation::ReadCommitted);
+            let _ = tx.send(());
+        });
+        assert!(
+            rx.recv_timeout(std::time::Duration::from_secs(10)).is_ok(),
+            "lock analysis of a recursive function must terminate (memoization)"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn showplan_names_a_table_valued_function() {
+        let path = unique_temp_path("tvf-showplan");
+        let engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE nums (id INT NOT NULL PRIMARY KEY, grp INT NOT NULL)")
+            .expect("nums");
+        engine
+            .execute(
+                "CREATE FUNCTION dbo.in_group (@g INT) RETURNS TABLE AS \
+                 RETURN (SELECT id FROM nums WHERE grp = @g)",
+            )
+            .expect("tvf");
+        // A lone TVF in FROM must not render as a phantom nested-loops join over
+        // a base table named after the function.
+        let plan = plan_lines(&engine, "SELECT id FROM dbo.in_group(20)");
+        assert!(
+            plan.iter().any(|l| l.contains("Table-valued Function")),
+            "plan names the TVF: {plan:?}"
+        );
+        assert!(
+            !plan.iter().any(|l| l.contains("Nested Loops")),
+            "no phantom join: {plan:?}"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
     fn cf_review_describe_stops_at_control_flow() {
         // sp_describe_first_result_set: a batch whose FIRST possible rowset
         // sits inside an IF must answer "not statically derivable" — skipping

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -1032,7 +1032,10 @@ fn run_user_scalar_function(
     caller: &EvalContext,
 ) -> Result<SqlValue, SqlError> {
     let function = def.function.as_ref().expect("checked by the caller");
-    let FunctionReturns::Scalar { type_spec, body } = &function.returns;
+    // The caller (resolve_scalar_function) only routes scalar functions here.
+    let FunctionReturns::Scalar { type_spec, body } = &function.returns else {
+        return Err(function_not_a_table(&def.name));
+    };
     if arg_values.len() < function.params.len() {
         return Err(SqlError::new(
             313,
@@ -4877,19 +4880,28 @@ fn exec_create_function(
             })
         })
         .collect::<Result<Vec<_>, _>>()?;
-    let ReturnsClause::Scalar(return_type) = &create.returns;
-    let return_type = data_type_to_column_type(return_type, bare)?;
-    // Validate the body: it must be side-effect-free and end in RETURN <expr>
-    // (SQL Server's function-body rules). Re-parse under the function grammar.
-    let body = truthdb_sql::parse_function_body(&create.body)?;
-    validate_scalar_function_body(&body)?;
-    let function = FunctionDef {
-        params,
-        returns: FunctionReturns::Scalar {
-            type_spec: return_type.name(),
-            body: create.body.clone(),
-        },
+    let returns = match &create.returns {
+        ReturnsClause::Scalar(return_type) => {
+            let return_type = data_type_to_column_type(return_type, bare)?;
+            // Validate the body: side-effect-free, ending in RETURN <expr> (SQL
+            // Server's function-body rules). Re-parse under the function grammar.
+            let body = truthdb_sql::parse_function_body(&create.body)?;
+            validate_scalar_function_body(&body)?;
+            FunctionReturns::Scalar {
+                type_spec: return_type.name(),
+                body: create.body.clone(),
+            }
+        }
+        ReturnsClause::InlineTable => {
+            // The body is a single SELECT expanded like a parameterized view —
+            // validate it parses (no side-effect body check: it is a query).
+            parse_view_query(&create.body, bare)?;
+            FunctionReturns::InlineTable {
+                select_text: create.body.clone(),
+            }
+        }
     };
+    let function = FunctionDef { params, returns };
     if create.alter {
         match resolve_table(storage, &create.name.value) {
             Some(def) if def.is_function() => {
@@ -6388,6 +6400,13 @@ fn expand_from_ctes(tref: &TableRef, resolved: &CteMap) -> TableRef {
             subquery: Box::new(expand_select_ctes(subquery, resolved)),
             alias: alias.clone(),
         },
+        // A TVF name is never a CTE (CTE names are unqualified); only its
+        // arguments may reference one.
+        TableRef::Function { name, args, alias } => TableRef::Function {
+            name: name.clone(),
+            args: args.iter().map(|a| expand_expr_ctes(a, resolved)).collect(),
+            alias: alias.clone(),
+        },
     }
 }
 
@@ -6854,6 +6873,9 @@ fn from_column_names(storage: &Storage, from: &TableRef) -> Option<Vec<(Option<S
             }
             Some(cols)
         }
+        // A TVF's output columns are its body SELECT's projection — only known
+        // after the body is parsed and bound, like a view. Defer to expansion.
+        TableRef::Function { .. } => None,
     }
 }
 
@@ -6966,6 +6988,9 @@ fn from_has_correlated_derived(
                 || from_has_correlated_derived(storage, Some(right), outer)
         }
         Some(TableRef::Derived { subquery, .. }) => is_correlated(storage, subquery, outer),
+        // A TVF's literal/non-outer arguments do not correlate it to the outer
+        // FROM (APPLY, with outer-referencing args, is out of scope).
+        Some(TableRef::Function { .. }) => false,
     }
 }
 
@@ -7372,6 +7397,9 @@ fn substitute_from_outer_refs(
             **subquery = substitute_subquery_outer_refs(storage, subquery, outer, outer_row)?;
             Some(())
         }
+        // A TVF's body lives in the catalog (bound at expansion, not here) and
+        // its literal arguments carry no outer references.
+        TableRef::Function { .. } => Some(()),
     }
 }
 
@@ -7405,6 +7433,8 @@ fn resolve_scalar_function(storage: &Storage, name: &str) -> Option<TableDef> {
     let def = resolve_table(storage, name)?;
     match def.function.as_ref()?.returns {
         FunctionReturns::Scalar { .. } => Some(def),
+        // A table-valued function is not a scalar call (it resolves in FROM).
+        FunctionReturns::InlineTable { .. } => None,
     }
 }
 
@@ -9112,6 +9142,7 @@ fn collect_table_names<'a>(tref: &'a TableRef, out: &mut Vec<&'a Name>) {
                 collect_table_names(from, out);
             }
         }
+        TableRef::Function { name, .. } => out.push(name),
     }
 }
 
@@ -9166,6 +9197,14 @@ fn collect_from_tables<'a>(tref: &'a TableRef, out: &mut Vec<&'a Name>) {
             }
         }
         TableRef::Derived { subquery, .. } => collect_locked_tables(subquery, out),
+        // A TVF in FROM: its name resolves (via read_lock_object_ids) to the
+        // tables its body reads, and its arguments may embed subqueries.
+        TableRef::Function { name, args, .. } => {
+            out.push(name);
+            for arg in args {
+                collect_expr_tables(arg, out);
+            }
+        }
     }
 }
 
@@ -9431,6 +9470,14 @@ fn collect_from_read_names(tref: &TableRef, tables: &mut Vec<String>, funcs: &mu
             }
         }
         TableRef::Derived { subquery, .. } => collect_select_read_names(subquery, tables, funcs),
+        // A TVF in FROM: push the name into `funcs` so select_function_read_ids
+        // recurses its body (the owned-collector twin of collect_from_tables).
+        TableRef::Function { name, args, .. } => {
+            funcs.push(name.value.clone());
+            for arg in args {
+                collect_expr_read_names(arg, tables, funcs);
+            }
+        }
     }
 }
 
@@ -9503,6 +9550,7 @@ fn collect_exposed_names(tref: &TableRef, out: &mut Vec<String>) {
             collect_exposed_names(right, out);
         }
         TableRef::Derived { alias, .. } => out.push(alias.value.clone()),
+        TableRef::Function { name, alias, .. } => out.push(exposed_name(name, alias.as_ref())),
     }
 }
 
@@ -9725,6 +9773,87 @@ fn build_table_source(
     })
 }
 
+/// Expands an inline table-valued function call `dbo.f(args) [AS alias]` in a
+/// FROM clause: binds the call's argument values to the function's `@params`,
+/// then runs its stored body SELECT as a derived table under the call's
+/// qualifier — a parameterized view. The body's table reads are locked and
+/// snapshotted up front by the lock analysis and the snapshot-scope arming,
+/// which both resolve the function name into its body (see collect_read_lock_ids
+/// and statement_reads_tables); the body reads under the caller's ambient
+/// snapshot on this thread. Recursion is bounded by the shared view-depth guard.
+fn build_function_source(
+    storage: &Storage,
+    name: &Name,
+    args: &[Expr],
+    alias: Option<&Name>,
+    eval_ctx: &EvalContext,
+) -> Result<Source, SqlError> {
+    let def = resolve_table(storage, &name.value)
+        .ok_or_else(|| SqlError::invalid_object(&name.value).at(name.span))?;
+    let function = def
+        .function
+        .as_ref()
+        .ok_or_else(|| function_not_a_table(&def.name).at(name.span))?;
+    let FunctionReturns::InlineTable { select_text } = &function.returns else {
+        // A scalar function called in table position is not a rowset.
+        return Err(function_not_a_table(&def.name).at(name.span));
+    };
+    if args.len() < function.params.len() {
+        return Err(SqlError::new(
+            313,
+            16,
+            3,
+            format!(
+                "An insufficient number of arguments were supplied for the procedure or function {}.",
+                def.name
+            ),
+        )
+        .at(name.span));
+    }
+    if args.len() > function.params.len() {
+        return Err(SqlError::new(
+            8144,
+            16,
+            2,
+            format!(
+                "Procedure or function {} has too many arguments specified.",
+                def.name
+            ),
+        )
+        .at(name.span));
+    }
+    // Bind the arguments to the parameters, coercing to the declared types, in a
+    // FRESH variable scope (a TVF body sees only its parameters, not caller
+    // locals). Arguments may themselves contain subqueries or scalar UDFs.
+    let no_outer = |_: &str| -> Option<usize> { None };
+    let mut variables = std::collections::HashMap::new();
+    for (param, arg) in function.params.iter().zip(args) {
+        let column_type = ColumnType::parse(&param.type_spec)
+            .map_err(|e| SqlError::message_only(245, e.to_string()))?;
+        let value = substitute_correlated_in_expr(storage, arg, &no_outer, &[], eval_ctx)
+            .and_then(|bound| eval_constant(&bound, eval_ctx))?;
+        let datum = value::sql_to_datum(&value, &column_type, &param.name)?;
+        variables.insert(
+            param.name.clone(),
+            value::datum_to_sql(&datum, &column_type),
+        );
+    }
+    let mut fn_ctx = eval_ctx.clone();
+    fn_ctx.variables = variables;
+    // Expand the body like a view (bounded by the shared nesting guard).
+    let _guard = ViewDepthGuard::enter(&def.name)?;
+    let body = parse_view_query(select_text, &def.name)?;
+    let qualifier = alias
+        .map(|a| a.value.clone())
+        .unwrap_or_else(|| strip_schema(&name.value).to_string());
+    let qual = Name {
+        value: qualifier,
+        quoted: false,
+        span: name.span,
+    };
+    build_derived_source(storage, &body, &qual, &fn_ctx)
+}
+
 /// Recursively builds a join tree's combined row source (base tables scan
 /// fully).
 fn build_join(
@@ -9748,6 +9877,9 @@ fn build_join(
         }
         TableRef::Derived { subquery, alias } => {
             build_derived_source(storage, subquery, alias, eval_ctx)
+        }
+        TableRef::Function { name, args, alias } => {
+            build_function_source(storage, name, args, alias.as_ref(), eval_ctx)
         }
     }
 }
@@ -10496,6 +10628,7 @@ fn sys_sql_modules(storage: &Storage) -> Source {
                 .or_else(|| {
                     def.function.as_ref().map(|f| match &f.returns {
                         FunctionReturns::Scalar { body, .. } => body.clone(),
+                        FunctionReturns::InlineTable { select_text } => select_text.clone(),
                     })
                 })?;
             Some(vec![
@@ -10575,17 +10708,19 @@ fn sys_parameters(storage: &Storage) -> Source {
                 );
             }
         } else if let Some(function) = &def.function {
-            // A scalar function's return value is parameter_id 0 with an empty
-            // name and is_output set (SQL Server's convention).
-            let FunctionReturns::Scalar { type_spec, .. } = &function.returns;
-            push_param(
-                def.object_id,
-                String::new(),
-                0,
-                type_spec.clone(),
-                true,
-                false,
-            );
+            // A SCALAR function's return value is parameter_id 0 (empty name,
+            // is_output set — SQL Server's convention). A table-valued function
+            // returns a table, so it has no scalar return parameter.
+            if let FunctionReturns::Scalar { type_spec, .. } = &function.returns {
+                push_param(
+                    def.object_id,
+                    String::new(),
+                    0,
+                    type_spec.clone(),
+                    true,
+                    false,
+                );
+            }
             for (index, param) in function.params.iter().enumerate() {
                 push_param(
                     def.object_id,
@@ -10624,6 +10759,9 @@ fn sys_objects(storage: &Storage) -> Source {
             let (code, desc) = if let Some(function) = &def.function {
                 match function.returns {
                     FunctionReturns::Scalar { .. } => ("FN", "SQL_SCALAR_FUNCTION"),
+                    FunctionReturns::InlineTable { .. } => {
+                        ("IF", "SQL_INLINE_TABLE_VALUED_FUNCTION")
+                    }
                 }
             } else if def.is_procedure() {
                 ("P ", "SQL_STORED_PROCEDURE")
@@ -10891,21 +11029,30 @@ fn collect_read_lock_ids(storage: &Storage, name: &str, depth: u32, out: &mut Ve
     let Some(def) = resolve_table(storage, name) else {
         return;
     };
-    // A scalar function: its inner reads (subqueries in its body, nested
-    // function calls) must be locked up front, or the body would read tables
-    // with no lock held under 2PL — the seam-defect class. Recurse into the
-    // body's read targets, bounded by the same depth guard.
+    // A function: its inner reads (subqueries in a scalar body, or an inline
+    // TVF's body SELECT, plus nested function calls) must be locked up front, or
+    // the body would read tables with no lock held under 2PL — the seam-defect
+    // class. Recurse into the body's read targets, bounded by the same guard.
     if let Some(function) = &def.function {
-        let FunctionReturns::Scalar { body, .. } = &function.returns;
-        if let Ok(statements) = truthdb_sql::parse_function_body(body) {
-            let mut tables = Vec::new();
-            let mut funcs = Vec::new();
-            for statement in &statements {
-                collect_statement_read_names(statement, &mut tables, &mut funcs);
+        let mut tables = Vec::new();
+        let mut funcs = Vec::new();
+        match &function.returns {
+            FunctionReturns::Scalar { body, .. } => {
+                if let Ok(statements) = truthdb_sql::parse_function_body(body) {
+                    for statement in &statements {
+                        collect_statement_read_names(statement, &mut tables, &mut funcs);
+                    }
+                }
             }
-            for referenced in tables.iter().chain(funcs.iter()) {
-                collect_read_lock_ids(storage, referenced, depth + 1, out);
+            FunctionReturns::InlineTable { select_text } => {
+                if let Ok(body) = parse_view_query(select_text, &def.name) {
+                    let expanded = expand_ctes(&body);
+                    collect_select_read_names(&expanded, &mut tables, &mut funcs);
+                }
             }
+        }
+        for referenced in tables.iter().chain(funcs.iter()) {
+            collect_read_lock_ids(storage, referenced, depth + 1, out);
         }
         return;
     }

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -3167,6 +3167,12 @@ fn showplan_rows(
             }
         }
         Some(TableRef::Table { name, .. }) => vec![format!("Table Scan({})", name.value)],
+        // A lone table-valued function call: name it honestly rather than
+        // letting it fall into the join catch-all (which would invent a
+        // "Nested Loops" over a phantom base table named after the function).
+        Some(TableRef::Function { name, .. }) => {
+            vec![format!("Table-valued Function({})", name.value)]
+        }
         Some(join) => {
             // Multi-table: a nested-loop join over full scans (Stage 8).
             let mut tables = Vec::new();
@@ -10988,7 +10994,8 @@ fn strip_schema(name: &str) -> &str {
 /// one level deep, matching the executor.
 fn read_lock_object_ids(storage: &Storage, name: &str) -> Vec<u32> {
     let mut out = Vec::new();
-    collect_read_lock_ids(storage, name, 0, &mut out);
+    let mut visited = std::collections::HashSet::new();
+    collect_read_lock_ids(storage, name, 0, &mut out, &mut visited);
     out
 }
 
@@ -11000,8 +11007,9 @@ fn select_function_read_ids(storage: &Storage, select: &Select) -> Vec<u32> {
     let mut funcs = Vec::new();
     collect_select_read_names(select, &mut tables, &mut funcs);
     let mut out = Vec::new();
+    let mut visited = std::collections::HashSet::new();
     for func in &funcs {
-        collect_read_lock_ids(storage, func, 0, &mut out);
+        collect_read_lock_ids(storage, func, 0, &mut out, &mut visited);
     }
     out
 }
@@ -11013,8 +11021,9 @@ fn expr_function_read_ids(storage: &Storage, expr: &Expr) -> Vec<u32> {
     let mut funcs = Vec::new();
     collect_expr_read_names(expr, &mut tables, &mut funcs);
     let mut out = Vec::new();
+    let mut visited = std::collections::HashSet::new();
     for func in &funcs {
-        collect_read_lock_ids(storage, func, 0, &mut out);
+        collect_read_lock_ids(storage, func, 0, &mut out, &mut visited);
     }
     out
 }
@@ -11022,13 +11031,27 @@ fn expr_function_read_ids(storage: &Storage, expr: &Expr) -> Vec<u32> {
 /// Resolves `name` to the base-table object ids the executor will read,
 /// recursing through nested views (so a view over a view locks the inner view's
 /// base tables). Bounded by [`MAX_VIEW_NESTING`] so a view cycle terminates.
-fn collect_read_lock_ids(storage: &Storage, name: &str, depth: u32, out: &mut Vec<u32>) {
+fn collect_read_lock_ids(
+    storage: &Storage,
+    name: &str,
+    depth: u32,
+    out: &mut Vec<u32>,
+    visited: &mut std::collections::HashSet<u32>,
+) {
     if depth > MAX_VIEW_NESTING || name.to_ascii_lowercase().starts_with("sys.") {
         return;
     }
     let Some(def) = resolve_table(storage, name) else {
         return;
     };
+    // Expand each function/view body at most once per analysis. The depth guard
+    // bounds recursion depth but NOT fan-out: a self- or mutually-referential
+    // body that references itself twice would otherwise recurse exponentially
+    // (2^depth), hanging analysis — and, because analyze_locks runs under the
+    // scheduler mutex, freezing every session.
+    if (def.is_function() || def.view_query.is_some()) && !visited.insert(def.object_id) {
+        return;
+    }
     // A function: its inner reads (subqueries in a scalar body, or an inline
     // TVF's body SELECT, plus nested function calls) must be locked up front, or
     // the body would read tables with no lock held under 2PL — the seam-defect
@@ -11052,7 +11075,7 @@ fn collect_read_lock_ids(storage: &Storage, name: &str, depth: u32, out: &mut Ve
             }
         }
         for referenced in tables.iter().chain(funcs.iter()) {
-            collect_read_lock_ids(storage, referenced, depth + 1, out);
+            collect_read_lock_ids(storage, referenced, depth + 1, out, visited);
         }
         return;
     }
@@ -11075,7 +11098,7 @@ fn collect_read_lock_ids(storage: &Storage, name: &str, depth: u32, out: &mut Ve
     let mut funcs = Vec::new();
     collect_select_read_names(&expanded, &mut tables, &mut funcs);
     for referenced in tables.iter().chain(funcs.iter()) {
-        collect_read_lock_ids(storage, referenced, depth + 1, out);
+        collect_read_lock_ids(storage, referenced, depth + 1, out, visited);
     }
 }
 

--- a/crates/truthdb-core/src/relstore/catalog.rs
+++ b/crates/truthdb-core/src/relstore/catalog.rs
@@ -170,6 +170,10 @@ pub enum FunctionReturns {
     /// is the declared return type (same round-trip as a column type); `body` is
     /// the source text after `AS`, re-parsed per call.
     Scalar { type_spec: String, body: String },
+    /// `RETURNS TABLE AS RETURN ( <select> )`: an inline table-valued function.
+    /// `select_text` is the body SELECT's source, re-parsed and expanded like a
+    /// parameterized view (the call's arguments bind to the `@params`).
+    InlineTable { select_text: String },
 }
 
 impl TableDef {

--- a/crates/truthdb-core/tests/slt/inline_tvf.slt
+++ b/crates/truthdb-core/tests/slt/inline_tvf.slt
@@ -1,0 +1,118 @@
+# Inline table-valued functions (Stage 15): RETURNS TABLE AS RETURN(select),
+# invoked in FROM as a parameterized view.
+
+statement ok
+CREATE TABLE nums (id INT NOT NULL PRIMARY KEY, grp INT NOT NULL)
+
+statement ok
+INSERT INTO nums VALUES (1, 10), (2, 10), (3, 20), (4, 20), (5, 20)
+
+statement ok
+CREATE FUNCTION dbo.in_group (@g INT) RETURNS TABLE AS RETURN (SELECT id FROM nums WHERE grp = @g)
+
+# Called in FROM; the argument binds to the body's @g.
+query I rowsort
+SELECT id FROM dbo.in_group(20)
+----
+3
+4
+5
+
+# Bare-name call and an alias.
+query I rowsort
+SELECT t.id FROM dbo.in_group(10) AS t
+----
+1
+2
+
+# Joined against a base table.
+statement ok
+CREATE TABLE label (id INT NOT NULL PRIMARY KEY, name NVARCHAR(20))
+
+statement ok
+INSERT INTO label VALUES (3, 'three'), (4, 'four'), (5, 'five')
+
+query IT rowsort
+SELECT g.id, l.name FROM dbo.in_group(20) AS g JOIN label AS l ON g.id = l.id
+----
+3 three
+4 four
+5 five
+
+# The argument can be an expression / a batch variable.
+query I rowsort
+SELECT id FROM dbo.in_group(10 + 10)
+----
+3
+4
+5
+
+# A projecting/aggregating body.
+statement ok
+CREATE FUNCTION dbo.group_count (@g INT) RETURNS TABLE AS RETURN (SELECT COUNT(*) AS n FROM nums WHERE grp = @g)
+
+query I
+SELECT n FROM dbo.group_count(20)
+----
+3
+
+# A TVF selecting from another TVF (nesting, bounded by the view-depth guard).
+statement ok
+CREATE FUNCTION dbo.in_group_twice (@g INT) RETURNS TABLE AS RETURN (SELECT id FROM dbo.in_group(@g) WHERE id > 3)
+
+query I rowsort
+SELECT id FROM dbo.in_group_twice(20)
+----
+4
+5
+
+# Wrong argument count is an error.
+statement error
+SELECT id FROM dbo.in_group()
+
+statement error
+SELECT id FROM dbo.in_group(1, 2)
+
+# A scalar function called in FROM (with args) is not a rowset.
+statement ok
+CREATE FUNCTION dbo.scalar_fn (@x INT) RETURNS INT AS BEGIN RETURN @x + 1 END
+
+statement error
+SELECT * FROM dbo.scalar_fn(1)
+
+# A table-valued function called in scalar position is not a scalar.
+statement error
+SELECT dbo.in_group(10)
+
+# ALTER and DROP.
+statement ok
+ALTER FUNCTION dbo.in_group (@g INT) RETURNS TABLE AS RETURN (SELECT id FROM nums WHERE grp = @g AND id < 5)
+
+query I rowsort
+SELECT id FROM dbo.in_group(20)
+----
+3
+4
+
+statement ok
+DROP FUNCTION dbo.group_count
+
+statement error
+SELECT n FROM dbo.group_count(20)
+
+# Catalog: sys.objects IF code, sys.sql_modules body, no parameter_id 0 row.
+query T
+SELECT type FROM sys.objects WHERE name = 'in_group'
+----
+IF
+
+query T
+SELECT type_desc FROM sys.objects WHERE name = 'in_group_twice'
+----
+SQL_INLINE_TABLE_VALUED_FUNCTION
+
+# An inline TVF has no scalar return row (parameter_id 0); only its @params.
+query I rowsort
+SELECT parameter_id FROM sys.parameters WHERE object_id = (SELECT object_id FROM sys.objects WHERE name = 'in_group')
+----
+1

--- a/crates/truthdb-sql/src/ast.rs
+++ b/crates/truthdb-sql/src/ast.rs
@@ -144,12 +144,14 @@ pub struct CreateFunction {
     pub span: Span,
 }
 
-/// A function's declared return shape. Only the scalar form exists today; the
-/// table-valued forms are added by later work.
+/// A function's declared return shape.
 #[derive(Debug, Clone, PartialEq)]
 pub enum ReturnsClause {
     /// `RETURNS <scalar type>`: a scalar UDF.
     Scalar(DataType),
+    /// `RETURNS TABLE AS RETURN ( <select> )`: an inline table-valued function.
+    /// The body is the SELECT (its source captured in `CreateFunction.body`).
+    InlineTable,
 }
 
 /// One declared procedure parameter.
@@ -536,6 +538,13 @@ pub enum TableRef {
     Derived {
         subquery: Box<Select>,
         alias: Name,
+    },
+    /// A table-valued function call in FROM: `dbo.f(args) [AS alias]`. The alias
+    /// is optional (an unaliased call exposes the bare function name).
+    Function {
+        name: Name,
+        args: Vec<Expr>,
+        alias: Option<Name>,
     },
 }
 

--- a/crates/truthdb-sql/src/parser.rs
+++ b/crates/truthdb-sql/src/parser.rs
@@ -1636,9 +1636,34 @@ impl Parser {
         }
         self.expect(&TokenKind::RParen)?;
         self.expect_keyword("RETURNS")?;
-        // Scalar form only: the return is a system type. (RETURNS TABLE / @t
-        // TABLE — the table-valued forms — are added by later work; a TABLE
-        // return type falls through to parse_data_type's 243.)
+        // `RETURNS TABLE` is an inline table-valued function: its body is a
+        // single `AS RETURN ( <select> )` captured as source text and expanded
+        // like a parameterized view. (Multi-statement `RETURNS @t TABLE(...)` is
+        // added by later work.) Anything else is a scalar return type.
+        if self.peek_keyword().as_deref() == Some("TABLE") {
+            self.bump(); // TABLE
+            self.expect_keyword("AS")?;
+            self.expect_keyword("RETURN")?;
+            let parens = self.eat(&TokenKind::LParen);
+            let select_start = self.peek().span.start;
+            let select = self.parse_select()?;
+            let select_text = self
+                .slice(Span::new(select_start, select.span.end))
+                .trim()
+                .to_string();
+            if parens {
+                self.expect(&TokenKind::RParen)?;
+            }
+            let span = start.to(self.prev_span());
+            return Ok(Statement::CreateFunction(CreateFunction {
+                name,
+                params,
+                returns: ReturnsClause::InlineTable,
+                body: select_text,
+                alter,
+                span,
+            }));
+        }
         let (return_type, _) = self.parse_data_type()?;
         let returns = ReturnsClause::Scalar(return_type);
         self.expect_keyword("AS")?;
@@ -2202,6 +2227,22 @@ impl Parser {
             return Ok(inner);
         }
         let name = self.parse_name()?;
+        // `name ( args )` in table position is a table-valued function call.
+        if self.check(&TokenKind::LParen) {
+            self.bump(); // (
+            let mut args = Vec::new();
+            if !self.check(&TokenKind::RParen) {
+                loop {
+                    args.push(self.parse_expr()?);
+                    if !self.eat(&TokenKind::Comma) {
+                        break;
+                    }
+                }
+            }
+            self.expect(&TokenKind::RParen)?;
+            let alias = self.parse_optional_table_alias()?;
+            return Ok(TableRef::Function { name, args, alias });
+        }
         let alias = self.parse_optional_table_alias()?;
         Ok(TableRef::Table { name, alias })
     }


### PR DESCRIPTION
# Stage 15: inline table-valued functions (`RETURNS TABLE AS RETURN(select)`)

The second `CREATE FUNCTION` form. An inline TVF is a **parameterized view**: stored as the body
SELECT's source text (`FunctionReturns::InlineTable`, re-parsed per call — recompile-on-schema-change
for free) and expanded in a FROM clause with the call's arguments bound to its `@params`.

## Parser
- After `RETURNS`, a `TABLE` keyword takes the inline path: `AS RETURN ( <select> )`, the SELECT
  captured as source text like a view.
- A new AST node `TableRef::Function { name, args, alias }`, produced by `parse_table_primary_body`
  when a name in table position is followed by `(args)`. `FROM dbo.f` without parens still parses as
  `TableRef::Table` and is rejected by the existing `is_function()` guard.

## Execution
`build_join` dispatches `TableRef::Function` to a new `build_function_source`, which fuses two
existing recipes: the scalar-UDF **param binding** (arg-count 313/8144, `ColumnType::parse` +
`sql_to_datum` coercion, evaluated in a **fresh scope** so the body sees only its parameters) and the
**view expansion** (`ViewDepthGuard`, `parse_view_query`, `build_derived_source` under the call's
qualifier). Args may themselves contain subqueries or scalar UDFs.

## Lock + snapshot seam (handled up front)
This is the class the scalar-UDF review rated HIGH; it's closed here proactively. A TVF in FROM has
its body's tables **locked and snapshotted** before it reads: both the borrowing collector
(`collect_from_tables`) and the owned collector (`collect_from_read_names`) push the function name,
and `collect_read_lock_ids` gains an `InlineTable` arm that parses the body SELECT and recurses into
its read targets (the view branch applied to the TVF body). So `analyze_locks` locks the body tables
AND `statement_reads_tables` arms the RCSI/SNAPSHOT scope. Every exhaustive `TableRef` match (9 sites)
and `FunctionReturns` match (6 sites) gets its arm.

## Catalog / namespace
`sys.objects` IF/`SQL_INLINE_TABLE_VALUED_FUNCTION`; `sys.sql_modules` stores the SELECT text;
`sys.parameters` emits the `@params` but **no parameter_id 0 return row** (the return is a table). A
scalar function called in FROM, or a TVF called in scalar position, errors.

## Tests
`inline_tvf.slt` (parameterized expansion, alias, join against a base table, expression/variable args,
aggregating body, nested TVFs, wrong-arg-count, scalar-in-FROM and TVF-in-scalar-position errors,
ALTER/DROP, catalog views) and an engine test that a TVF's body table is Shared-locked and the
snapshot armed (3952) — teeth-checked by mutation.

## Not yet
Multi-statement TVFs (`RETURNS @t TABLE` — needs a table-variable subsystem); `CROSS`/`OUTER APPLY`
(args referencing outer columns — those currently error cleanly as invalid columns).

## Adversarial review

A four-lens review (seam, expansion/binding, TableRef completeness, parser/catalog) with refute-by-default verification confirmed two defects, both fixed and mutation-teeth-checked. The proactive seam handling held — no dirty-read/unlocked defect was found. The findings were:

- **HIGH** — `collect_read_lock_ids` bounded recursion by depth but not fan-out, so a self-/mutually-referential function or view referencing itself twice recursed ~2^32 times and hung `analyze_locks` **under the scheduler mutex**, freezing every session. Pre-existing (scalar UDFs/views hit it too) but inline TVFs added a natural trigger. Fixed with a visited set that expands each body at most once — covering scalar UDFs, views, and TVFs together.
- **LOW** — SHOWPLAN for a lone TVF printed a phantom nested-loops join; now renders `Table-valued Function(name)`.
