### PR TITLE
Stage 15: table variables (DECLARE @t TABLE, INSERT/SELECT @t)

### DIFF
--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -5911,6 +5911,54 @@ mod tests {
     }
 
     #[test]
+    fn function_body_cannot_read_caller_table_variable() {
+        let path = unique_temp_path("tablevar-fn-isolation");
+        let engine = new_engine(&path);
+        // A scalar UDF and an inline TVF whose bodies reference @t are created
+        // without a bind-time check, but at call time each runs with its OWN
+        // (empty) table-variable scope — it must NOT see the caller's @t. The
+        // body's `FROM @t` therefore errors 1087, not silently reading caller
+        // rows. This is the scope seam: the read view armed by the calling
+        // statement must be shadowed, not inherited, across the body boundary.
+        engine
+            .execute(
+                "CREATE FUNCTION dbo.cnt () RETURNS INT AS BEGIN RETURN (SELECT COUNT(*) FROM @t) END",
+            )
+            .expect("create scalar udf");
+        let mut ctx = TxnContext::default();
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "DECLARE @t TABLE (id INT NOT NULL PRIMARY KEY); \
+             INSERT INTO @t VALUES (1), (2), (3); SELECT dbo.cnt() AS n",
+        );
+        assert_eq!(
+            out.error.as_ref().map(|e| e.number),
+            Some(1087),
+            "a scalar UDF body must not read the caller's table variable: {:?}",
+            out.error
+        );
+
+        engine
+            .execute("CREATE FUNCTION dbo.readt () RETURNS TABLE AS RETURN (SELECT id FROM @t)")
+            .expect("create inline tvf");
+        let mut ctx = TxnContext::default();
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "DECLARE @t TABLE (id INT NOT NULL PRIMARY KEY); \
+             INSERT INTO @t VALUES (99); SELECT id FROM dbo.readt()",
+        );
+        assert_eq!(
+            out.error.as_ref().map(|e| e.number),
+            Some(1087),
+            "an inline TVF body must not read the caller's table variable: {:?}",
+            out.error
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
     fn recursive_function_lock_analysis_terminates() {
         use crate::rel::Isolation;
         let path = unique_temp_path("udf-recursion-bomb");

--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -5955,6 +5955,26 @@ mod tests {
             "an inline TVF body must not read the caller's table variable: {:?}",
             out.error
         );
+
+        // A VIEW body is the same stored-object scope: it must not read the
+        // caller's @t either. (SQL Server rejects such a view at CREATE; TruthDB
+        // defers name resolution, so the isolation must hold at query time.)
+        engine
+            .execute("CREATE VIEW dbo.vt AS SELECT id FROM @t")
+            .expect("create view over @t");
+        let mut ctx = TxnContext::default();
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "DECLARE @t TABLE (id INT NOT NULL PRIMARY KEY); \
+             INSERT INTO @t VALUES (1), (2); SELECT id FROM dbo.vt",
+        );
+        assert_eq!(
+            out.error.as_ref().map(|e| e.number),
+            Some(1087),
+            "a view body must not read the caller's table variable: {:?}",
+            out.error
+        );
         let _ = std::fs::remove_file(path);
     }
 

--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -5807,6 +5807,110 @@ mod tests {
     }
 
     #[test]
+    fn table_variable_access_takes_no_table_locks() {
+        use crate::lock::Resource;
+        use crate::rel::Isolation;
+        let path = unique_temp_path("tablevar-nolocks");
+        let engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE base (id INT NOT NULL PRIMARY KEY)")
+            .expect("base");
+        // A table variable is session memory: its name never resolves to a base
+        // table, so reads and writes of @t take no table/row locks. (A Database
+        // intent lock may still appear; only object locks are asserted absent.)
+        let has_object_lock = |sql: &str| {
+            engine
+                .analyze_locks(sql, Isolation::ReadCommitted)
+                .iter()
+                .any(|(r, _)| matches!(r, Resource::Table(_) | Resource::Row(..)))
+        };
+        assert!(
+            !has_object_lock("SELECT * FROM @t"),
+            "SELECT FROM @t must take no object locks"
+        );
+        assert!(
+            !has_object_lock("INSERT INTO @t VALUES (1)"),
+            "INSERT @t VALUES must take no object locks"
+        );
+        // But an INSERT @t whose SOURCE reads a real table still locks the
+        // source — the seam: the @t target is free, the source read is not.
+        let base = table_object_id(&engine, "base");
+        // A join of base with @t locks only base; the @t side adds nothing.
+        let join_locks = engine.analyze_locks(
+            "SELECT * FROM base AS b JOIN @t AS t ON b.id = t.id",
+            Isolation::ReadCommitted,
+        );
+        assert!(
+            !join_locks
+                .iter()
+                .any(|(r, _)| matches!(r, Resource::Table(id) if *id != base)),
+            "the @t side of a join must add no table lock beyond base's: {join_locks:?}"
+        );
+        let locks = engine.analyze_locks(
+            "INSERT INTO @t SELECT id FROM base",
+            Isolation::ReadCommitted,
+        );
+        assert!(
+            locks
+                .iter()
+                .any(|(r, _)| matches!(r, Resource::Table(id) if *id == base)),
+            "INSERT @t SELECT FROM base must lock base: {locks:?}"
+        );
+        assert!(
+            !locks
+                .iter()
+                .any(|(r, _)| matches!(r, Resource::Table(id) if *id != base)),
+            "no phantom lock for @t itself: {locks:?}"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn table_variable_read_does_not_arm_snapshot() {
+        let path = unique_temp_path("tablevar-nosnapshot");
+        let engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE base (id INT NOT NULL PRIMARY KEY)")
+            .expect("base");
+        engine.execute("INSERT INTO base VALUES (7)").expect("seed");
+        let mut ctx = TxnContext::default();
+        batch(
+            &engine,
+            &mut ctx,
+            "SET TRANSACTION ISOLATION LEVEL SNAPSHOT",
+        );
+        // Under SNAPSHOT-not-allowed, a @t-only batch is NOT a data access: it
+        // must run to completion, not raise 3952.
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "DECLARE @t TABLE (id INT NOT NULL PRIMARY KEY); \
+             INSERT INTO @t VALUES (1), (2); SELECT id FROM @t",
+        );
+        assert!(
+            out.error.is_none(),
+            "a table-variable-only batch must not raise 3952: {:?}",
+            out.error
+        );
+        assert_eq!(ids(&out), vec![1, 2]);
+        // But INSERT @t whose SOURCE reads a real table IS a data access and
+        // must raise 3952 under SNAPSHOT-not-allowed (the source read needs the
+        // snapshot the database forbids).
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "DECLARE @t TABLE (id INT NOT NULL PRIMARY KEY); INSERT INTO @t SELECT id FROM base",
+        );
+        assert_eq!(
+            out.error.as_ref().map(|e| e.number),
+            Some(3952),
+            "INSERT @t SELECT FROM base must arm the snapshot scope: {:?}",
+            out.error
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
     fn recursive_function_lock_analysis_terminates() {
         use crate::rel::Isolation;
         let path = unique_temp_path("udf-recursion-bomb");

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -3810,6 +3810,27 @@ fn exec_declare_table_var(
             ),
         ));
     }
+    // Column names within the table variable must be unique (2705), the same
+    // rule a base table enforces in exec_create_table.
+    let mut seen: Vec<&str> = Vec::new();
+    for column in columns {
+        if seen
+            .iter()
+            .any(|n| n.eq_ignore_ascii_case(&column.name.value))
+        {
+            return Err(SqlError::new(
+                2705,
+                16,
+                3,
+                format!(
+                    "Column names in each table must be unique. Column name '{}' is specified more than once.",
+                    column.name.value
+                ),
+            )
+            .at(column.name.span));
+        }
+        seen.push(&column.name.value);
+    }
     let bound = columns
         .iter()
         .map(bind_column)
@@ -10064,6 +10085,13 @@ fn build_table_source(
                     quoted: false,
                     span: name.span,
                 };
+                // A view body is a stored-object scope, like a function/TVF
+                // body: it must not read the CALLER's table variables. Shadow
+                // the read view with an empty one so `SELECT ... FROM @t` inside
+                // a view errors 1087 rather than returning caller rows. (An
+                // in-statement derived table or CTE is NOT a separate scope and
+                // keeps the statement's view — only stored bodies shadow.)
+                let _table_var_scope = arm_table_var_view(&std::collections::HashMap::new());
                 return build_derived_source(storage, &body, &qual, eval_ctx);
             }
             let schema = def.schema().map_err(|e| map_storage_err(e, &def.name))?;

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -40,12 +40,15 @@ use crate::relstore::version::ReadSnapshot;
 use crate::storage::{RowLocator, Storage, StorageError, StorageTxn, TxnScope};
 
 /// A declared table variable's in-memory contents: its column schema, the key
-/// columns of its declared PRIMARY KEY (for uniqueness enforcement), and its
-/// rows. A row is a `Vec<Datum>` in schema order, exactly like a base-table row.
+/// columns of its declared PRIMARY KEY (for uniqueness enforcement), the
+/// per-column `DEFAULT` source text (parallel to the schema columns, re-parsed
+/// and evaluated per INSERT), and its rows. A row is a `Vec<Datum>` in schema
+/// order, exactly like a base-table row.
 #[derive(Clone)]
 struct TableVar {
     schema: Schema,
     key_columns: Vec<usize>,
+    defaults: Vec<Option<String>>,
     rows: Vec<Vec<Datum>>,
 }
 
@@ -1544,6 +1547,10 @@ fn run_block(
                 // A successful condition evaluation resets `@@ERROR` (the IF
                 // itself is a statement) — AFTER the condition read it, which
                 // is what makes `IF @@ERROR <> 0` work.
+                // A condition subquery reads table variables through the same
+                // FROM path as a SELECT, so it needs the same read view armed —
+                // the IF/WHILE arms bypass exec_statement_streamed, so arm here.
+                let _table_var_scope = arm_table_var_view(&txn_ctx.table_variables);
                 let taken = match enter_condition_scopes(storage, condition, txn_ctx, run)
                     .and_then(|_scopes| eval_condition(storage, condition, txn_ctx))
                 {
@@ -1576,6 +1583,9 @@ fn run_block(
                     // infinite `WHILE 1 = 1` must die on cancel even when its
                     // body runs no cancellable statement.
                     check_cancelled()?;
+                    // Re-armed each iteration: the body may INSERT into @t, and
+                    // the next condition read must see the updated rows.
+                    let _table_var_scope = arm_table_var_view(&txn_ctx.table_variables);
                     let taken = match enter_condition_scopes(storage, condition, txn_ctx, run)
                         .and_then(|_scopes| eval_condition(storage, condition, txn_ctx))
                     {
@@ -1614,6 +1624,10 @@ fn run_block(
                     let value = value
                         .as_ref()
                         .expect("a scalar function RETURN carries a value (parser-enforced)");
+                    // A RETURN subquery reads table variables through the FROM
+                    // path; arm the body's own (empty) view so it shadows the
+                    // caller's rather than reading caller locals.
+                    let _table_var_scope = arm_table_var_view(&txn_ctx.table_variables);
                     let eval_ctx = txn_ctx.eval_context();
                     let no_outer = |_: &str| -> Option<usize> { None };
                     let coerced =
@@ -2006,6 +2020,21 @@ impl Drop for TableVarScope {
     }
 }
 
+/// Installs `vars` as the table-variable read view for the returned guard's
+/// lifetime — the SINGLE arming rule shared by every path that can read a table
+/// variable: ordinary statements, IF/WHILE conditions, scalar-function RETURN
+/// expressions, and TVF bodies. Armed when `vars` is non-empty OR an outer scope
+/// is already armed. The second clause is the correctness hinge: a function,
+/// procedure, or TVF body runs with a fresh (empty) table-variable set, and it
+/// must SHADOW the caller's view — not inherit it — so its `FROM @t` resolves
+/// against its own (empty) locals and errors 1087, never the caller's rows.
+/// When neither holds (the common no-table-variable batch) it arms nothing, so
+/// the hot path pays only a thread-local read.
+fn arm_table_var_view(vars: &std::collections::HashMap<String, TableVar>) -> Option<TableVarScope> {
+    let outer_armed = CURRENT_TABLE_VARS.with(|c| c.borrow().is_some());
+    (!vars.is_empty() || outer_armed).then(|| TableVarScope::enter(std::rc::Rc::new(vars.clone())))
+}
+
 /// Statement-scoped snapshot registration: capture on entry, and release —
 /// pruning must not wait on a statement that errored — on every exit path.
 struct SnapshotScope<'a> {
@@ -2127,11 +2156,12 @@ fn exec_statement_streamed(
     );
     let mut _stmt_scope = None;
     let mut _txn_scope = None;
-    // Make the session's table variables visible to this statement's FROM
-    // reads (only when any exist — most batches have none). The clone is the
-    // statement's read view; INSERT/UPDATE write the real store on TxnContext.
-    let _table_var_scope = (!txn_ctx.table_variables.is_empty())
-        .then(|| TableVarScope::enter(std::rc::Rc::new(txn_ctx.table_variables.clone())));
+    // Make the running context's table variables visible to this statement's
+    // FROM reads. The clone is the statement's read view; INSERT/UPDATE write
+    // the real store on TxnContext. Inside a function/procedure body (fresh,
+    // empty table variables) this shadows the caller's view with an empty one,
+    // so the body cannot read the caller's @t — see arm_table_var_view.
+    let _table_var_scope = arm_table_var_view(&txn_ctx.table_variables);
     match txn_ctx.isolation() {
         Isolation::ReadCommitted
             if matches!(statement, Statement::Select(_)) && storage.rcsi_enabled() =>
@@ -3732,7 +3762,9 @@ fn exec_set(ctx: &mut TxnContext, set: &SetStatement) -> Result<StatementResult,
 /// variable) is coerced to the declared type, else the value starts NULL.
 fn exec_declare(ctx: &mut TxnContext, decls: &[Declaration]) -> Result<StatementResult, SqlError> {
     for decl in decls {
-        if ctx.variables.contains_key(&decl.name) {
+        // A name occupies the scalar and table-variable stores jointly, so a
+        // scalar DECLARE after a `DECLARE @t TABLE` of the same name is 134 too.
+        if ctx.variables.contains_key(&decl.name) || ctx.table_variables.contains_key(&decl.name) {
             return Err(SqlError::new(
                 134,
                 15,
@@ -3782,7 +3814,7 @@ fn exec_declare_table_var(
         .iter()
         .map(bind_column)
         .collect::<Result<Vec<_>, _>>()?;
-    let schema = Schema { columns: bound };
+    let mut schema = Schema { columns: bound };
     let mut key_columns = Vec::new();
     for pk in primary_key {
         let index = schema
@@ -3800,13 +3832,39 @@ fn exec_declare_table_var(
                     ),
                 )
             })?;
+        // A PRIMARY KEY column is implicitly NOT NULL; declaring it NULL is
+        // 8111, and a MAX-typed column cannot be a key — the same rules a base
+        // table enforces in exec_create_table.
+        let declared_null = columns
+            .iter()
+            .find(|c| c.name.eq_ignore_case(&pk.value))
+            .and_then(|c| c.nullable)
+            == Some(true);
+        if declared_null {
+            return Err(SqlError::new(
+                8111,
+                16,
+                1,
+                format!(
+                    "Cannot define PRIMARY KEY constraint on nullable column in table '@{name}'."
+                ),
+            ));
+        }
+        if schema.columns[index].column_type.is_max() {
+            return Err(max_key_column_error(&pk.value, &format!("@{name}")).at(pk.span));
+        }
+        schema.columns[index].nullable = false;
         key_columns.push(index);
     }
+    // Per-column DEFAULT source text (parallel to the schema columns), applied
+    // at INSERT to columns left unspecified — same as a base table.
+    let defaults: Vec<Option<String>> = columns.iter().map(|c| c.default.clone()).collect();
     ctx.table_variables.insert(
         name.to_string(),
         TableVar {
             schema,
             key_columns,
+            defaults,
             rows: Vec::new(),
         },
     );
@@ -5820,12 +5878,16 @@ fn exec_insert_table_var(
         .value
         .trim_start_matches('@')
         .to_ascii_lowercase();
-    let (schema, key_columns) = {
+    let (schema, key_columns, defaults) = {
         let tv = ctx
             .table_variables
             .get(&key)
             .ok_or_else(|| must_declare_table_var(&insert.table.value).at(insert.table.span))?;
-        (tv.schema.clone(), tv.key_columns.clone())
+        (
+            tv.schema.clone(),
+            tv.key_columns.clone(),
+            tv.defaults.clone(),
+        )
     };
     let ncols = schema.columns.len();
     // Target columns: an explicit list resolves against the declared schema (264
@@ -5865,7 +5927,20 @@ fn exec_insert_table_var(
             let column = &schema.columns[*position];
             values[*position] = value::sql_to_datum(sql_value, &column.column_type, &column.name)?;
         }
-        // NOT NULL after unspecified columns default to NULL.
+        // DEFAULTs fill columns that were not targeted and are still NULL,
+        // before the NOT NULL check — so `c INT NOT NULL DEFAULT 5` inserts 5,
+        // not a spurious 515.
+        for (index, column) in schema.columns.iter().enumerate() {
+            if !values[index].is_null() || target.contains(&index) {
+                continue;
+            }
+            if let Some(text) = &defaults[index] {
+                let sql_value = eval_default(text, eval_ctx)?;
+                values[index] = value::sql_to_datum(&sql_value, &column.column_type, &column.name)?;
+            }
+        }
+        // NOT NULL after defaults applied; unspecified columns without a
+        // default remain NULL.
         for (index, column) in schema.columns.iter().enumerate() {
             if !column.nullable && values[index].is_null() {
                 return Err(SqlError::null_into_not_null(
@@ -10140,6 +10215,14 @@ fn build_function_source(
         quoted: false,
         span: name.span,
     };
+    // A TVF body sees only its parameters, not caller locals — the scalar side
+    // is isolated above (fresh `variables`); do the same for the table-variable
+    // read view. Without this the body's `FROM @t` would resolve against the
+    // CALLER's table variable, since build_derived_source runs under whatever
+    // scope the calling statement armed. An empty view makes such a body error
+    // 1087, as SQL Server rejects it. (arm_table_var_view no-ops when nothing is
+    // armed, so a body with no @t reference pays nothing.)
+    let _table_var_scope = arm_table_var_view(&std::collections::HashMap::new());
     build_derived_source(storage, &body, &qual, &fn_ctx)
 }
 

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -39,6 +39,16 @@ use crate::relstore::types::{ColumnType, Datum};
 use crate::relstore::version::ReadSnapshot;
 use crate::storage::{RowLocator, Storage, StorageError, StorageTxn, TxnScope};
 
+/// A declared table variable's in-memory contents: its column schema, the key
+/// columns of its declared PRIMARY KEY (for uniqueness enforcement), and its
+/// rows. A row is a `Vec<Datum>` in schema order, exactly like a base-table row.
+#[derive(Clone)]
+struct TableVar {
+    schema: Schema,
+    key_columns: Vec<usize>,
+    rows: Vec<Vec<Datum>>,
+}
+
 /// Per-session transaction state carried across statements/batches. Lives in
 /// the session (engine thread); autocommit statements use `Default`.
 #[derive(Default)]
@@ -82,6 +92,11 @@ pub struct TxnContext {
     /// Declared batch variables (name without `@`, lowercased) to their type
     /// and current value. Cleared at the start of each batch.
     variables: std::collections::HashMap<String, (ColumnType, SqlValue)>,
+    /// Declared table variables (name without `@`, lowercased): in-memory
+    /// rowsets that live only on the session (never on Storage), so they survive
+    /// ROLLBACK and are cleared at batch end — SQL Server table-variable
+    /// semantics. Kept disjoint from `variables`; a name lives in exactly one.
+    table_variables: std::collections::HashMap<String, TableVar>,
     /// Connection identity for session intrinsics (`DB_NAME()`,
     /// `SUSER_SNAME()`, `@@SPID`), set once when the session opens.
     database: String,
@@ -198,6 +213,7 @@ impl TxnContext {
     /// Clears batch-scoped variables (called at the start of each batch).
     pub fn clear_variables(&mut self) {
         self.variables.clear();
+        self.table_variables.clear();
     }
 
     /// The final value and type of a batch variable, as a `Datum`, for the
@@ -953,6 +969,7 @@ fn run_user_procedure(
 
     // Fresh scope, SET options reverting at exit — the sp_executesql shape.
     let outer_vars = std::mem::take(&mut txn_ctx.variables);
+    let outer_table_vars = std::mem::take(&mut txn_ctx.table_variables);
     let outer_xact_abort = txn_ctx.xact_abort;
     let outer_nocount = txn_ctx.nocount;
     let outer_isolation = txn_ctx.isolation;
@@ -993,6 +1010,7 @@ fn run_user_procedure(
         })
         .collect();
     txn_ctx.variables = outer_vars;
+    txn_ctx.table_variables = outer_table_vars;
     txn_ctx.xact_abort = outer_xact_abort;
     txn_ctx.nocount = outer_nocount;
     txn_ctx.isolation = outer_isolation;
@@ -1223,6 +1241,7 @@ fn run_exec(
     // EXEC, or a post-EXEC statement would run under an isolation the up-front
     // lock analysis never saw.
     let outer_vars = std::mem::take(&mut txn_ctx.variables);
+    let outer_table_vars = std::mem::take(&mut txn_ctx.table_variables);
     let outer_xact_abort = txn_ctx.xact_abort;
     let outer_nocount = txn_ctx.nocount;
     let outer_isolation = txn_ctx.isolation;
@@ -1256,6 +1275,7 @@ fn run_exec(
     };
     EXEC_DEPTH.with(|d| d.set(d.get() - 1));
     txn_ctx.variables = outer_vars;
+    txn_ctx.table_variables = outer_table_vars;
     txn_ctx.xact_abort = outer_xact_abort;
     txn_ctx.nocount = outer_nocount;
     txn_ctx.isolation = outer_isolation;
@@ -1948,6 +1968,44 @@ fn current_snapshot() -> Option<ReadSnapshot> {
     CURRENT_SNAPSHOT.get()
 }
 
+thread_local! {
+    /// The running statement's table variables (the session's, shared read-only
+    /// for the statement). Thread-local for the same reason as CURRENT_SNAPSHOT:
+    /// a batch runs on one worker thread, and the FROM-source builders carry
+    /// only an EvalContext (a truthdb-sql type that cannot hold core `Datum`
+    /// rows), so the store cannot ride through it.
+    static CURRENT_TABLE_VARS: std::cell::RefCell<
+        Option<std::rc::Rc<std::collections::HashMap<String, TableVar>>>,
+    > = const { std::cell::RefCell::new(None) };
+}
+
+/// The table variable `@name` visible to the running statement, cloned out for a
+/// FROM read (an in-memory rowset).
+fn current_table_var(name: &str) -> Option<TableVar> {
+    let key = name.trim_start_matches('@').to_ascii_lowercase();
+    CURRENT_TABLE_VARS.with(|c| c.borrow().as_ref().and_then(|m| m.get(&key).cloned()))
+}
+
+/// Installs the statement's table variables for its execution, restoring the
+/// prior installation on drop (scopes can nest — a subquery or TVF body reads
+/// within the caller's — so restore rather than clear).
+struct TableVarScope {
+    prev: Option<std::rc::Rc<std::collections::HashMap<String, TableVar>>>,
+}
+
+impl TableVarScope {
+    fn enter(vars: std::rc::Rc<std::collections::HashMap<String, TableVar>>) -> Self {
+        let prev = CURRENT_TABLE_VARS.with(|c| c.borrow_mut().replace(vars));
+        TableVarScope { prev }
+    }
+}
+
+impl Drop for TableVarScope {
+    fn drop(&mut self) {
+        CURRENT_TABLE_VARS.with(|c| *c.borrow_mut() = self.prev.take());
+    }
+}
+
 /// Statement-scoped snapshot registration: capture on entry, and release —
 /// pruning must not wait on a statement that errored — on every exit path.
 struct SnapshotScope<'a> {
@@ -2008,18 +2066,26 @@ impl Drop for TxnSnapshotScope {
 /// defers both to the first read of an actual object.
 fn statement_reads_tables(storage: &Storage, statement: &Statement) -> bool {
     match statement {
-        Statement::Select(select) => {
-            let expanded = expand_ctes(select);
-            let mut tables = Vec::new();
-            collect_locked_tables(&expanded, &mut tables);
-            // A scalar function the SELECT calls reads tables through its body;
-            // that read must observe the statement/transaction snapshot too, so
-            // it counts as a table access (matching the lock analysis, which
-            // resolves the same function bodies).
-            !tables.is_empty() || !select_function_read_ids(storage, &expanded).is_empty()
-        }
+        Statement::Select(select) => select_reads_tables(storage, select),
+        // An INSERT whose TARGET is a table variable writes only session memory,
+        // so — unlike a base-table INSERT — it is not itself a data access; but a
+        // `SELECT` source still reads real tables and must arm the snapshot.
+        Statement::Insert(insert) if insert.table.value.starts_with('@') => match &insert.source {
+            InsertSource::Select(select) => select_reads_tables(storage, select),
+            _ => false,
+        },
         _ => true,
     }
+}
+
+/// Whether a SELECT reads any real table — directly (FROM/subqueries) or through
+/// a scalar function it calls. A `@t` table-variable source is session-local and
+/// is not counted (it neither locks nor snapshots).
+fn select_reads_tables(storage: &Storage, select: &Select) -> bool {
+    let expanded = expand_ctes(select);
+    let mut tables = Vec::new();
+    collect_locked_tables(&expanded, &mut tables);
+    !tables.is_empty() || !select_function_read_ids(storage, &expanded).is_empty()
 }
 
 /// SQL Server 3952: SNAPSHOT isolation used while the database does not
@@ -2061,6 +2127,11 @@ fn exec_statement_streamed(
     );
     let mut _stmt_scope = None;
     let mut _txn_scope = None;
+    // Make the session's table variables visible to this statement's FROM
+    // reads (only when any exist — most batches have none). The clone is the
+    // statement's read view; INSERT/UPDATE write the real store on TxnContext.
+    let _table_var_scope = (!txn_ctx.table_variables.is_empty())
+        .then(|| TableVarScope::enter(std::rc::Rc::new(txn_ctx.table_variables.clone())));
     match txn_ctx.isolation() {
         Isolation::ReadCommitted
             if matches!(statement, Statement::Select(_)) && storage.rcsi_enabled() =>
@@ -2808,6 +2879,7 @@ fn analyze_statements_locks(
             | Statement::SaveTransaction { .. }
             | Statement::Set(_)
             | Statement::Declare(_)
+            | Statement::DeclareTableVar { .. }
             | Statement::Use { .. }
             | Statement::Throw(_)
             | Statement::RaiseError(_)
@@ -2954,6 +3026,12 @@ fn exec_statement_dispatch(
         Statement::SaveTransaction { name, .. } => exec_save(storage, txn_ctx, name),
         Statement::Set(set) => exec_set(txn_ctx, set),
         Statement::Declare(decls) => exec_declare(txn_ctx, decls),
+        Statement::DeclareTableVar {
+            name,
+            columns,
+            primary_key,
+            ..
+        } => exec_declare_table_var(txn_ctx, name, columns, primary_key),
         Statement::CreateTable(create) => {
             if txn_ctx.in_txn() {
                 return Err(ddl_in_txn_err());
@@ -3012,6 +3090,12 @@ fn exec_statement_dispatch(
         }
         Statement::Insert(insert) => {
             let eval_ctx = txn_ctx.eval_context();
+            // INSERT into a `@t` table variable is pure session memory (no
+            // Storage, no lock, no WAL) — handled here where `&mut TxnContext`
+            // is in hand, before the storage scope is taken.
+            if insert.table.value.starts_with('@') {
+                return exec_insert_table_var(storage, insert, txn_ctx, &eval_ctx);
+            }
             let (result, identity) = {
                 let mut scope = txn_ctx.scope();
                 exec_insert(storage, insert, &mut scope, &eval_ctx)?
@@ -3670,6 +3754,62 @@ fn exec_declare(ctx: &mut TxnContext, decls: &[Declaration]) -> Result<Statement
         ctx.variables
             .insert(decl.name.clone(), (column_type, value));
     }
+    Ok(StatementResult::Done)
+}
+
+/// `DECLARE @t TABLE ( ... )`: registers an empty in-memory table variable. Its
+/// schema is bound like a base table's columns; its declared PRIMARY KEY becomes
+/// the key columns used for uniqueness at INSERT time.
+fn exec_declare_table_var(
+    ctx: &mut TxnContext,
+    name: &str,
+    columns: &[ColumnDef],
+    primary_key: &[Name],
+) -> Result<StatementResult, SqlError> {
+    // A name occupies the scalar and table-variable stores jointly.
+    if ctx.variables.contains_key(name) || ctx.table_variables.contains_key(name) {
+        return Err(SqlError::new(
+            134,
+            15,
+            2,
+            format!(
+                "The variable name '@{name}' has already been declared. Variable names must be \
+                 unique within a query batch."
+            ),
+        ));
+    }
+    let bound = columns
+        .iter()
+        .map(bind_column)
+        .collect::<Result<Vec<_>, _>>()?;
+    let schema = Schema { columns: bound };
+    let mut key_columns = Vec::new();
+    for pk in primary_key {
+        let index = schema
+            .columns
+            .iter()
+            .position(|c| c.name.eq_ignore_ascii_case(&pk.value))
+            .ok_or_else(|| {
+                SqlError::new(
+                    1911,
+                    16,
+                    1,
+                    format!(
+                        "Column name '{}' does not exist in the target table or view.",
+                        pk.value
+                    ),
+                )
+            })?;
+        key_columns.push(index);
+    }
+    ctx.table_variables.insert(
+        name.to_string(),
+        TableVar {
+            schema,
+            key_columns,
+            rows: Vec::new(),
+        },
+    );
     Ok(StatementResult::Done)
 }
 
@@ -5663,6 +5803,114 @@ fn exec_insert(
         _ => None,
     };
     Ok((StatementResult::RowsAffected(inserted), last_identity))
+}
+
+/// `INSERT [INTO] @t ...`: appends rows to an in-memory table variable. No
+/// Storage, no lock, no WAL, no identity/default/CHECK/FK (deferred) — just the
+/// declared column coercion, NOT NULL, and PRIMARY KEY uniqueness, all in memory
+/// so a ROLLBACK leaves the rows intact (SQL Server table-variable semantics).
+fn exec_insert_table_var(
+    storage: &Storage,
+    insert: &Insert,
+    ctx: &mut TxnContext,
+    eval_ctx: &EvalContext,
+) -> Result<StatementResult, SqlError> {
+    let key = insert
+        .table
+        .value
+        .trim_start_matches('@')
+        .to_ascii_lowercase();
+    let (schema, key_columns) = {
+        let tv = ctx
+            .table_variables
+            .get(&key)
+            .ok_or_else(|| must_declare_table_var(&insert.table.value).at(insert.table.span))?;
+        (tv.schema.clone(), tv.key_columns.clone())
+    };
+    let ncols = schema.columns.len();
+    // Target columns: an explicit list resolves against the declared schema (264
+    // for a repeat); an omitted list targets every column in order.
+    let target: Vec<usize> = match &insert.columns {
+        Some(names) => {
+            let mut indices = Vec::with_capacity(names.len());
+            for n in names {
+                let index = column_index(&schema, &n.value)
+                    .ok_or_else(|| SqlError::invalid_column(&n.value).at(n.span))?;
+                if indices.contains(&index) {
+                    return Err(SqlError::new(
+                        264,
+                        16,
+                        1,
+                        format!(
+                            "The column name '{}' is specified more than once in the SET clause or column list of an INSERT.",
+                            n.value
+                        ),
+                    )
+                    .at(n.span));
+                }
+                indices.push(index);
+            }
+            indices
+        }
+        None => (0..ncols).collect(),
+    };
+    // A SELECT source is fully materialized here before any append, so
+    // `INSERT @t SELECT ... FROM @t` reads @t's pre-insert rows (Halloween-safe).
+    let input_rows = insert_input_rows(storage, &insert.source, target.len(), eval_ctx)?;
+    let mut new_rows = Vec::with_capacity(input_rows.len());
+    for input in &input_rows {
+        check_cancelled()?;
+        let mut values = vec![Datum::Null; ncols];
+        for (position, sql_value) in target.iter().zip(input) {
+            let column = &schema.columns[*position];
+            values[*position] = value::sql_to_datum(sql_value, &column.column_type, &column.name)?;
+        }
+        // NOT NULL after unspecified columns default to NULL.
+        for (index, column) in schema.columns.iter().enumerate() {
+            if !column.nullable && values[index].is_null() {
+                return Err(SqlError::null_into_not_null(
+                    &column.name,
+                    &insert.table.value,
+                ));
+            }
+        }
+        new_rows.push(values);
+    }
+    let tv = ctx.table_variables.get_mut(&key).expect("checked above");
+    // PRIMARY KEY uniqueness (collation-aware, against existing and same-batch
+    // rows). Checked before any append, so a violation appends nothing.
+    if !key_columns.is_empty() {
+        let mut seen: std::collections::HashSet<Vec<u8>> = tv
+            .rows
+            .iter()
+            .filter_map(|r| crate::relstore::key::encode_key(&schema, &key_columns, r).ok())
+            .collect();
+        for row in &new_rows {
+            let encoded = crate::relstore::key::encode_key(&schema, &key_columns, row)
+                .map_err(|e| SqlError::message_only(245, e.to_string()))?;
+            if !seen.insert(encoded) {
+                return Err(SqlError::new(
+                    2627,
+                    14,
+                    1,
+                    "Violation of PRIMARY KEY constraint. Cannot insert duplicate key in a table variable.",
+                ));
+            }
+        }
+    }
+    let inserted = new_rows.len() as u64;
+    tv.rows.extend(new_rows);
+    Ok(StatementResult::RowsAffected(inserted))
+}
+
+/// SQL Server 1087: a `@t` table variable used before it was declared.
+fn must_declare_table_var(name: &str) -> SqlError {
+    SqlError::new(
+        1087,
+        15,
+        2,
+        format!("Must declare the table variable \"{name}\"."),
+    )
 }
 
 /// Produces the input rows an INSERT supplies, each already in target-column
@@ -9192,6 +9440,10 @@ fn collect_locked_tables<'a>(select: &'a Select, out: &mut Vec<&'a Name>) {
 /// join `ON` predicates (which may contain their own subqueries).
 fn collect_from_tables<'a>(tref: &'a TableRef, out: &mut Vec<&'a Name>) {
     match tref {
+        // A `@t` table variable is session-local: it takes no lock and — via
+        // statement_reads_tables — must not arm a snapshot, so it is never
+        // collected as a locked/snapshotted table.
+        TableRef::Table { name, .. } if name.value.starts_with('@') => {}
         TableRef::Table { name, .. } => out.push(name),
         TableRef::Join {
             left, right, on, ..
@@ -9465,6 +9717,8 @@ fn collect_select_read_names(select: &Select, tables: &mut Vec<String>, funcs: &
 
 fn collect_from_read_names(tref: &TableRef, tables: &mut Vec<String>, funcs: &mut Vec<String>) {
     match tref {
+        // A `@t` table variable is session-local — no lock, no snapshot.
+        TableRef::Table { name, .. } if name.value.starts_with('@') => {}
         TableRef::Table { name, .. } => tables.push(name.value.clone()),
         TableRef::Join {
             left, right, on, ..
@@ -9666,6 +9920,35 @@ fn build_table_source(
     let qualifier = alias
         .map(|a| a.value.clone())
         .unwrap_or_else(|| strip_schema(&name.value).to_string());
+    // A `@t` table variable: serve its in-memory rows as a materialized source.
+    // (The catalog resolver never matches an `@`-name, so this is the only path
+    // that handles it — and it never touches Storage.)
+    if name.value.starts_with('@') {
+        let tv = current_table_var(&name.value)
+            .ok_or_else(|| must_declare_table_var(&name.value).at(name.span))?;
+        let count = tv.schema.columns.len();
+        let columns = tv
+            .schema
+            .columns
+            .iter()
+            .map(|c| ResultColumn {
+                name: c.name.clone(),
+                column_type: c.column_type,
+            })
+            .collect();
+        let collations = tv
+            .schema
+            .columns
+            .iter()
+            .map(|c| c.collation.clone())
+            .collect();
+        return Ok(Source {
+            columns,
+            qualifiers: vec![Some(qualifier); count],
+            collations,
+            rows: SourceRows::Materialized(tv.rows),
+        });
+    }
     let base = match name.value.to_ascii_lowercase().as_str() {
         "sys.tables" => sys_tables(storage),
         "sys.databases" => sys_databases(storage, eval_ctx),

--- a/crates/truthdb-core/tests/slt/table_variables.slt
+++ b/crates/truthdb-core/tests/slt/table_variables.slt
@@ -127,3 +127,7 @@ DECLARE @t TABLE (id INT UNIQUE)
 
 statement error
 DECLARE @t TABLE (id INT CHECK (id > 0))
+
+# Duplicate column names in the declaration are 2705 (as for a base table).
+statement error
+DECLARE @t TABLE (id INT, id INT)

--- a/crates/truthdb-core/tests/slt/table_variables.slt
+++ b/crates/truthdb-core/tests/slt/table_variables.slt
@@ -1,0 +1,76 @@
+# Table variables (Stage 15): DECLARE @t TABLE, INSERT @t (VALUES and SELECT),
+# SELECT FROM @t, NOT NULL + PRIMARY KEY enforcement, ROLLBACK survival.
+
+statement ok
+DECLARE @t TABLE (id INT NOT NULL PRIMARY KEY, name NVARCHAR(20)); INSERT INTO @t (id, name) VALUES (1, 'a'), (2, 'b'); INSERT INTO @t (id, name) VALUES (3, 'c')
+
+# NOTE: each slt statement/query is its own batch, so a table variable declared
+# in one line is gone by the next. The read cases below declare + populate +
+# read within a single multi-statement batch (one `query` block).
+
+# SELECT FROM @t within the same batch.
+query IT rowsort
+DECLARE @t TABLE (id INT NOT NULL PRIMARY KEY, name NVARCHAR(20)); INSERT INTO @t VALUES (1, 'a'), (2, 'b'), (3, 'c'); SELECT id, name FROM @t
+----
+1 a
+2 b
+3 c
+
+# Filter and an alias.
+query I
+DECLARE @t TABLE (id INT NOT NULL PRIMARY KEY); INSERT INTO @t VALUES (1), (2), (3); SELECT COUNT(*) AS n FROM @t AS x WHERE x.id >= 2
+----
+2
+
+# INSERT @t SELECT ... FROM a base table.
+statement ok
+CREATE TABLE src (id INT NOT NULL PRIMARY KEY, v INT)
+
+statement ok
+INSERT INTO src VALUES (10, 100), (20, 200)
+
+query II rowsort
+DECLARE @t TABLE (id INT NOT NULL PRIMARY KEY, v INT); INSERT INTO @t SELECT id, v FROM src; SELECT id, v FROM @t
+----
+10 100
+20 200
+
+# Join @t against a base table.
+query IT rowsort
+DECLARE @t TABLE (id INT NOT NULL PRIMARY KEY, tag NVARCHAR(10)); INSERT INTO @t VALUES (10, 'ten'), (20, 'twenty'); SELECT s.v, t.tag FROM src AS s JOIN @t AS t ON s.id = t.id
+----
+100 ten
+200 twenty
+
+# INSERT @t SELECT FROM @t is Halloween-safe (the SELECT reads the pre-insert
+# rows): starting from 2 rows, self-insert yields 4, not an unbounded loop.
+query I
+DECLARE @t TABLE (id INT NOT NULL PRIMARY KEY); INSERT INTO @t VALUES (1), (2); INSERT INTO @t SELECT id + 100 FROM @t; SELECT COUNT(*) AS n FROM @t
+----
+4
+
+# NOT NULL is enforced.
+statement error
+DECLARE @t TABLE (id INT NOT NULL PRIMARY KEY); INSERT INTO @t VALUES (NULL)
+
+# PRIMARY KEY uniqueness is enforced (2627), incl. within one INSERT.
+statement error
+DECLARE @t TABLE (id INT NOT NULL PRIMARY KEY); INSERT INTO @t VALUES (1), (1)
+
+# A table variable survives ROLLBACK (it is session memory, not transactional).
+query I
+DECLARE @t TABLE (id INT NOT NULL PRIMARY KEY); BEGIN TRAN; INSERT INTO @t VALUES (1), (2); ROLLBACK; SELECT COUNT(*) AS n FROM @t
+----
+2
+
+# Re-declaring the same name in a batch is 134.
+statement error
+DECLARE @t TABLE (id INT NOT NULL PRIMARY KEY); DECLARE @t TABLE (x INT)
+
+# A name cannot be both a scalar and a table variable (134).
+statement error
+DECLARE @t INT; DECLARE @t TABLE (id INT)
+
+# An undeclared table variable is an error.
+statement error
+SELECT * FROM @undeclared

--- a/crates/truthdb-core/tests/slt/table_variables.slt
+++ b/crates/truthdb-core/tests/slt/table_variables.slt
@@ -67,10 +67,63 @@ DECLARE @t TABLE (id INT NOT NULL PRIMARY KEY); BEGIN TRAN; INSERT INTO @t VALUE
 statement error
 DECLARE @t TABLE (id INT NOT NULL PRIMARY KEY); DECLARE @t TABLE (x INT)
 
-# A name cannot be both a scalar and a table variable (134).
+# A name cannot be both a scalar and a table variable (134), either order.
 statement error
 DECLARE @t INT; DECLARE @t TABLE (id INT)
+
+statement error
+DECLARE @t TABLE (id INT); DECLARE @t INT
 
 # An undeclared table variable is an error.
 statement error
 SELECT * FROM @undeclared
+
+# A table variable is visible inside an IF condition subquery (the read view is
+# armed for condition evaluation, not only for ordinary statements).
+query I
+DECLARE @t TABLE (id INT NOT NULL PRIMARY KEY); INSERT INTO @t VALUES (1), (2); IF EXISTS (SELECT 1 FROM @t) SELECT 42 AS n
+----
+42
+
+query I
+DECLARE @t TABLE (id INT NOT NULL PRIMARY KEY); INSERT INTO @t VALUES (1), (2); IF (SELECT COUNT(*) FROM @t) = 2 SELECT 7 AS n
+----
+7
+
+# ... and inside a WHILE condition subquery (here the count is 1, so the loop
+# body never runs and control reaches the trailing SELECT).
+query I
+DECLARE @t TABLE (id INT NOT NULL PRIMARY KEY); INSERT INTO @t VALUES (1); WHILE (SELECT COUNT(*) FROM @t) > 5 SELECT 0; SELECT 99 AS n
+----
+99
+
+# A table-level PRIMARY KEY column is implicitly NOT NULL (515 on a NULL insert),
+# exactly as the inline form is.
+statement error
+DECLARE @t TABLE (id INT, PRIMARY KEY (id)); INSERT INTO @t VALUES (NULL)
+
+# Declaring a PRIMARY KEY column explicitly NULL is 8111.
+statement error
+DECLARE @t TABLE (id INT NULL, PRIMARY KEY (id))
+
+# Column DEFAULT is applied to unspecified columns, before the NOT NULL check.
+query I
+DECLARE @t TABLE (id INT, c INT NOT NULL DEFAULT 5); INSERT INTO @t (id) VALUES (1); SELECT c FROM @t
+----
+5
+
+query I
+DECLARE @t TABLE (id INT, c INT DEFAULT 42); INSERT INTO @t (id) VALUES (1); SELECT c FROM @t
+----
+42
+
+# Column constraints the table-variable executor does not enforce are rejected
+# at parse time rather than silently ignored.
+statement error
+DECLARE @t TABLE (id INT IDENTITY(1,1))
+
+statement error
+DECLARE @t TABLE (id INT UNIQUE)
+
+statement error
+DECLARE @t TABLE (id INT CHECK (id > 0))

--- a/crates/truthdb-sql/src/ast.rs
+++ b/crates/truthdb-sql/src/ast.rs
@@ -44,6 +44,15 @@ pub enum Statement {
     AlterDatabase(AlterDatabase),
     /// `DECLARE @a TYPE [= expr], ...` — batch variable declarations.
     Declare(Vec<Declaration>),
+    /// `DECLARE @t TABLE ( <column-defs> )` — an in-memory table variable. It is
+    /// a standalone declaration (SQL Server forbids mixing it with others).
+    DeclareTableVar {
+        /// The variable name, without the leading `@`, lowercased.
+        name: String,
+        columns: Vec<ColumnDef>,
+        primary_key: Vec<Name>,
+        span: Span,
+    },
     /// `EXEC[UTE] <proc> [args...]` — the T-SQL text path to the system
     /// procedures (`sp_executesql` is the supported one).
     Exec(ExecStatement),

--- a/crates/truthdb-sql/src/parser.rs
+++ b/crates/truthdb-sql/src/parser.rs
@@ -544,6 +544,22 @@ impl Parser {
             let name = name.clone();
             self.bump();
             let _ = self.eat_keyword("AS"); // `DECLARE @v AS INT` — AS optional
+            // `DECLARE @t TABLE ( ... )` — an in-memory table variable, which
+            // must be a declaration on its own (SQL Server forbids mixing it).
+            if self.peek_keyword().as_deref() == Some("TABLE") {
+                if !decls.is_empty() {
+                    let token = self.peek().clone();
+                    return Err(SqlError::syntax(self.token_text(&token), token.span));
+                }
+                self.bump(); // TABLE
+                let (columns, primary_key) = self.parse_table_var_columns()?;
+                return Ok(Statement::DeclareTableVar {
+                    name,
+                    columns,
+                    primary_key,
+                    span: token.span.to(self.prev_span()),
+                });
+            }
             let (data_type, type_span) = self.parse_data_type()?;
             let (initializer, end) = if self.eat(&TokenKind::Eq) {
                 let expr = self.parse_expr()?;
@@ -563,6 +579,53 @@ impl Parser {
             }
         }
         Ok(Statement::Declare(decls))
+    }
+
+    /// Parses a table variable's `( <column-defs> )` body: column definitions
+    /// (with inline `NOT NULL` / `PRIMARY KEY`) plus a table-level `PRIMARY KEY
+    /// (cols)`. Other table constraints (UNIQUE/CHECK/FOREIGN KEY) are not yet
+    /// supported on a table variable.
+    fn parse_table_var_columns(&mut self) -> SqlResult<(Vec<ColumnDef>, Vec<Name>)> {
+        self.expect(&TokenKind::LParen)?;
+        let mut columns = Vec::new();
+        let mut primary_key: Vec<Name> = Vec::new();
+        loop {
+            if self.peek_keyword().as_deref() == Some("PRIMARY") {
+                if !primary_key.is_empty() {
+                    return Err(SqlError::message_only(
+                        8110,
+                        "Cannot add multiple PRIMARY KEY constraints to a table.",
+                    ));
+                }
+                self.bump();
+                self.expect_keyword("KEY")?;
+                self.expect(&TokenKind::LParen)?;
+                loop {
+                    primary_key.push(self.parse_name()?);
+                    if !self.eat(&TokenKind::Comma) {
+                        break;
+                    }
+                }
+                self.expect(&TokenKind::RParen)?;
+            } else {
+                let column = self.parse_column_def()?;
+                if column.primary_key {
+                    if !primary_key.is_empty() {
+                        return Err(SqlError::message_only(
+                            8110,
+                            "Cannot add multiple PRIMARY KEY constraints to a table.",
+                        ));
+                    }
+                    primary_key.push(column.name.clone());
+                }
+                columns.push(column);
+            }
+            if !self.eat(&TokenKind::Comma) {
+                break;
+            }
+        }
+        self.expect(&TokenKind::RParen)?;
+        Ok((columns, primary_key))
     }
 
     /// `USE <database>`.
@@ -1772,7 +1835,7 @@ impl Parser {
         if self.peek_keyword().as_deref() == Some("INTO") {
             self.bump();
         }
-        let table = self.parse_name()?;
+        let table = self.parse_table_name()?;
         let columns = if self.check(&TokenKind::LParen) {
             // Column list, unless this paren opens VALUES-less tuple (it
             // does not in our grammar), so it is always a column list.
@@ -2226,9 +2289,10 @@ impl Parser {
             self.expect(&TokenKind::RParen)?;
             return Ok(inner);
         }
-        let name = self.parse_name()?;
-        // `name ( args )` in table position is a table-valued function call.
-        if self.check(&TokenKind::LParen) {
+        let name = self.parse_table_name()?;
+        // `name ( args )` in table position is a table-valued function call — but
+        // a `@t` table variable is never a function call.
+        if !name.value.starts_with('@') && self.check(&TokenKind::LParen) {
             self.bump(); // (
             let mut args = Vec::new();
             if !self.check(&TokenKind::RParen) {
@@ -2802,6 +2866,24 @@ impl Parser {
     /// parts with `.` into a single value (e.g. `sys.tables`). Stage 3 has
     /// one user schema (`dbo`) plus the `sys` catalog views; deeper
     /// qualification is left to later stages.
+    /// Parses a name in TABLE position (an INSERT/UPDATE/DELETE target or a FROM
+    /// primary): a `@t` local variable there names a table variable, kept with
+    /// its leading `@` in `Name.value` as the marker the executor detects (the
+    /// catalog resolver never matches a name containing `@`). Any other name is
+    /// an ordinary (possibly schema-qualified) table name.
+    fn parse_table_name(&mut self) -> SqlResult<Name> {
+        if let TokenKind::LocalVar(name) = &self.peek().kind {
+            let name = name.clone();
+            let span = self.bump().span;
+            return Ok(Name {
+                value: format!("@{name}"),
+                quoted: false,
+                span,
+            });
+        }
+        self.parse_name()
+    }
+
     fn parse_name(&mut self) -> SqlResult<Name> {
         let first = self.parse_ident()?;
         let mut value = first.value;

--- a/crates/truthdb-sql/src/parser.rs
+++ b/crates/truthdb-sql/src/parser.rs
@@ -582,9 +582,10 @@ impl Parser {
     }
 
     /// Parses a table variable's `( <column-defs> )` body: column definitions
-    /// (with inline `NOT NULL` / `PRIMARY KEY`) plus a table-level `PRIMARY KEY
-    /// (cols)`. Other table constraints (UNIQUE/CHECK/FOREIGN KEY) are not yet
-    /// supported on a table variable.
+    /// (with inline `NULL`/`NOT NULL`, `PRIMARY KEY`, and `DEFAULT`) plus a
+    /// table-level `PRIMARY KEY (cols)`. IDENTITY, UNIQUE, CHECK, and FOREIGN KEY
+    /// — supported on a base table — are rejected here rather than silently
+    /// ignored, since the table-variable executor does not enforce them.
     fn parse_table_var_columns(&mut self) -> SqlResult<(Vec<ColumnDef>, Vec<Name>)> {
         self.expect(&TokenKind::LParen)?;
         let mut columns = Vec::new();
@@ -609,6 +610,23 @@ impl Parser {
                 self.expect(&TokenKind::RParen)?;
             } else {
                 let column = self.parse_column_def()?;
+                // The table-variable executor honors columns, NULL/NOT NULL,
+                // PRIMARY KEY, and DEFAULT; the rest of parse_column_def's
+                // grammar it would ignore, so reject those constructs here.
+                let unsupported = if column.identity.is_some() {
+                    Some("IDENTITY")
+                } else if column.unique {
+                    Some("UNIQUE")
+                } else if !column.checks.is_empty() {
+                    Some("CHECK")
+                } else if !column.foreign_keys.is_empty() {
+                    Some("REFERENCES")
+                } else {
+                    None
+                };
+                if let Some(feature) = unsupported {
+                    return Err(SqlError::syntax(feature, column.span));
+                }
                 if column.primary_key {
                     if !primary_key.is_empty() {
                         return Err(SqlError::message_only(


### PR DESCRIPTION
Adds T-SQL **table variables** to TruthDB: `DECLARE @t TABLE (cols)`, `INSERT @t` (VALUES and SELECT), and `@t` in a `FROM` clause. A table variable is session memory — no Storage, lock, or WAL — so it survives ROLLBACK, is cleared at batch end, and is isolated at the EXEC/sp_executesql/function-body boundaries.

## Semantics
- **Store**: `TxnContext.table_variables` (disjoint from scalar `variables`; a name lives in exactly one — 134 either declaration order).
- **INSERT @t**: declared-column coercion, column `DEFAULT`, NOT NULL (515), PRIMARY KEY uniqueness (2627, collation-aware, checked before any append). `INSERT @t SELECT ... FROM @t` is Halloween-safe (source fully materialized against the pre-insert view).
- **PRIMARY KEY** columns are implicitly NOT NULL (8111 on an explicit-NULL PK; MAX-typed key rejected), matching base tables.
- **Read view** armed via a single rule (`arm_table_var_view`) at every boundary a table-var read can originate — ordinary statement, IF/WHILE condition, scalar RETURN expression, and TVF body. A function/procedure/TVF body **shadows** the caller's view with its own (empty) one, so its `FROM @t` errors 1087 rather than reading caller rows.

## Lock/snapshot seam
An `@`-name resolves to no base table → no lock. The FROM collectors skip `@`-names so a `@t`-only statement arms no snapshot (no spurious 3952). The exception is honored: `INSERT @t SELECT FROM realtable` locks and snapshots the *source* table.

## Not supported (rejected, not silently ignored)
`UPDATE`/`DELETE @t`, and `IDENTITY`/`UNIQUE`/`CHECK`/`FOREIGN KEY` on a table-variable column (parse-time error). Multi-statement TVFs (`RETURNS @t TABLE`) are a follow-up built on this store.

## Review
A 5-lens adversarial review (seam / scope-lifetime / DML / parser / availability) surfaced 9 findings → 5 distinct defects, all fixed in the second commit: the IF/WHILE-condition invisibility and the UDF/TVF caller-leak (both HIGH, unified into the single arming rule and mutation-verified), PK-not-NULL, DEFAULT, and the dup-name check.

## Tests
`table_variables.slt` (inserts/joins/NOT NULL/PK/ROLLBACK/IF/WHILE/DEFAULT/rejections) plus engine tests: @t takes no table/row locks and arms no snapshot; `INSERT @t SELECT FROM base` does both; UDF and TVF bodies error 1087 rather than read caller rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)