### PR TITLE
Stage 15: multi-statement table-valued functions (RETURNS @t TABLE)

### DIFF
--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -6037,6 +6037,132 @@ mod tests {
     }
 
     #[test]
+    fn multi_statement_tvf_returns_body_populated_rows() {
+        let path = unique_temp_path("multi-tvf-basic");
+        let engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE nums (id INT NOT NULL PRIMARY KEY)")
+            .expect("nums");
+        engine
+            .execute("INSERT INTO nums VALUES (1),(2),(3),(4),(5),(6)")
+            .expect("seed");
+        // A multi-statement TVF: its body populates the RETURNS table variable
+        // from a real table, and the accumulated rows are the result.
+        engine
+            .execute(
+                "CREATE FUNCTION dbo.evens (@n INT) RETURNS @r TABLE (v INT NOT NULL PRIMARY KEY) \
+                 AS BEGIN INSERT INTO @r SELECT id FROM nums WHERE id % 2 = 0 AND id <= @n; RETURN END",
+            )
+            .expect("create multi-tvf");
+        let (_cols, rows) = sql_rows(&engine, "SELECT v FROM dbo.evens(5) ORDER BY v");
+        assert_eq!(
+            rows,
+            vec![vec![Some("2".to_string())], vec![Some("4".to_string())]],
+            "the body filtered nums to the evens ≤ 5"
+        );
+        // A different argument reruns the body.
+        let (_c, rows) = sql_rows(&engine, "SELECT COUNT(*) AS n FROM dbo.evens(6)");
+        assert_eq!(rows, vec![vec![Some("3".to_string())]], "evens ≤ 6 = 2,4,6");
+        // The RETURNS table's PRIMARY KEY is enforced when the body populates it:
+        // a duplicate key raises 2627 at call time (the body is not run at CREATE).
+        engine
+            .execute(
+                "CREATE FUNCTION dbo.dup () RETURNS @r TABLE (id INT NOT NULL PRIMARY KEY) \
+                 AS BEGIN INSERT INTO @r VALUES (1), (1); RETURN END",
+            )
+            .expect("create dup TVF");
+        let mut ctx = TxnContext::default();
+        let out = batch(&engine, &mut ctx, "SELECT id FROM dbo.dup()");
+        assert_eq!(
+            out.error.as_ref().map(|e| e.number),
+            Some(2627),
+            "a duplicate result PRIMARY KEY raises 2627: {:?}",
+            out.error
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn multi_statement_tvf_body_reads_are_locked_and_snapshotted() {
+        use crate::lock::{LockMode, Resource};
+        use crate::rel::Isolation;
+        let path = unique_temp_path("multi-tvf-seam");
+        let engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE secret (z INT NOT NULL PRIMARY KEY)")
+            .expect("secret");
+        engine
+            .execute(
+                "CREATE FUNCTION dbo.copy_secret () RETURNS @r TABLE (z INT NOT NULL PRIMARY KEY) \
+                 AS BEGIN INSERT INTO @r SELECT z FROM secret; RETURN END",
+            )
+            .expect("multi-tvf");
+        let secret = table_object_id(&engine, "secret");
+        // The body's read of `secret` must be Shared-locked up front, just like
+        // an inline TVF or a scalar UDF body — the lock seam.
+        let locks =
+            engine.analyze_locks("SELECT z FROM dbo.copy_secret()", Isolation::ReadCommitted);
+        assert!(
+            locks.contains(&(Resource::Table(secret), LockMode::Shared)),
+            "a multi-statement TVF's body table must be Shared-locked: {locks:?}"
+        );
+        // And it must arm the snapshot scope: under SNAPSHOT-not-allowed the body
+        // read is a data access, so the call raises 3952.
+        let mut ctx = TxnContext::default();
+        batch(
+            &engine,
+            &mut ctx,
+            "SET TRANSACTION ISOLATION LEVEL SNAPSHOT",
+        );
+        let out = batch(&engine, &mut ctx, "SELECT z FROM dbo.copy_secret()");
+        assert_eq!(
+            out.error.as_ref().map(|e| e.number),
+            Some(3952),
+            "a body-reading multi-statement TVF must arm the snapshot scope: {:?}",
+            out.error
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn multi_statement_tvf_rejects_real_table_dml_at_create() {
+        let path = unique_temp_path("multi-tvf-sideeffect");
+        let engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE log (id INT NOT NULL PRIMARY KEY)")
+            .expect("log");
+        let mut ctx = TxnContext::default();
+        // A multi-statement TVF may DML its result table variable, but writing a
+        // real table is a side effect rejected at CREATE (443).
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "CREATE FUNCTION dbo.bad () RETURNS @r TABLE (id INT NOT NULL PRIMARY KEY) \
+             AS BEGIN INSERT INTO log VALUES (1); RETURN END",
+        );
+        assert_eq!(
+            out.error.as_ref().map(|e| e.number),
+            Some(443),
+            "side-effecting DML in a TVF body is 443: {:?}",
+            out.error
+        );
+        // Its body must end in RETURN (455).
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "CREATE FUNCTION dbo.noret () RETURNS @r TABLE (id INT NOT NULL PRIMARY KEY) \
+             AS BEGIN INSERT INTO @r VALUES (1) END",
+        );
+        assert_eq!(
+            out.error.as_ref().map(|e| e.number),
+            Some(455),
+            "a function body must end in RETURN: {:?}",
+            out.error
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
     fn cf_review_describe_stops_at_control_flow() {
         // sp_describe_first_result_set: a batch whose FIRST possible rowset
         // sits inside an IF must answer "not statically derivable" — skipping

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -3810,6 +3810,35 @@ fn exec_declare_table_var(
             ),
         ));
     }
+    let (schema, key_columns, defaults) = build_table_var_definition(name, columns, primary_key)?;
+    ctx.table_variables.insert(
+        name.to_string(),
+        TableVar {
+            schema,
+            key_columns,
+            defaults,
+            rows: Vec::new(),
+        },
+    );
+    Ok(StatementResult::Done)
+}
+
+/// A table variable's built definition: its column schema, the schema indices of
+/// its PRIMARY KEY columns, and the per-column DEFAULT source text (parallel to
+/// the schema columns).
+type TableVarDefinition = (Schema, Vec<usize>, Vec<Option<String>>);
+
+/// Builds the schema, key-column indices, and per-column DEFAULT source text for
+/// a table-variable declaration (`DECLARE @name TABLE(cols)` and the RETURNS
+/// clause of a multi-statement TVF share this): unique column names (2705), PK
+/// columns forced NOT NULL (8111 on explicit-NULL, MAX-key rejected), and the
+/// DEFAULT texts applied per INSERT. `name` (without `@`) names the table in the
+/// error messages.
+fn build_table_var_definition(
+    name: &str,
+    columns: &[ColumnDef],
+    primary_key: &[Name],
+) -> Result<TableVarDefinition, SqlError> {
     // Column names within the table variable must be unique (2705), the same
     // rule a base table enforces in exec_create_table.
     let mut seen: Vec<&str> = Vec::new();
@@ -3880,16 +3909,7 @@ fn exec_declare_table_var(
     // Per-column DEFAULT source text (parallel to the schema columns), applied
     // at INSERT to columns left unspecified — same as a base table.
     let defaults: Vec<Option<String>> = columns.iter().map(|c| c.default.clone()).collect();
-    ctx.table_variables.insert(
-        name.to_string(),
-        TableVar {
-            schema,
-            key_columns,
-            defaults,
-            rows: Vec::new(),
-        },
-    );
-    Ok(StatementResult::Done)
+    Ok((schema, key_columns, defaults))
 }
 
 fn undeclared_variable_err(name: &str) -> SqlError {
@@ -5125,6 +5145,25 @@ fn exec_create_function(
                 select_text: create.body.clone(),
             }
         }
+        ReturnsClause::MultiTable {
+            var_name,
+            columns_text,
+        } => {
+            // Validate the RETURNS table declaration builds (mirrors DECLARE @t
+            // TABLE) and the body parses under the multi-statement TVF rules (may
+            // populate the result / local table variables but not touch real
+            // tables; must end in RETURN). Both are stored as text, re-parsed and
+            // re-built per call.
+            let (columns, primary_key) = truthdb_sql::parse_table_var_columns(columns_text)?;
+            build_table_var_definition(var_name, &columns, &primary_key)?;
+            let body = truthdb_sql::parse_table_function_body(&create.body)?;
+            validate_multi_tvf_body(&body)?;
+            FunctionReturns::MultiStatementTable {
+                returns_var: var_name.clone(),
+                columns_text: columns_text.clone(),
+                body: create.body.clone(),
+            }
+        }
     };
     let function = FunctionDef { params, returns };
     if create.alter {
@@ -5231,6 +5270,59 @@ fn check_function_statement(statement: &Statement) -> Result<(), SqlError> {
             1,
             "Invalid use of a side-effecting operator within a function.",
         )),
+    }
+}
+
+/// Validates a multi-statement TVF body: like a scalar function it is
+/// side-effect-free against the database, but it MAY populate table variables
+/// (its result and any locals it declares), and its last statement must be a
+/// (valueless) RETURN.
+fn validate_multi_tvf_body(statements: &[Statement]) -> Result<(), SqlError> {
+    for statement in statements {
+        check_multi_tvf_statement(statement)?;
+    }
+    match last_effective_statement(statements) {
+        Some(Statement::Return { .. }) => Ok(()),
+        _ => Err(SqlError::new(
+            455,
+            16,
+            2,
+            "The last statement included within a function must be a return statement.",
+        )),
+    }
+}
+
+/// Rejects a statement a multi-statement TVF body may not contain. The only
+/// difference from a scalar body (`check_function_statement`) is that DML into a
+/// table variable (an `@`-target) is allowed — that is how the result is built.
+fn check_multi_tvf_statement(statement: &Statement) -> Result<(), SqlError> {
+    match statement {
+        // INSERT into a table variable (the result or a local) is how a
+        // multi-statement TVF produces rows.
+        Statement::Insert(insert) if insert.table.value.starts_with('@') => Ok(()),
+        Statement::DeclareTableVar { .. } => Ok(()),
+        Statement::Block { body, .. } => {
+            for inner in body {
+                check_multi_tvf_statement(inner)?;
+            }
+            Ok(())
+        }
+        Statement::If {
+            then_branch,
+            else_branch,
+            ..
+        } => {
+            check_multi_tvf_statement(then_branch)?;
+            if let Some(else_branch) = else_branch {
+                check_multi_tvf_statement(else_branch)?;
+            }
+            Ok(())
+        }
+        Statement::While { body, .. } => check_multi_tvf_statement(body),
+        // Everything else defers to the scalar-body rules (DECLARE/SET/RETURN/
+        // assignment-SELECT allowed; real-table DML/EXEC/DDL 443; data SELECT
+        // 444).
+        other => check_function_statement(other),
     }
 }
 
@@ -7784,7 +7876,7 @@ fn resolve_scalar_function(storage: &Storage, name: &str) -> Option<TableDef> {
     match def.function.as_ref()?.returns {
         FunctionReturns::Scalar { .. } => Some(def),
         // A table-valued function is not a scalar call (it resolves in FROM).
-        FunctionReturns::InlineTable { .. } => None,
+        FunctionReturns::InlineTable { .. } | FunctionReturns::MultiStatementTable { .. } => None,
     }
 }
 
@@ -9854,6 +9946,19 @@ fn collect_statement_read_names(
         }
         // An assignment SELECT in a function body reads its FROM tables.
         Statement::Select(select) => collect_select_read_names(select, tables, funcs),
+        // A multi-statement TVF body's `INSERT @t SELECT …` / `INSERT @t VALUES
+        // (subquery)` reads real tables through its source, which must be locked
+        // up front. The @t target itself is session-local (no lock).
+        Statement::Insert(insert) => match &insert.source {
+            InsertSource::Select(select) => collect_select_read_names(select, tables, funcs),
+            InsertSource::Values(rows) => {
+                for row in rows {
+                    for expr in row {
+                        collect_expr_read_names(expr, tables, funcs);
+                    }
+                }
+            }
+        },
         Statement::Declare(declarations) => {
             for decl in declarations {
                 if let Some(init) = &decl.initializer {
@@ -10186,10 +10291,6 @@ fn build_function_source(
         .function
         .as_ref()
         .ok_or_else(|| function_not_a_table(&def.name).at(name.span))?;
-    let FunctionReturns::InlineTable { select_text } = &function.returns else {
-        // A scalar function called in table position is not a rowset.
-        return Err(function_not_a_table(&def.name).at(name.span));
-    };
     if args.len() < function.params.len() {
         return Err(SqlError::new(
             313,
@@ -10214,27 +10315,6 @@ fn build_function_source(
         )
         .at(name.span));
     }
-    // Bind the arguments to the parameters, coercing to the declared types, in a
-    // FRESH variable scope (a TVF body sees only its parameters, not caller
-    // locals). Arguments may themselves contain subqueries or scalar UDFs.
-    let no_outer = |_: &str| -> Option<usize> { None };
-    let mut variables = std::collections::HashMap::new();
-    for (param, arg) in function.params.iter().zip(args) {
-        let column_type = ColumnType::parse(&param.type_spec)
-            .map_err(|e| SqlError::message_only(245, e.to_string()))?;
-        let value = substitute_correlated_in_expr(storage, arg, &no_outer, &[], eval_ctx)
-            .and_then(|bound| eval_constant(&bound, eval_ctx))?;
-        let datum = value::sql_to_datum(&value, &column_type, &param.name)?;
-        variables.insert(
-            param.name.clone(),
-            value::datum_to_sql(&datum, &column_type),
-        );
-    }
-    let mut fn_ctx = eval_ctx.clone();
-    fn_ctx.variables = variables;
-    // Expand the body like a view (bounded by the shared nesting guard).
-    let _guard = ViewDepthGuard::enter(&def.name)?;
-    let body = parse_view_query(select_text, &def.name)?;
     let qualifier = alias
         .map(|a| a.value.clone())
         .unwrap_or_else(|| strip_schema(&name.value).to_string());
@@ -10243,15 +10323,167 @@ fn build_function_source(
         quoted: false,
         span: name.span,
     };
-    // A TVF body sees only its parameters, not caller locals — the scalar side
-    // is isolated above (fresh `variables`); do the same for the table-variable
-    // read view. Without this the body's `FROM @t` would resolve against the
-    // CALLER's table variable, since build_derived_source runs under whatever
-    // scope the calling statement armed. An empty view makes such a body error
-    // 1087, as SQL Server rejects it. (arm_table_var_view no-ops when nothing is
-    // armed, so a body with no @t reference pays nothing.)
-    let _table_var_scope = arm_table_var_view(&std::collections::HashMap::new());
-    build_derived_source(storage, &body, &qual, &fn_ctx)
+    match &function.returns {
+        FunctionReturns::InlineTable { select_text } => {
+            // Bind the arguments to the parameters, coercing to the declared
+            // types, in a FRESH variable scope (a TVF body sees only its
+            // parameters, not caller locals). Arguments may themselves contain
+            // subqueries or scalar UDFs.
+            let no_outer = |_: &str| -> Option<usize> { None };
+            let mut variables = std::collections::HashMap::new();
+            for (param, arg) in function.params.iter().zip(args) {
+                let column_type = ColumnType::parse(&param.type_spec)
+                    .map_err(|e| SqlError::message_only(245, e.to_string()))?;
+                let value = substitute_correlated_in_expr(storage, arg, &no_outer, &[], eval_ctx)
+                    .and_then(|bound| eval_constant(&bound, eval_ctx))?;
+                let datum = value::sql_to_datum(&value, &column_type, &param.name)?;
+                variables.insert(
+                    param.name.clone(),
+                    value::datum_to_sql(&datum, &column_type),
+                );
+            }
+            let mut fn_ctx = eval_ctx.clone();
+            fn_ctx.variables = variables;
+            // Expand the body like a view (bounded by the shared nesting guard).
+            let _guard = ViewDepthGuard::enter(&def.name)?;
+            let body = parse_view_query(select_text, &def.name)?;
+            // A TVF body sees only its parameters, not caller locals — the scalar
+            // side is isolated above (fresh `variables`); do the same for the
+            // table-variable read view. Without this the body's `FROM @t` would
+            // resolve against the CALLER's table variable, since build_derived_
+            // source runs under whatever scope the calling statement armed. An
+            // empty view makes such a body error 1087, as SQL Server rejects it.
+            let _table_var_scope = arm_table_var_view(&std::collections::HashMap::new());
+            build_derived_source(storage, &body, &qual, &fn_ctx)
+        }
+        FunctionReturns::MultiStatementTable {
+            returns_var,
+            columns_text,
+            body,
+        } => run_multi_statement_tvf(
+            storage,
+            function,
+            returns_var,
+            columns_text,
+            body,
+            args,
+            &qual,
+            eval_ctx,
+        ),
+        // A scalar function called in table position is not a rowset.
+        FunctionReturns::Scalar { .. } => Err(function_not_a_table(&def.name).at(name.span)),
+    }
+}
+
+/// Runs a multi-statement TVF and returns its result table variable's rows as a
+/// materialized source. The body runs in an isolated context (a fresh
+/// `TxnContext`, like a scalar UDF: parameters only, no transaction, ambient
+/// snapshot for its reads) seeded with the empty result table variable, which
+/// its statements populate; the accumulated rows are the function's result.
+#[allow(clippy::too_many_arguments)]
+fn run_multi_statement_tvf(
+    storage: &Storage,
+    function: &FunctionDef,
+    returns_var: &str,
+    columns_text: &str,
+    body_text: &str,
+    args: &[Expr],
+    qual: &Name,
+    eval_ctx: &EvalContext,
+) -> Result<Source, SqlError> {
+    // Rebuild the result table variable's schema (re-parsed per call, like the
+    // body — the CREATE-time validation guarantees this succeeds).
+    let (columns, primary_key) = truthdb_sql::parse_table_var_columns(columns_text)?;
+    let (schema, key_columns, defaults) =
+        build_table_var_definition(returns_var, &columns, &primary_key)?;
+    // Fresh isolated scope: parameters only, caller session identity carried for
+    // DB_NAME()/SUSER_SNAME()/@@SPID. Arguments evaluate in the CALLER's context.
+    let mut txn_ctx = TxnContext::default();
+    txn_ctx.set_session_identity(
+        eval_ctx.database.clone(),
+        eval_ctx.login.clone(),
+        eval_ctx.spid,
+    );
+    let no_outer = |_: &str| -> Option<usize> { None };
+    for (param, arg) in function.params.iter().zip(args) {
+        let column_type = ColumnType::parse(&param.type_spec)
+            .map_err(|e| SqlError::message_only(245, e.to_string()))?;
+        let value = substitute_correlated_in_expr(storage, arg, &no_outer, &[], eval_ctx)
+            .and_then(|bound| eval_constant(&bound, eval_ctx))?;
+        let datum = value::sql_to_datum(&value, &column_type, &param.name)?;
+        txn_ctx.variables.insert(
+            param.name.clone(),
+            (column_type, value::datum_to_sql(&datum, &column_type)),
+        );
+    }
+    // Seed the empty result table variable; the body populates it.
+    txn_ctx.table_variables.insert(
+        returns_var.to_string(),
+        TableVar {
+            schema,
+            key_columns,
+            defaults,
+            rows: Vec::new(),
+        },
+    );
+    let statements = truthdb_sql::parse_table_function_body(body_text)?;
+    // Same nesting cap as a scalar UDF (217), decremented on every exit path.
+    let depth = EXEC_DEPTH.with(|d| {
+        let v = d.get() + 1;
+        d.set(v);
+        v
+    });
+    let result = if depth > 32 {
+        Err(SqlError::new(
+            217,
+            16,
+            1,
+            "Maximum stored procedure, function, trigger, or view nesting level exceeded (limit 32).",
+        ))
+    } else {
+        let mut emitter = DiscardEmitter;
+        let mut run = BatchRun {
+            emitter: &mut emitter,
+            deferred: Vec::new(),
+            rowset_open: false,
+            durability_failed: false,
+            committed: false,
+            last_error: None,
+            // A multi-statement TVF's RETURN carries no value.
+            function_return_type: None,
+        };
+        run_block(storage, &statements, &mut txn_ctx, &mut run, false).map(|_| ())
+    };
+    EXEC_DEPTH.with(|d| d.set(d.get() - 1));
+    result?;
+    // The accumulated rows are the result. Serve them as a materialized source
+    // stamped with the call's qualifier (identical shape to the @t FROM branch).
+    let tv = txn_ctx
+        .table_variables
+        .get(returns_var)
+        .expect("seeded above");
+    let count = tv.schema.columns.len();
+    let columns_out = tv
+        .schema
+        .columns
+        .iter()
+        .map(|c| ResultColumn {
+            name: c.name.clone(),
+            column_type: c.column_type,
+        })
+        .collect();
+    let collations = tv
+        .schema
+        .columns
+        .iter()
+        .map(|c| c.collation.clone())
+        .collect();
+    Ok(Source {
+        columns: columns_out,
+        qualifiers: vec![Some(qual.value.clone()); count],
+        collations,
+        rows: SourceRows::Materialized(tv.rows.clone()),
+    })
 }
 
 /// Recursively builds a join tree's combined row source (base tables scan
@@ -11029,6 +11261,7 @@ fn sys_sql_modules(storage: &Storage) -> Source {
                     def.function.as_ref().map(|f| match &f.returns {
                         FunctionReturns::Scalar { body, .. } => body.clone(),
                         FunctionReturns::InlineTable { select_text } => select_text.clone(),
+                        FunctionReturns::MultiStatementTable { body, .. } => body.clone(),
                     })
                 })?;
             Some(vec![
@@ -11161,6 +11394,9 @@ fn sys_objects(storage: &Storage) -> Source {
                     FunctionReturns::Scalar { .. } => ("FN", "SQL_SCALAR_FUNCTION"),
                     FunctionReturns::InlineTable { .. } => {
                         ("IF", "SQL_INLINE_TABLE_VALUED_FUNCTION")
+                    }
+                    FunctionReturns::MultiStatementTable { .. } => {
+                        ("TF", "SQL_TABLE_VALUED_FUNCTION")
                     }
                 }
             } else if def.is_procedure() {
@@ -11465,6 +11701,17 @@ fn collect_read_lock_ids(
                 if let Ok(body) = parse_view_query(select_text, &def.name) {
                     let expanded = expand_ctes(&body);
                     collect_select_read_names(&expanded, &mut tables, &mut funcs);
+                }
+            }
+            // A multi-statement TVF body may read real tables (e.g. INSERT @t
+            // SELECT FROM base): those reads must be locked up front, exactly
+            // like a scalar body. (@-targets are session-local and are skipped
+            // by the read-name collectors, so they add no lock.)
+            FunctionReturns::MultiStatementTable { body, .. } => {
+                if let Ok(statements) = truthdb_sql::parse_table_function_body(body) {
+                    for statement in &statements {
+                        collect_statement_read_names(statement, &mut tables, &mut funcs);
+                    }
                 }
             }
         }

--- a/crates/truthdb-core/src/relstore/catalog.rs
+++ b/crates/truthdb-core/src/relstore/catalog.rs
@@ -161,9 +161,9 @@ pub struct FunctionDef {
     pub returns: FunctionReturns,
 }
 
-/// A function's return shape. Only the scalar form exists today; the inline and
-/// multi-statement table-valued forms are added by later work (the enum is
-/// forward-compatible — an old catalog only ever holds `Scalar`).
+/// A function's return shape (scalar, inline table-valued, or multi-statement
+/// table-valued). The enum is forward-compatible — an old catalog only ever
+/// holds the variants that existed when it was written.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum FunctionReturns {
     /// `RETURNS <type> AS BEGIN … RETURN <expr>; END`: a scalar UDF. `type_spec`
@@ -174,6 +174,18 @@ pub enum FunctionReturns {
     /// `select_text` is the body SELECT's source, re-parsed and expanded like a
     /// parameterized view (the call's arguments bind to the `@params`).
     InlineTable { select_text: String },
+    /// `RETURNS @t TABLE ( <cols> ) AS BEGIN … RETURN END`: a multi-statement
+    /// table-valued function. Both the RETURNS column list and the body are kept
+    /// as source text (re-parsed per call, exactly like the scalar/inline forms):
+    /// each call re-declares the (empty) result table variable, runs the body to
+    /// populate it, and returns its final rows.
+    MultiStatementTable {
+        /// The result table variable's name, without `@`, lowercased.
+        returns_var: String,
+        /// The `( <column-defs> )` source text of the RETURNS table.
+        columns_text: String,
+        body: String,
+    },
 }
 
 impl TableDef {

--- a/crates/truthdb-core/tests/slt/multistatement_tvf.slt
+++ b/crates/truthdb-core/tests/slt/multistatement_tvf.slt
@@ -1,0 +1,87 @@
+# Multi-statement table-valued functions (Stage 15):
+# RETURNS @t TABLE(cols) AS BEGIN <body populates @t>; RETURN END.
+
+statement ok
+CREATE TABLE nums (id INT NOT NULL PRIMARY KEY, grp INT NOT NULL)
+
+statement ok
+INSERT INTO nums VALUES (1, 10), (2, 10), (3, 20), (4, 20), (5, 30)
+
+# Body populates the result from VALUES and control flow.
+statement ok
+CREATE FUNCTION dbo.two_rows () RETURNS @r TABLE (v INT NOT NULL PRIMARY KEY) AS BEGIN INSERT INTO @r VALUES (7), (8); RETURN END
+
+query I rowsort
+SELECT v FROM dbo.two_rows()
+----
+7
+8
+
+# Body reads a base table with a parameter-driven filter.
+statement ok
+CREATE FUNCTION dbo.in_group (@g INT) RETURNS @r TABLE (id INT NOT NULL PRIMARY KEY) AS BEGIN INSERT INTO @r SELECT id FROM nums WHERE grp = @g; RETURN END
+
+query I rowsort
+SELECT id FROM dbo.in_group(20)
+----
+3
+4
+
+query I
+SELECT COUNT(*) AS n FROM dbo.in_group(10)
+----
+2
+
+# A multi-statement TVF joins against a base table like any rowset.
+query II rowsort
+SELECT n.id, n.grp FROM nums AS n JOIN dbo.in_group(20) AS g ON n.id = g.id
+----
+3 20
+4 20
+
+# Control flow inside the body (WHILE loop accumulating rows).
+statement ok
+CREATE FUNCTION dbo.count_to (@n INT) RETURNS @r TABLE (v INT NOT NULL PRIMARY KEY) AS BEGIN DECLARE @i INT = 1; WHILE @i <= @n BEGIN INSERT INTO @r VALUES (@i); SET @i = @i + 1 END; RETURN END
+
+query I rowsort
+SELECT v FROM dbo.count_to(3)
+----
+1
+2
+3
+
+# The RETURNS table's DEFAULT and NOT NULL apply to body inserts.
+statement ok
+CREATE FUNCTION dbo.with_default () RETURNS @r TABLE (id INT NOT NULL PRIMARY KEY, tag NVARCHAR(10) NOT NULL DEFAULT 'x') AS BEGIN INSERT INTO @r (id) VALUES (1); RETURN END
+
+query IT
+SELECT id, tag FROM dbo.with_default()
+----
+1 x
+
+# A body that violates the result PRIMARY KEY is accepted at CREATE (the body is
+# not run then) but errors (2627) when the function is called.
+statement ok
+CREATE FUNCTION dbo.dup_pk () RETURNS @r TABLE (id INT NOT NULL PRIMARY KEY) AS BEGIN INSERT INTO @r VALUES (1), (1); RETURN END
+
+statement error
+SELECT id FROM dbo.dup_pk()
+
+# An empty body result is a valid empty rowset.
+statement ok
+CREATE FUNCTION dbo.nothing () RETURNS @r TABLE (id INT NOT NULL PRIMARY KEY) AS BEGIN RETURN END
+
+query I
+SELECT COUNT(*) AS n FROM dbo.nothing()
+----
+0
+
+# sys.objects classifies a multi-statement TVF as TF.
+query TT
+SELECT name, type FROM sys.objects WHERE name = 'in_group'
+----
+in_group TF
+
+# A body writing a real table is rejected at CREATE (443).
+statement error
+CREATE FUNCTION dbo.side_effect () RETURNS @r TABLE (id INT NOT NULL PRIMARY KEY) AS BEGIN INSERT INTO nums VALUES (99, 99); RETURN END

--- a/crates/truthdb-sql/src/ast.rs
+++ b/crates/truthdb-sql/src/ast.rs
@@ -161,6 +161,17 @@ pub enum ReturnsClause {
     /// `RETURNS TABLE AS RETURN ( <select> )`: an inline table-valued function.
     /// The body is the SELECT (its source captured in `CreateFunction.body`).
     InlineTable,
+    /// `RETURNS @t TABLE ( <column-defs> ) AS BEGIN … RETURN END`: a
+    /// multi-statement table-valued function. The named table variable is
+    /// declared here, populated by the body (captured in `CreateFunction.body`),
+    /// and its final rows are the function's result. The column list is kept as
+    /// source text and re-parsed per call, exactly like the scalar/inline body.
+    MultiTable {
+        /// The result table variable's name, without the leading `@`, lowercased.
+        var_name: String,
+        /// The `( <column-defs> )` source text (including the parentheses).
+        columns_text: String,
+    },
 }
 
 /// One declared procedure parameter.

--- a/crates/truthdb-sql/src/lib.rs
+++ b/crates/truthdb-sql/src/lib.rs
@@ -19,7 +19,7 @@ pub mod parser;
 pub mod temporal;
 pub mod value;
 
-pub use ast::{Expr, Statement};
+pub use ast::{ColumnDef, Expr, Name, Statement};
 pub use error::{SqlError, SqlResult};
 pub use value::SqlValue;
 
@@ -45,6 +45,25 @@ pub fn parse_function_body(sql: &str) -> SqlResult<Vec<Statement>> {
     let mut parser = parser::Parser::from_tokens(sql, tokens);
     parser.set_in_function();
     parser.parse_statements()
+}
+
+/// Parses a multi-statement table-valued function body: the in-table-function
+/// grammar, where `RETURN` takes no value (it returns the accumulated result
+/// table variable).
+pub fn parse_table_function_body(sql: &str) -> SqlResult<Vec<Statement>> {
+    let tokens = lexer::Lexer::new(sql).tokenize()?;
+    let mut parser = parser::Parser::from_tokens(sql, tokens);
+    parser.set_in_table_function();
+    parser.parse_statements()
+}
+
+/// Parses a table-variable column list — the `( <column-defs> )` text of a
+/// multi-statement TVF's RETURNS clause, re-parsed per call to rebuild the
+/// result table variable's schema.
+pub fn parse_table_var_columns(sql: &str) -> SqlResult<(Vec<ColumnDef>, Vec<Name>)> {
+    let tokens = lexer::Lexer::new(sql).tokenize()?;
+    let mut parser = parser::Parser::from_tokens(sql, tokens);
+    parser.parse_table_var_columns_entry()
 }
 
 /// Parses a single standalone expression (e.g. a column DEFAULT re-parsed at

--- a/crates/truthdb-sql/src/parser.rs
+++ b/crates/truthdb-sql/src/parser.rs
@@ -39,6 +39,10 @@ pub struct Parser {
     /// the function's typed result, so the value is always parsed (not gated on
     /// a leading-token whitelist) and the 178 batch-return check does not apply.
     in_function: bool,
+    /// Parsing a multi-statement table-valued function body: `RETURN` takes NO
+    /// value (it returns the accumulated result table variable), unlike the
+    /// scalar-function body where a value is mandatory.
+    in_table_function: bool,
     /// Nesting depth inside blocks / IF branches / WHILE bodies — procedure
     /// DDL must be top-level (SQL Server 156/111 classes).
     sub_depth: usize,
@@ -63,6 +67,7 @@ impl Parser {
             while_depth: 0,
             in_procedure: false,
             in_function: false,
+            in_table_function: false,
             sub_depth: 0,
             statement_index: 0,
             nodes: 0,
@@ -109,6 +114,22 @@ impl Parser {
     /// entry for parsing a scalar function's body text.
     pub fn set_in_function(&mut self) {
         self.in_function = true;
+    }
+
+    pub fn set_in_table_function(&mut self) {
+        self.in_table_function = true;
+    }
+
+    /// Parses a standalone table-variable column list `( <column-defs> )` and
+    /// rejects trailing tokens — the entry used to re-parse a multi-statement
+    /// TVF's stored RETURNS column text per call.
+    pub fn parse_table_var_columns_entry(&mut self) -> SqlResult<(Vec<ColumnDef>, Vec<Name>)> {
+        let result = self.parse_table_var_columns()?;
+        if !self.at_eof() {
+            let token = self.peek().clone();
+            return Err(SqlError::syntax(self.token_text(&token), token.span));
+        }
+        Ok(result)
     }
 
     /// Parses exactly one expression followed by EOF (for a re-parsed DEFAULT).
@@ -324,6 +345,14 @@ impl Parser {
     /// start one (T-SQL RETURN takes an integer expression).
     fn parse_return(&mut self) -> SqlResult<Statement> {
         let start = self.expect_keyword("RETURN")?;
+        // A multi-statement TVF's RETURN carries no value — it returns the
+        // accumulated result table variable — so never parse an expression.
+        if self.in_table_function {
+            return Ok(Statement::Return {
+                span: start.to(self.prev_span()),
+                value: None,
+            });
+        }
         // A scalar function's RETURN yields its mandatory typed result, so the
         // expression is always parsed (it commonly begins with a word — a
         // column, CASE, CAST, NULL, or a nested call — which the batch/procedure
@@ -1717,10 +1746,65 @@ impl Parser {
         }
         self.expect(&TokenKind::RParen)?;
         self.expect_keyword("RETURNS")?;
+        // `RETURNS @t TABLE ( <cols> ) AS BEGIN … RETURN END` is a
+        // multi-statement table-valued function: the named table variable is
+        // declared here and populated by the body (captured verbatim like a
+        // scalar body, re-parsed under the function grammar per call).
+        if let TokenKind::LocalVar(var_name) = &self.peek().kind {
+            let var_name = var_name.clone();
+            self.bump(); // @t
+            self.expect_keyword("TABLE")?;
+            // Capture the `( <cols> )` source verbatim (re-parsed per call, like
+            // the scalar/inline bodies); parse it now to validate it and to find
+            // where the column list ends.
+            let cols_start = self.peek().span.start;
+            self.parse_table_var_columns()?;
+            let columns_text = self
+                .slice(Span::new(cols_start, self.prev_span().end))
+                .trim()
+                .to_string();
+            self.expect_keyword("AS")?;
+            let body_start = self.peek().span.start;
+            let body = self.src[body_start..].trim().to_string();
+            if body.is_empty() {
+                let token = self.peek().clone();
+                return Err(SqlError::syntax(self.token_text(&token), token.span));
+            }
+            // Validate the body parses under the multi-statement-TVF grammar
+            // (RETURN takes no value here — it returns the accumulated table).
+            self.in_table_function = true;
+            let validated = (|| -> SqlResult<()> {
+                loop {
+                    while self.eat(&TokenKind::Semicolon) {}
+                    if self.at_eof() {
+                        return Ok(());
+                    }
+                    self.nodes = 0;
+                    self.parse_statement()?;
+                    if !self.at_eof() && !self.check(&TokenKind::Semicolon) {
+                        let token = self.peek().clone();
+                        return Err(SqlError::syntax(self.token_text(&token), token.span));
+                    }
+                }
+            })();
+            self.in_table_function = false;
+            validated?;
+            let span = start.to(self.prev_span());
+            return Ok(Statement::CreateFunction(CreateFunction {
+                name,
+                params,
+                returns: ReturnsClause::MultiTable {
+                    var_name,
+                    columns_text,
+                },
+                body,
+                alter,
+                span,
+            }));
+        }
         // `RETURNS TABLE` is an inline table-valued function: its body is a
         // single `AS RETURN ( <select> )` captured as source text and expanded
-        // like a parameterized view. (Multi-statement `RETURNS @t TABLE(...)` is
-        // added by later work.) Anything else is a scalar return type.
+        // like a parameterized view. Anything else is a scalar return type.
         if self.peek_keyword().as_deref() == Some("TABLE") {
             self.bump(); // TABLE
             self.expect_keyword("AS")?;


### PR DESCRIPTION
The last CREATE FUNCTION form: `RETURNS @t TABLE(cols) AS BEGIN <body populates @t>; RETURN END`. Built on the table-variable store from #131 — the body runs in an isolated context seeded with the empty result table variable, and its accumulated rows are the result.

## Design
- **Parser**: a third `RETURNS` branch (a `@var` before `TABLE`) captures the column list and body as source text, re-parsed per call like the scalar/inline forms. A new `in_table_function` mode makes `RETURN` valueless.
- **Catalog**: `FunctionReturns::MultiStatementTable { returns_var, columns_text, body }` — text only (Schema isn't serializable; the codebase stores schemas as text).
- **Execution**: `run_multi_statement_tvf` mirrors scalar-UDF isolation (fresh `TxnContext`, params only, ambient snapshot, `EXEC_DEPTH` cap 217, args evaluated in the caller's scope), seeds the result table variable, runs the body, and serves its final rows as a materialized source. The body reads its own table variables (shadowing the caller's, per #131).
- **CREATE validation**: the body may INSERT into table variables but real-table DML/EXEC/DDL is 443, a data-returning SELECT is 444, the body must end in RETURN (455). The RETURNS table schema is built exactly as `DECLARE @t TABLE` (factored `build_table_var_definition`, shared with #131).

## The lock seam
A body's `INSERT @t SELECT FROM realtable` reads a real table that must be locked up front. `collect_read_lock_ids` recurses the body, and `collect_statement_read_names` gained an INSERT arm so the source SELECT's tables are collected (they were dropped before — scalar bodies never INSERT). Verified: `analyze_locks` Shared-locks the body table, and a body-reading TVF raises 3952 under SNAPSHOT-not-allowed.

`sys.objects` classifies it `TF`/`SQL_TABLE_VALUED_FUNCTION`; `sys.sql_modules` returns the body.

## Tests
`multistatement_tvf.slt` (VALUES/SELECT population, base-table reads, joins, WHILE-loop bodies, DEFAULT/NOT NULL, empty result, 443/455/2627, sys.objects TF) plus engine tests (body-populated rows, the lock+snapshot seam, 2627 on a duplicate result key, CREATE-time 443/455 rejection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)