### PR TITLE
Stage 15: AFTER DML triggers (CREATE TRIGGER, inserted/deleted)

### DIFF
--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -6010,6 +6010,191 @@ mod tests {
     }
 
     #[test]
+    fn after_insert_trigger_fires_reading_inserted() {
+        use crate::lock::{LockMode, Resource};
+        use crate::rel::Isolation;
+        let path = unique_temp_path("trg-insert");
+        let engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE t (id INT NOT NULL PRIMARY KEY, v INT)")
+            .expect("t");
+        engine
+            .execute("CREATE TABLE audit (id INT NOT NULL PRIMARY KEY, v INT)")
+            .expect("audit");
+        engine
+            .execute("CREATE TRIGGER trg_t ON t AFTER INSERT AS INSERT INTO audit SELECT id, v FROM inserted")
+            .expect("trigger");
+        let mut ctx = TxnContext::default();
+        let out = batch(&engine, &mut ctx, "INSERT INTO t VALUES (1, 100), (2, 200)");
+        assert!(out.error.is_none(), "insert+trigger: {:?}", out.error);
+        let (_c, rows) = sql_rows(&engine, "SELECT id, v FROM audit ORDER BY id");
+        assert_eq!(
+            rows,
+            vec![
+                vec![Some("1".to_string()), Some("100".to_string())],
+                vec![Some("2".to_string()), Some("200".to_string())],
+            ],
+            "the AFTER INSERT trigger copied `inserted` into audit"
+        );
+        // The lock seam: analyze_locks over the INSERT must hold `audit`'s
+        // Exclusive lock up front (the trigger body writes it) — else the body
+        // writes unlocked under 2PL.
+        let audit = table_object_id(&engine, "audit");
+        let locks = engine.analyze_locks("INSERT INTO t VALUES (9, 9)", Isolation::ReadCommitted);
+        assert!(
+            locks.contains(&(Resource::Table(audit), LockMode::Exclusive)),
+            "the trigger body's audit write must be X-locked up front: {locks:?}"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn after_update_and_delete_triggers_read_deleted_and_inserted() {
+        let path = unique_temp_path("trg-upd-del");
+        let engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE t (id INT NOT NULL PRIMARY KEY, v INT)")
+            .expect("t");
+        engine
+            .execute("INSERT INTO t VALUES (1, 10), (2, 20)")
+            .expect("seed");
+        engine
+            .execute("CREATE TABLE log (k INT NOT NULL PRIMARY KEY, oldv INT, newv INT)")
+            .expect("log");
+        // UPDATE trigger sees both `deleted` (old) and `inserted` (new).
+        engine
+            .execute(
+                "CREATE TRIGGER trg_u ON t AFTER UPDATE AS INSERT INTO log \
+                 SELECT i.id, d.v, i.v FROM inserted AS i JOIN deleted AS d ON i.id = d.id",
+            )
+            .expect("update trigger");
+        let mut ctx = TxnContext::default();
+        let out = batch(&engine, &mut ctx, "UPDATE t SET v = 99 WHERE id = 1");
+        assert!(out.error.is_none(), "update+trigger: {:?}", out.error);
+        let (_c, rows) = sql_rows(&engine, "SELECT k, oldv, newv FROM log");
+        assert_eq!(
+            rows,
+            vec![vec![
+                Some("1".to_string()),
+                Some("10".to_string()),
+                Some("99".to_string())
+            ]],
+            "UPDATE trigger joined deleted(old) and inserted(new)"
+        );
+        // DELETE trigger sees `deleted`.
+        engine
+            .execute("CREATE TABLE gone (id INT NOT NULL PRIMARY KEY)")
+            .expect("gone");
+        engine
+            .execute(
+                "CREATE TRIGGER trg_d ON t AFTER DELETE AS INSERT INTO gone SELECT id FROM deleted",
+            )
+            .expect("delete trigger");
+        let out = batch(&engine, &mut ctx, "DELETE FROM t WHERE id = 2");
+        assert!(out.error.is_none(), "delete+trigger: {:?}", out.error);
+        let (_c, rows) = sql_rows(&engine, "SELECT id FROM gone");
+        assert_eq!(
+            rows,
+            vec![vec![Some("2".to_string())]],
+            "DELETE trigger read deleted"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn trigger_rollback_raises_3609_and_undoes_the_dml() {
+        let path = unique_temp_path("trg-3609");
+        let engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE t (id INT NOT NULL PRIMARY KEY)")
+            .expect("t");
+        // A trigger that rolls back ends the transaction: 3609, and the firing
+        // INSERT is undone (atomic under the implicit transaction).
+        engine
+            .execute("CREATE TRIGGER trg_rb ON t AFTER INSERT AS ROLLBACK")
+            .expect("rollback trigger");
+        let mut ctx = TxnContext::default();
+        let out = batch(&engine, &mut ctx, "INSERT INTO t VALUES (1)");
+        assert_eq!(
+            out.error.as_ref().map(|e| e.number),
+            Some(3609),
+            "a trigger ROLLBACK raises 3609: {:?}",
+            out.error
+        );
+        let (_c, rows) = sql_rows(&engine, "SELECT COUNT(*) AS n FROM t");
+        assert_eq!(
+            rows,
+            vec![vec![Some("0".to_string())]],
+            "the INSERT must be rolled back with the trigger"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn recursive_trigger_does_not_refire_itself() {
+        let path = unique_temp_path("trg-recursive");
+        let engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE t (id INT NOT NULL PRIMARY KEY)")
+            .expect("t");
+        // A trigger whose body inserts into its OWN table must not re-fire itself
+        // (recursive triggers OFF by default) — otherwise it would loop.
+        engine
+            .execute(
+                "CREATE TRIGGER trg_self ON t AFTER INSERT AS INSERT INTO t SELECT id + 100 FROM inserted WHERE id < 100",
+            )
+            .expect("self trigger");
+        let mut ctx = TxnContext::default();
+        let out = batch(&engine, &mut ctx, "INSERT INTO t VALUES (1)");
+        assert!(out.error.is_none(), "recursive-off insert: {:?}", out.error);
+        // The original row plus one from the (non-re-firing) trigger body.
+        let (_c, rows) = sql_rows(&engine, "SELECT id FROM t ORDER BY id");
+        assert_eq!(
+            rows,
+            vec![vec![Some("1".to_string())], vec![Some("101".to_string())]],
+            "the trigger fired once, did not recurse on its own insert"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn trigger_cycle_lock_analysis_terminates() {
+        use crate::rel::Isolation;
+        let path = unique_temp_path("trg-cycle");
+        let engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE a (id INT NOT NULL PRIMARY KEY)")
+            .expect("a");
+        engine
+            .execute("CREATE TABLE b (id INT NOT NULL PRIMARY KEY)")
+            .expect("b");
+        // A trigger cycle: a's trigger writes b, b's trigger writes a. Lock
+        // analysis recurses trigger bodies — without the visited-set it would
+        // recurse forever and hang under the scheduler mutex. Run in a thread so
+        // a regression fails on the timeout rather than hanging the test binary.
+        engine
+            .execute(
+                "CREATE TRIGGER trg_a ON a AFTER INSERT AS INSERT INTO b SELECT id FROM inserted",
+            )
+            .expect("trg_a");
+        engine
+            .execute(
+                "CREATE TRIGGER trg_b ON b AFTER INSERT AS INSERT INTO a SELECT id FROM inserted",
+            )
+            .expect("trg_b");
+        let (tx, rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let _ = engine.analyze_locks("INSERT INTO a VALUES (1)", Isolation::ReadCommitted);
+            let _ = tx.send(());
+        });
+        assert!(
+            rx.recv_timeout(std::time::Duration::from_secs(10)).is_ok(),
+            "trigger-cycle lock analysis must terminate (visited-set)"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
     fn showplan_names_a_table_valued_function() {
         let path = unique_temp_path("tvf-showplan");
         let engine = new_engine(&path);

--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -6497,6 +6497,77 @@ mod tests {
     }
 
     #[test]
+    fn trigger_that_rolls_back_and_errors_does_not_wedge_the_session() {
+        let path = unique_temp_path("trg-rollback-error");
+        let engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE t (id INT NOT NULL PRIMARY KEY)")
+            .expect("t");
+        engine
+            .execute("CREATE TABLE other (id INT NOT NULL PRIMARY KEY)")
+            .expect("other");
+        // The idiomatic abort-in-trigger pattern: ROLLBACK then RAISERROR. The
+        // trigger ends the transaction AND errors — it must abort cleanly (3609
+        // path), not doom a torn-down transaction and leave the session wedged.
+        engine
+            .execute("CREATE TRIGGER trg ON t AFTER INSERT AS BEGIN ROLLBACK; RAISERROR('reject', 16, 1) END")
+            .expect("trigger");
+        let mut ctx = TxnContext::default();
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "BEGIN TRANSACTION; INSERT INTO t VALUES (1)",
+        );
+        assert!(out.error.is_some(), "the trigger's RAISERROR must surface");
+        // The session is not wedged: a subsequent autocommit write succeeds
+        // (no leftover doomed state rejecting it with 3930).
+        let out = batch(&engine, &mut ctx, "INSERT INTO other VALUES (1)");
+        assert!(
+            out.error.is_none(),
+            "the session must not be wedged after ROLLBACK; RAISERROR: {:?}",
+            out.error
+        );
+        let (_c, rows) = sql_rows(&engine, "SELECT COUNT(*) AS n FROM other");
+        assert_eq!(
+            rows,
+            vec![vec![Some("1".to_string())]],
+            "the later write committed"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn uncaught_trigger_error_aborts_the_rest_of_the_batch() {
+        let path = unique_temp_path("trg-uncaught-abort");
+        let engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE t (id INT NOT NULL PRIMARY KEY)")
+            .expect("t");
+        engine
+            .execute("CREATE TABLE other (id INT NOT NULL PRIMARY KEY)")
+            .expect("other");
+        engine
+            .execute("CREATE TRIGGER trg ON t AFTER INSERT AS RAISERROR('reject', 16, 1)")
+            .expect("trigger");
+        // An uncaught trigger error in an explicit transaction aborts the batch:
+        // the statement after the failing INSERT must NOT run.
+        let mut ctx = TxnContext::default();
+        batch(
+            &engine,
+            &mut ctx,
+            "BEGIN TRANSACTION; INSERT INTO t VALUES (1); INSERT INTO other VALUES (2)",
+        );
+        batch(&engine, &mut ctx, "IF @@TRANCOUNT > 0 ROLLBACK");
+        let (_c, rows) = sql_rows(&engine, "SELECT COUNT(*) AS n FROM other");
+        assert_eq!(
+            rows,
+            vec![vec![Some("0".to_string())]],
+            "the batch must abort on the uncaught trigger error, not run the next INSERT"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
     fn trigger_is_not_an_alter_or_dml_target() {
         let path = unique_temp_path("trg-alter-target");
         let engine = new_engine(&path);

--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -6399,6 +6399,119 @@ mod tests {
     }
 
     #[test]
+    fn trigger_body_read_is_locked_under_inline_isolation_escalation() {
+        use crate::lock::{LockMode, Resource};
+        use crate::rel::Isolation;
+        let path = unique_temp_path("trg-escalation");
+        let engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE t (id INT NOT NULL PRIMARY KEY)")
+            .expect("t");
+        engine
+            .execute("CREATE TABLE r (id INT NOT NULL PRIMARY KEY)")
+            .expect("r");
+        engine
+            .execute("CREATE TRIGGER trg ON t AFTER INSERT AS SELECT id FROM r")
+            .expect("trigger");
+        let r = table_object_id(&engine, "r");
+        // A batch that escalates the isolation in-line (SET SERIALIZABLE) under a
+        // versioned session (Snapshot) must analyze the trigger body's read of r
+        // lock-based — Table S — not drop it as a versioned read. The trigger
+        // body analysis now forwards the escalation-corrected isolation.
+        let locks = engine.analyze_locks(
+            "SET TRANSACTION ISOLATION LEVEL SERIALIZABLE; INSERT INTO t VALUES (1)",
+            Isolation::Snapshot,
+        );
+        assert!(
+            locks.contains(&(Resource::Table(r), LockMode::Shared)),
+            "the trigger body's read of r must be Table-S locked under escalation: {locks:?}"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn trigger_error_rolls_back_the_dml_inside_an_explicit_transaction() {
+        let path = unique_temp_path("trg-explicit-txn");
+        let engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE t (id INT NOT NULL PRIMARY KEY)")
+            .expect("t");
+        engine
+            .execute("CREATE TRIGGER trg ON t AFTER INSERT AS RAISERROR('reject', 16, 1)")
+            .expect("trigger");
+        // Inside an explicit transaction, a trigger error must roll back the
+        // firing statement — not just under autocommit.
+        let mut ctx = TxnContext::default();
+        let out = batch(
+            &engine,
+            &mut ctx,
+            "BEGIN TRANSACTION; INSERT INTO t VALUES (1); COMMIT",
+        );
+        assert!(out.error.is_some(), "the trigger error must surface");
+        let (_c, rows) = sql_rows(&engine, "SELECT COUNT(*) AS n FROM t");
+        assert_eq!(
+            rows,
+            vec![vec![Some("0".to_string())]],
+            "the trigger error must roll back the row inside an explicit transaction"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn trigger_is_not_an_alter_or_dml_target() {
+        let path = unique_temp_path("trg-alter-target");
+        let engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE t (id INT NOT NULL PRIMARY KEY)")
+            .expect("t");
+        engine
+            .execute("CREATE TRIGGER trg ON t AFTER INSERT AS INSERT INTO t SELECT 0 WHERE 1 = 0")
+            .expect("trigger");
+        let mut ctx = TxnContext::default();
+        let out = batch(&engine, &mut ctx, "ALTER TABLE trg ADD c INT");
+        assert!(out.error.is_some(), "ALTER TABLE on a trigger must error");
+        let out = batch(&engine, &mut ctx, "INSERT INTO trg VALUES (1)");
+        assert!(out.error.is_some(), "INSERT into a trigger must error");
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn drop_table_cascade_drops_its_triggers() {
+        let path = unique_temp_path("trg-cascade-drop");
+        let engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE t (id INT NOT NULL PRIMARY KEY)")
+            .expect("t");
+        engine
+            .execute("CREATE TABLE audit (id INT NOT NULL PRIMARY KEY)")
+            .expect("audit");
+        engine
+            .execute(
+                "CREATE TRIGGER trg ON t AFTER INSERT AS INSERT INTO audit SELECT id FROM inserted",
+            )
+            .expect("trigger");
+        engine.execute("DROP TABLE t").expect("drop t");
+        // The trigger is gone (not orphaned): its name is free to reuse.
+        let (_c, rows) = sql_rows(
+            &engine,
+            "SELECT COUNT(*) AS n FROM sys.objects WHERE name = 'trg'",
+        );
+        assert_eq!(
+            rows,
+            vec![vec![Some("0".to_string())]],
+            "DROP TABLE must cascade-drop its triggers"
+        );
+        let mut ctx = TxnContext::default();
+        let out = batch(&engine, &mut ctx, "CREATE TABLE trg (x INT)");
+        assert!(
+            out.error.is_none(),
+            "the orphaned trigger name must be reusable: {:?}",
+            out.error
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
     fn showplan_names_a_table_valued_function() {
         let path = unique_temp_path("tvf-showplan");
         let engine = new_engine(&path);

--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -6439,20 +6439,59 @@ mod tests {
         engine
             .execute("CREATE TRIGGER trg ON t AFTER INSERT AS RAISERROR('reject', 16, 1)")
             .expect("trigger");
-        // Inside an explicit transaction, a trigger error must roll back the
-        // firing statement — not just under autocommit.
+        // Inside an explicit transaction, a trigger error dooms it — the COMMIT
+        // of the uncommittable transaction fails, so the firing row can never
+        // durably commit (it stays staged in the doomed, still-open transaction).
         let mut ctx = TxnContext::default();
         let out = batch(
             &engine,
             &mut ctx,
             "BEGIN TRANSACTION; INSERT INTO t VALUES (1); COMMIT",
         );
-        assert!(out.error.is_some(), "the trigger error must surface");
+        assert!(
+            out.error.is_some(),
+            "the trigger error (and the failed COMMIT of the doomed txn) must surface"
+        );
+        // Roll the doomed transaction back; nothing was ever durable.
+        batch(&engine, &mut ctx, "IF @@TRANCOUNT > 0 ROLLBACK");
         let (_c, rows) = sql_rows(&engine, "SELECT COUNT(*) AS n FROM t");
         assert_eq!(
             rows,
             vec![vec![Some("0".to_string())]],
-            "the trigger error must roll back the row inside an explicit transaction"
+            "the firing row must never durably commit after a trigger error"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn trigger_error_dooms_explicit_transaction_caught_by_try_catch() {
+        let path = unique_temp_path("trg-doomed-catch");
+        let engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE t (id INT NOT NULL PRIMARY KEY)")
+            .expect("t");
+        engine
+            .execute("CREATE TABLE audit (id INT NOT NULL PRIMARY KEY)")
+            .expect("audit");
+        engine
+            .execute("CREATE TRIGGER trg ON t AFTER INSERT AS RAISERROR('reject', 16, 1)")
+            .expect("trigger");
+        // A trigger error inside an explicit transaction DOOMS it (does not tear
+        // it down): the CATCH runs under an uncommittable transaction, so its
+        // write is rejected (3930), never silently autocommitted. After the
+        // ROLLBACK nothing is durable.
+        let mut ctx = TxnContext::default();
+        batch(
+            &engine,
+            &mut ctx,
+            "BEGIN TRANSACTION; BEGIN TRY INSERT INTO t VALUES (1); END TRY \
+             BEGIN CATCH INSERT INTO audit VALUES (99); END CATCH; ROLLBACK",
+        );
+        let (_c, rows) = sql_rows(&engine, "SELECT COUNT(*) AS n FROM audit");
+        assert_eq!(
+            rows,
+            vec![vec![Some("0".to_string())]],
+            "the CATCH write must be rejected under the doomed transaction, not autocommitted"
         );
         let _ = std::fs::remove_file(path);
     }

--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -6537,8 +6537,8 @@ mod tests {
     }
 
     #[test]
-    fn uncaught_trigger_error_aborts_the_rest_of_the_batch() {
-        let path = unique_temp_path("trg-uncaught-abort");
+    fn uncaught_trigger_error_dooms_so_later_writes_are_rejected() {
+        let path = unique_temp_path("trg-uncaught-doom");
         let engine = new_engine(&path);
         engine
             .execute("CREATE TABLE t (id INT NOT NULL PRIMARY KEY)")
@@ -6549,8 +6549,9 @@ mod tests {
         engine
             .execute("CREATE TRIGGER trg ON t AFTER INSERT AS RAISERROR('reject', 16, 1)")
             .expect("trigger");
-        // An uncaught trigger error in an explicit transaction aborts the batch:
-        // the statement after the failing INSERT must NOT run.
+        // An uncaught trigger error in an explicit transaction dooms it, so a
+        // later write in the same transaction is rejected (3930) — it cannot
+        // durably commit new work over the uncommittable transaction.
         let mut ctx = TxnContext::default();
         batch(
             &engine,
@@ -6562,7 +6563,36 @@ mod tests {
         assert_eq!(
             rows,
             vec![vec![Some("0".to_string())]],
-            "the batch must abort on the uncaught trigger error, not run the next INSERT"
+            "the doomed transaction must reject the later write, not commit it"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn doomed_transaction_catch_reaches_its_rollback_after_a_benign_error() {
+        let path = unique_temp_path("trg-catch-benign");
+        let engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE t (id INT NOT NULL PRIMARY KEY)")
+            .expect("t");
+        engine
+            .execute("CREATE TRIGGER trg ON t AFTER INSERT AS RAISERROR('reject', 16, 1)")
+            .expect("trigger");
+        // A trigger error dooms the explicit transaction and transfers to the
+        // CATCH. A benign statement-terminating error inside the CATCH (division
+        // by zero) must NOT abort the batch before the CATCH reaches its
+        // ROLLBACK — otherwise the uncommittable transaction is left open holding
+        // its locks (the wedge class). After the batch the transaction is closed.
+        let mut ctx = TxnContext::default();
+        batch(
+            &engine,
+            &mut ctx,
+            "BEGIN TRANSACTION; BEGIN TRY INSERT INTO t VALUES (1); END TRY \
+             BEGIN CATCH SELECT 1 / 0 AS x; IF XACT_STATE() <> 0 ROLLBACK; END CATCH",
+        );
+        assert!(
+            !ctx.has_open_transaction(),
+            "the CATCH must reach ROLLBACK despite the divide-by-zero; no wedged transaction"
         );
         let _ = std::fs::remove_file(path);
     }

--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -6195,6 +6195,210 @@ mod tests {
     }
 
     #[test]
+    fn trigger_raiserror_aborts_and_undoes_the_dml() {
+        let path = unique_temp_path("trg-validate");
+        let engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE t (id INT NOT NULL PRIMARY KEY)")
+            .expect("t");
+        // A validation trigger: RAISERROR (severity 16) must abort the firing
+        // statement and roll it back — not be silently swallowed.
+        engine
+            .execute(
+                "CREATE TRIGGER trg ON t AFTER INSERT AS RAISERROR('rejected by trigger', 16, 1)",
+            )
+            .expect("trigger");
+        let mut ctx = TxnContext::default();
+        let out = batch(&engine, &mut ctx, "INSERT INTO t VALUES (1)");
+        assert!(
+            out.error.is_some(),
+            "a trigger RAISERROR must fail the INSERT, not be swallowed"
+        );
+        let (_c, rows) = sql_rows(&engine, "SELECT COUNT(*) AS n FROM t");
+        assert_eq!(
+            rows,
+            vec![vec![Some("0".to_string())]],
+            "the rejected INSERT must be rolled back"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn trigger_body_exec_and_fk_reads_are_locked_up_front() {
+        use crate::lock::{LockMode, Resource};
+        use crate::rel::Isolation;
+        let path = unique_temp_path("trg-exec-fk-locks");
+        let engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE t (id INT NOT NULL PRIMARY KEY)")
+            .expect("t");
+        engine
+            .execute("CREATE TABLE w (id INT NOT NULL PRIMARY KEY)")
+            .expect("w");
+        engine
+            .execute("CREATE PROCEDURE do_write AS INSERT INTO w VALUES (1)")
+            .expect("proc");
+        engine
+            .execute("CREATE TABLE parent (id INT NOT NULL PRIMARY KEY)")
+            .expect("parent");
+        engine
+            .execute("CREATE TABLE child (id INT NOT NULL PRIMARY KEY, pid INT NOT NULL REFERENCES parent(id))")
+            .expect("child");
+        // The body EXECs a proc that writes w, and inserts into child (FK to
+        // parent). analyze_locks over the firing INSERT must include w's X lock
+        // (the EXEC'd proc's write) AND parent's S lock (the FK integrity read) —
+        // the trigger-body analysis now reuses the real lock analysis.
+        engine
+            .execute("CREATE TRIGGER trg ON t AFTER INSERT AS BEGIN EXEC do_write; INSERT INTO child VALUES (1, 1) END")
+            .expect("trigger");
+        let w = table_object_id(&engine, "w");
+        let parent = table_object_id(&engine, "parent");
+        let locks = engine.analyze_locks("INSERT INTO t VALUES (1)", Isolation::ReadCommitted);
+        // The single-row proc INSERT locks w at Table-IX + Row-X; assert w is
+        // locked at all (a write lock, IX or X), proving the EXEC was analyzed.
+        assert!(
+            locks
+                .iter()
+                .any(|(r, m)| matches!(r, Resource::Table(id) if *id == w)
+                    && matches!(m, LockMode::Exclusive | LockMode::IntentExclusive)),
+            "the EXEC'd proc's write to w must be write-locked up front: {locks:?}"
+        );
+        assert!(
+            locks.contains(&(Resource::Table(parent), LockMode::Shared)),
+            "the trigger body's FK read of parent must be S-locked up front: {locks:?}"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn procedure_called_from_trigger_cannot_read_inserted() {
+        let path = unique_temp_path("trg-proc-shadow");
+        let engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE t (id INT NOT NULL PRIMARY KEY)")
+            .expect("t");
+        engine
+            .execute("CREATE TABLE sink (id INT NOT NULL PRIMARY KEY)")
+            .expect("sink");
+        engine
+            .execute("CREATE PROCEDURE logproc AS INSERT INTO sink SELECT id FROM inserted")
+            .expect("proc");
+        engine
+            .execute("CREATE TRIGGER trg ON t AFTER INSERT AS EXEC logproc")
+            .expect("trigger");
+        // inserted is visible only in the trigger's OWN statements; a proc it
+        // EXECs cannot see it — the reference errors (and aborts the INSERT).
+        let mut ctx = TxnContext::default();
+        let out = batch(&engine, &mut ctx, "INSERT INTO t VALUES (1)");
+        assert!(
+            out.error.is_some(),
+            "a proc called from a trigger must not resolve `inserted`"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn trigger_unbalanced_begin_transaction_raises_3609() {
+        let path = unique_temp_path("trg-leak-txn");
+        let engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE t (id INT NOT NULL PRIMARY KEY)")
+            .expect("t");
+        // A trigger that opens a transaction without closing it changes
+        // @@TRANCOUNT — 3609, and the leaked transaction is rolled back.
+        engine
+            .execute("CREATE TRIGGER trg ON t AFTER INSERT AS BEGIN TRANSACTION")
+            .expect("trigger");
+        let mut ctx = TxnContext::default();
+        let out = batch(&engine, &mut ctx, "INSERT INTO t VALUES (1)");
+        assert_eq!(
+            out.error.as_ref().map(|e| e.number),
+            Some(3609),
+            "an unbalanced BEGIN in a trigger raises 3609: {:?}",
+            out.error
+        );
+        assert!(
+            !ctx.has_open_transaction(),
+            "the leaked transaction must be rolled back"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn trigger_name_is_not_a_droppable_or_queryable_table() {
+        let path = unique_temp_path("trg-not-a-table");
+        let engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE t (id INT NOT NULL PRIMARY KEY)")
+            .expect("t");
+        engine
+            .execute("CREATE TRIGGER trg ON t AFTER INSERT AS INSERT INTO t SELECT 0 WHERE 1 = 0")
+            .expect("trigger");
+        let mut ctx = TxnContext::default();
+        // DROP TABLE on the trigger name must NOT silently destroy it (3701).
+        let out = batch(&engine, &mut ctx, "DROP TABLE trg");
+        assert_eq!(
+            out.error.as_ref().map(|e| e.number),
+            Some(3701),
+            "DROP TABLE must not destroy a trigger: {:?}",
+            out.error
+        );
+        // SELECT FROM the trigger name must error, not heap-scan its root page.
+        let out = batch(&engine, &mut ctx, "SELECT * FROM trg");
+        assert_eq!(
+            out.error.as_ref().map(|e| e.number),
+            Some(208),
+            "SELECT FROM a trigger name must be invalid object: {:?}",
+            out.error
+        );
+        // sys.tables must not list the trigger.
+        let (_c, rows) = sql_rows(
+            &engine,
+            "SELECT COUNT(*) AS n FROM sys.tables WHERE name = 'trg'",
+        );
+        assert_eq!(
+            rows,
+            vec![vec![Some("0".to_string())]],
+            "sys.tables excludes triggers"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn indirect_trigger_recursion_is_allowed() {
+        let path = unique_temp_path("trg-indirect");
+        let engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE a (id INT NOT NULL PRIMARY KEY)")
+            .expect("a");
+        engine
+            .execute("CREATE TABLE b (id INT NOT NULL PRIMARY KEY)")
+            .expect("b");
+        // Recursive-OFF suppresses only DIRECT self-recursion; indirect
+        // recursion (a's trigger writes b, b's trigger writes a) is allowed and
+        // bounded by the nesting cap. The IF EXISTS guard stops the FIRING (not
+        // just the row insert) so the chain terminates — a bare WHERE would still
+        // do a 0-row INSERT that fires the next trigger, looping to the cap.
+        engine
+            .execute("CREATE TRIGGER ta ON a AFTER INSERT AS INSERT INTO b SELECT id FROM inserted")
+            .expect("ta");
+        engine
+            .execute("CREATE TRIGGER tb ON b AFTER INSERT AS IF EXISTS (SELECT 1 FROM inserted WHERE id < 10) INSERT INTO a SELECT id + 10 FROM inserted WHERE id < 10")
+            .expect("tb");
+        let mut ctx = TxnContext::default();
+        let out = batch(&engine, &mut ctx, "INSERT INTO a VALUES (1)");
+        assert!(out.error.is_none(), "indirect recursion: {:?}", out.error);
+        // a = {1 (seed), 11 (via a->b->a)}: the indirect path fired once.
+        let (_c, rows) = sql_rows(&engine, "SELECT id FROM a ORDER BY id");
+        assert_eq!(
+            rows,
+            vec![vec![Some("1".to_string())], vec![Some("11".to_string())]],
+            "indirect a->b->a recursion must fire (id 11 came through b)"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
     fn showplan_names_a_table_valued_function() {
         let path = unique_temp_path("tvf-showplan");
         let engine = new_engine(&path);

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -15,10 +15,10 @@ mod value;
 
 use truthdb_sql::ast::{
     AlterAction, AlterDatabase, AlterTable, CheckConstraint, ColumnDef, CreateFunction,
-    CreateIndex, CreateProcedure, CreateTable, CreateView, DataType, DatabaseOption, Declaration,
-    Delete, DropIndex, DropTable, DropView, ExecStatement, Expr, ExprKind, ForeignKey, Insert,
-    InsertSource, IsolationLevel, JoinKind, Name, OrderItem, RaiseError, ReturnsClause, Select,
-    SelectItem, SetStatement, Statement, TableRef, ThrowArgs, ThrowStatement, Update,
+    CreateIndex, CreateProcedure, CreateTable, CreateTrigger, CreateView, DataType, DatabaseOption,
+    Declaration, Delete, DropIndex, DropTable, DropView, ExecStatement, Expr, ExprKind, ForeignKey,
+    Insert, InsertSource, IsolationLevel, JoinKind, Name, OrderItem, RaiseError, ReturnsClause,
+    Select, SelectItem, SetStatement, Statement, TableRef, ThrowArgs, ThrowStatement, Update,
 };
 use truthdb_sql::collation::CollationSensitivity;
 use truthdb_sql::error::SqlError;
@@ -32,7 +32,7 @@ use xxhash_rust::xxh64::xxh64;
 use crate::lock::{LockMode, Resource};
 use crate::relstore::btree::ScanCursor;
 use crate::relstore::catalog::{
-    self, FunctionDef, FunctionReturns, ProcParamDef, ProcedureDef, TableDef,
+    self, FunctionDef, FunctionReturns, ProcParamDef, ProcedureDef, TableDef, TriggerDef,
 };
 use crate::relstore::row::{Column, Schema};
 use crate::relstore::types::{ColumnType, Datum};
@@ -2035,6 +2035,123 @@ fn arm_table_var_view(vars: &std::collections::HashMap<String, TableVar>) -> Opt
     (!vars.is_empty() || outer_armed).then(|| TableVarScope::enter(std::rc::Rc::new(vars.clone())))
 }
 
+/// The `inserted`/`deleted` pseudo-tables a firing trigger body reads: the new
+/// and old row images of the statement that fired it, with the parent table's
+/// schema. Rows are in schema order, exactly like a base-table row.
+struct TriggerTables {
+    schema: Schema,
+    inserted: Vec<Vec<Datum>>,
+    deleted: Vec<Vec<Datum>>,
+}
+
+thread_local! {
+    /// The `inserted`/`deleted` view visible to the running trigger body (like
+    /// CURRENT_TABLE_VARS for table variables — a batch runs on one thread and
+    /// the FROM-source builders carry only an EvalContext).
+    static CURRENT_TRIGGER_TABLES: std::cell::RefCell<Option<std::rc::Rc<TriggerTables>>> =
+        const { std::cell::RefCell::new(None) };
+}
+
+/// The `inserted` or `deleted` pseudo-table rows visible to the running trigger,
+/// as a materialized source, if a trigger scope is armed and `name` is one of
+/// them. Returns `None` for any other name (falls through to catalog resolution).
+fn current_trigger_source(name: &str, qualifier: &str) -> Option<Source> {
+    let which = name.to_ascii_lowercase();
+    if which != "inserted" && which != "deleted" {
+        return None;
+    }
+    CURRENT_TRIGGER_TABLES.with(|c| {
+        let borrow = c.borrow();
+        let tables = borrow.as_ref()?;
+        let rows = if which == "inserted" {
+            tables.inserted.clone()
+        } else {
+            tables.deleted.clone()
+        };
+        let count = tables.schema.columns.len();
+        let columns = tables
+            .schema
+            .columns
+            .iter()
+            .map(|col| ResultColumn {
+                name: col.name.clone(),
+                column_type: col.column_type,
+            })
+            .collect();
+        let collations = tables
+            .schema
+            .columns
+            .iter()
+            .map(|col| col.collation.clone())
+            .collect();
+        Some(Source {
+            columns,
+            qualifiers: vec![Some(qualifier.to_string()); count],
+            collations,
+            rows: SourceRows::Materialized(rows),
+        })
+    })
+}
+
+/// Installs the `inserted`/`deleted` view for a trigger body's execution,
+/// restoring the prior installation on drop (a nested trigger's body shadows the
+/// outer's — restore rather than clear).
+struct TriggerScope {
+    prev: Option<std::rc::Rc<TriggerTables>>,
+}
+
+impl TriggerScope {
+    fn enter(tables: std::rc::Rc<TriggerTables>) -> Self {
+        let prev = CURRENT_TRIGGER_TABLES.with(|c| c.borrow_mut().replace(tables));
+        TriggerScope { prev }
+    }
+}
+
+impl Drop for TriggerScope {
+    fn drop(&mut self) {
+        CURRENT_TRIGGER_TABLES.with(|c| *c.borrow_mut() = self.prev.take());
+    }
+}
+
+thread_local! {
+    /// The row images captured by the DML that is currently firing triggers, so
+    /// exec_insert/update/delete can populate `inserted`/`deleted` without a
+    /// signature change. Armed by the firing wrapper ONLY when the target table
+    /// has triggers — the common no-trigger path leaves this `None` (no clone).
+    static TRIGGER_CAPTURE: std::cell::RefCell<Option<CapturedImages>> =
+        const { std::cell::RefCell::new(None) };
+}
+
+/// New (`inserted`) and old (`deleted`) row images collected during a DML that
+/// has AFTER triggers to fire.
+#[derive(Default)]
+struct CapturedImages {
+    inserted: Vec<Vec<Datum>>,
+    deleted: Vec<Vec<Datum>>,
+}
+
+/// Records row images into the active capture, if one is armed. `f` builds the
+/// (inserted, deleted) images for a statement; it runs only when capture is on,
+/// so the no-trigger path pays nothing.
+fn capture_trigger_images(f: impl FnOnce() -> (Vec<Vec<Datum>>, Vec<Vec<Datum>>)) {
+    TRIGGER_CAPTURE.with(|c| {
+        let mut borrow = c.borrow_mut();
+        if let Some(images) = borrow.as_mut() {
+            let (ins, del) = f();
+            images.inserted.extend(ins);
+            images.deleted.extend(del);
+        }
+    });
+}
+
+thread_local! {
+    /// The object_ids of triggers whose bodies are currently on the stack. With
+    /// recursive triggers OFF (the default), a trigger must not re-fire itself
+    /// (direct recursion) — a trigger on T whose body DMLs T is suppressed for
+    /// that same trigger. Nested triggers on OTHER tables are not affected.
+    static FIRING_TRIGGERS: std::cell::RefCell<Vec<u32>> = const { std::cell::RefCell::new(Vec::new()) };
+}
+
 /// Statement-scoped snapshot registration: capture on entry, and release —
 /// pruning must not wait on a statement that errored — on every exit path.
 struct SnapshotScope<'a> {
@@ -2261,6 +2378,8 @@ fn statement_may_commit(statement: &Statement) -> bool {
             | Statement::DropProcedure { .. }
             | Statement::CreateFunction(_)
             | Statement::DropFunction { .. }
+            | Statement::CreateTrigger(_)
+            | Statement::DropTrigger { .. }
             | Statement::Commit { .. }
     )
 }
@@ -2687,6 +2806,16 @@ fn analyze_statements_locks(
                         add(Resource::Database, LockMode::IntentShared);
                         add(Resource::Table(oid), LockMode::Shared);
                     }
+                    // A firing AFTER-INSERT trigger's body reads/writes further
+                    // tables; hold those locks up front too (strict 2PL).
+                    let mut tvisited = std::collections::HashSet::new();
+                    add_trigger_locks(
+                        storage,
+                        def.object_id,
+                        catalog::TriggerEvent::Insert,
+                        &mut tvisited,
+                        &mut add,
+                    );
                 }
                 // INSERT ... SELECT also reads its source tables (and any
                 // subqueries in the SELECT); lock them like a SELECT so it
@@ -2740,6 +2869,14 @@ fn analyze_statements_locks(
                         add(Resource::Database, LockMode::IntentShared);
                         add(Resource::Table(oid), LockMode::Shared);
                     }
+                    let mut tvisited = std::collections::HashSet::new();
+                    add_trigger_locks(
+                        storage,
+                        def.object_id,
+                        catalog::TriggerEvent::Update,
+                        &mut tvisited,
+                        &mut add,
+                    );
                 }
             }
             Statement::Delete(delete) => {
@@ -2768,6 +2905,14 @@ fn analyze_statements_locks(
                         add(Resource::Database, LockMode::IntentShared);
                         add(Resource::Table(oid), LockMode::Shared);
                     }
+                    let mut tvisited = std::collections::HashSet::new();
+                    add_trigger_locks(
+                        storage,
+                        def.object_id,
+                        catalog::TriggerEvent::Delete,
+                        &mut tvisited,
+                        &mut add,
+                    );
                 }
             }
             // DDL serializes against every active transaction via a
@@ -2868,7 +3013,9 @@ fn analyze_statements_locks(
             Statement::CreateProcedure(_)
             | Statement::DropProcedure { .. }
             | Statement::CreateFunction(_)
-            | Statement::DropFunction { .. } => {
+            | Statement::DropFunction { .. }
+            | Statement::CreateTrigger(_)
+            | Statement::DropTrigger { .. } => {
                 add(Resource::Database, LockMode::Exclusive);
             }
             // IF/WHILE conditions read tables through their subqueries —
@@ -3039,6 +3186,20 @@ fn exec_statement_dispatch(
             }
             exec_drop_function(storage, name, *if_exists)
         }
+        Statement::CreateTrigger(create) => {
+            if txn_ctx.in_txn() {
+                return Err(ddl_in_txn_err());
+            }
+            exec_create_trigger(storage, create)
+        }
+        Statement::DropTrigger {
+            name, if_exists, ..
+        } => {
+            if txn_ctx.in_txn() {
+                return Err(ddl_in_txn_err());
+            }
+            exec_drop_trigger(storage, name, *if_exists)
+        }
         // Executed by `run_block`'s own arms; nothing routes them here.
         Statement::Block { .. }
         | Statement::If { .. }
@@ -3119,33 +3280,64 @@ fn exec_statement_dispatch(
             exec_alter_database(storage, alter, txn_ctx)
         }
         Statement::Insert(insert) => {
-            let eval_ctx = txn_ctx.eval_context();
             // INSERT into a `@t` table variable is pure session memory (no
             // Storage, no lock, no WAL) — handled here where `&mut TxnContext`
             // is in hand, before the storage scope is taken.
             if insert.table.value.starts_with('@') {
+                let eval_ctx = txn_ctx.eval_context();
                 return exec_insert_table_var(storage, insert, txn_ctx, &eval_ctx);
             }
-            let (result, identity) = {
-                let mut scope = txn_ctx.scope();
-                exec_insert(storage, insert, &mut scope, &eval_ctx)?
+            let (target, triggers) =
+                after_triggers_for(storage, &insert.table.value, catalog::TriggerEvent::Insert);
+            let run_insert = |txn_ctx: &mut TxnContext| -> Result<StatementResult, SqlError> {
+                let eval_ctx = txn_ctx.eval_context();
+                let (result, identity) = {
+                    let mut scope = txn_ctx.scope();
+                    exec_insert(storage, insert, &mut scope, &eval_ctx)?
+                };
+                // An identity INSERT updates SCOPE_IDENTITY(); a non-identity one
+                // (identity == None) leaves it unchanged.
+                if let Some(value) = identity {
+                    txn_ctx.scope_identity = Some(value);
+                }
+                Ok(result)
             };
-            // An identity INSERT updates SCOPE_IDENTITY(); a non-identity one
-            // (identity == None) leaves it unchanged.
-            if let Some(value) = identity {
-                txn_ctx.scope_identity = Some(value);
+            match target {
+                Some(target) if !triggers.is_empty() => {
+                    run_dml_with_triggers(storage, txn_ctx, &target, triggers, run_insert)
+                }
+                _ => run_insert(txn_ctx),
             }
-            Ok(result)
         }
         Statement::Update(update) => {
-            let eval_ctx = txn_ctx.eval_context();
-            let mut scope = txn_ctx.scope();
-            exec_update(storage, update, &mut scope, &eval_ctx)
+            let (target, triggers) =
+                after_triggers_for(storage, &update.table.value, catalog::TriggerEvent::Update);
+            let run_update = |txn_ctx: &mut TxnContext| -> Result<StatementResult, SqlError> {
+                let eval_ctx = txn_ctx.eval_context();
+                let mut scope = txn_ctx.scope();
+                exec_update(storage, update, &mut scope, &eval_ctx)
+            };
+            match target {
+                Some(target) if !triggers.is_empty() => {
+                    run_dml_with_triggers(storage, txn_ctx, &target, triggers, run_update)
+                }
+                _ => run_update(txn_ctx),
+            }
         }
         Statement::Delete(delete) => {
-            let eval_ctx = txn_ctx.eval_context();
-            let mut scope = txn_ctx.scope();
-            exec_delete(storage, delete, &mut scope, &eval_ctx)
+            let (target, triggers) =
+                after_triggers_for(storage, &delete.table.value, catalog::TriggerEvent::Delete);
+            let run_delete = |txn_ctx: &mut TxnContext| -> Result<StatementResult, SqlError> {
+                let eval_ctx = txn_ctx.eval_context();
+                let mut scope = txn_ctx.scope();
+                exec_delete(storage, delete, &mut scope, &eval_ctx)
+            };
+            match target {
+                Some(target) if !triggers.is_empty() => {
+                    run_dml_with_triggers(storage, txn_ctx, &target, triggers, run_delete)
+                }
+                _ => run_delete(txn_ctx),
+            }
         }
         Statement::Select(select) => {
             if select
@@ -5352,6 +5544,249 @@ fn exec_drop_function(
     }
 }
 
+/// `CREATE|ALTER TRIGGER <name> ON <table> AFTER <events> AS <body>`: registers
+/// an AFTER DML trigger as a catalog object attached to its target table.
+fn exec_create_trigger(
+    storage: &Storage,
+    create: &CreateTrigger,
+) -> Result<StatementResult, SqlError> {
+    let bare = strip_schema(&create.name.value);
+    // The target must be an existing base table (not a view/procedure/function/
+    // trigger). SQL Server 4929-class.
+    let target = resolve_table(storage, &create.target.value)
+        .ok_or_else(|| SqlError::invalid_object(&create.target.value).at(create.target.span))?;
+    if target.is_view() || target.is_procedure() || target.is_function() || target.is_trigger() {
+        return Err(SqlError::new(
+            4929,
+            16,
+            1,
+            format!(
+                "Cannot create trigger '{bare}' because its target '{}' is not a base table.",
+                target.name
+            ),
+        )
+        .at(create.target.span));
+    }
+    // Validate the body parses under the in-procedure grammar (re-parsed per
+    // firing). inserted/deleted resolve at firing time, not here.
+    truthdb_sql::parse_procedure_body(&create.body)?;
+    let events: Vec<catalog::TriggerEvent> = create
+        .events
+        .iter()
+        .map(|e| match e {
+            ast::TriggerEvent::Insert => catalog::TriggerEvent::Insert,
+            ast::TriggerEvent::Update => catalog::TriggerEvent::Update,
+            ast::TriggerEvent::Delete => catalog::TriggerEvent::Delete,
+        })
+        .collect();
+    let trigger = TriggerDef {
+        parent_object_id: target.object_id,
+        events,
+        body: create.body.clone(),
+        is_disabled: false,
+    };
+    if create.alter {
+        match resolve_table(storage, &create.name.value) {
+            Some(def) if def.is_trigger() => {
+                storage
+                    .rel_alter_trigger(&def.name, trigger)
+                    .map_err(|e| map_storage_err(e, &create.name.value))?;
+                return Ok(StatementResult::Done);
+            }
+            _ => {
+                return Err(SqlError::invalid_object(bare).at(create.name.span));
+            }
+        }
+    }
+    if resolve_table(storage, &create.name.value).is_some() {
+        return Err(SqlError::new(
+            2714,
+            16,
+            6,
+            format!("There is already an object named '{bare}' in the database."),
+        ));
+    }
+    storage
+        .rel_create_trigger(bare, trigger)
+        .map_err(|e| map_storage_err(e, &create.name.value))?;
+    Ok(StatementResult::Done)
+}
+
+fn exec_drop_trigger(
+    storage: &Storage,
+    name: &Name,
+    if_exists: bool,
+) -> Result<StatementResult, SqlError> {
+    match resolve_table(storage, &name.value) {
+        Some(def) if def.is_trigger() => {
+            storage
+                .rel_drop_table(&def.name)
+                .map_err(|e| map_storage_err(e, &def.name))?;
+            Ok(StatementResult::Done)
+        }
+        Some(_) | None if if_exists => Ok(StatementResult::Done),
+        _ => Err(SqlError::new(
+            3701,
+            11,
+            5,
+            format!(
+                "Cannot drop the trigger '{}', because it does not exist or you do not have \
+                 permission.",
+                name.value
+            ),
+        )),
+    }
+}
+
+/// Resolves the AFTER triggers to fire for a DML on `target_name` for `event`,
+/// plus the target's definition (for the pseudo-table schema). Empty when no
+/// trigger exists anywhere (the cheap `rel_has_triggers` gate keeps the common
+/// path free) or the target is not a base table.
+fn after_triggers_for(
+    storage: &Storage,
+    target_name: &str,
+    event: catalog::TriggerEvent,
+) -> (Option<TableDef>, Vec<TableDef>) {
+    if !storage.rel_has_triggers() {
+        return (None, Vec::new());
+    }
+    match resolve_table(storage, target_name) {
+        Some(def)
+            if def.trigger.is_none()
+                && def.procedure.is_none()
+                && def.function.is_none()
+                && def.view_query.is_none() =>
+        {
+            let triggers = storage.rel_triggers_for(def.object_id, event);
+            (Some(def), triggers)
+        }
+        _ => (None, Vec::new()),
+    }
+}
+
+/// Runs a DML statement (via `dml`) and fires its AFTER triggers atomically.
+/// Under autocommit an implicit transaction is opened so the DML stages rather
+/// than commits, so DML + triggers share one transaction (a trigger ROLLBACK
+/// undoes the DML) and a trigger that ends the transaction raises 3609.
+fn run_dml_with_triggers(
+    storage: &Storage,
+    txn_ctx: &mut TxnContext,
+    target_def: &TableDef,
+    triggers: Vec<TableDef>,
+    dml: impl FnOnce(&mut TxnContext) -> Result<StatementResult, SqlError>,
+) -> Result<StatementResult, SqlError> {
+    let schema = target_def
+        .schema()
+        .map_err(|e| map_storage_err(e, &target_def.name))?;
+    let implicit = !txn_ctx.in_txn();
+    if implicit {
+        exec_begin(storage, txn_ctx)?;
+    }
+    let tc_before = txn_ctx.trancount;
+    // Arm the row-image capture, run the DML (staged on the transaction), then
+    // take the captured images for the trigger bodies.
+    TRIGGER_CAPTURE.with(|c| *c.borrow_mut() = Some(CapturedImages::default()));
+    let dml_result = dml(txn_ctx);
+    let images = TRIGGER_CAPTURE
+        .with(|c| c.borrow_mut().take())
+        .unwrap_or_default();
+    let result = match dml_result {
+        Ok(r) => r,
+        Err(e) => {
+            if implicit {
+                txn_ctx.abort(storage);
+            }
+            return Err(e);
+        }
+    };
+    let tables = std::rc::Rc::new(TriggerTables {
+        schema,
+        inserted: images.inserted,
+        deleted: images.deleted,
+    });
+    // Fire each trigger once, in creation order, even for an empty image set.
+    for trig_def in &triggers {
+        if let Err(e) = fire_one_trigger(storage, txn_ctx, trig_def, &tables) {
+            if implicit {
+                txn_ctx.abort(storage);
+            }
+            return Err(e);
+        }
+        // 3609: a trigger that issued ROLLBACK/COMMIT ended (or reduced) the
+        // transaction — the batch is aborted. `abort` normalizes the state.
+        if txn_ctx.trancount < tc_before {
+            txn_ctx.abort(storage);
+            return Err(SqlError::new(
+                3609,
+                16,
+                1,
+                "The transaction ended in the trigger. The batch has been aborted.",
+            ));
+        }
+    }
+    if implicit {
+        exec_commit(storage, txn_ctx)?;
+    }
+    Ok(result)
+}
+
+/// Fires one trigger body: parses it, runs it in the firing statement's
+/// transaction (procedure posture — shared txn, fresh variable scope) with the
+/// `inserted`/`deleted` view armed, bounded by the nesting cap. Direct
+/// self-recursion is suppressed (recursive triggers OFF).
+fn fire_one_trigger(
+    storage: &Storage,
+    txn_ctx: &mut TxnContext,
+    trig_def: &TableDef,
+    tables: &std::rc::Rc<TriggerTables>,
+) -> Result<(), SqlError> {
+    let trigger = trig_def.trigger.as_ref().expect("caller passes a trigger");
+    // Recursive triggers OFF (the default): a trigger must not re-fire itself.
+    if FIRING_TRIGGERS.with(|f| f.borrow().contains(&trig_def.object_id)) {
+        return Ok(());
+    }
+    let statements = truthdb_sql::parse_procedure_body(&trigger.body)?;
+    let depth = EXEC_DEPTH.with(|d| {
+        let v = d.get() + 1;
+        d.set(v);
+        v
+    });
+    if depth > 32 {
+        EXEC_DEPTH.with(|d| d.set(d.get() - 1));
+        return Err(SqlError::new(
+            217,
+            16,
+            1,
+            "Maximum stored procedure, function, trigger, or view nesting level exceeded (limit 32).",
+        ));
+    }
+    // Procedure posture: fresh variable/table-variable scope, shared transaction.
+    let outer_vars = std::mem::take(&mut txn_ctx.variables);
+    let outer_table_vars = std::mem::take(&mut txn_ctx.table_variables);
+    FIRING_TRIGGERS.with(|f| f.borrow_mut().push(trig_def.object_id));
+    let result = {
+        let _trigger_scope = TriggerScope::enter(std::rc::Rc::clone(tables));
+        let mut emitter = DiscardEmitter;
+        let mut run = BatchRun {
+            emitter: &mut emitter,
+            deferred: Vec::new(),
+            rowset_open: false,
+            durability_failed: false,
+            committed: false,
+            last_error: None,
+            function_return_type: None,
+        };
+        run_block(storage, &statements, txn_ctx, &mut run, false).map(|_| ())
+    };
+    FIRING_TRIGGERS.with(|f| {
+        f.borrow_mut().pop();
+    });
+    EXEC_DEPTH.with(|d| d.set(d.get() - 1));
+    txn_ctx.variables = outer_vars;
+    txn_ctx.table_variables = outer_table_vars;
+    result
+}
+
 fn exec_drop_view(storage: &Storage, drop: &DropView) -> Result<StatementResult, SqlError> {
     match resolve_table(storage, &drop.name.value) {
         Some(def) if def.is_view() => {
@@ -5960,6 +6395,9 @@ fn exec_insert(
         }
     }
 
+    // Capture the new row images for an AFTER trigger's `inserted` table (only
+    // when a capture is armed — the no-trigger path clones nothing).
+    capture_trigger_images(|| (rows.clone(), Vec::new()));
     let inserted = rows.len() as u64;
     storage
         .rel_insert_many(&def.name, rows, scope)
@@ -6381,6 +6819,15 @@ fn exec_update(
         }
     }
 
+    // Capture the old/new images for an AFTER trigger's `deleted`/`inserted`
+    // tables (a row that did not change still appears in both, as SQL Server
+    // does — every matched row is in `updates`).
+    capture_trigger_images(|| {
+        (
+            updates.iter().map(|(_, _, new)| new.clone()).collect(),
+            updates.iter().map(|(_, old, _)| old.clone()).collect(),
+        )
+    });
     let count = storage
         .rel_update_located(&def.name, updates, scope)
         .map_err(|e| map_storage_err(e, &def.name))?;
@@ -6420,6 +6867,13 @@ fn exec_delete(
         enforce_parent_fks(storage, &def, &removed, "DELETE", true)?;
     }
 
+    // Capture the deleted images for an AFTER trigger's `deleted` table.
+    capture_trigger_images(|| {
+        (
+            Vec::new(),
+            targets.iter().map(|(_, row)| row.clone()).collect(),
+        )
+    });
     let count = storage
         .rel_delete_located(&def.name, targets, scope)
         .map_err(|e| map_storage_err(e, &def.name))?;
@@ -10150,12 +10604,21 @@ fn build_table_source(
             rows: SourceRows::Materialized(tv.rows),
         });
     }
+    // `inserted`/`deleted`: the firing trigger's pseudo-tables. Resolved before
+    // the catalog so a real table named `inserted` cannot be reached from inside
+    // a trigger body (SQL Server reserves them there too). Only matches when a
+    // trigger scope is armed; otherwise falls through to catalog resolution.
+    if let Some(source) = current_trigger_source(&name.value, &qualifier) {
+        return Ok(source);
+    }
     let base = match name.value.to_ascii_lowercase().as_str() {
         "sys.tables" => sys_tables(storage),
         "sys.databases" => sys_databases(storage, eval_ctx),
         "sys.configurations" => sys_configurations(),
         "sys.views" => sys_views(storage),
         "sys.procedures" => sys_procedures(storage),
+        "sys.triggers" => sys_triggers(storage),
+        "sys.trigger_events" => sys_trigger_events(storage),
         "sys.parameters" => sys_parameters(storage),
         "sys.objects" => sys_objects(storage),
         "sys.sql_modules" => sys_sql_modules(storage),
@@ -11263,7 +11726,8 @@ fn sys_sql_modules(storage: &Storage) -> Source {
                         FunctionReturns::InlineTable { select_text } => select_text.clone(),
                         FunctionReturns::MultiStatementTable { body, .. } => body.clone(),
                     })
-                })?;
+                })
+                .or_else(|| def.trigger.as_ref().map(|t| t.body.clone()))?;
             Some(vec![
                 Datum::Int(def.object_id as i32),
                 Datum::NVarChar(definition),
@@ -11293,6 +11757,75 @@ fn sys_procedures(storage: &Storage) -> Source {
             ]
         })
         .collect();
+    let collations = vec![None; columns.len()];
+    let qualifiers = vec![None; columns.len()];
+    Source {
+        columns,
+        qualifiers,
+        collations,
+        rows: SourceRows::Materialized(rows),
+    }
+}
+
+fn sys_triggers(storage: &Storage) -> Source {
+    let columns = vec![
+        nvarchar("name", 128),
+        int_col("object_id"),
+        int_col("parent_id"),
+        nvarchar("type", 2),
+        int_col("is_disabled"),
+        int_col("is_instead_of_trigger"),
+    ];
+    let rows = storage
+        .rel_tables()
+        .into_iter()
+        .filter_map(|def| {
+            let trigger = def.trigger.as_ref()?;
+            Some(vec![
+                Datum::NVarChar(def.name.clone()),
+                Datum::Int(def.object_id as i32),
+                Datum::Int(trigger.parent_object_id as i32),
+                Datum::NVarChar("TR".to_string()),
+                Datum::Int(i32::from(trigger.is_disabled)),
+                // Only AFTER triggers exist here (INSTEAD OF is not supported).
+                Datum::Int(0),
+            ])
+        })
+        .collect();
+    let collations = vec![None; columns.len()];
+    let qualifiers = vec![None; columns.len()];
+    Source {
+        columns,
+        qualifiers,
+        collations,
+        rows: SourceRows::Materialized(rows),
+    }
+}
+
+fn sys_trigger_events(storage: &Storage) -> Source {
+    let columns = vec![
+        int_col("object_id"),
+        int_col("type"),
+        nvarchar("type_desc", 128),
+    ];
+    let mut rows = Vec::new();
+    for def in storage.rel_tables() {
+        let Some(trigger) = def.trigger.as_ref() else {
+            continue;
+        };
+        for event in &trigger.events {
+            let (code, desc) = match event {
+                catalog::TriggerEvent::Insert => (1, "INSERT"),
+                catalog::TriggerEvent::Update => (2, "UPDATE"),
+                catalog::TriggerEvent::Delete => (3, "DELETE"),
+            };
+            rows.push(vec![
+                Datum::Int(def.object_id as i32),
+                Datum::Int(code),
+                Datum::NVarChar(desc.to_string()),
+            ]);
+        }
+    }
     let collations = vec![None; columns.len()];
     let qualifiers = vec![None; columns.len()];
     Source {
@@ -11401,6 +11934,8 @@ fn sys_objects(storage: &Storage) -> Source {
                 }
             } else if def.is_procedure() {
                 ("P ", "SQL_STORED_PROCEDURE")
+            } else if def.is_trigger() {
+                ("TR", "SQL_TRIGGER")
             } else if def.is_view() {
                 ("V ", "VIEW")
             } else {
@@ -11627,6 +12162,145 @@ fn read_lock_object_ids(storage: &Storage, name: &str) -> Vec<u32> {
     let mut visited = std::collections::HashSet::new();
     collect_read_lock_ids(storage, name, 0, &mut out, &mut visited);
     out
+}
+
+/// Adds the locks the AFTER-`event` trigger bodies of `parent_object_id` take,
+/// so a DML that fires them holds every lock its bodies acquire UP FRONT (strict
+/// 2PL — a trigger body reading/writing another table with no pre-acquired lock
+/// is the recurring seam-defect class). Recursion (a trigger whose body DMLs a
+/// table with its own triggers) is bounded by `visited` (trigger object_ids), so
+/// a trigger cycle terminates cleanly rather than hanging analysis under the
+/// scheduler mutex.
+fn add_trigger_locks(
+    storage: &Storage,
+    parent_object_id: u32,
+    event: catalog::TriggerEvent,
+    visited: &mut std::collections::HashSet<u32>,
+    add: &mut impl FnMut(Resource, LockMode),
+) {
+    for trig in storage.rel_triggers_for(parent_object_id, event) {
+        if !visited.insert(trig.object_id) {
+            continue;
+        }
+        let Some(t) = &trig.trigger else { continue };
+        if let Ok(statements) = truthdb_sql::parse_procedure_body(&t.body) {
+            collect_trigger_body_locks(storage, &statements, visited, add);
+        }
+    }
+}
+
+/// Walks a trigger body's statements and adds the locks they require: Exclusive
+/// on DML write targets (plus their own triggers, recursively), Shared on the
+/// tables SELECTs and INSERT..SELECT sources read.
+fn collect_trigger_body_locks(
+    storage: &Storage,
+    statements: &[Statement],
+    visited: &mut std::collections::HashSet<u32>,
+    add: &mut impl FnMut(Resource, LockMode),
+) {
+    // A base table (not a view/proc/func/trigger, not a `@t` table variable):
+    // the write-lock target of a DML in a trigger body.
+    fn write_target(storage: &Storage, name: &str) -> Option<TableDef> {
+        if name.starts_with('@') {
+            return None;
+        }
+        resolve_table(storage, name).filter(|def| {
+            def.trigger.is_none()
+                && def.view_query.is_none()
+                && def.procedure.is_none()
+                && def.function.is_none()
+        })
+    }
+    let add_reads =
+        |storage: &Storage, select: &Select, add: &mut dyn FnMut(Resource, LockMode)| {
+            let expanded = expand_ctes(select);
+            let mut tables = Vec::new();
+            collect_locked_tables(&expanded, &mut tables);
+            for name in tables {
+                for oid in read_lock_object_ids(storage, &name.value) {
+                    add(Resource::Database, LockMode::IntentShared);
+                    add(Resource::Table(oid), LockMode::Shared);
+                }
+            }
+            for oid in select_function_read_ids(storage, &expanded) {
+                add(Resource::Database, LockMode::IntentShared);
+                add(Resource::Table(oid), LockMode::Shared);
+            }
+        };
+    for statement in statements {
+        match statement {
+            Statement::Insert(insert) => {
+                if let Some(def) = write_target(storage, &insert.table.value) {
+                    add(Resource::Database, LockMode::IntentExclusive);
+                    add(Resource::Table(def.object_id), LockMode::Exclusive);
+                    add_trigger_locks(
+                        storage,
+                        def.object_id,
+                        catalog::TriggerEvent::Insert,
+                        visited,
+                        add,
+                    );
+                }
+                if let InsertSource::Select(select) = &insert.source {
+                    add_reads(storage, select, add);
+                }
+            }
+            Statement::Update(update) => {
+                if let Some(def) = write_target(storage, &update.table.value) {
+                    add(Resource::Database, LockMode::IntentExclusive);
+                    add(Resource::Table(def.object_id), LockMode::Exclusive);
+                    add_trigger_locks(
+                        storage,
+                        def.object_id,
+                        catalog::TriggerEvent::Update,
+                        visited,
+                        add,
+                    );
+                }
+            }
+            Statement::Delete(delete) => {
+                if let Some(def) = write_target(storage, &delete.table.value) {
+                    add(Resource::Database, LockMode::IntentExclusive);
+                    add(Resource::Table(def.object_id), LockMode::Exclusive);
+                    add_trigger_locks(
+                        storage,
+                        def.object_id,
+                        catalog::TriggerEvent::Delete,
+                        visited,
+                        add,
+                    );
+                }
+            }
+            Statement::Select(select) => add_reads(storage, select, add),
+            Statement::Block { body, .. } => {
+                collect_trigger_body_locks(storage, body, visited, add)
+            }
+            Statement::If {
+                then_branch,
+                else_branch,
+                ..
+            } => {
+                collect_trigger_body_locks(
+                    storage,
+                    std::slice::from_ref(then_branch),
+                    visited,
+                    add,
+                );
+                if let Some(else_branch) = else_branch {
+                    collect_trigger_body_locks(
+                        storage,
+                        std::slice::from_ref(else_branch),
+                        visited,
+                        add,
+                    );
+                }
+            }
+            Statement::While { body, .. } => {
+                collect_trigger_body_locks(storage, std::slice::from_ref(body), visited, add)
+            }
+            _ => {}
+        }
+    }
 }
 
 /// The base-table object ids the scalar functions called in a SELECT read

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -982,6 +982,9 @@ fn run_user_procedure(
     }
     txn_ctx.proc_stack.push(def.name.clone());
     txn_ctx.proc_return = None;
+    // A procedure called from a trigger body does NOT see the trigger's
+    // inserted/deleted (they are visible only in the trigger's own statements).
+    let _trigger_shadow = TriggerScope::clear();
     let depth = EXEC_DEPTH.with(|d| {
         let v = d.get() + 1;
         d.set(v);
@@ -1095,6 +1098,8 @@ fn run_user_scalar_function(
             .insert(param.name.clone(), (column_type, coerced));
     }
     let statements = truthdb_sql::parse_function_body(body)?;
+    // A scalar function called from a trigger body does not see inserted/deleted.
+    let _trigger_shadow = TriggerScope::clear();
     let depth = EXEC_DEPTH.with(|d| {
         let v = d.get() + 1;
         d.set(v);
@@ -1254,6 +1259,8 @@ fn run_exec(
         let column_type = value::infer_type(std::slice::from_ref(&value));
         txn_ctx.variables.insert(key, (column_type, value));
     }
+    // Dynamic SQL run from a trigger body does not see inserted/deleted.
+    let _trigger_shadow = TriggerScope::clear();
     let depth = EXEC_DEPTH.with(|d| {
         let v = d.get() + 1;
         d.set(v);
@@ -2105,6 +2112,16 @@ impl TriggerScope {
         let prev = CURRENT_TRIGGER_TABLES.with(|c| c.borrow_mut().replace(tables));
         TriggerScope { prev }
     }
+
+    /// Clears the `inserted`/`deleted` view for a stored-object body (a
+    /// procedure, function, TVF, or view called from within a trigger body):
+    /// those pseudo-tables are visible only in the trigger's OWN statements, not
+    /// in objects it calls. Restores the prior view on drop. A no-op (cheap) when
+    /// no trigger scope is armed.
+    fn clear() -> Self {
+        let prev = CURRENT_TRIGGER_TABLES.with(|c| c.borrow_mut().take());
+        TriggerScope { prev }
+    }
 }
 
 impl Drop for TriggerScope {
@@ -2688,7 +2705,14 @@ pub fn analyze_locks(
     // executing with no Table S. The regime lattice is finite, so
     // termination survives.
     let mut visited = std::collections::HashSet::new();
-    analyze_statements_locks(storage, &parsed, isolation, &mut visited)
+    let mut trigger_visited = std::collections::HashSet::new();
+    analyze_statements_locks(
+        storage,
+        &parsed,
+        isolation,
+        &mut visited,
+        &mut trigger_visited,
+    )
 }
 
 fn analyze_statements_locks(
@@ -2696,6 +2720,7 @@ fn analyze_statements_locks(
     parsed: &[Statement],
     isolation: Isolation,
     visited: &mut std::collections::HashSet<(String, Isolation)>,
+    trigger_visited: &mut std::collections::HashSet<u32>,
 ) -> Vec<(Resource, LockMode)> {
     // Flatten TRY/CATCH so the locks a batch needs are pre-acquired for the
     // statements inside its try/catch blocks too, not just the top level.
@@ -2808,12 +2833,13 @@ fn analyze_statements_locks(
                     }
                     // A firing AFTER-INSERT trigger's body reads/writes further
                     // tables; hold those locks up front too (strict 2PL).
-                    let mut tvisited = std::collections::HashSet::new();
                     add_trigger_locks(
                         storage,
                         def.object_id,
                         catalog::TriggerEvent::Insert,
-                        &mut tvisited,
+                        isolation,
+                        visited,
+                        trigger_visited,
                         &mut add,
                     );
                 }
@@ -2869,12 +2895,13 @@ fn analyze_statements_locks(
                         add(Resource::Database, LockMode::IntentShared);
                         add(Resource::Table(oid), LockMode::Shared);
                     }
-                    let mut tvisited = std::collections::HashSet::new();
                     add_trigger_locks(
                         storage,
                         def.object_id,
                         catalog::TriggerEvent::Update,
-                        &mut tvisited,
+                        isolation,
+                        visited,
+                        trigger_visited,
                         &mut add,
                     );
                 }
@@ -2905,12 +2932,13 @@ fn analyze_statements_locks(
                         add(Resource::Database, LockMode::IntentShared);
                         add(Resource::Table(oid), LockMode::Shared);
                     }
-                    let mut tvisited = std::collections::HashSet::new();
                     add_trigger_locks(
                         storage,
                         def.object_id,
                         catalog::TriggerEvent::Delete,
-                        &mut tvisited,
+                        isolation,
+                        visited,
+                        trigger_visited,
                         &mut add,
                     );
                 }
@@ -2956,9 +2984,13 @@ fn analyze_statements_locks(
                     if visited.insert((def.name.clone(), inner_isolation))
                         && let Ok(body) = truthdb_sql::parse_procedure_body(&procedure.body)
                     {
-                        for (resource, mode) in
-                            analyze_statements_locks(storage, &body, inner_isolation, visited)
-                        {
+                        for (resource, mode) in analyze_statements_locks(
+                            storage,
+                            &body,
+                            inner_isolation,
+                            visited,
+                            trigger_visited,
+                        ) {
                             add(resource, mode);
                         }
                     }
@@ -2999,9 +3031,13 @@ fn analyze_statements_locks(
                         isolation
                     };
                     if let Ok(parsed) = truthdb_sql::parse(&inner) {
-                        for (resource, mode) in
-                            analyze_statements_locks(storage, &parsed, inner_isolation, visited)
-                        {
+                        for (resource, mode) in analyze_statements_locks(
+                            storage,
+                            &parsed,
+                            inner_isolation,
+                            visited,
+                            trigger_visited,
+                        ) {
                             add(resource, mode);
                         }
                     }
@@ -5074,7 +5110,7 @@ fn exec_drop_table(storage: &Storage, drop: &DropTable) -> Result<StatementResul
     // rather than silently no-op — the review showed DROP TABLE silently
     // DESTROYING a procedure through the shared catalog path.
     if resolve_table(storage, &drop.table.value)
-        .is_some_and(|d| d.is_view() || d.is_procedure() || d.is_function())
+        .is_some_and(|d| d.is_view() || d.is_procedure() || d.is_function() || d.is_trigger())
     {
         return Err(SqlError::new(
             3701,
@@ -5712,9 +5748,11 @@ fn run_dml_with_triggers(
             }
             return Err(e);
         }
-        // 3609: a trigger that issued ROLLBACK/COMMIT ended (or reduced) the
-        // transaction — the batch is aborted. `abort` normalizes the state.
-        if txn_ctx.trancount < tc_before {
+        // 3609: a trigger body that changed @@TRANCOUNT — a ROLLBACK/COMMIT that
+        // reduced it, OR an unbalanced BEGIN that raised it (a leaked open txn) —
+        // ended the transaction contract; the batch is aborted. `abort`
+        // normalizes the state (rolls back and clears any leaked transaction).
+        if txn_ctx.trancount != tc_before {
             txn_ctx.abort(storage);
             return Err(SqlError::new(
                 3609,
@@ -5741,8 +5779,12 @@ fn fire_one_trigger(
     tables: &std::rc::Rc<TriggerTables>,
 ) -> Result<(), SqlError> {
     let trigger = trig_def.trigger.as_ref().expect("caller passes a trigger");
-    // Recursive triggers OFF (the default): a trigger must not re-fire itself.
-    if FIRING_TRIGGERS.with(|f| f.borrow().contains(&trig_def.object_id)) {
+    // Recursive triggers OFF (the default) suppresses only DIRECT recursion: a
+    // trigger whose own body re-fires itself (it is the currently-executing
+    // trigger — top of the firing stack). Indirect recursion (a fires b fires a,
+    // where a is deeper in the stack, not the top) stays enabled and is bounded
+    // by the nesting cap, matching "nested triggers ON".
+    if FIRING_TRIGGERS.with(|f| f.borrow().last() == Some(&trig_def.object_id)) {
         return Ok(());
     }
     let statements = truthdb_sql::parse_procedure_body(&trigger.body)?;
@@ -5776,7 +5818,17 @@ fn fire_one_trigger(
             last_error: None,
             function_return_type: None,
         };
-        run_block(storage, &statements, txn_ctx, &mut run, false).map(|_| ())
+        let flow = run_block(storage, &statements, txn_ctx, &mut run, false);
+        // An error raised in the trigger body — a terminating one (Err), or a
+        // non-terminating RAISERROR/THROW/failed-statement (severity >= 11) that
+        // run_block records in last_error and NOT caught by an inner TRY/CATCH —
+        // aborts the firing statement: SQL Server rolls back the DML and returns
+        // the error. (A successful CATCH clears last_error, so a trigger that
+        // handles its own error still succeeds.)
+        flow.map(|_| ()).and_then(|()| match run.last_error.take() {
+            Some(err) => Err(err),
+            None => Ok(()),
+        })
     };
     FIRING_TRIGGERS.with(|f| {
         f.borrow_mut().pop();
@@ -7711,10 +7763,10 @@ fn from_column_names(storage: &Storage, from: &TableRef) -> Option<Vec<(Option<S
     match from {
         TableRef::Table { name, alias } => {
             let def = resolve_table(storage, &name.value)?;
-            // A view defers to its expansion; a PROCEDURE must not read as a
-            // zero-column table — bailing here routes to the collecting path,
-            // which errors 2809.
-            if def.is_view() || def.is_procedure() || def.is_function() {
+            // A view defers to its expansion; a PROCEDURE/FUNCTION/TRIGGER must
+            // not read as a zero-column table — bailing here routes to the
+            // collecting path, which errors 2809/208.
+            if def.is_view() || def.is_procedure() || def.is_function() || def.is_trigger() {
                 return None;
             }
             let qualifier = alias
@@ -8910,9 +8962,9 @@ fn scan_plan(storage: &Storage, select: &Select, eval_ctx: &EvalContext) -> Opti
     // A view is its own SELECT, expanded as a derived table — and its TableDef
     // has no columns and a `root_page` of 0, so a wildcard over it would project
     // nothing and the scan would read the catalog root instead of the view. A
-    // PROCEDURE has the same empty shape and must not stream as an empty
-    // table: the collecting path rejects it (2809).
-    if def.view_query.is_some() || def.is_procedure() || def.is_function() {
+    // PROCEDURE/FUNCTION/TRIGGER has the same empty shape and must not stream as
+    // an empty table: the collecting path rejects it (2809/208).
+    if def.view_query.is_some() || def.is_procedure() || def.is_function() || def.is_trigger() {
         return None;
     }
     let schema = def.schema().ok()?;
@@ -10634,6 +10686,11 @@ fn build_table_source(
             if def.is_procedure() {
                 return Err(procedure_not_a_table(&def.name).at(name.span));
             }
+            // A trigger is not a queryable object either — resolving it as a base
+            // table would heap-scan its (empty) root page 0. 208 invalid object.
+            if def.is_trigger() {
+                return Err(SqlError::invalid_object(&name.value).at(name.span));
+            }
             // A scalar function is not a rowset — it cannot appear in FROM.
             // (Table-valued functions, added later, expand here instead.)
             if def.is_function() {
@@ -10660,6 +10717,7 @@ fn build_table_source(
                 // in-statement derived table or CTE is NOT a separate scope and
                 // keeps the statement's view — only stored bodies shadow.)
                 let _table_var_scope = arm_table_var_view(&std::collections::HashMap::new());
+                let _trigger_shadow = TriggerScope::clear();
                 return build_derived_source(storage, &body, &qual, eval_ctx);
             }
             let schema = def.schema().map_err(|e| map_storage_err(e, &def.name))?;
@@ -10817,6 +10875,7 @@ fn build_function_source(
             // source runs under whatever scope the calling statement armed. An
             // empty view makes such a body error 1087, as SQL Server rejects it.
             let _table_var_scope = arm_table_var_view(&std::collections::HashMap::new());
+            let _trigger_shadow = TriggerScope::clear();
             build_derived_source(storage, &body, &qual, &fn_ctx)
         }
         FunctionReturns::MultiStatementTable {
@@ -10890,6 +10949,9 @@ fn run_multi_statement_tvf(
         },
     );
     let statements = truthdb_sql::parse_table_function_body(body_text)?;
+    // A multi-statement TVF called from a trigger body does not see
+    // inserted/deleted.
+    let _trigger_shadow = TriggerScope::clear();
     // Same nesting cap as a scalar UDF (217), decremented on every exit path.
     let depth = EXEC_DEPTH.with(|d| {
         let v = d.get() + 1;
@@ -11561,7 +11623,9 @@ fn sys_tables(storage: &Storage) -> Source {
         .into_iter()
         // Only base tables. (The `!is_view()` filter alone let procedures leak
         // in — a pre-existing gap — so exclude every non-table object kind.)
-        .filter(|def| !def.is_view() && !def.is_procedure() && !def.is_function())
+        .filter(|def| {
+            !def.is_view() && !def.is_procedure() && !def.is_function() && !def.is_trigger()
+        })
         .map(|def| vec![Datum::Int(def.object_id as i32), Datum::NVarChar(def.name)])
         .collect();
     let collations = vec![None; columns.len()];
@@ -12167,138 +12231,33 @@ fn read_lock_object_ids(storage: &Storage, name: &str) -> Vec<u32> {
 /// Adds the locks the AFTER-`event` trigger bodies of `parent_object_id` take,
 /// so a DML that fires them holds every lock its bodies acquire UP FRONT (strict
 /// 2PL — a trigger body reading/writing another table with no pre-acquired lock
-/// is the recurring seam-defect class). Recursion (a trigger whose body DMLs a
-/// table with its own triggers) is bounded by `visited` (trigger object_ids), so
-/// a trigger cycle terminates cleanly rather than hanging analysis under the
-/// scheduler mutex.
+/// is the recurring seam-defect class). Each body is analyzed by the SAME
+/// machinery the batch uses (`analyze_statements_locks`), so its EXEC, TRY/CATCH,
+/// FK-integrity reads, subquery reads, and its own nested triggers are ALL
+/// covered — not a hand-rolled subset. Recursion (a trigger whose body DMLs a
+/// table with its own triggers) is bounded by `trigger_visited` (trigger
+/// object_ids), so a trigger cycle terminates cleanly rather than hanging
+/// analysis under the scheduler mutex.
 fn add_trigger_locks(
     storage: &Storage,
     parent_object_id: u32,
     event: catalog::TriggerEvent,
-    visited: &mut std::collections::HashSet<u32>,
+    isolation: Isolation,
+    visited: &mut std::collections::HashSet<(String, Isolation)>,
+    trigger_visited: &mut std::collections::HashSet<u32>,
     add: &mut impl FnMut(Resource, LockMode),
 ) {
     for trig in storage.rel_triggers_for(parent_object_id, event) {
-        if !visited.insert(trig.object_id) {
+        if !trigger_visited.insert(trig.object_id) {
             continue;
         }
         let Some(t) = &trig.trigger else { continue };
         if let Ok(statements) = truthdb_sql::parse_procedure_body(&t.body) {
-            collect_trigger_body_locks(storage, &statements, visited, add);
-        }
-    }
-}
-
-/// Walks a trigger body's statements and adds the locks they require: Exclusive
-/// on DML write targets (plus their own triggers, recursively), Shared on the
-/// tables SELECTs and INSERT..SELECT sources read.
-fn collect_trigger_body_locks(
-    storage: &Storage,
-    statements: &[Statement],
-    visited: &mut std::collections::HashSet<u32>,
-    add: &mut impl FnMut(Resource, LockMode),
-) {
-    // A base table (not a view/proc/func/trigger, not a `@t` table variable):
-    // the write-lock target of a DML in a trigger body.
-    fn write_target(storage: &Storage, name: &str) -> Option<TableDef> {
-        if name.starts_with('@') {
-            return None;
-        }
-        resolve_table(storage, name).filter(|def| {
-            def.trigger.is_none()
-                && def.view_query.is_none()
-                && def.procedure.is_none()
-                && def.function.is_none()
-        })
-    }
-    let add_reads =
-        |storage: &Storage, select: &Select, add: &mut dyn FnMut(Resource, LockMode)| {
-            let expanded = expand_ctes(select);
-            let mut tables = Vec::new();
-            collect_locked_tables(&expanded, &mut tables);
-            for name in tables {
-                for oid in read_lock_object_ids(storage, &name.value) {
-                    add(Resource::Database, LockMode::IntentShared);
-                    add(Resource::Table(oid), LockMode::Shared);
-                }
+            for (resource, mode) in
+                analyze_statements_locks(storage, &statements, isolation, visited, trigger_visited)
+            {
+                add(resource, mode);
             }
-            for oid in select_function_read_ids(storage, &expanded) {
-                add(Resource::Database, LockMode::IntentShared);
-                add(Resource::Table(oid), LockMode::Shared);
-            }
-        };
-    for statement in statements {
-        match statement {
-            Statement::Insert(insert) => {
-                if let Some(def) = write_target(storage, &insert.table.value) {
-                    add(Resource::Database, LockMode::IntentExclusive);
-                    add(Resource::Table(def.object_id), LockMode::Exclusive);
-                    add_trigger_locks(
-                        storage,
-                        def.object_id,
-                        catalog::TriggerEvent::Insert,
-                        visited,
-                        add,
-                    );
-                }
-                if let InsertSource::Select(select) = &insert.source {
-                    add_reads(storage, select, add);
-                }
-            }
-            Statement::Update(update) => {
-                if let Some(def) = write_target(storage, &update.table.value) {
-                    add(Resource::Database, LockMode::IntentExclusive);
-                    add(Resource::Table(def.object_id), LockMode::Exclusive);
-                    add_trigger_locks(
-                        storage,
-                        def.object_id,
-                        catalog::TriggerEvent::Update,
-                        visited,
-                        add,
-                    );
-                }
-            }
-            Statement::Delete(delete) => {
-                if let Some(def) = write_target(storage, &delete.table.value) {
-                    add(Resource::Database, LockMode::IntentExclusive);
-                    add(Resource::Table(def.object_id), LockMode::Exclusive);
-                    add_trigger_locks(
-                        storage,
-                        def.object_id,
-                        catalog::TriggerEvent::Delete,
-                        visited,
-                        add,
-                    );
-                }
-            }
-            Statement::Select(select) => add_reads(storage, select, add),
-            Statement::Block { body, .. } => {
-                collect_trigger_body_locks(storage, body, visited, add)
-            }
-            Statement::If {
-                then_branch,
-                else_branch,
-                ..
-            } => {
-                collect_trigger_body_locks(
-                    storage,
-                    std::slice::from_ref(then_branch),
-                    visited,
-                    add,
-                );
-                if let Some(else_branch) = else_branch {
-                    collect_trigger_body_locks(
-                        storage,
-                        std::slice::from_ref(else_branch),
-                        visited,
-                        add,
-                    );
-                }
-            }
-            Statement::While { body, .. } => {
-                collect_trigger_body_locks(storage, std::slice::from_ref(body), visited, add)
-            }
-            _ => {}
         }
     }
 }

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -5779,12 +5779,20 @@ fn run_dml_with_triggers(
     // Fire each trigger once, in creation order, even for an empty image set.
     for trig_def in &triggers {
         if let Err(e) = fire_one_trigger(storage, txn_ctx, trig_def, &tables) {
-            // An unhandled trigger error rolls back the WHOLE transaction — the
-            // firing statement and everything else in it — whether the
-            // transaction is the implicit one opened here or the caller's
-            // explicit one, matching SQL Server (and the 3609 path below). The
-            // `if implicit` gate is deliberately NOT used here.
-            txn_ctx.abort(storage);
+            // A trigger error makes the transaction uncommittable. For the
+            // IMPLICIT transaction opened here (autocommit), roll it back fully —
+            // there is no caller transaction to preserve. For the caller's
+            // EXPLICIT transaction, DOOM it (leave it open with @@TRANCOUNT
+            // intact, XACT_STATE() = -1) rather than tearing it down: SQL
+            // Server's uncommittable-transaction semantics, so a TRY/CATCH sees
+            // the doomed state and must ROLLBACK — never silently autocommitting
+            // CATCH work or losing pre-statement work. The doomed transaction's
+            // staged rows (including the firing row) can never commit.
+            if implicit {
+                txn_ctx.abort(storage);
+            } else {
+                txn_ctx.doomed = true;
+            }
             return Err(e);
         }
         // 3609: a trigger body that changed @@TRANCOUNT — a ROLLBACK/COMMIT that

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -2720,7 +2720,7 @@ fn analyze_statements_locks(
     parsed: &[Statement],
     isolation: Isolation,
     visited: &mut std::collections::HashSet<(String, Isolation)>,
-    trigger_visited: &mut std::collections::HashSet<u32>,
+    trigger_visited: &mut std::collections::HashSet<(u32, Isolation)>,
 ) -> Vec<(Resource, LockMode)> {
     // Flatten TRY/CATCH so the locks a batch needs are pre-acquired for the
     // statements inside its try/catch blocks too, not just the top level.
@@ -2761,6 +2761,22 @@ fn analyze_statements_locks(
     let versioned_reads = !escalates_reads
         && (matches!(isolation, Isolation::Snapshot)
             || (matches!(isolation, Isolation::ReadCommitted) && storage.rcsi_enabled()));
+    // The isolation a fired trigger body (and any EXEC it makes) must be analyzed
+    // under: an in-line SET that raises the level locks the body's reads too, so
+    // forward a lock-based level whenever this batch locks reads — the SAME
+    // correction the EXEC path applies. Without it a trigger body under a
+    // versioned session (Snapshot / RCSI) would recompute versioned_reads=true
+    // and drop the Table S it actually reads lock-based at runtime (a dirty read,
+    // the Stage-13 seam class).
+    let nested_isolation = if reads_lock {
+        if matches!(isolation, Isolation::ReadCommitted | Isolation::Snapshot) && !escalates_reads {
+            isolation
+        } else {
+            Isolation::RepeatableRead
+        }
+    } else {
+        isolation
+    };
     let mut needs: std::collections::HashMap<Resource, LockMode> = std::collections::HashMap::new();
     let mut add = |resource: Resource, mode: LockMode| {
         needs
@@ -2837,7 +2853,7 @@ fn analyze_statements_locks(
                         storage,
                         def.object_id,
                         catalog::TriggerEvent::Insert,
-                        isolation,
+                        nested_isolation,
                         visited,
                         trigger_visited,
                         &mut add,
@@ -2899,7 +2915,7 @@ fn analyze_statements_locks(
                         storage,
                         def.object_id,
                         catalog::TriggerEvent::Update,
-                        isolation,
+                        nested_isolation,
                         visited,
                         trigger_visited,
                         &mut add,
@@ -2936,7 +2952,7 @@ fn analyze_statements_locks(
                         storage,
                         def.object_id,
                         catalog::TriggerEvent::Delete,
-                        isolation,
+                        nested_isolation,
                         visited,
                         trigger_visited,
                         &mut add,
@@ -5148,6 +5164,26 @@ fn exec_drop_table(storage: &Storage, drop: &DropTable) -> Result<StatementResul
                     ),
                 ));
             }
+            // Cascade-drop the table's triggers — a trigger outlives its parent
+            // table nowhere in SQL Server, and an orphan would permanently block
+            // its own name (and dangle in sys.triggers).
+            if let Some(parent_oid) = resolve_table(storage, &name).map(|d| d.object_id) {
+                let orphan_triggers: Vec<String> = storage
+                    .rel_tables()
+                    .into_iter()
+                    .filter(|d| {
+                        d.trigger
+                            .as_ref()
+                            .is_some_and(|t| t.parent_object_id == parent_oid)
+                    })
+                    .map(|d| d.name)
+                    .collect();
+                for trigger_name in orphan_triggers {
+                    storage
+                        .rel_drop_table(&trigger_name)
+                        .map_err(|err| map_storage_err(err, &trigger_name))?;
+                }
+            }
             storage
                 .rel_drop_table(&name)
                 .map_err(|err| map_storage_err(err, &drop.table.value))?;
@@ -5743,9 +5779,12 @@ fn run_dml_with_triggers(
     // Fire each trigger once, in creation order, even for an empty image set.
     for trig_def in &triggers {
         if let Err(e) = fire_one_trigger(storage, txn_ctx, trig_def, &tables) {
-            if implicit {
-                txn_ctx.abort(storage);
-            }
+            // An unhandled trigger error rolls back the WHOLE transaction — the
+            // firing statement and everything else in it — whether the
+            // transaction is the implicit one opened here or the caller's
+            // explicit one, matching SQL Server (and the 3609 path below). The
+            // `if implicit` gate is deliberately NOT used here.
+            txn_ctx.abort(storage);
             return Err(e);
         }
         // 3609: a trigger body that changed @@TRANCOUNT — a ROLLBACK/COMMIT that
@@ -12244,11 +12283,11 @@ fn add_trigger_locks(
     event: catalog::TriggerEvent,
     isolation: Isolation,
     visited: &mut std::collections::HashSet<(String, Isolation)>,
-    trigger_visited: &mut std::collections::HashSet<u32>,
+    trigger_visited: &mut std::collections::HashSet<(u32, Isolation)>,
     add: &mut impl FnMut(Resource, LockMode),
 ) {
     for trig in storage.rel_triggers_for(parent_object_id, event) {
-        if !trigger_visited.insert(trig.object_id) {
+        if !trigger_visited.insert((trig.object_id, isolation)) {
             continue;
         }
         let Some(t) = &trig.trigger else { continue };
@@ -12385,6 +12424,9 @@ fn reject_dml_on_view(def: &TableDef) -> Result<(), SqlError> {
     if def.is_function() {
         return Err(function_not_a_table(&def.name));
     }
+    if def.is_trigger() {
+        return Err(SqlError::invalid_object(&def.name));
+    }
     if def.is_view() {
         return Err(SqlError::new(
             4406,
@@ -12434,6 +12476,9 @@ fn reject_view_as_table(def: &TableDef) -> Result<(), SqlError> {
     }
     if def.is_function() {
         return Err(function_not_a_table(&def.name));
+    }
+    if def.is_trigger() {
+        return Err(SqlError::invalid_object(&def.name));
     }
     if def.is_view() {
         return Err(SqlError::new(

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -1359,8 +1359,11 @@ fn statement_error_ladder(
     }
     // Other statements: a non-dooming in-transaction error rolls back only
     // the statement and the batch continues; a dooming one ends the batch
-    // (only ROLLBACK is then accepted, error 3930).
-    if txn_ctx.in_txn() && !dooms {
+    // (only ROLLBACK is then accepted, error 3930). A transaction ALREADY
+    // doomed (e.g. by an AFTER-trigger error, which SQL Server makes
+    // uncommittable regardless of the firing statement's severity) must not
+    // continue either — the batch ends.
+    if txn_ctx.in_txn() && !dooms && !txn_ctx.doomed {
         run.abort_open_rowset(txn_ctx.in_txn());
         run.last_error = Some(error);
         return Ok(());
@@ -5778,35 +5781,40 @@ fn run_dml_with_triggers(
     });
     // Fire each trigger once, in creation order, even for an empty image set.
     for trig_def in &triggers {
-        if let Err(e) = fire_one_trigger(storage, txn_ctx, trig_def, &tables) {
-            // A trigger error makes the transaction uncommittable. For the
-            // IMPLICIT transaction opened here (autocommit), roll it back fully —
-            // there is no caller transaction to preserve. For the caller's
-            // EXPLICIT transaction, DOOM it (leave it open with @@TRANCOUNT
-            // intact, XACT_STATE() = -1) rather than tearing it down: SQL
-            // Server's uncommittable-transaction semantics, so a TRY/CATCH sees
-            // the doomed state and must ROLLBACK — never silently autocommitting
-            // CATCH work or losing pre-statement work. The doomed transaction's
-            // staged rows (including the firing row) can never commit.
+        let fired = fire_one_trigger(storage, txn_ctx, trig_def, &tables);
+        // A trigger body that changed @@TRANCOUNT — a ROLLBACK/COMMIT that
+        // reduced it or an unbalanced BEGIN that raised it — ENDED the
+        // transaction (3609). This is checked BEFORE the error branch so the
+        // idiomatic `ROLLBACK; RAISERROR` abort pattern does not doom a
+        // transaction the trigger already tore down (which would wedge the
+        // session doomed with no open transaction). `abort` normalizes the
+        // state; surface the trigger's own error if it raised one, else 3609.
+        if txn_ctx.trancount != tc_before {
+            txn_ctx.abort(storage);
+            return Err(fired.err().unwrap_or_else(|| {
+                SqlError::new(
+                    3609,
+                    16,
+                    1,
+                    "The transaction ended in the trigger. The batch has been aborted.",
+                )
+            }));
+        }
+        // A trigger error with the transaction still open makes it
+        // uncommittable. Roll back the IMPLICIT (autocommit) transaction opened
+        // here; DOOM the caller's EXPLICIT one (leave it open, @@TRANCOUNT
+        // intact, XACT_STATE() = -1) — SQL Server's uncommittable-transaction
+        // semantics, so a TRY/CATCH sees the doomed state and must ROLLBACK
+        // (its writes hit the 3930 guard), and an uncaught error terminates the
+        // batch (statement_error_ladder does not continue past a doomed txn).
+        // The doomed transaction's staged rows can never commit.
+        if let Err(e) = fired {
             if implicit {
                 txn_ctx.abort(storage);
             } else {
                 txn_ctx.doomed = true;
             }
             return Err(e);
-        }
-        // 3609: a trigger body that changed @@TRANCOUNT — a ROLLBACK/COMMIT that
-        // reduced it, OR an unbalanced BEGIN that raised it (a leaked open txn) —
-        // ended the transaction contract; the batch is aborted. `abort`
-        // normalizes the state (rolls back and clears any leaked transaction).
-        if txn_ctx.trancount != tc_before {
-            txn_ctx.abort(storage);
-            return Err(SqlError::new(
-                3609,
-                16,
-                1,
-                "The transaction ended in the trigger. The batch has been aborted.",
-            ));
         }
     }
     if implicit {

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -1359,11 +1359,13 @@ fn statement_error_ladder(
     }
     // Other statements: a non-dooming in-transaction error rolls back only
     // the statement and the batch continues; a dooming one ends the batch
-    // (only ROLLBACK is then accepted, error 3930). A transaction ALREADY
-    // doomed (e.g. by an AFTER-trigger error, which SQL Server makes
-    // uncommittable regardless of the firing statement's severity) must not
-    // continue either — the batch ends.
-    if txn_ctx.in_txn() && !dooms && !txn_ctx.doomed {
+    // (only ROLLBACK is then accepted, error 3930). This must stay keyed on the
+    // ERROR (its severity / XACT_ABORT), NOT on whether the transaction is
+    // already doomed: a doomed transaction still runs a CATCH's reads and
+    // statement-terminating errors (division by zero, conversion) so the CATCH
+    // can reach `IF XACT_STATE() <> 0 ROLLBACK` — terminating the batch on those
+    // would leave the uncommittable transaction open holding its locks.
+    if txn_ctx.in_txn() && !dooms {
         run.abort_open_rowset(txn_ctx.in_txn());
         run.last_error = Some(error);
         return Ok(());

--- a/crates/truthdb-core/src/relstore/catalog.rs
+++ b/crates/truthdb-core/src/relstore/catalog.rs
@@ -128,6 +128,35 @@ pub struct TableDef {
     /// data pages, columns, or key.
     #[serde(default)]
     pub function: Option<FunctionDef>,
+    /// For a TRIGGER: the table it is attached to, the events it fires on, and
+    /// its body source text (re-parsed per firing, procedure posture). `None`
+    /// for every other object kind. A trigger carries no data pages, columns, or
+    /// key — it is a schema object with its own object_id, like a procedure.
+    #[serde(default)]
+    pub trigger: Option<TriggerDef>,
+}
+
+/// A DML event a trigger can fire on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum TriggerEvent {
+    Insert,
+    Update,
+    Delete,
+}
+
+/// A trigger's catalog payload: the parent table it fires on, the DML events it
+/// responds to, its body source text, and whether it is disabled.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TriggerDef {
+    /// The object_id of the table this trigger is attached to.
+    pub parent_object_id: u32,
+    /// The DML events (INSERT/UPDATE/DELETE) this trigger fires on.
+    pub events: Vec<TriggerEvent>,
+    /// The body source text (the statements after `AS`), parsed with the
+    /// in-procedure grammar per firing.
+    pub body: String,
+    /// `DISABLE TRIGGER` sets this; a disabled trigger does not fire.
+    pub is_disabled: bool,
 }
 
 /// A stored procedure's catalog payload: declared parameters and body text.
@@ -202,6 +231,11 @@ impl TableDef {
     /// True if this catalog entry is a user-defined function.
     pub fn is_function(&self) -> bool {
         self.function.is_some()
+    }
+
+    /// True if this catalog entry is a trigger.
+    pub fn is_trigger(&self) -> bool {
+        self.trigger.is_some()
     }
 }
 

--- a/crates/truthdb-core/src/storage.rs
+++ b/crates/truthdb-core/src/storage.rs
@@ -602,6 +602,29 @@ impl Storage {
         result
     }
 
+    pub fn rel_create_trigger(
+        &self,
+        name: &str,
+        trigger: crate::relstore::catalog::TriggerDef,
+    ) -> Result<(), StorageError> {
+        let result = self.lock().rel_create_trigger(name, trigger);
+        // A trigger changes which locks a DML statement on its parent table must
+        // hold (its body reads/writes other tables), so a parked batch analyzed
+        // against the old catalog carries a stale lock set — bump to re-analyze.
+        self.bump_lock_epoch();
+        result
+    }
+
+    pub fn rel_alter_trigger(
+        &self,
+        name: &str,
+        trigger: crate::relstore::catalog::TriggerDef,
+    ) -> Result<(), StorageError> {
+        let result = self.lock().rel_alter_trigger(name, trigger);
+        self.bump_lock_epoch();
+        result
+    }
+
     pub fn rel_table(&self, name: &str) -> Option<TableDef> {
         self.lock().rel_table(name)
     }
@@ -617,6 +640,22 @@ impl Storage {
 
     pub fn rel_tables(&self) -> Vec<TableDef> {
         self.lock().rel_tables()
+    }
+
+    /// True if any trigger exists in the catalog — a cheap no-clone check that
+    /// keeps the common no-trigger DML path off the firing machinery.
+    pub fn rel_has_triggers(&self) -> bool {
+        self.lock().rel_has_triggers()
+    }
+
+    /// The enabled triggers attached to `parent_object_id` that fire on `event`,
+    /// in creation (object_id) order.
+    pub fn rel_triggers_for(
+        &self,
+        parent_object_id: u32,
+        event: crate::relstore::catalog::TriggerEvent,
+    ) -> Vec<TableDef> {
+        self.lock().rel_triggers_for(parent_object_id, event)
     }
 
     pub fn rel_drop_table(&self, name: &str) -> Result<bool, StorageError> {
@@ -1401,6 +1440,7 @@ impl StorageFile {
                 view_query: None,
                 procedure: None,
                 function: None,
+                trigger: None,
                 counter_page: Some(counter_page),
             };
             catalog::insert_table(ctx, &mut OpMode::Txn(txn), catalog_root, &def)?;
@@ -1454,6 +1494,7 @@ impl StorageFile {
                 view_query: Some(query),
                 procedure: None,
                 function: None,
+                trigger: None,
                 counter_page: None,
             };
             catalog::insert_table(ctx, &mut OpMode::Txn(txn), catalog_root, &def)?;
@@ -1503,6 +1544,7 @@ impl StorageFile {
                 view_query: None,
                 procedure: Some(procedure),
                 function: None,
+                trigger: None,
                 counter_page: None,
             };
             catalog::insert_table(ctx, &mut OpMode::Txn(txn), catalog_root, &def)?;
@@ -1553,6 +1595,7 @@ impl StorageFile {
                 view_query: None,
                 procedure: None,
                 function: Some(function),
+                trigger: None,
                 counter_page: None,
             };
             catalog::insert_table(ctx, &mut OpMode::Txn(txn), catalog_root, &def)?;
@@ -1629,6 +1672,85 @@ impl StorageFile {
         Ok(())
     }
 
+    /// Creates a trigger: a catalog entry (its own object_id, like a procedure)
+    /// whose stored form is its parent table, event set, and body text.
+    pub fn rel_create_trigger(
+        &mut self,
+        name: &str,
+        trigger: crate::relstore::catalog::TriggerDef,
+    ) -> Result<(), StorageError> {
+        self.ensure_rel_usable()?;
+        if self.rel.tables.contains_key(name) {
+            return Err(StorageError::Constraint(format!(
+                "object '{name}' already exists"
+            )));
+        }
+        if self.rel.catalog_root.is_none() {
+            let root = {
+                let mut ctx = self.rel_ctx();
+                catalog::create_catalog(&mut ctx)?
+            };
+            self.rel.catalog_root = Some(root);
+        }
+        let catalog_root = self.rel.catalog_root.expect("catalog exists");
+        let object_id = self.rel.next_object_id;
+        let trig_name = name.to_string();
+        let def = self.rel_statement(move |ctx, txn| {
+            let def = TableDef {
+                object_id,
+                name: trig_name,
+                columns: Vec::new(),
+                key_columns: Vec::new(),
+                root_page: 0,
+                defaults: Vec::new(),
+                collations: Vec::new(),
+                identity: None,
+                indexes: Vec::new(),
+                check_constraints: Vec::new(),
+                foreign_keys: Vec::new(),
+                view_query: None,
+                procedure: None,
+                function: None,
+                trigger: Some(trigger),
+                counter_page: None,
+            };
+            catalog::insert_table(ctx, &mut OpMode::Txn(txn), catalog_root, &def)?;
+            Ok(def)
+        })?;
+        self.rel.next_object_id += 1;
+        self.rel.tables.insert(name.to_string(), def);
+        Ok(())
+    }
+
+    /// Replaces a trigger's definition (`ALTER TRIGGER`).
+    pub fn rel_alter_trigger(
+        &mut self,
+        name: &str,
+        trigger: crate::relstore::catalog::TriggerDef,
+    ) -> Result<(), StorageError> {
+        self.ensure_rel_usable()?;
+        let Some(existing) = self.rel.tables.get(name) else {
+            return Err(StorageError::Constraint(format!(
+                "trigger '{name}' does not exist"
+            )));
+        };
+        if !existing.is_trigger() {
+            return Err(StorageError::Constraint(format!(
+                "object '{name}' is not a trigger"
+            )));
+        }
+        let mut def = existing.clone();
+        def.trigger = Some(trigger);
+        let catalog_root = self.rel.catalog_root.expect("triggers live in the catalog");
+        let write = def.clone();
+        self.rel_statement(move |ctx, txn| {
+            catalog::update_table(ctx, &mut OpMode::Txn(txn), catalog_root, &write)?;
+            Ok(())
+        })?;
+        self.rel.tables.insert(name.to_string(), def);
+        Ok(())
+    }
+
     /// The table's definition (schema and layout), if it exists.
     pub fn rel_table(&self, name: &str) -> Option<TableDef> {
         self.rel.tables.get(name).cloned()
@@ -1640,6 +1762,35 @@ impl StorageFile {
         let mut defs: Vec<TableDef> = self.rel.tables.values().cloned().collect();
         defs.sort_by_key(|d| d.object_id);
         defs
+    }
+
+    /// True if any trigger exists in the catalog (no clone).
+    pub fn rel_has_triggers(&self) -> bool {
+        self.rel.tables.values().any(|d| d.is_trigger())
+    }
+
+    /// The enabled triggers attached to `parent_object_id` firing on `event`, in
+    /// creation (object_id) order.
+    pub fn rel_triggers_for(
+        &self,
+        parent_object_id: u32,
+        event: crate::relstore::catalog::TriggerEvent,
+    ) -> Vec<TableDef> {
+        let mut trigs: Vec<TableDef> = self
+            .rel
+            .tables
+            .values()
+            .filter(|d| {
+                d.trigger.as_ref().is_some_and(|t| {
+                    !t.is_disabled
+                        && t.parent_object_id == parent_object_id
+                        && t.events.contains(&event)
+                })
+            })
+            .cloned()
+            .collect();
+        trigs.sort_by_key(|d| d.object_id);
+        trigs
     }
 
     /// Drops a table (logical: removes the catalog row; data pages leak

--- a/crates/truthdb-core/tests/slt/triggers.slt
+++ b/crates/truthdb-core/tests/slt/triggers.slt
@@ -1,0 +1,82 @@
+# AFTER triggers (Stage 15): CREATE TRIGGER ... ON t AFTER {INSERT|UPDATE|DELETE}
+# AS <body>, inserted/deleted pseudo-tables, catalog visibility, DROP TRIGGER.
+
+statement ok
+CREATE TABLE t (id INT NOT NULL PRIMARY KEY, v INT)
+
+statement ok
+CREATE TABLE audit (id INT NOT NULL PRIMARY KEY, kind NVARCHAR(10))
+
+# A trigger firing on both INSERT and UPDATE, recording rows from `inserted`.
+statement ok
+CREATE TRIGGER trg_iu ON t AFTER INSERT, UPDATE AS INSERT INTO audit SELECT id, 'iu' FROM inserted WHERE id NOT IN (SELECT id FROM audit)
+
+statement ok
+INSERT INTO t VALUES (1, 10), (2, 20)
+
+query IT rowsort
+SELECT id, kind FROM audit
+----
+1 iu
+2 iu
+
+# sys.objects classifies the trigger as TR.
+query TT
+SELECT name, type FROM sys.objects WHERE name = 'trg_iu'
+----
+trg_iu TR
+
+# sys.trigger_events lists one row per event (1=INSERT, 2=UPDATE).
+query I rowsort
+SELECT te.type FROM sys.trigger_events te JOIN sys.objects o ON te.object_id = o.object_id WHERE o.name = 'trg_iu'
+----
+1
+2
+
+# sys.sql_modules carries the body.
+query I
+SELECT COUNT(*) AS n FROM sys.sql_modules m JOIN sys.objects o ON m.object_id = o.object_id WHERE o.name = 'trg_iu'
+----
+1
+
+# A 0-row DML fires the trigger once but inserts nothing (the WHERE matches no rows).
+statement ok
+UPDATE t SET v = 0 WHERE id = 999
+
+query I
+SELECT COUNT(*) AS n FROM audit
+----
+2
+
+# DROP TRIGGER: after dropping, the trigger no longer fires.
+statement ok
+DROP TRIGGER trg_iu
+
+statement ok
+INSERT INTO t VALUES (3, 30)
+
+query I
+SELECT COUNT(*) AS n FROM audit
+----
+2
+
+# The trigger is gone from the catalog.
+query I
+SELECT COUNT(*) AS n FROM sys.objects WHERE name = 'trg_iu'
+----
+0
+
+# A trigger can only target a base table.
+statement ok
+CREATE VIEW v AS SELECT id FROM t
+
+statement error
+CREATE TRIGGER trg_bad ON v AFTER INSERT AS INSERT INTO audit SELECT id, 'x' FROM inserted
+
+# INSTEAD OF triggers are not supported.
+statement error
+CREATE TRIGGER trg_io ON t INSTEAD OF INSERT AS INSERT INTO audit SELECT id, 'io' FROM inserted
+
+# DROP TRIGGER IF EXISTS on a missing trigger is a no-op.
+statement ok
+DROP TRIGGER IF EXISTS never_existed

--- a/crates/truthdb-sql/src/ast.rs
+++ b/crates/truthdb-sql/src/ast.rs
@@ -126,6 +126,39 @@ pub enum Statement {
         if_exists: bool,
         span: Span,
     },
+    /// `CREATE|ALTER TRIGGER <name> ON <table> AFTER {INSERT|UPDATE|DELETE}[,...]
+    /// AS <body>` — an AFTER DML trigger. The body is stored as source text and
+    /// re-parsed per firing (the procedure posture).
+    CreateTrigger(CreateTrigger),
+    /// `DROP TRIGGER [IF EXISTS] <name>`.
+    DropTrigger {
+        name: Name,
+        if_exists: bool,
+        span: Span,
+    },
+}
+
+/// `CREATE|ALTER TRIGGER <name> ON <table> AFTER <events> AS <body>`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CreateTrigger {
+    pub name: Name,
+    /// The table the trigger is attached to.
+    pub target: Name,
+    /// The DML events it fires on (at least one; deduplicated by the parser).
+    pub events: Vec<TriggerEvent>,
+    /// The body source text (everything after `AS`), re-parsed per firing.
+    pub body: String,
+    /// `ALTER TRIGGER` replaces an existing definition.
+    pub alter: bool,
+    pub span: Span,
+}
+
+/// A DML event a trigger fires on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TriggerEvent {
+    Insert,
+    Update,
+    Delete,
 }
 
 /// `CREATE|ALTER PROC[EDURE] <name> [@p TYPE [= default] [OUTPUT], ...] AS <body>`.

--- a/crates/truthdb-sql/src/parser.rs
+++ b/crates/truthdb-sql/src/parser.rs
@@ -941,6 +941,7 @@ impl Parser {
                 self.parse_create_procedure(start, false)
             }
             Some("FUNCTION") if !unique => self.parse_create_function(start, false),
+            Some("TRIGGER") if !unique => self.parse_create_trigger(start, false),
             _ => {
                 let token = self.peek().clone();
                 Err(SqlError::syntax(self.token_text(&token), token.span))
@@ -1454,6 +1455,9 @@ impl Parser {
         if self.peek_keyword().as_deref() == Some("FUNCTION") {
             return self.parse_create_function(start, true);
         }
+        if self.peek_keyword().as_deref() == Some("TRIGGER") {
+            return self.parse_create_trigger(start, true);
+        }
         self.expect_keyword("TABLE")?;
         let table = self.parse_name()?;
         let (action, end) = match self.peek_keyword().as_deref() {
@@ -1552,6 +1556,7 @@ impl Parser {
             Some("VIEW") => self.parse_drop_view(start),
             Some("PROCEDURE") | Some("PROC") => self.parse_drop_procedure(start),
             Some("FUNCTION") => self.parse_drop_function(start),
+            Some("TRIGGER") => self.parse_drop_trigger(start),
             _ => {
                 let token = self.peek().clone();
                 Err(SqlError::syntax(self.token_text(&token), token.span))
@@ -1676,6 +1681,114 @@ impl Parser {
         };
         let name = self.parse_name()?;
         Ok(Statement::DropProcedure {
+            span: start.to(name.span),
+            name,
+            if_exists,
+        })
+    }
+
+    /// `CREATE|ALTER TRIGGER <name> ON <table> {AFTER|FOR} {INSERT|UPDATE|DELETE}
+    /// [,...] AS <body-to-end-of-batch>`. Only AFTER (its `FOR` synonym)
+    /// DML triggers are supported; `INSTEAD OF` is rejected as a syntax error.
+    fn parse_create_trigger(&mut self, start: Span, alter: bool) -> SqlResult<Statement> {
+        self.bump(); // TRIGGER
+        if self.in_procedure || self.in_function || self.in_table_function {
+            return Err(
+                SqlError::new(156, 15, 1, "Incorrect syntax near the keyword 'TRIGGER'.").at(start),
+            );
+        }
+        if self.statement_index > 0 || self.sub_depth > 0 {
+            return Err(SqlError::new(
+                111,
+                15,
+                1,
+                "'CREATE/ALTER TRIGGER' must be the first statement in a query batch.",
+            )
+            .at(start));
+        }
+        let name = self.parse_name()?;
+        self.expect_keyword("ON")?;
+        let target = self.parse_name()?;
+        // AFTER (or its FOR synonym) is the only supported timing.
+        match self.peek_keyword().as_deref() {
+            Some("AFTER") | Some("FOR") => {
+                self.bump();
+            }
+            _ => {
+                let token = self.peek().clone();
+                return Err(SqlError::syntax(self.token_text(&token), token.span));
+            }
+        }
+        // The event list: INSERT/UPDATE/DELETE, comma-separated, at least one,
+        // deduplicated.
+        let mut events = Vec::new();
+        loop {
+            let event = match self.peek_keyword().as_deref() {
+                Some("INSERT") => TriggerEvent::Insert,
+                Some("UPDATE") => TriggerEvent::Update,
+                Some("DELETE") => TriggerEvent::Delete,
+                _ => {
+                    let token = self.peek().clone();
+                    return Err(SqlError::syntax(self.token_text(&token), token.span));
+                }
+            };
+            self.bump();
+            if !events.contains(&event) {
+                events.push(event);
+            }
+            if !self.eat(&TokenKind::Comma) {
+                break;
+            }
+        }
+        self.expect_keyword("AS")?;
+        // The body is everything to the end of the batch, stored verbatim and
+        // re-parsed per firing; parse it now (in the procedure grammar) to
+        // validate its syntax at CREATE.
+        let body_start = self.peek().span.start;
+        let body = self.src[body_start..].trim().to_string();
+        if body.is_empty() {
+            let token = self.peek().clone();
+            return Err(SqlError::syntax(self.token_text(&token), token.span));
+        }
+        self.in_procedure = true;
+        let validated = (|| -> SqlResult<()> {
+            loop {
+                while self.eat(&TokenKind::Semicolon) {}
+                if self.at_eof() {
+                    return Ok(());
+                }
+                self.nodes = 0;
+                self.parse_statement()?;
+                if !self.at_eof() && !self.check(&TokenKind::Semicolon) {
+                    let token = self.peek().clone();
+                    return Err(SqlError::syntax(self.token_text(&token), token.span));
+                }
+            }
+        })();
+        self.in_procedure = false;
+        validated?;
+        let span = start.to(self.prev_span());
+        Ok(Statement::CreateTrigger(CreateTrigger {
+            name,
+            target,
+            events,
+            body,
+            alter,
+            span,
+        }))
+    }
+
+    fn parse_drop_trigger(&mut self, start: Span) -> SqlResult<Statement> {
+        self.bump(); // TRIGGER
+        let if_exists = if self.peek_keyword().as_deref() == Some("IF") {
+            self.bump();
+            self.expect_keyword("EXISTS")?;
+            true
+        } else {
+            false
+        };
+        let name = self.parse_name()?;
+        Ok(Statement::DropTrigger {
             span: start.to(name.span),
             name,
             if_exists,


### PR DESCRIPTION
AFTER INSERT/UPDATE/DELETE triggers: `CREATE TRIGGER t ON tbl AFTER {INSERT|UPDATE|DELETE}[,...] AS <body>`, with `inserted`/`deleted` pseudo-tables, fired once per statement (even 0-row), in creation order, nested (bounded by the depth cap) with recursion off by default.

## Design
- **Catalog**: a trigger is its own catalog object (own object_id, name-global, DROP by name) carrying `TriggerDef { parent_object_id, events, body, is_disabled }` — the view/procedure/function posture. `rel_create/alter_trigger` bump the lock-analysis epoch; `rel_has_triggers`/`rel_triggers_for` resolve firing sets.
- **Parser**: CREATE|ALTER/DROP TRIGGER; AFTER (or `FOR`) only — INSTEAD OF is a syntax error. Body stored as text, re-parsed per firing. `inserted`/`deleted` stay contextual.
- **Firing** (from the DML dispatch arms, gated on the target having triggers): under autocommit an **implicit transaction** is opened so the DML stages rather than commits — DML + triggers are atomic, a trigger ROLLBACK undoes the firing statement and raises **3609**. Row images are captured cheaply at the DML sites (cloned only when armed) and served via a `CURRENT_TRIGGER_TABLES` read view (mirroring the table-variable machinery). Each body runs in the firing statement's transaction with a fresh variable scope (procedure shape), bounded by the nesting cap; a per-trigger firing-set suppresses direct self-recursion.
- **The lock seam** (mandatory under strict 2PL): a DML that fires triggers holds every lock its bodies take up front. `analyze_locks` recurses each target trigger's body — Exclusive on its write targets (and their triggers, recursively), Shared on its SELECT reads — bounded by a visited-set so a trigger cycle terminates instead of hanging analysis (the #130 fan-out lesson).
- **sys.***: `TR`/SQL_TRIGGER in sys.objects, body in sys.sql_modules, new sys.triggers and sys.trigger_events.

Deferred: INSTEAD OF triggers, DISABLE/ENABLE, UPDATE()/COLUMNS_UPDATED.

## Tests
`triggers.slt` (multi-event, inserted, 0-row, DROP, view/INSTEAD-OF rejection, catalog views) and engine tests (INSERT reading inserted + the audit-write lock seam; UPDATE/DELETE reading deleted/inserted; trigger ROLLBACK → 3609 + undone DML; recursive-off self-insert fires once; trigger-cycle lock analysis terminates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)