### PR TITLE
Stage 15 exit matrices: trigger crash-atomicity + live user-proc callproc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,6 +220,9 @@ jobs:
       - name: Conformance — pytds parameterized (sp_executesql RPC)
         run: python3 scripts/tds_conformance_rpc.py 127.0.0.1 1433 sa secret
 
+      - name: Conformance — pytds user-procedure callproc (OUTPUT + RETURN status)
+        run: python3 scripts/tds_conformance_procs.py 127.0.0.1 1433 sa secret
+
       - name: Conformance — pytds prepared statements (sp_prepare family)
         run: python3 scripts/tds_conformance_prepared.py 127.0.0.1 1433 sa secret
 

--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -7908,6 +7908,72 @@ mod tests {
     }
 
     #[test]
+    fn trigger_writes_are_fully_undone_after_a_crash() {
+        let path = unique_temp_path("trg-crash-undo");
+        let engine = new_engine(&path);
+        let mut ctx = TxnContext::default();
+        batch(
+            &engine,
+            &mut ctx,
+            "CREATE TABLE t (id INT NOT NULL PRIMARY KEY)",
+        );
+        batch(
+            &engine,
+            &mut ctx,
+            "CREATE TABLE audit (id INT NOT NULL PRIMARY KEY)",
+        );
+        batch(
+            &engine,
+            &mut ctx,
+            "CREATE TRIGGER trg ON t AFTER INSERT AS INSERT INTO audit SELECT id FROM inserted",
+        );
+
+        // Session A: an explicit transaction whose INSERT fires the trigger
+        // (writing `audit`), never committed. The firing row and the trigger's
+        // write both stage on A's transaction.
+        let mut ctx_a = TxnContext::default();
+        batch(&engine, &mut ctx_a, "BEGIN TRAN; INSERT INTO t VALUES (99)");
+        assert!(ctx_a.has_open_transaction());
+        // A committed autocommit insert forces the WAL (including A's
+        // uncommitted records) to disk.
+        batch(
+            &engine,
+            &mut TxnContext::default(),
+            "INSERT INTO audit VALUES (1)",
+        );
+
+        // Crash: no graceful rollback.
+        drop(ctx_a);
+        drop(engine);
+
+        // Recovery undoes the loser A entirely — the whole statement, DML AND
+        // its trigger's write, is atomic: t=99 is gone and the trigger's
+        // audit=99 is gone; the separately-committed audit=1 survives.
+        let storage = Storage::open(path.clone()).expect("reopen");
+        let engine = Engine::new(storage).expect("replay");
+        let out_t = batch(
+            &engine,
+            &mut TxnContext::default(),
+            "SELECT id FROM t ORDER BY id",
+        );
+        assert!(
+            ids(&out_t).is_empty(),
+            "the firing row must be undone after the crash"
+        );
+        let out_a = batch(
+            &engine,
+            &mut TxnContext::default(),
+            "SELECT id FROM audit ORDER BY id",
+        );
+        assert_eq!(
+            ids(&out_a),
+            vec![1],
+            "the trigger's write must be undone with the statement; the committed row survives"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
     fn txn_statement_rollback_then_crash_recovers_cleanly() {
         // A statement rolled back to a savepoint writes CLRs; if the transaction
         // then crashes uncommitted, recovery must undo the surviving ops and SKIP

--- a/scripts/tds_conformance_procs.py
+++ b/scripts/tds_conformance_procs.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""TDS user-procedure callproc conformance: OUTPUT parameters and RETURN status.
+
+pytds `cur.callproc(name, params)` issues an RPC-by-name (packet 0x03) to a user
+stored procedure — distinct from the sp_executesql path in tds_conformance_rpc.py
+and the sp_prepare family in tds_conformance_prepared.py. This adjudicates, from a
+real driver, the OUTPUT copy-back (RETURNVALUE tokens, one per output ordinal) and
+the RETURN status (RETURNSTATUS token) that #128 implemented — including the
+per-ordinal placement that a single-OUTPUT test would not catch.
+
+Usage: tds_conformance_procs.py <host> <port> <user> <password>
+Exits non-zero on any mismatch.
+"""
+import sys
+
+import pytds
+
+
+def main() -> int:
+    host, port, user, password = sys.argv[1], int(sys.argv[2]), sys.argv[3], sys.argv[4]
+    conn = pytds.connect(
+        host, "truthdb", user, password, port=port, login_timeout=10, autocommit=True
+    )
+    cur = conn.cursor()
+
+    # A procedure with one input, two OUTPUT parameters on DISTINCT ordinals, and
+    # a RETURN status. The two outputs catch a per-ordinal placement bug (a single
+    # output would pass even if every RETURNVALUE were stamped ordinal 0).
+    cur.execute(
+        "CREATE PROCEDURE add_and_double (@x INT, @sum INT OUTPUT, @doubled INT OUTPUT) AS "
+        "BEGIN SET @sum = @x + 10; SET @doubled = @x * 2; RETURN 42 END"
+    )
+
+    # Positional callproc: the OUTPUT slots come back filled, in order.
+    result = cur.callproc(
+        "add_and_double", (5, pytds.output(param_type=int), pytds.output(param_type=int))
+    )
+    if result[1] != 15 or result[2] != 10:
+        print(f"FAIL: positional OUTPUT: got sum={result[1]} doubled={result[2]}, want 15/10")
+        return 1
+    if cur.return_value != 42:
+        print(f"FAIL: RETURN status: got {cur.return_value}, want 42")
+        return 1
+
+    # A different input reruns the proc; the outputs track it.
+    result = cur.callproc(
+        "add_and_double", (100, pytds.output(param_type=int), pytds.output(param_type=int))
+    )
+    if result[1] != 110 or result[2] != 200:
+        print(f"FAIL: second call OUTPUT: got sum={result[1]} doubled={result[2]}, want 110/200")
+        return 1
+
+    # Named callproc: parameters supplied by @name, OUTPUT still copied back.
+    cur.execute(
+        "CREATE PROCEDURE describe (@id INT, @label NVARCHAR(20) OUTPUT) AS "
+        "BEGIN SET @label = 'row-' + CAST(@id AS NVARCHAR(10)); RETURN 0 END"
+    )
+    named = cur.callproc(
+        "describe", {"@id": 7, "@label": pytds.output(param_type=str)}
+    )
+    # The dict callproc returns values positionally in declaration order.
+    if named[1] != "row-7":
+        print(f"FAIL: named OUTPUT: got label={named[1]!r}, want 'row-7'")
+        return 1
+
+    # A negative RETURN status round-trips as a signed int.
+    cur.execute(
+        "CREATE PROCEDURE classify (@n INT, @kind INT OUTPUT) AS "
+        "BEGIN SET @kind = @n; IF @n < 0 RETURN -1; RETURN 1 END"
+    )
+    cur.callproc("classify", (-5, pytds.output(param_type=int)))
+    if cur.return_value != -1:
+        print(f"FAIL: negative RETURN status: got {cur.return_value}, want -1")
+        return 1
+    cur.callproc("classify", (5, pytds.output(param_type=int)))
+    if cur.return_value != 1:
+        print(f"FAIL: positive RETURN status: got {cur.return_value}, want 1")
+        return 1
+
+    conn.close()
+    print("tds procs conformance: OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes the remaining Stage 15 exit-criteria items (plan line 566). The TRY/CATCH × severity × XACT_ABORT truth table and the trigger firing/nesting suites are already covered exhaustively by ~20 engine tests + severity.slt / triggers.slt; the two genuinely-missing pieces:

- **kill-mid-trigger crash test**: an explicit transaction whose INSERT fires a trigger writing an audit table, crashed before commit, is fully undone on recovery — firing row AND trigger write both vanish, a separately-committed row survives. The whole statement (DML + trigger) is atomic under ARIES recovery.
- **user-procedure callproc conformance** (`scripts/tds_conformance_procs.py`, wired into CI): pytds `callproc` drives a real RPC-by-name against a live server, adjudicating the OUTPUT copy-back (RETURNVALUE per output ordinal — two distinct ordinals catch a per-ordinal bug a single output would miss) and RETURN status (±), named + positional. The live end-to-end validation of #128's OUTPUT/return-status framing. Verified live locally (pytds → server) before wiring into CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)