### PR TITLE
Stage 16 auth: catalog logins, PBKDF2, TDS handshake, throttle, first-boot migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1195,6 +1195,7 @@ dependencies = [
  "icu_locale_core",
  "io-uring",
  "libc",
+ "ring",
  "rstest",
  "serde",
  "serde_json",

--- a/config/default.toml
+++ b/config/default.toml
@@ -38,5 +38,11 @@ snapshot_wal_threshold = 0.7
 # tls_cert = "/etc/truthdb/tls.crt"
 # tls_key = "/etc/truthdb/tls.key"
 #
-# [tds.auth]           # username = password (send it over TLS: see encryption)
+# [tds.auth]  — FIRST-BOOT SEED ONLY. These username = password entries are
+# hashed into catalog logins the first time the server starts; the catalog is
+# then authoritative and is never consulted from this file for authentication.
+# Once the built-in sa login exists this section is inert (editing it does not
+# add, remove, or rotate a login — use CREATE/ALTER/DROP LOGIN). If no sa is set
+# here, an sa login is still created but DISABLED. Send passwords over TLS: see
+# encryption above.
 # sa = "change-me"

--- a/crates/truthdb-core/Cargo.toml
+++ b/crates/truthdb-core/Cargo.toml
@@ -17,6 +17,9 @@ libc = { workspace = true }
 io-uring = { workspace = true }
 icu_collator = { version = "2.2", features = ["compiled_data", "unstable"] }
 icu_locale_core = "2.0"
+# PBKDF2-HMAC-SHA256 for login password hashing. Already in the tree via rustls
+# (truthdb-tds), so this is a manifest entry only — zero new compiled crates.
+ring = "0.17"
 
 [dev-dependencies]
 rstest = { workspace = true }

--- a/crates/truthdb-core/src/auth.rs
+++ b/crates/truthdb-core/src/auth.rs
@@ -1,0 +1,215 @@
+//! Login password hashing: PBKDF2-HMAC-SHA256, salted and versioned.
+//!
+//! The stored credential is a self-describing text blob `v1$<iters>$<hex
+//! salt>$<hex hash>` so the iteration count and salt travel with the hash and a
+//! future version can raise the work factor without a migration. The KDF is
+//! `ring::pbkdf2` (already in the tree via rustls — no new compiled dependency).
+//! This is deliberately NOT SQL Server's on-disk hash format: a modern salted
+//! KDF beats bug-for-bug faithfulness for stored credentials.
+//!
+//! Verification is pure CPU with no storage access, so the TDS login path runs
+//! it off the engine worker pool (a `spawn_blocking` task) — ~30 ms of PBKDF2
+//! must not sit on a worker thread or the async reactor.
+
+use std::num::NonZeroU32;
+
+use ring::pbkdf2;
+use ring::rand::SecureRandom;
+
+/// PBKDF2 iteration count for new hashes (OWASP-scale for HMAC-SHA256).
+const ITERATIONS: u32 = 210_000;
+const SALT_LEN: usize = 16;
+const HASH_LEN: usize = 32;
+static ALGORITHM: pbkdf2::Algorithm = pbkdf2::PBKDF2_HMAC_SHA256;
+
+/// A well-formed credential blob that no real password matches, used by the
+/// login path to spend the same PBKDF2 time when a login does not exist (or is
+/// disabled). Verifying against it always yields [`VerifyOutcome::BadPassword`]
+/// but costs the same ~30 ms as a real check, so response latency does not
+/// reveal which usernames are valid. Its salt/hash are all-zero — the iteration
+/// count and lengths match [`ITERATIONS`]/[`SALT_LEN`]/[`HASH_LEN`], which is
+/// all that determines timing.
+pub const DUMMY_BLOB: &str = "v1$210000$00000000000000000000000000000000$\
+    0000000000000000000000000000000000000000000000000000000000000000";
+
+/// The result of verifying a password against a stored credential blob.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VerifyOutcome {
+    /// The password matches the stored hash.
+    Ok,
+    /// The password does not match.
+    BadPassword,
+    /// The stored blob could not be parsed (corrupt or unknown version).
+    Malformed,
+}
+
+/// Hashes a plaintext password into a storable versioned blob. A fresh random
+/// salt is drawn per call, so hashing the same password twice yields different
+/// blobs — do not compare blobs for equality; verify with [`verify_password`].
+pub fn hash_password(password: &str) -> String {
+    let rng = ring::rand::SystemRandom::new();
+    let mut salt = [0u8; SALT_LEN];
+    rng.fill(&mut salt)
+        .expect("system RNG must produce a salt for password hashing");
+    let mut hash = [0u8; HASH_LEN];
+    pbkdf2::derive(
+        ALGORITHM,
+        NonZeroU32::new(ITERATIONS).expect("iteration count is non-zero"),
+        &salt,
+        password.as_bytes(),
+        &mut hash,
+    );
+    format!("v1${ITERATIONS}${}${}", hex(&salt), hex(&hash))
+}
+
+/// Produces a credential blob for a fresh random 32-byte password that is then
+/// discarded. Nobody knows the plaintext, so the login can never authenticate —
+/// used to materialize a placeholder (disabled) `sa` when the config supplied no
+/// `sa` password. An admin resets it later via `ALTER LOGIN`.
+pub fn hash_random_password() -> String {
+    let rng = ring::rand::SystemRandom::new();
+    let mut secret = [0u8; 32];
+    rng.fill(&mut secret)
+        .expect("system RNG must produce a placeholder secret");
+    hash_password(&hex(&secret))
+}
+
+/// Verifies a plaintext password against a stored credential blob in constant
+/// time (via `ring::pbkdf2::verify`). Returns [`VerifyOutcome::Malformed`] if the
+/// blob cannot be parsed — the caller treats that as an authentication failure.
+pub fn verify_password(blob: &str, password: &str) -> VerifyOutcome {
+    let Some((iterations, salt, hash)) = parse_blob(blob) else {
+        return VerifyOutcome::Malformed;
+    };
+    let Some(iterations) = NonZeroU32::new(iterations) else {
+        return VerifyOutcome::Malformed;
+    };
+    match pbkdf2::verify(ALGORITHM, iterations, &salt, password.as_bytes(), &hash) {
+        Ok(()) => VerifyOutcome::Ok,
+        Err(_) => VerifyOutcome::BadPassword,
+    }
+}
+
+/// Parses `v1$<iters>$<hex salt>$<hex hash>` into (iterations, salt, hash).
+fn parse_blob(blob: &str) -> Option<(u32, Vec<u8>, Vec<u8>)> {
+    let mut parts = blob.split('$');
+    if parts.next()? != "v1" {
+        return None;
+    }
+    let iterations: u32 = parts.next()?.parse().ok()?;
+    let salt = unhex(parts.next()?)?;
+    let hash = unhex(parts.next()?)?;
+    if parts.next().is_some() || salt.len() != SALT_LEN || hash.len() != HASH_LEN {
+        return None;
+    }
+    Some((iterations, salt, hash))
+}
+
+fn hex(bytes: &[u8]) -> String {
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        s.push_str(&format!("{b:02x}"));
+    }
+    s
+}
+
+fn unhex(s: &str) -> Option<Vec<u8>> {
+    if !s.len().is_multiple_of(2) {
+        return None;
+    }
+    (0..s.len())
+        .step_by(2)
+        .map(|i| u8::from_str_radix(&s[i..i + 2], 16).ok())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hash_then_verify_round_trips() {
+        let blob = hash_password("Correct Horse Battery Staple");
+        assert!(blob.starts_with("v1$210000$"));
+        assert_eq!(
+            verify_password(&blob, "Correct Horse Battery Staple"),
+            VerifyOutcome::Ok
+        );
+        assert_eq!(
+            verify_password(&blob, "correct horse battery staple"),
+            VerifyOutcome::BadPassword
+        );
+        assert_eq!(verify_password(&blob, ""), VerifyOutcome::BadPassword);
+    }
+
+    #[test]
+    fn a_fresh_salt_is_drawn_per_hash() {
+        // Same password, two calls: different blobs (different salts), both verify.
+        let a = hash_password("hunter2");
+        let b = hash_password("hunter2");
+        assert_ne!(a, b, "each hash must use a fresh random salt");
+        assert_eq!(verify_password(&a, "hunter2"), VerifyOutcome::Ok);
+        assert_eq!(verify_password(&b, "hunter2"), VerifyOutcome::Ok);
+    }
+
+    #[test]
+    fn malformed_blobs_are_rejected() {
+        assert_eq!(verify_password("", "x"), VerifyOutcome::Malformed);
+        assert_eq!(verify_password("v2$1$00$00", "x"), VerifyOutcome::Malformed);
+        assert_eq!(
+            verify_password("v1$notanumber$aa$bb", "x"),
+            VerifyOutcome::Malformed
+        );
+        // Wrong salt/hash lengths.
+        assert_eq!(
+            verify_password("v1$210000$00$00", "x"),
+            VerifyOutcome::Malformed
+        );
+        // Extra field.
+        let good = hash_password("x");
+        assert_eq!(
+            verify_password(&format!("{good}$extra"), "x"),
+            VerifyOutcome::Malformed
+        );
+    }
+
+    #[test]
+    fn dummy_blob_is_well_formed_and_never_matches() {
+        // It must PARSE (so verify spends the full KDF time) and reject every
+        // password — a Malformed result would short-circuit and leak timing.
+        assert_eq!(verify_password(DUMMY_BLOB, ""), VerifyOutcome::BadPassword);
+        assert_eq!(
+            verify_password(DUMMY_BLOB, "any password at all"),
+            VerifyOutcome::BadPassword
+        );
+    }
+
+    #[test]
+    fn known_pbkdf2_hmac_sha256_vector() {
+        // RFC-style check: PBKDF2-HMAC-SHA256(password="password", salt="salt",
+        // c=1, dkLen=32) = 120fb6cffcf8b32c43e7225256c4f837a86548c9
+        // 2ccc35480805987cb70be17b (a widely published test vector). We build a
+        // v1 blob with those parameters and confirm verify accepts the password.
+        let salt = b"salt";
+        let expected = [
+            0x12, 0x0f, 0xb6, 0xcf, 0xfc, 0xf8, 0xb3, 0x2c, 0x43, 0xe7, 0x22, 0x52, 0x56, 0xc4,
+            0xf8, 0x37, 0xa8, 0x65, 0x48, 0xc9, 0x2c, 0xcc, 0x35, 0x48, 0x08, 0x05, 0x98, 0x7c,
+            0xb7, 0x0b, 0xe1, 0x7b,
+        ];
+        // Our derive must reproduce the vector for iterations=1.
+        let mut hash = [0u8; HASH_LEN];
+        pbkdf2::derive(
+            ALGORITHM,
+            NonZeroU32::new(1).unwrap(),
+            salt,
+            b"password",
+            &mut hash,
+        );
+        assert_eq!(
+            hash,
+            expected,
+            "PBKDF2-HMAC-SHA256 test vector mismatch: got {}",
+            hex(&hash)
+        );
+    }
+}

--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -108,6 +108,87 @@ impl Engine {
         }
     }
 
+    /// Reads a login's stored credential for the TDS handshake. This is a
+    /// session-less catalog read: the handshake runs before any session or
+    /// transaction exists. Returns `None` when no such login is registered.
+    pub fn lookup_login(&self, name: &str) -> Option<crate::session::LoginRecord> {
+        let def = self.storage.rel_login(name)?;
+        let principal = def.principal?;
+        Some(crate::session::LoginRecord {
+            principal_id: def.object_id,
+            name: def.name,
+            password_blob: principal.password_blob,
+            is_disabled: principal.is_disabled,
+        })
+    }
+
+    /// First-boot migration of config-file `[tds.auth]` users into catalog
+    /// logins. Each configured user becomes an enabled login; `sa` is always
+    /// ensured — enabled with its configured password, or, when the config
+    /// supplied none, created DISABLED with an unguessable random password so the
+    /// principal exists (SUSER_SNAME, the dbo↔sa mapping) but cannot authenticate
+    /// until an admin resets it over the unauthenticated native admin protocol.
+    /// After this runs, `[tds.auth]` is dead for authentication: the catalog is
+    /// authoritative, and a login is created here only if it does not already
+    /// exist. Returns the names created, for startup logging.
+    ///
+    /// `sa` is created LAST and doubles as the completion marker: the migration
+    /// is skipped entirely once `sa` exists. Because ARIES recovery restores only
+    /// a contiguous durable prefix of the log, `sa` present after a crash implies
+    /// every login written before it is durable too — so a crash mid-migration
+    /// leaves `sa` absent and the whole thing simply re-runs, with the
+    /// per-login existence check making that re-run idempotent (it also collapses
+    /// a case-variant duplicate config key onto the first-seen login rather than
+    /// erroring). This runs before the engine thread is spawned, single-threaded.
+    pub fn migrate_logins(
+        &self,
+        config_users: &BTreeMap<String, String>,
+    ) -> Result<Vec<String>, EngineError> {
+        if self.storage.rel_login("sa").is_some() {
+            return Ok(Vec::new());
+        }
+        let mut created = Vec::new();
+        let mut sa_password: Option<&String> = None;
+        for (name, password) in config_users {
+            if name.eq_ignore_ascii_case("sa") {
+                sa_password = Some(password);
+                continue; // ensured last, as the completion marker
+            }
+            if self.storage.rel_login(name).is_some() {
+                continue; // already migrated (idempotent re-run or case-dup key)
+            }
+            self.storage.rel_create_login(
+                name,
+                crate::relstore::catalog::PrincipalDef {
+                    password_blob: crate::auth::hash_password(password),
+                    is_disabled: false,
+                },
+            )?;
+            created.push(name.clone());
+        }
+        let (password_blob, is_disabled, label) = match sa_password {
+            Some(password) => (
+                crate::auth::hash_password(password),
+                false,
+                "sa".to_string(),
+            ),
+            None => (
+                crate::auth::hash_random_password(),
+                true,
+                "sa (disabled — no password configured)".to_string(),
+            ),
+        };
+        self.storage.rel_create_login(
+            "sa",
+            crate::relstore::catalog::PrincipalDef {
+                password_blob,
+                is_disabled,
+            },
+        )?;
+        created.push(label);
+        Ok(created)
+    }
+
     /// Runs a search against an index and renders the hits.
     fn render_search(
         meta: &EngineMeta,
@@ -6647,6 +6728,158 @@ mod tests {
             out.error.is_none(),
             "the orphaned trigger name must be reusable: {:?}",
             out.error
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn create_login_persists_survives_restart_and_stays_out_of_the_object_namespace() {
+        let path = unique_temp_path("login-ddl");
+        let engine = new_engine(&path);
+        engine
+            .execute("CREATE LOGIN alice WITH PASSWORD = 'S3cret!'")
+            .expect("create login");
+        // sys.server_principals shows it as a SQL login.
+        let (_c, rows) = sql_rows(
+            &engine,
+            "SELECT name, type, is_disabled FROM sys.server_principals WHERE name = 'alice'",
+        );
+        assert_eq!(
+            rows,
+            vec![vec![
+                Some("alice".to_string()),
+                Some("S".to_string()),
+                Some("0".to_string())
+            ]],
+            "the login appears in sys.server_principals"
+        );
+        // It is NOT a schema object: not in sys.tables, not queryable as a table.
+        let (_c, rows) = sql_rows(
+            &engine,
+            "SELECT COUNT(*) AS n FROM sys.tables WHERE name = 'alice'",
+        );
+        assert_eq!(
+            rows,
+            vec![vec![Some("0".to_string())]],
+            "a login is not a table"
+        );
+        let mut ctx = TxnContext::default();
+        let out = batch(&engine, &mut ctx, "SELECT * FROM alice");
+        assert_eq!(
+            out.error.as_ref().map(|e| e.number),
+            Some(208),
+            "a login name is not a queryable object: {:?}",
+            out.error
+        );
+        // Survives a restart (persisted in the catalog b-tree).
+        drop(engine);
+        let storage = Storage::open(path.clone()).expect("reopen");
+        let engine = Engine::new(storage).expect("replay");
+        let (_c, rows) = sql_rows(
+            &engine,
+            "SELECT name FROM sys.server_principals WHERE name = 'alice'",
+        );
+        assert_eq!(
+            rows,
+            vec![vec![Some("alice".to_string())]],
+            "the login survives restart"
+        );
+
+        // ALTER LOGIN ... DISABLE.
+        engine
+            .execute("ALTER LOGIN alice DISABLE")
+            .expect("disable");
+        let (_c, rows) = sql_rows(
+            &engine,
+            "SELECT is_disabled FROM sys.sql_logins WHERE name = 'alice'",
+        );
+        assert_eq!(
+            rows,
+            vec![vec![Some("1".to_string())]],
+            "ALTER DISABLE sets is_disabled"
+        );
+
+        // DROP LOGIN.
+        engine.execute("DROP LOGIN alice").expect("drop login");
+        let (_c, rows) = sql_rows(
+            &engine,
+            "SELECT COUNT(*) AS n FROM sys.server_principals WHERE name = 'alice'",
+        );
+        assert_eq!(
+            rows,
+            vec![vec![Some("0".to_string())]],
+            "DROP LOGIN removes it"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn migrate_logins_is_idempotent_ensures_sa_last_and_survives_config_case_dups() {
+        use std::collections::BTreeMap;
+        let path = unique_temp_path("login-migrate");
+        let engine = new_engine(&path);
+
+        // Case-variant duplicate keys and a lowercase app user; NO sa configured.
+        // The dup must NOT error the migration — the second is collapsed onto the
+        // first-seen login (names are case-insensitive) — and sa is created LAST,
+        // disabled, because no password was configured.
+        let mut users = BTreeMap::new();
+        users.insert("Admin".to_string(), "p1".to_string());
+        users.insert("admin".to_string(), "p2".to_string());
+        users.insert("app".to_string(), "app-pw".to_string());
+        let created = engine.migrate_logins(&users).expect("first migration");
+        assert!(
+            created.iter().any(|c| c.starts_with("sa (disabled")),
+            "sa is ensured disabled when unconfigured: {created:?}"
+        );
+
+        // Exactly one of the case-variant admins exists (the first-sorted, Admin),
+        // plus app and sa — the dup did not create a second principal.
+        let (_c, rows) = sql_rows(
+            &engine,
+            "SELECT name, is_disabled FROM sys.server_principals ORDER BY name",
+        );
+        assert_eq!(
+            rows,
+            vec![
+                vec![Some("Admin".to_string()), Some("0".to_string())],
+                vec![Some("app".to_string()), Some("0".to_string())],
+                vec![Some("sa".to_string()), Some("1".to_string())],
+            ],
+            "case-dup collapsed to one login; sa present and disabled: {rows:?}"
+        );
+
+        // Idempotent: a second run is a no-op (sa exists → the whole thing skips),
+        // and it does NOT resurrect a login the admin dropped.
+        engine.execute("DROP LOGIN app").expect("drop app");
+        let again = engine.migrate_logins(&users).expect("second migration");
+        assert!(again.is_empty(), "re-run is a no-op: {again:?}");
+        let (_c, rows) = sql_rows(
+            &engine,
+            "SELECT COUNT(*) AS n FROM sys.server_principals WHERE name = 'app'",
+        );
+        assert_eq!(
+            rows,
+            vec![vec![Some("0".to_string())]],
+            "a dropped login is not resurrected by re-migration"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn migrate_logins_uses_the_configured_sa_password_and_enables_it() {
+        use std::collections::BTreeMap;
+        let path = unique_temp_path("login-migrate-sa");
+        let engine = new_engine(&path);
+        let mut users = BTreeMap::new();
+        users.insert("sa".to_string(), "secret".to_string());
+        engine.migrate_logins(&users).expect("migration");
+        let rec = engine.lookup_login("sa").expect("sa exists");
+        assert!(!rec.is_disabled, "configured sa is enabled");
+        assert_eq!(
+            crate::auth::verify_password(&rec.password_blob, "secret"),
+            crate::auth::VerifyOutcome::Ok,
+            "sa authenticates with its configured password"
         );
         let _ = std::fs::remove_file(path);
     }

--- a/crates/truthdb-core/src/lib.rs
+++ b/crates/truthdb-core/src/lib.rs
@@ -1,4 +1,5 @@
 mod allocator;
+pub mod auth;
 pub mod client_listener;
 mod direct_io;
 pub mod dispatcher;

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -15,10 +15,11 @@ mod value;
 
 use truthdb_sql::ast::{
     AlterAction, AlterDatabase, AlterTable, CheckConstraint, ColumnDef, CreateFunction,
-    CreateIndex, CreateProcedure, CreateTable, CreateTrigger, CreateView, DataType, DatabaseOption,
-    Declaration, Delete, DropIndex, DropTable, DropView, ExecStatement, Expr, ExprKind, ForeignKey,
-    Insert, InsertSource, IsolationLevel, JoinKind, Name, OrderItem, RaiseError, ReturnsClause,
-    Select, SelectItem, SetStatement, Statement, TableRef, ThrowArgs, ThrowStatement, Update,
+    CreateIndex, CreateLogin, CreateProcedure, CreateTable, CreateTrigger, CreateView, DataType,
+    DatabaseOption, Declaration, Delete, DropIndex, DropTable, DropView, ExecStatement, Expr,
+    ExprKind, ForeignKey, Insert, InsertSource, IsolationLevel, JoinKind, Name, OrderItem,
+    RaiseError, ReturnsClause, Select, SelectItem, SetStatement, Statement, TableRef, ThrowArgs,
+    ThrowStatement, Update,
 };
 use truthdb_sql::collation::CollationSensitivity;
 use truthdb_sql::error::SqlError;
@@ -32,7 +33,8 @@ use xxhash_rust::xxh64::xxh64;
 use crate::lock::{LockMode, Resource};
 use crate::relstore::btree::ScanCursor;
 use crate::relstore::catalog::{
-    self, FunctionDef, FunctionReturns, ProcParamDef, ProcedureDef, TableDef, TriggerDef,
+    self, FunctionDef, FunctionReturns, PrincipalDef, ProcParamDef, ProcedureDef, TableDef,
+    TriggerDef,
 };
 use crate::relstore::row::{Column, Schema};
 use crate::relstore::types::{ColumnType, Datum};
@@ -2402,6 +2404,8 @@ fn statement_may_commit(statement: &Statement) -> bool {
             | Statement::DropFunction { .. }
             | Statement::CreateTrigger(_)
             | Statement::DropTrigger { .. }
+            | Statement::CreateLogin(_)
+            | Statement::DropLogin { .. }
             | Statement::Commit { .. }
     )
 }
@@ -3072,7 +3076,9 @@ fn analyze_statements_locks(
             | Statement::CreateFunction(_)
             | Statement::DropFunction { .. }
             | Statement::CreateTrigger(_)
-            | Statement::DropTrigger { .. } => {
+            | Statement::DropTrigger { .. }
+            | Statement::CreateLogin(_)
+            | Statement::DropLogin { .. } => {
                 add(Resource::Database, LockMode::Exclusive);
             }
             // IF/WHILE conditions read tables through their subqueries —
@@ -3256,6 +3262,20 @@ fn exec_statement_dispatch(
                 return Err(ddl_in_txn_err());
             }
             exec_drop_trigger(storage, name, *if_exists)
+        }
+        Statement::CreateLogin(create) => {
+            if txn_ctx.in_txn() {
+                return Err(ddl_in_txn_err());
+            }
+            exec_create_login(storage, create)
+        }
+        Statement::DropLogin {
+            name, if_exists, ..
+        } => {
+            if txn_ctx.in_txn() {
+                return Err(ddl_in_txn_err());
+            }
+            exec_drop_login(storage, name, *if_exists)
         }
         // Executed by `run_block`'s own arms; nothing routes them here.
         Statement::Block { .. }
@@ -5713,6 +5733,86 @@ fn exec_drop_trigger(
             ),
         )),
     }
+}
+
+/// `CREATE|ALTER LOGIN <name> WITH PASSWORD = '<pw>'` / `ALTER LOGIN <name>
+/// {ENABLE | DISABLE}`. Logins are server principals in their own namespace
+/// (disjoint from schema objects); the password is hashed here (on the worker —
+/// CREATE/ALTER LOGIN is rare admin DDL, unlike verification which runs off the
+/// worker per connection).
+fn exec_create_login(storage: &Storage, create: &CreateLogin) -> Result<StatementResult, SqlError> {
+    let bare = strip_schema(&create.name.value);
+    if create.alter {
+        let Some(existing) = storage.rel_login(bare) else {
+            return Err(SqlError::new(
+                15151,
+                16,
+                1,
+                format!(
+                    "Cannot alter the login '{bare}', because it does not exist or you do not have permission."
+                ),
+            )
+            .at(create.name.span));
+        };
+        let mut principal = existing
+            .principal
+            .clone()
+            .expect("rel_login returns a login");
+        if let Some(password) = &create.password {
+            principal.password_blob = crate::auth::hash_password(password);
+        }
+        if let Some(disable) = create.disable {
+            principal.is_disabled = disable;
+        }
+        storage
+            .rel_alter_login(bare, principal)
+            .map_err(|e| map_storage_err(e, &create.name.value))?;
+        return Ok(StatementResult::Done);
+    }
+    if storage.rel_login(bare).is_some() {
+        return Err(SqlError::new(
+            15025,
+            16,
+            1,
+            format!("The server principal '{bare}' already exists."),
+        )
+        .at(create.name.span));
+    }
+    let password = create
+        .password
+        .as_ref()
+        .expect("CREATE LOGIN carries a password (parser-enforced)");
+    let principal = PrincipalDef {
+        password_blob: crate::auth::hash_password(password),
+        is_disabled: create.disable.unwrap_or(false),
+    };
+    storage
+        .rel_create_login(bare, principal)
+        .map_err(|e| map_storage_err(e, &create.name.value))?;
+    Ok(StatementResult::Done)
+}
+
+fn exec_drop_login(
+    storage: &Storage,
+    name: &Name,
+    if_exists: bool,
+) -> Result<StatementResult, SqlError> {
+    let bare = strip_schema(&name.value);
+    let dropped = storage
+        .rel_drop_login(bare)
+        .map_err(|e| map_storage_err(e, &name.value))?;
+    if !dropped && !if_exists {
+        return Err(SqlError::new(
+            15151,
+            16,
+            1,
+            format!(
+                "Cannot drop the login '{bare}', because it does not exist or you do not have permission."
+            ),
+        )
+        .at(name.span));
+    }
+    Ok(StatementResult::Done)
 }
 
 /// Resolves the AFTER triggers to fire for a DML on `target_name` for `event`,
@@ -10728,6 +10828,8 @@ fn build_table_source(
         "sys.procedures" => sys_procedures(storage),
         "sys.triggers" => sys_triggers(storage),
         "sys.trigger_events" => sys_trigger_events(storage),
+        "sys.server_principals" => sys_server_principals(storage),
+        "sys.sql_logins" => sys_sql_logins(storage),
         "sys.parameters" => sys_parameters(storage),
         "sys.objects" => sys_objects(storage),
         "sys.sql_modules" => sys_sql_modules(storage),
@@ -11947,6 +12049,67 @@ fn sys_trigger_events(storage: &Storage) -> Source {
             ]);
         }
     }
+    let collations = vec![None; columns.len()];
+    let qualifiers = vec![None; columns.len()];
+    Source {
+        columns,
+        qualifiers,
+        collations,
+        rows: SourceRows::Materialized(rows),
+    }
+}
+
+fn sys_server_principals(storage: &Storage) -> Source {
+    let columns = vec![
+        nvarchar("name", 128),
+        int_col("principal_id"),
+        nvarchar("type", 1),
+        nvarchar("type_desc", 60),
+        int_col("is_disabled"),
+    ];
+    let rows = storage
+        .rel_logins()
+        .into_iter()
+        .filter_map(|def| {
+            let principal = def.principal.as_ref()?;
+            Some(vec![
+                Datum::NVarChar(def.name.clone()),
+                Datum::Int(def.object_id as i32),
+                // Only SQL logins exist today: type 'S' / SQL_LOGIN.
+                Datum::NVarChar("S".to_string()),
+                Datum::NVarChar("SQL_LOGIN".to_string()),
+                Datum::Int(i32::from(principal.is_disabled)),
+            ])
+        })
+        .collect();
+    let collations = vec![None; columns.len()];
+    let qualifiers = vec![None; columns.len()];
+    Source {
+        columns,
+        qualifiers,
+        collations,
+        rows: SourceRows::Materialized(rows),
+    }
+}
+
+fn sys_sql_logins(storage: &Storage) -> Source {
+    let columns = vec![
+        nvarchar("name", 128),
+        int_col("principal_id"),
+        int_col("is_disabled"),
+    ];
+    let rows = storage
+        .rel_logins()
+        .into_iter()
+        .filter_map(|def| {
+            let principal = def.principal.as_ref()?;
+            Some(vec![
+                Datum::NVarChar(def.name.clone()),
+                Datum::Int(def.object_id as i32),
+                Datum::Int(i32::from(principal.is_disabled)),
+            ])
+        })
+        .collect();
     let collations = vec![None; columns.len()];
     let qualifiers = vec![None; columns.len()];
     Source {

--- a/crates/truthdb-core/src/relstore/catalog.rs
+++ b/crates/truthdb-core/src/relstore/catalog.rs
@@ -134,6 +134,23 @@ pub struct TableDef {
     /// key — it is a schema object with its own object_id, like a procedure.
     #[serde(default)]
     pub trigger: Option<TriggerDef>,
+    /// For a server-scoped LOGIN (SQL authentication principal): its hashed
+    /// password blob and disabled flag. A login is NOT a schema object — the
+    /// storage layer keeps these rows in a separate in-memory map so they never
+    /// appear in the object namespace (sys.tables, name resolution, DROP TABLE).
+    /// `None` for every schema object.
+    #[serde(default)]
+    pub principal: Option<PrincipalDef>,
+}
+
+/// A server principal's catalog payload. Today only SQL logins exist; the
+/// password blob is the versioned PBKDF2 hash from [`crate::auth`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PrincipalDef {
+    /// The versioned PBKDF2 credential blob (`v1$iters$salt$hash`).
+    pub password_blob: String,
+    /// `ALTER LOGIN ... DISABLE` sets this; a disabled login cannot authenticate.
+    pub is_disabled: bool,
 }
 
 /// A DML event a trigger can fire on.
@@ -236,6 +253,12 @@ impl TableDef {
     /// True if this catalog entry is a trigger.
     pub fn is_trigger(&self) -> bool {
         self.trigger.is_some()
+    }
+
+    /// True if this catalog entry is a server login (a principal, not a schema
+    /// object).
+    pub fn is_login(&self) -> bool {
+        self.principal.is_some()
     }
 }
 

--- a/crates/truthdb-core/src/relstore/mod.rs
+++ b/crates/truthdb-core/src/relstore/mod.rs
@@ -40,6 +40,11 @@ pub(crate) struct RelState {
     pub catalog_root: Option<u64>,
     /// Catalog cache: table name -> definition.
     pub tables: HashMap<String, TableDef>,
+    /// Server logins (principals), keyed by lowercased login name. Persisted in
+    /// the SAME catalog b-tree as `tables` (a row with `principal: Some(..)`),
+    /// but partitioned into a separate map on load so a login never enters the
+    /// object namespace (name resolution, sys.tables, DROP TABLE).
+    pub principals: HashMap<String, TableDef>,
     pub next_txn_id: u64,
     pub next_object_id: u32,
     /// Open explicit (multi-statement) transactions: txn id → its `BEGIN` LSN.
@@ -58,6 +63,7 @@ impl RelState {
             dpt: HashMap::new(),
             catalog_root: None,
             tables: HashMap::new(),
+            principals: HashMap::new(),
             next_txn_id: 1,
             next_object_id: FIRST_USER_OBJECT_ID,
             active_txn_begins: std::collections::BTreeMap::new(),

--- a/crates/truthdb-core/src/session.rs
+++ b/crates/truthdb-core/src/session.rs
@@ -586,6 +586,13 @@ enum EngineCall {
         command: String,
         reply: oneshot::Sender<Result<String, EngineError>>,
     },
+    /// A session-less catalog read: fetch a login's credential for the TDS
+    /// handshake, which runs BEFORE any session/transaction exists. The reply
+    /// carries only the stored blob — PBKDF2 verification runs off the worker.
+    LookupLogin {
+        name: String,
+        reply: oneshot::Sender<Option<LoginRecord>>,
+    },
     CloseSession {
         session: SessionId,
     },
@@ -701,6 +708,18 @@ impl Drop for HandleToken {
     fn drop(&mut self) {
         self.0.close();
     }
+}
+
+/// A login's stored authentication data, read by the TDS handshake before any
+/// session exists. The credential is verified in the TDS task (off the worker
+/// pool) so a ~30 ms PBKDF2 does not occupy a worker thread.
+#[derive(Debug, Clone)]
+pub struct LoginRecord {
+    pub principal_id: u32,
+    /// The stored login name in its canonical casing (for `SUSER_SNAME()`).
+    pub name: String,
+    pub password_blob: String,
+    pub is_disabled: bool,
 }
 
 /// A cloneable handle to the engine's worker pool. Cheap to clone (shares the
@@ -933,6 +952,14 @@ impl EngineHandle {
         let (reply, rx) = oneshot::channel();
         self.inbox.send(EngineCall::RunNative { command, reply });
         rx.await.map_err(|_| EngineError::Unavailable)?
+    }
+
+    /// Fetches a login's stored credential for the TDS handshake. Returns
+    /// `None` if the login does not exist or the worker pool is gone.
+    pub async fn lookup_login(&self, name: String) -> Option<LoginRecord> {
+        let (reply, rx) = oneshot::channel();
+        self.inbox.send(EngineCall::LookupLogin { name, reply });
+        rx.await.ok().flatten()
     }
 
     /// Closes a session (rolling back any open transaction — later milestone).
@@ -1236,6 +1263,9 @@ fn worker_loop(shared: &Arc<Shared>) {
             }) => dispatch_rpc(shared, session, command, cancel, reply),
             Work::Call(EngineCall::RunNative { command, reply }) => {
                 let _ = reply.send(shared.engine.execute(&command));
+            }
+            Work::Call(EngineCall::LookupLogin { name, reply }) => {
+                let _ = reply.send(shared.engine.lookup_login(&name));
             }
             Work::Call(EngineCall::CloseSession { session }) => {
                 shared

--- a/crates/truthdb-core/src/storage.rs
+++ b/crates/truthdb-core/src/storage.rs
@@ -625,6 +625,36 @@ impl Storage {
         result
     }
 
+    // Logins do not participate in lock analysis, so — unlike table/proc DDL —
+    // they do not bump the lock-analysis epoch.
+    pub fn rel_create_login(
+        &self,
+        name: &str,
+        principal: crate::relstore::catalog::PrincipalDef,
+    ) -> Result<(), StorageError> {
+        self.lock().rel_create_login(name, principal)
+    }
+
+    pub fn rel_alter_login(
+        &self,
+        name: &str,
+        principal: crate::relstore::catalog::PrincipalDef,
+    ) -> Result<(), StorageError> {
+        self.lock().rel_alter_login(name, principal)
+    }
+
+    pub fn rel_drop_login(&self, name: &str) -> Result<bool, StorageError> {
+        self.lock().rel_drop_login(name)
+    }
+
+    pub fn rel_login(&self, name: &str) -> Option<TableDef> {
+        self.lock().rel_login(name)
+    }
+
+    pub fn rel_logins(&self) -> Vec<TableDef> {
+        self.lock().rel_logins()
+    }
+
     pub fn rel_table(&self, name: &str) -> Option<TableDef> {
         self.lock().rel_table(name)
     }
@@ -1441,6 +1471,7 @@ impl StorageFile {
                 procedure: None,
                 function: None,
                 trigger: None,
+                principal: None,
                 counter_page: Some(counter_page),
             };
             catalog::insert_table(ctx, &mut OpMode::Txn(txn), catalog_root, &def)?;
@@ -1495,6 +1526,7 @@ impl StorageFile {
                 procedure: None,
                 function: None,
                 trigger: None,
+                principal: None,
                 counter_page: None,
             };
             catalog::insert_table(ctx, &mut OpMode::Txn(txn), catalog_root, &def)?;
@@ -1545,6 +1577,7 @@ impl StorageFile {
                 procedure: Some(procedure),
                 function: None,
                 trigger: None,
+                principal: None,
                 counter_page: None,
             };
             catalog::insert_table(ctx, &mut OpMode::Txn(txn), catalog_root, &def)?;
@@ -1596,6 +1629,7 @@ impl StorageFile {
                 procedure: None,
                 function: Some(function),
                 trigger: None,
+                principal: None,
                 counter_page: None,
             };
             catalog::insert_table(ctx, &mut OpMode::Txn(txn), catalog_root, &def)?;
@@ -1712,6 +1746,7 @@ impl StorageFile {
                 procedure: None,
                 function: None,
                 trigger: Some(trigger),
+                principal: None,
                 counter_page: None,
             };
             catalog::insert_table(ctx, &mut OpMode::Txn(txn), catalog_root, &def)?;
@@ -1749,6 +1784,114 @@ impl StorageFile {
         })?;
         self.rel.tables.insert(name.to_string(), def);
         Ok(())
+    }
+
+    /// Creates a server login: a catalog row (its own object_id, like a
+    /// procedure) carrying the hashed password, routed into the principals map
+    /// so it never enters the object namespace.
+    pub fn rel_create_login(
+        &mut self,
+        name: &str,
+        principal: crate::relstore::catalog::PrincipalDef,
+    ) -> Result<(), StorageError> {
+        self.ensure_rel_usable()?;
+        let key = name.to_ascii_lowercase();
+        if self.rel.principals.contains_key(&key) {
+            return Err(StorageError::Constraint(format!(
+                "login '{name}' already exists"
+            )));
+        }
+        if self.rel.catalog_root.is_none() {
+            let root = {
+                let mut ctx = self.rel_ctx();
+                catalog::create_catalog(&mut ctx)?
+            };
+            self.rel.catalog_root = Some(root);
+        }
+        let catalog_root = self.rel.catalog_root.expect("catalog exists");
+        let object_id = self.rel.next_object_id;
+        let login_name = name.to_string();
+        let def = self.rel_statement(move |ctx, txn| {
+            let def = TableDef {
+                object_id,
+                name: login_name,
+                columns: Vec::new(),
+                key_columns: Vec::new(),
+                root_page: 0,
+                defaults: Vec::new(),
+                collations: Vec::new(),
+                identity: None,
+                indexes: Vec::new(),
+                check_constraints: Vec::new(),
+                foreign_keys: Vec::new(),
+                view_query: None,
+                procedure: None,
+                function: None,
+                trigger: None,
+                principal: Some(principal),
+                counter_page: None,
+            };
+            catalog::insert_table(ctx, &mut OpMode::Txn(txn), catalog_root, &def)?;
+            Ok(def)
+        })?;
+        self.rel.next_object_id += 1;
+        self.rel.principals.insert(key, def);
+        Ok(())
+    }
+
+    /// Replaces a login's payload (`ALTER LOGIN` — new password or enable/
+    /// disable). The name (and object_id) is preserved.
+    pub fn rel_alter_login(
+        &mut self,
+        name: &str,
+        principal: crate::relstore::catalog::PrincipalDef,
+    ) -> Result<(), StorageError> {
+        self.ensure_rel_usable()?;
+        let key = name.to_ascii_lowercase();
+        let Some(existing) = self.rel.principals.get(&key) else {
+            return Err(StorageError::Constraint(format!(
+                "login '{name}' does not exist"
+            )));
+        };
+        let mut def = existing.clone();
+        def.principal = Some(principal);
+        let catalog_root = self.rel.catalog_root.expect("logins live in the catalog");
+        let write = def.clone();
+        self.rel_statement(move |ctx, txn| {
+            catalog::update_table(ctx, &mut OpMode::Txn(txn), catalog_root, &write)?;
+            Ok(())
+        })?;
+        self.rel.principals.insert(key, def);
+        Ok(())
+    }
+
+    /// Drops a login. Returns false if it does not exist.
+    pub fn rel_drop_login(&mut self, name: &str) -> Result<bool, StorageError> {
+        self.ensure_rel_usable()?;
+        let key = name.to_ascii_lowercase();
+        let Some(def) = self.rel.principals.get(&key).cloned() else {
+            return Ok(false);
+        };
+        let Some(catalog_root) = self.rel.catalog_root else {
+            return Ok(false);
+        };
+        self.rel_statement(move |ctx, txn| {
+            catalog::delete_table(ctx, &mut OpMode::Txn(txn), catalog_root, def.object_id)
+        })?;
+        self.rel.principals.remove(&key);
+        Ok(true)
+    }
+
+    /// A login's definition, by (case-insensitive) name.
+    pub fn rel_login(&self, name: &str) -> Option<TableDef> {
+        self.rel.principals.get(&name.to_ascii_lowercase()).cloned()
+    }
+
+    /// All logins, ordered by object id (for sys.server_principals).
+    pub fn rel_logins(&self) -> Vec<TableDef> {
+        let mut defs: Vec<TableDef> = self.rel.principals.values().cloned().collect();
+        defs.sort_by_key(|d| d.object_id);
+        defs
     }
 
     /// The table's definition (schema and layout), if it exists.
@@ -3582,8 +3725,9 @@ impl StorageFile {
             rel_recovery::undo_losers(&mut ctx, &records, &outcome.losers, &roots)?;
             self.reload_catalog()?;
         }
-        // Object ids are shared by tables and their secondary indexes, so the
-        // next id must clear both (an index can outrank every table).
+        // Object ids are shared by tables, their secondary indexes, and logins
+        // (principals draw from the same counter), so the next id must clear all
+        // three — an index or a login can outrank every table.
         self.rel.next_object_id = self
             .rel
             .tables
@@ -3592,6 +3736,7 @@ impl StorageFile {
                 std::iter::once(def.object_id)
                     .chain(def.indexes.iter().map(|index| index.object_id))
             })
+            .chain(self.rel.principals.values().map(|def| def.object_id))
             .map(|object_id| object_id + 1)
             .max()
             .unwrap_or(FIRST_USER_OBJECT_ID)
@@ -3603,16 +3748,26 @@ impl StorageFile {
     fn reload_catalog(&mut self) -> Result<(), StorageError> {
         let Some(root) = self.rel.catalog_root else {
             self.rel.tables.clear();
+            self.rel.principals.clear();
             return Ok(());
         };
         let defs = {
             let mut ctx = self.rel_ctx();
             catalog::load_tables(&mut ctx, root)?
         };
-        self.rel.tables = defs
-            .into_iter()
-            .map(|def| (def.name.clone(), def))
-            .collect();
+        self.rel.tables.clear();
+        self.rel.principals.clear();
+        for def in defs {
+            if def.is_login() {
+                // Logins live in their own map, keyed case-insensitively — never
+                // in the object namespace.
+                self.rel
+                    .principals
+                    .insert(def.name.to_ascii_lowercase(), def);
+            } else {
+                self.rel.tables.insert(def.name.clone(), def);
+            }
+        }
         Ok(())
     }
 

--- a/crates/truthdb-sql/src/ast.rs
+++ b/crates/truthdb-sql/src/ast.rs
@@ -136,6 +136,30 @@ pub enum Statement {
         if_exists: bool,
         span: Span,
     },
+    /// `CREATE|ALTER LOGIN <name> WITH PASSWORD = '<pw>'` or `ALTER LOGIN <name>
+    /// {ENABLE | DISABLE}` — a SQL-authentication server login.
+    CreateLogin(CreateLogin),
+    /// `DROP LOGIN [IF EXISTS] <name>`.
+    DropLogin {
+        name: Name,
+        if_exists: bool,
+        span: Span,
+    },
+}
+
+/// `CREATE|ALTER LOGIN <name> WITH PASSWORD = '<pw>'` / `ALTER LOGIN <name>
+/// {ENABLE | DISABLE}`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CreateLogin {
+    pub name: Name,
+    /// The plaintext password to hash. `Some` for CREATE and for ALTER ... WITH
+    /// PASSWORD; `None` for an ALTER that only toggles enabled/disabled.
+    pub password: Option<String>,
+    /// `Some(true)` = DISABLE, `Some(false)` = ENABLE, `None` = unchanged.
+    pub disable: Option<bool>,
+    /// `ALTER LOGIN` replaces an existing login's payload.
+    pub alter: bool,
+    pub span: Span,
 }
 
 /// `CREATE|ALTER TRIGGER <name> ON <table> AFTER <events> AS <body>`.

--- a/crates/truthdb-sql/src/parser.rs
+++ b/crates/truthdb-sql/src/parser.rs
@@ -942,6 +942,7 @@ impl Parser {
             }
             Some("FUNCTION") if !unique => self.parse_create_function(start, false),
             Some("TRIGGER") if !unique => self.parse_create_trigger(start, false),
+            Some("LOGIN") if !unique => self.parse_create_login(start, false),
             _ => {
                 let token = self.peek().clone();
                 Err(SqlError::syntax(self.token_text(&token), token.span))
@@ -1458,6 +1459,9 @@ impl Parser {
         if self.peek_keyword().as_deref() == Some("TRIGGER") {
             return self.parse_create_trigger(start, true);
         }
+        if self.peek_keyword().as_deref() == Some("LOGIN") {
+            return self.parse_create_login(start, true);
+        }
         self.expect_keyword("TABLE")?;
         let table = self.parse_name()?;
         let (action, end) = match self.peek_keyword().as_deref() {
@@ -1557,6 +1561,7 @@ impl Parser {
             Some("PROCEDURE") | Some("PROC") => self.parse_drop_procedure(start),
             Some("FUNCTION") => self.parse_drop_function(start),
             Some("TRIGGER") => self.parse_drop_trigger(start),
+            Some("LOGIN") => self.parse_drop_login(start),
             _ => {
                 let token = self.peek().clone();
                 Err(SqlError::syntax(self.token_text(&token), token.span))
@@ -1789,6 +1794,73 @@ impl Parser {
         };
         let name = self.parse_name()?;
         Ok(Statement::DropTrigger {
+            span: start.to(name.span),
+            name,
+            if_exists,
+        })
+    }
+
+    /// `CREATE|ALTER LOGIN <name> WITH PASSWORD = '<pw>'` or `ALTER LOGIN <name>
+    /// {ENABLE | DISABLE}`.
+    fn parse_create_login(&mut self, start: Span, alter: bool) -> SqlResult<Statement> {
+        self.bump(); // LOGIN
+        if self.in_procedure || self.in_function || self.in_table_function {
+            return Err(
+                SqlError::new(156, 15, 1, "Incorrect syntax near the keyword 'LOGIN'.").at(start),
+            );
+        }
+        if self.statement_index > 0 || self.sub_depth > 0 {
+            return Err(SqlError::new(
+                111,
+                15,
+                1,
+                "'CREATE/ALTER LOGIN' must be the first statement in a query batch.",
+            )
+            .at(start));
+        }
+        let name = self.parse_name()?;
+        let mut password = None;
+        let mut disable = None;
+        if alter
+            && matches!(
+                self.peek_keyword().as_deref(),
+                Some("ENABLE") | Some("DISABLE")
+            )
+        {
+            disable = Some(self.peek_keyword().as_deref() == Some("DISABLE"));
+            self.bump();
+        } else {
+            self.expect_keyword("WITH")?;
+            self.expect_keyword("PASSWORD")?;
+            self.expect(&TokenKind::Eq)?;
+            let token = self.peek().clone();
+            let TokenKind::String(pw) = &token.kind else {
+                return Err(SqlError::syntax(self.token_text(&token), token.span));
+            };
+            password = Some(pw.clone());
+            self.bump();
+        }
+        let span = start.to(self.prev_span());
+        Ok(Statement::CreateLogin(CreateLogin {
+            name,
+            password,
+            disable,
+            alter,
+            span,
+        }))
+    }
+
+    fn parse_drop_login(&mut self, start: Span) -> SqlResult<Statement> {
+        self.bump(); // LOGIN
+        let if_exists = if self.peek_keyword().as_deref() == Some("IF") {
+            self.bump();
+            self.expect_keyword("EXISTS")?;
+            true
+        } else {
+            false
+        };
+        let name = self.parse_name()?;
+        Ok(Statement::DropLogin {
             span: start.to(name.span),
             name,
             if_exists,

--- a/crates/truthdb-tds/src/lib.rs
+++ b/crates/truthdb-tds/src/lib.rs
@@ -11,10 +11,12 @@ pub mod login;
 pub mod packet;
 pub mod rpc;
 pub mod server;
+pub mod throttle;
 pub mod tls;
 pub mod token;
 pub mod typeinfo;
 
+use std::net::IpAddr;
 use std::sync::Arc;
 
 use tokio::net::{TcpListener, TcpStream};
@@ -23,12 +25,15 @@ use tracing::{debug, error, info};
 use truthdb_core::session::EngineHandle;
 
 pub use server::{Encryption, TdsConfig, serve_connection};
+pub use throttle::LoginThrottle;
 
 /// A TDS listener bound to an address; serves connections until shutdown.
 pub struct TdsListener {
     listener: TcpListener,
     engine: EngineHandle,
     config: Arc<TdsConfig>,
+    /// Per-`(login, IP)` brute-force throttle, shared across connections.
+    throttle: LoginThrottle,
 }
 
 impl TdsListener {
@@ -44,6 +49,7 @@ impl TdsListener {
             listener,
             engine,
             config: Arc::new(config),
+            throttle: LoginThrottle::new(),
         })
     }
 
@@ -63,8 +69,9 @@ impl TdsListener {
                     debug!(%peer, "TDS connection accepted");
                     let engine = self.engine.clone();
                     let config = Arc::clone(&self.config);
+                    let throttle = self.throttle.clone();
                     tokio::spawn(async move {
-                        if let Err(err) = handle(stream, engine, config).await {
+                        if let Err(err) = handle(stream, engine, config, throttle, peer.ip()).await {
                             debug!(%peer, error = %err, "TDS connection closed");
                         }
                     });
@@ -84,9 +91,11 @@ async fn handle(
     stream: TcpStream,
     engine: EngineHandle,
     config: Arc<TdsConfig>,
+    throttle: LoginThrottle,
+    peer: IpAddr,
 ) -> std::io::Result<()> {
     stream.set_nodelay(true).ok();
-    match serve_connection(stream, engine, config).await {
+    match serve_connection(stream, engine, config, throttle, peer).await {
         Ok(()) => Ok(()),
         Err(err) => {
             error!(error = %err, "TDS connection error");

--- a/crates/truthdb-tds/src/server.rs
+++ b/crates/truthdb-tds/src/server.rs
@@ -1,11 +1,12 @@
 //! TDS connection handler: PRELOGIN -> LOGIN7 (auth) -> SQLBatch loop.
 
-use std::collections::HashMap;
+use std::net::IpAddr;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use tokio::io::{self, AsyncRead, AsyncReadExt, AsyncWrite};
 use tokio::sync::mpsc;
+use truthdb_core::auth;
 use truthdb_core::engine::EngineError;
 use truthdb_core::rel::ResultColumn;
 use truthdb_core::session::{BatchEvent, EngineHandle, PreparedRpc, SessionId};
@@ -17,6 +18,7 @@ use crate::packet::{
     read_message, write_message,
 };
 use crate::rpc::{self, RpcProc};
+use crate::throttle::{self, LoginThrottle};
 use crate::token;
 
 /// How many bytes of encoded rows may build up before the buffer is handed to
@@ -44,12 +46,12 @@ pub enum Encryption {
     Required,
 }
 
-/// Server-side TDS configuration: the login users, the reported database,
-/// optional TLS, and the encryption policy.
+/// Server-side TDS configuration: the reported database, optional TLS, and the
+/// encryption policy. Login credentials no longer live here — authentication is
+/// against catalog logins (see [`crate::throttle`] and `serve_connection`); the
+/// config's `[tds.auth]` users are migrated into the catalog at first boot.
 #[derive(Debug, Clone)]
 pub struct TdsConfig {
-    /// username -> password (plaintext config auth for Stage 4).
-    pub users: HashMap<String, String>,
     /// The single database name reported to clients.
     pub database: String,
     /// TLS certificate/key. When present, the server offers encryption to
@@ -67,6 +69,8 @@ pub async fn serve_connection<S>(
     mut stream: S,
     engine: EngineHandle,
     config: Arc<TdsConfig>,
+    throttle: LoginThrottle,
+    peer: IpAddr,
 ) -> io::Result<()>
 where
     S: AsyncRead + AsyncWrite + Unpin,
@@ -123,20 +127,43 @@ where
     }
     let login = parse_login7(&login_msg.payload).map_err(|e| protocol_err(e.0))?;
 
-    if !authenticate(&config, &login.username, &login.password) {
-        let mut out = Vec::new();
-        // 18456: login failed for user.
-        token::error(
-            &mut out,
-            18456,
-            1,
-            14,
-            &format!("Login failed for user '{}'.", login.username),
-        );
-        token::done(&mut out, false, true, false, None, 0);
-        write_message(&mut stream, PKT_TABULAR_RESULT, &out, packet_size).await?;
-        return Ok(());
+    // Catalog-backed authentication. The throttle counts this attempt up front
+    // (atomically, so a parallel burst cannot slip past the free window) and
+    // either imposes a growing delay or, past a hard cap, refuses without
+    // checking the credential. The PBKDF2 verification then runs off both the
+    // reactor and the engine worker pool (`spawn_blocking`). Not-found, disabled
+    // and bad-password all fail identically — same wire response AND same CPU
+    // time (a dummy hash is verified when the login is absent) — so nothing
+    // reveals which usernames exist.
+    match throttle.note_attempt(&login.username, peer) {
+        throttle::Decision::Reject => {
+            deny_login(&mut stream, &login.username, packet_size).await?;
+            return Ok(());
+        }
+        throttle::Decision::Proceed(delay) => {
+            if !delay.is_zero() {
+                tokio::time::sleep(delay).await;
+            }
+        }
     }
+    let record = engine.lookup_login(login.username.clone()).await;
+    let blob = record
+        .as_ref()
+        .map(|rec| rec.password_blob.clone())
+        .unwrap_or_else(|| auth::DUMMY_BLOB.to_string());
+    let password = login.password.clone();
+    let verified = tokio::task::spawn_blocking(move || auth::verify_password(&blob, &password))
+        .await
+        .map_err(|_| protocol_err("password verification task panicked"))?;
+    let canonical_login = match &record {
+        Some(rec) if !rec.is_disabled && verified == auth::VerifyOutcome::Ok => rec.name.clone(),
+        _ => {
+            // The attempt was already counted by note_attempt above.
+            deny_login(&mut stream, &login.username, packet_size).await?;
+            return Ok(());
+        }
+    };
+    throttle.record_success(&login.username, peer);
 
     // Negotiate packet size if the client requested a valid one.
     let requested = login.packet_size as usize;
@@ -168,12 +195,32 @@ where
     // Each connection gets an engine-side session; it is closed (rolling back
     // any open transaction) whenever the connection ends, cleanly or not. The
     // database and login are recorded for session intrinsics (DB_NAME() etc.).
-    let session = engine
-        .open_session(database.clone(), login.username.clone())
-        .await;
+    let session = engine.open_session(database.clone(), canonical_login).await;
     let result = request_loop(&mut stream, &engine, session, packet_size).await;
     engine.close_session(session);
     result
+}
+
+/// Writes the single generic login-failure response: error 18456, level 14,
+/// state 1, and a DONE. Every failure kind (unknown login, wrong password,
+/// disabled, throttle lockout) uses this exact response so nothing on the wire
+/// distinguishes them — SQL Server sanitizes the state to 1 for the same reason
+/// (a client must not be able to enumerate valid usernames).
+async fn deny_login<S: AsyncWrite + Unpin>(
+    stream: &mut S,
+    username: &str,
+    packet_size: usize,
+) -> io::Result<()> {
+    let mut out = Vec::new();
+    token::error(
+        &mut out,
+        18456,
+        1,
+        14,
+        &format!("Login failed for user '{username}'."),
+    );
+    token::done(&mut out, false, true, false, None, 0);
+    write_message(stream, PKT_TABULAR_RESULT, &out, packet_size).await
 }
 
 async fn request_loop<S>(
@@ -378,13 +425,6 @@ fn isolation_set_clause(isolation: u8) -> Option<&'static str> {
         // 0 (unspecified) keeps the default.
         _ => None,
     }
-}
-
-fn authenticate(config: &TdsConfig, username: &str, password: &str) -> bool {
-    config
-        .users
-        .get(username)
-        .is_some_and(|expected| expected == password)
 }
 
 /// Waits for a cancelled batch to finish, discarding the rest of its reply.

--- a/crates/truthdb-tds/src/throttle.rs
+++ b/crates/truthdb-tds/src/throttle.rs
@@ -1,0 +1,207 @@
+//! In-memory brute-force throttle for the TDS login path.
+//!
+//! Each LOGIN7 attempt for a `(login, client IP)` pair is *counted up front*
+//! ([`note_attempt`], atomically under the map lock) and, once past a free
+//! window, delayed by a growing exponential backoff before the server even
+//! looks up the credential. Past a hard [`LOCKOUT_AFTER`] count the attempt is
+//! [`Decision::Reject`]ed without checking the credential at all. Counting
+//! before the (concurrent) verify is what makes this resist a *parallel* burst:
+//! N connections opened in one window observe N distinct counts — not the same
+//! stale one — so at most [`LOCKOUT_AFTER`] guesses per pair are ever verified,
+//! regardless of concurrency. A successful login clears the pair; a pair idle
+//! past [`FORGET_AFTER`] is forgotten. The map is bounded ([`MAX_ENTRIES`]) so a
+//! username/IP flood cannot exhaust memory.
+//!
+//! State is per-process and in memory only: a restart resets every counter, and
+//! the plan scopes it to a single instance (no shared/distributed throttle).
+
+use std::collections::HashMap;
+use std::net::IpAddr;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+/// A pair is not delayed until its attempt count exceeds this (room for typos).
+const FREE_ATTEMPTS: u32 = 3;
+/// Delay imposed on the first throttled attempt; doubles per further failure.
+const BASE_DELAY: Duration = Duration::from_millis(100);
+/// The delay never exceeds this, so a client cannot pin a connection open.
+const MAX_DELAY: Duration = Duration::from_secs(5);
+/// Past this many attempts in a window, a pair is refused *without* a credential
+/// check — a hard ceiling on guesses per pair that concurrency cannot beat.
+const LOCKOUT_AFTER: u32 = 50;
+/// A pair with no attempt for this long is forgotten (its counter resets).
+const FORGET_AFTER: Duration = Duration::from_secs(900);
+/// Hard cap on tracked pairs; a flood evicts the least-recently-seen one.
+const MAX_ENTRIES: usize = 4096;
+
+/// What the login path should do with an attempt, per [`LoginThrottle::note_attempt`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Decision {
+    /// Proceed to check the credential after sleeping this long (may be zero).
+    Proceed(Duration),
+    /// Refuse immediately without checking the credential (too many attempts).
+    Reject,
+}
+
+/// A cloneable handle to the shared throttle map (one per listener).
+#[derive(Clone, Default)]
+pub struct LoginThrottle {
+    inner: Arc<Mutex<HashMap<(String, IpAddr), Entry>>>,
+}
+
+struct Entry {
+    attempts: u32,
+    last_seen: Instant,
+}
+
+impl LoginThrottle {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Counts an attempt for the pair and returns what to do with it. The count
+    /// is incremented BEFORE the (concurrent, ~30 ms) credential check — the
+    /// whole read-decide-increment happens under one lock — so parallel attempts
+    /// see distinct counts and cannot all slip through the free window together.
+    /// Prunes forgotten pairs and bounds the map as side effects.
+    pub fn note_attempt(&self, login: &str, ip: IpAddr) -> Decision {
+        let now = Instant::now();
+        let key = (login.to_ascii_lowercase(), ip);
+        let mut map = self.inner.lock().expect("throttle poisoned");
+        map.retain(|_, e| now.saturating_duration_since(e.last_seen) < FORGET_AFTER);
+        if !map.contains_key(&key) && map.len() >= MAX_ENTRIES {
+            evict_oldest(&mut map);
+        }
+        let entry = map.entry(key).or_insert(Entry {
+            attempts: 0,
+            last_seen: now,
+        });
+        let count = entry.attempts;
+        entry.attempts = count.saturating_add(1);
+        entry.last_seen = now;
+        if count >= LOCKOUT_AFTER {
+            Decision::Reject
+        } else if count > FREE_ATTEMPTS {
+            Decision::Proceed(backoff(count - FREE_ATTEMPTS))
+        } else {
+            Decision::Proceed(Duration::ZERO)
+        }
+    }
+
+    /// Clears the pair's history after a successful login.
+    pub fn record_success(&self, login: &str, ip: IpAddr) {
+        self.inner
+            .lock()
+            .expect("throttle poisoned")
+            .remove(&(login.to_ascii_lowercase(), ip));
+    }
+}
+
+/// `BASE_DELAY * 2^(steps-1)`, saturating and capped at `MAX_DELAY`.
+fn backoff(steps: u32) -> Duration {
+    let shift = steps.saturating_sub(1).min(20);
+    BASE_DELAY.saturating_mul(1u32 << shift).min(MAX_DELAY)
+}
+
+fn evict_oldest(map: &mut HashMap<(String, IpAddr), Entry>) {
+    if let Some(key) = map
+        .iter()
+        .min_by_key(|(_, e)| e.last_seen)
+        .map(|(k, _)| k.clone())
+    {
+        map.remove(&key);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::Ipv4Addr;
+
+    fn ip(n: u8) -> IpAddr {
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, n))
+    }
+
+    fn proceed(d: Decision) -> Duration {
+        match d {
+            Decision::Proceed(delay) => delay,
+            Decision::Reject => panic!("unexpected Reject"),
+        }
+    }
+
+    #[test]
+    fn backoff_is_monotonic_and_capped() {
+        // Called only with steps >= 1. First few steps grow, then it pins at the
+        // cap and never exceeds it.
+        assert_eq!(backoff(1), BASE_DELAY);
+        assert_eq!(backoff(2), BASE_DELAY * 2);
+        assert_eq!(backoff(3), BASE_DELAY * 4);
+        assert_eq!(backoff(100), MAX_DELAY);
+        assert!(backoff(u32::MAX) <= MAX_DELAY);
+    }
+
+    #[test]
+    fn free_attempts_are_not_delayed_then_backoff_grows() {
+        let t = LoginThrottle::new();
+        let (login, addr) = ("sa", ip(1));
+        // Counts 0..=FREE_ATTEMPTS proceed with no delay (each note_attempt
+        // consumes one count), then the delay grows.
+        for _ in 0..=FREE_ATTEMPTS {
+            assert_eq!(proceed(t.note_attempt(login, addr)), Duration::ZERO);
+        }
+        // count == FREE_ATTEMPTS + 1: the first delayed attempt.
+        assert_eq!(proceed(t.note_attempt(login, addr)), backoff(1));
+        assert_eq!(proceed(t.note_attempt(login, addr)), backoff(2));
+    }
+
+    #[test]
+    fn success_clears_the_pair() {
+        let t = LoginThrottle::new();
+        let (login, addr) = ("sa", ip(1));
+        for _ in 0..(FREE_ATTEMPTS + 3) {
+            t.note_attempt(login, addr);
+        }
+        assert!(proceed(t.note_attempt(login, addr)) > Duration::ZERO);
+        t.record_success(login, addr);
+        assert_eq!(proceed(t.note_attempt(login, addr)), Duration::ZERO);
+    }
+
+    #[test]
+    fn pairs_are_independent_by_login_and_ip() {
+        let t = LoginThrottle::new();
+        for _ in 0..(FREE_ATTEMPTS + 1) {
+            t.note_attempt("sa", ip(1));
+        }
+        assert!(proceed(t.note_attempt("sa", ip(1))) > Duration::ZERO);
+        // Different login, same IP — untouched.
+        assert_eq!(proceed(t.note_attempt("dbo", ip(1))), Duration::ZERO);
+        // Same login, different IP — untouched.
+        assert_eq!(proceed(t.note_attempt("sa", ip(2))), Duration::ZERO);
+        // Login match is case-insensitive (this attempt shares sa/ip(1)'s count).
+        assert!(proceed(t.note_attempt("SA", ip(1))) > Duration::ZERO);
+    }
+
+    #[test]
+    fn a_hard_cap_rejects_without_a_credential_check_no_matter_the_concurrency() {
+        // Counting up front means a parallel burst cannot exceed the cap: the
+        // mutex serializes note_attempt, so exactly LOCKOUT_AFTER attempts
+        // Proceed (are ever verified) before every further one is Rejected.
+        let t = LoginThrottle::new();
+        let (login, addr) = ("sa", ip(1));
+        let proceeds = (0..(LOCKOUT_AFTER + 25))
+            .filter(|_| matches!(t.note_attempt(login, addr), Decision::Proceed(_)))
+            .count();
+        assert_eq!(proceeds as u32, LOCKOUT_AFTER);
+        assert_eq!(t.note_attempt(login, addr), Decision::Reject);
+    }
+
+    #[test]
+    fn the_map_is_bounded_by_eviction() {
+        let t = LoginThrottle::new();
+        for n in 0..(MAX_ENTRIES + 100) {
+            t.note_attempt(&format!("user{n}"), ip((n % 251) as u8));
+        }
+        let len = t.inner.lock().unwrap().len();
+        assert!(len <= MAX_ENTRIES, "map grew to {len}, past the cap");
+    }
+}

--- a/crates/truthdb-tds/tests/tds_client.rs
+++ b/crates/truthdb-tds/tests/tds_client.rs
@@ -4,14 +4,19 @@
 //! path a real driver would (PRELOGIN, LOGIN7, SQLBatch, COLMETADATA, ROW,
 //! DONE, ERROR) without needing an external SQL Server driver.
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
+use std::net::{IpAddr, Ipv4Addr};
 use std::sync::Arc;
 
 use tokio::io::{AsyncReadExt, AsyncWriteExt, DuplexStream};
 use truthdb_core::engine::Engine;
 use truthdb_core::session::{EngineHandle, spawn_engine};
 use truthdb_core::storage::{Storage, StorageOptions};
+use truthdb_tds::LoginThrottle;
 use truthdb_tds::server::{TdsConfig, serve_connection};
+
+/// The loopback IP the in-process test client presents to the server.
+const TEST_PEER: IpAddr = IpAddr::V4(Ipv4Addr::LOCALHOST);
 
 // Packet types.
 const PKT_SQL_BATCH: u8 = 0x01;
@@ -40,16 +45,19 @@ fn engine(path: &std::path::Path) -> EngineHandle {
         default_collation: None,
     };
     let storage = Storage::create(path.to_path_buf(), opts).expect("storage");
-    // The JoinHandle is dropped; the engine thread exits when the last
+    // Seed the login the tests authenticate as (sa/secret) into the catalog
+    // before the engine thread starts — auth is catalog-backed now, not from
+    // config. The JoinHandle is dropped; the engine thread exits when the last
     // EngineHandle drops at end of test.
-    spawn_engine(Engine::new(storage).expect("engine")).0
+    let engine = Engine::new(storage).expect("engine");
+    let mut users = BTreeMap::new();
+    users.insert("sa".to_string(), "secret".to_string());
+    engine.migrate_logins(&users).expect("seed logins");
+    spawn_engine(engine).0
 }
 
 fn config() -> TdsConfig {
-    let mut users = HashMap::new();
-    users.insert("sa".to_string(), "secret".to_string());
     TdsConfig {
-        users,
         database: "truthdb".to_string(),
         tls: None,
         encryption: truthdb_tds::Encryption::default(),
@@ -301,6 +309,7 @@ enum Token {
     Row(Vec<Cell>),
     Error {
         number: i32,
+        state: u8,
     },
     Info {
         number: i32,
@@ -372,7 +381,9 @@ fn parse_tokens(payload: &[u8]) -> Vec<Token> {
                 let body = &payload[i + 2..i + 2 + len];
                 if token == 0xaa {
                     let number = i32::from_le_bytes(body[0..4].try_into().unwrap());
-                    tokens.push(Token::Error { number });
+                    // ERROR token (MS-TDS 2.2.7.10): Number(4), State(1), Class(1)…
+                    let state = body[4];
+                    tokens.push(Token::Error { number, state });
                 } else if token == 0xab {
                     let number = i32::from_le_bytes(body[0..4].try_into().unwrap());
                     tokens.push(Token::Info { number });
@@ -596,10 +607,18 @@ fn parse_row(bytes: &[u8], meta: &[ColType]) -> (Vec<Cell>, usize) {
 }
 
 async fn connect_with(engine: EngineHandle, cfg: TdsConfig) -> Client {
+    connect_with_throttle(engine, cfg, LoginThrottle::new()).await
+}
+
+async fn connect_with_throttle(
+    engine: EngineHandle,
+    cfg: TdsConfig,
+    throttle: LoginThrottle,
+) -> Client {
     let (client_half, server_half) = tokio::io::duplex(64 * 1024);
     let cfg = Arc::new(cfg);
     tokio::spawn(async move {
-        let _ = serve_connection(server_half, engine, cfg).await;
+        let _ = serve_connection(server_half, engine, cfg, throttle, TEST_PEER).await;
     });
     Client {
         stream: client_half,
@@ -608,15 +627,7 @@ async fn connect_with(engine: EngineHandle, cfg: TdsConfig) -> Client {
 }
 
 async fn connect(engine: EngineHandle) -> Client {
-    let (client_half, server_half) = tokio::io::duplex(64 * 1024);
-    let cfg = Arc::new(config());
-    tokio::spawn(async move {
-        let _ = serve_connection(server_half, engine, cfg).await;
-    });
-    Client {
-        stream: client_half,
-        tran_descriptor: 0,
-    }
+    connect_with(engine, config()).await
 }
 
 /// Reads the ENCRYPTION option out of a PRELOGIN response.
@@ -748,11 +759,29 @@ async fn full_handshake_query_and_error() {
     let dup = client.batch("INSERT INTO t VALUES (1, 'x', 1)").await;
     assert!(
         dup.iter()
-            .any(|t| matches!(t, Token::Error { number: 2627 })),
+            .any(|t| matches!(t, Token::Error { number: 2627, .. })),
         "dup tokens: {dup:?}"
     );
 
     let _ = std::fs::remove_file(path);
+}
+
+/// The single 18456 error a login failure must produce: number 18456, wire
+/// state 1, and NO LoginAck. Returns the matched error's state for equality
+/// checks across failure kinds.
+fn assert_login_denied(tokens: &[Token]) -> u8 {
+    assert!(
+        !tokens.iter().any(|t| matches!(t, Token::LoginAck)),
+        "a denied login must not ack: {tokens:?}"
+    );
+    let state = tokens.iter().find_map(|t| match t {
+        Token::Error {
+            number: 18456,
+            state,
+        } => Some(*state),
+        _ => None,
+    });
+    state.unwrap_or_else(|| panic!("expected an 18456 error: {tokens:?}"))
 }
 
 #[tokio::test]
@@ -763,11 +792,102 @@ async fn login_failure_reports_18456() {
 
     client.prelogin().await;
     let tokens = client.login("sa", "wrong-password").await;
+    // SQL Server sanitizes the wire state to 1 for every login failure.
+    assert_eq!(assert_login_denied(&tokens), 1, "tokens: {tokens:?}");
+    let _ = std::fs::remove_file(path);
+}
+
+#[tokio::test]
+async fn unknown_user_is_indistinguishable_from_a_wrong_password() {
+    // Username enumeration defense: a non-existent login and a real login with
+    // the wrong password must produce the SAME wire response (18456, state 1).
+    let path = temp_path("login-enum");
+    let engine = engine(&path);
+
+    let mut c1 = connect(engine.clone()).await;
+    c1.prelogin().await;
+    let wrong_pw = c1.login("sa", "definitely-not-secret").await;
+
+    let mut c2 = connect(engine).await;
+    c2.prelogin().await;
+    let no_such = c2.login("nobody-here", "whatever").await;
+
+    assert_eq!(assert_login_denied(&wrong_pw), 1);
+    assert_eq!(assert_login_denied(&no_such), 1);
+    let _ = std::fs::remove_file(path);
+}
+
+#[tokio::test]
+async fn a_migrated_login_authenticates_with_its_configured_password() {
+    // The engine() helper migrated sa=secret; the correct password logs in.
+    let path = temp_path("login-ok");
+    let engine = engine(&path);
+    let mut client = connect(engine).await;
+    client.prelogin().await;
+    let tokens = client.login("sa", "secret").await;
+    assert!(tokens.contains(&Token::LoginAck), "tokens: {tokens:?}");
+    assert!(!tokens.iter().any(|t| matches!(t, Token::Error { .. })));
+    let _ = std::fs::remove_file(path);
+}
+
+#[tokio::test]
+async fn a_disabled_login_cannot_authenticate_even_with_the_right_password() {
+    // CREATE a login, then DISABLE it: the correct password is still rejected,
+    // with the same generic 18456/state 1 as any other failure.
+    let path = temp_path("login-disabled");
+    let engine = engine(&path);
+    let mut admin = connect(engine.clone()).await;
+    admin.prelogin().await;
+    admin.login("sa", "secret").await;
+    admin
+        .batch("CREATE LOGIN app WITH PASSWORD = 'app-secret'")
+        .await;
+
+    // Enabled: the password works.
+    let mut ok = connect(engine.clone()).await;
+    ok.prelogin().await;
     assert!(
-        tokens
-            .iter()
-            .any(|t| matches!(t, Token::Error { number: 18456 })),
-        "tokens: {tokens:?}"
+        ok.login("app", "app-secret")
+            .await
+            .contains(&Token::LoginAck),
+        "enabled login should authenticate"
+    );
+
+    admin.batch("ALTER LOGIN app DISABLE").await;
+
+    // Disabled: the same correct password is now rejected, generically.
+    let mut denied = connect(engine).await;
+    denied.prelogin().await;
+    let tokens = denied.login("app", "app-secret").await;
+    assert_eq!(assert_login_denied(&tokens), 1, "tokens: {tokens:?}");
+    let _ = std::fs::remove_file(path);
+}
+
+#[tokio::test]
+async fn repeated_failures_from_one_pair_are_throttled() {
+    // A shared throttle across connections: after the free attempts, the next
+    // failure is delayed measurably. Keeps the delay small (backoff base) so
+    // the test stays fast while still proving the throttle is wired in.
+    let path = temp_path("login-throttle");
+    let engine = engine(&path);
+    let throttle = LoginThrottle::new();
+
+    // Burn the free attempts (each a fresh connection sharing the throttle).
+    for _ in 0..4 {
+        let mut c = connect_with_throttle(engine.clone(), config(), throttle.clone()).await;
+        c.prelogin().await;
+        let _ = c.login("sa", "nope").await;
+    }
+    // The next attempt is now delayed before the response arrives.
+    let mut c = connect_with_throttle(engine.clone(), config(), throttle.clone()).await;
+    c.prelogin().await;
+    let start = std::time::Instant::now();
+    let tokens = c.login("sa", "nope").await;
+    let elapsed = start.elapsed();
+    assert_eq!(assert_login_denied(&tokens), 1);
+    assert!(
+        elapsed >= std::time::Duration::from_millis(80),
+        "throttled attempt returned in {elapsed:?}, expected a backoff delay"
     );
     let _ = std::fs::remove_file(path);
 }
@@ -925,7 +1045,7 @@ async fn a_multi_rpc_request_answers_each_rpc_in_one_response() {
     assert!(
         tokens
             .iter()
-            .any(|t| matches!(t, Token::Error { number: 8179 })),
+            .any(|t| matches!(t, Token::Error { number: 8179, .. })),
         "tokens: {tokens:?}"
     );
     assert_eq!(row_ints(&tokens), [3], "tokens: {tokens:?}");
@@ -950,7 +1070,7 @@ async fn a_multi_rpc_request_answers_each_rpc_in_one_response() {
     assert!(
         tokens
             .iter()
-            .any(|t| matches!(t, Token::Error { number: 2812 })),
+            .any(|t| matches!(t, Token::Error { number: 2812, .. })),
         "tokens: {tokens:?}"
     );
     assert_eq!(row_ints(&tokens), [4], "tokens: {tokens:?}");
@@ -1123,7 +1243,7 @@ async fn rpc_by_name_unknown_proc_is_2812() {
     assert!(
         tokens
             .iter()
-            .any(|t| matches!(t, Token::Error { number: 2812 })),
+            .any(|t| matches!(t, Token::Error { number: 2812, .. })),
         "tokens: {tokens:?}"
     );
     assert!(
@@ -1223,7 +1343,7 @@ async fn rpc_by_name_completed_proc_with_warning_still_returns_tail() {
     assert!(
         tokens
             .iter()
-            .any(|t| matches!(t, Token::Error { number: 50000 })),
+            .any(|t| matches!(t, Token::Error { number: 50000, .. })),
         "tokens: {tokens:?}"
     );
     assert!(
@@ -1291,7 +1411,7 @@ async fn rpc_by_name_out_of_range_return_is_8115() {
     assert!(
         tokens
             .iter()
-            .any(|t| matches!(t, Token::Error { number: 8115 })),
+            .any(|t| matches!(t, Token::Error { number: 8115, .. })),
         "tokens: {tokens:?}"
     );
     // The procedure aborted, so no clean status and no OUTPUT are reported.
@@ -1392,7 +1512,7 @@ async fn use_statement_emits_the_database_envchange() {
     assert!(
         tokens
             .iter()
-            .any(|t| matches!(t, Token::Error { number: 911 })),
+            .any(|t| matches!(t, Token::Error { number: 911, .. })),
         "a wrong database is 911: {tokens:?}"
     );
     assert!(
@@ -1451,7 +1571,7 @@ async fn fatal_severity_closes_the_connection() {
     assert!(
         tokens
             .iter()
-            .any(|t| matches!(t, Token::Error { number: 50000 })),
+            .any(|t| matches!(t, Token::Error { number: 50000, .. })),
         "the fatal error is delivered first: {tokens:?}"
     );
     // The server hangs up: the next read is EOF (no reply will ever come).
@@ -1492,7 +1612,7 @@ async fn review_poc_fatal_inside_an_rpc_closes_the_connection() {
     assert!(
         tokens
             .iter()
-            .any(|t| matches!(t, Token::Error { number: 50000 })),
+            .any(|t| matches!(t, Token::Error { number: 50000, .. })),
         "the fatal error is delivered: {tokens:?}"
     );
     let mut byte = [0u8; 1];
@@ -1528,7 +1648,7 @@ async fn review_poc_fatal_in_a_multi_rpc_request_skips_the_rest() {
     assert!(
         tokens
             .iter()
-            .any(|t| matches!(t, Token::Error { number: 50000 })),
+            .any(|t| matches!(t, Token::Error { number: 50000, .. })),
         "the fatal error is delivered: {tokens:?}"
     );
     assert!(

--- a/scripts/tds_conformance.py
+++ b/scripts/tds_conformance.py
@@ -246,6 +246,34 @@ def main() -> int:
         print("FAIL: NVARCHAR(MAX) equality predicate")
         return 1
 
+    # Stage 16: catalog-backed authentication end to end, via an independent
+    # driver. A login created over the wire authenticates a *fresh* connection;
+    # a wrong password is refused; disabling it refuses even the right password.
+    cur.execute("CREATE LOGIN conf_login WITH PASSWORD = 'Conf-Pass-1'")
+    probe = pytds.connect(host, "truthdb", "conf_login", "Conf-Pass-1",
+                          port=port, login_timeout=10, autocommit=True)
+    pcur = probe.cursor()
+    pcur.execute("SELECT SUSER_SNAME()")
+    if pcur.fetchone()[0] != "conf_login":
+        print("FAIL: created login's SUSER_SNAME mismatch")
+        return 1
+    probe.close()
+    try:
+        pytds.connect(host, "truthdb", "conf_login", "wrong-pass",
+                      port=port, login_timeout=10)
+        print("FAIL: created login accepted a wrong password")
+        return 1
+    except pytds.Error:
+        pass  # expected
+    cur.execute("ALTER LOGIN conf_login DISABLE")
+    try:
+        pytds.connect(host, "truthdb", "conf_login", "Conf-Pass-1",
+                      port=port, login_timeout=10)
+        print("FAIL: disabled login still authenticated")
+        return 1
+    except pytds.Error:
+        pass  # expected
+
     conn.close()
     print("tds conformance: OK")
     return 0

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,8 +17,9 @@ pub struct Config {
 }
 
 /// TDS (SQL Server protocol) gateway settings. Disabled by default; when
-/// enabled it listens on `port` (default 1433) and authenticates against the
-/// `[tds.auth]` username→password map.
+/// enabled it listens on `port` (default 1433). Authentication is against
+/// catalog logins with salted PBKDF2 hashes, NOT this config: `[tds.auth]` only
+/// SEEDS logins into the catalog on the first boot (see [`Self::auth`]).
 #[derive(Debug, Deserialize)]
 pub struct TdsConfig {
     #[serde(default)]
@@ -33,6 +34,13 @@ pub struct TdsConfig {
     #[serde(default = "default_tds_database")]
     pub database: String,
 
+    /// First-boot seed only: `username = password` entries are hashed into
+    /// catalog logins the first time the server starts (and `sa` is always
+    /// ensured). The catalog is authoritative — this map is NEVER consulted for
+    /// authentication. Once the built-in `sa` login exists the seed is inert:
+    /// editing this map does not add, remove, or rotate a login; manage logins
+    /// with `CREATE`/`ALTER`/`DROP LOGIN`. (Dropping `sa` re-arms the seed on the
+    /// next start, recreating every configured login that is currently absent.)
     #[serde(default)]
     pub auth: HashMap<String, String>,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -93,6 +93,26 @@ async fn main() {
             return;
         }
     };
+    // First boot migrates `[tds.auth]` config users into catalog logins (and
+    // always ensures `sa`), then config auth is dead. Runs before the engine
+    // thread is spawned — single-threaded, no session — and is a no-op once any
+    // login already exists. A sorted map gives deterministic object-id order.
+    let config_users: std::collections::BTreeMap<String, String> =
+        config.tds.auth.clone().into_iter().collect();
+    match engine.migrate_logins(&config_users) {
+        Ok(created) if !created.is_empty() => {
+            info!(
+                "Migrated {} login(s) into the catalog: {}",
+                created.len(),
+                created.join(", ")
+            );
+        }
+        Ok(_) => {}
+        Err(err) => {
+            eprintln!("Failed to migrate config logins: {err}");
+            return;
+        }
+    }
     // The engine runs on its own thread behind a message channel; the async
     // listeners talk to it through a cloneable handle.
     let (engine, engine_join) = truthdb_core::session::spawn_engine(engine);
@@ -147,7 +167,6 @@ async fn main() {
             info!("TDS encryption = \"off\": the configured certificate will not be offered");
         }
         let tds_config = truthdb_tds::TdsConfig {
-            users: config.tds.auth.clone(),
             database: config.tds.database.clone(),
             tls,
             encryption,


### PR DESCRIPTION
First slice of Stage 16 (security): authentication moves from plaintext config-file users to **catalog logins with salted, versioned PBKDF2-HMAC-SHA256 hashes**. Principals/roles, GRANT/DENY/REVOKE, and binder enforcement follow in later PRs.

## What changed
- **Crypto** (`auth.rs`): PBKDF2-HMAC-SHA256 (210k iters, 16B salt, 32B hash), versioned blob `v1$iters$salt$hash`, constant-time verify. `DUMMY_BLOB` equalizes CPU time for a not-found login; `hash_random_password` backs the disabled-`sa` placeholder. Uses `ring` (already in-tree via rustls — no new compiled dependency). Deliberately **not** SQL Server's hash format (documented).
- **Catalog / storage**: logins are `TableDef` rows carrying an optional `PrincipalDef`, routed into a separate `rel.principals` map so they stay **out of the table namespace**; persisted through the catalog b-tree + WAL. `CREATE/ALTER/DROP LOGIN ... WITH PASSWORD / {ENABLE|DISABLE}`; `sys.server_principals` / `sys.sql_logins`. `CreateLogin`/`DropLogin` take `Database` Exclusive in lock analysis, like every other DDL; `next_object_id` maxes over principals too.
- **Engine bridge**: `EngineCall::LookupLogin` + `EngineHandle::lookup_login` (session-less worker read of the credential blob); `Engine::lookup_login`.
- **TDS handshake**: throttle-count → optional delay → `lookup_login` → PBKDF2 verify off the reactor and the worker pool (`spawn_blocking`) → session opened under the login's canonical catalog name. Every failure (unknown / wrong password / disabled / throttle lockout) is one generic **18456, level 14, state 1**, with timing equalized by a dummy-blob verify — nothing enumerates usernames.
- **Throttle** (`throttle.rs`): per-`(login, IP)` counter incremented **atomically before** the verify, so a parallel connection burst cannot slip past the free window; exponential backoff capped at 5 s and a hard `LOCKOUT_AFTER` cap that refuses without a credential check; bounded map with idle pruning.
- **First-boot migration**: `[tds.auth]` users are hashed into catalog logins and `sa` is always ensured (enabled if configured, else disabled with a random password — recoverable via the unauthenticated native admin protocol). `sa` is created **last as a durable completion marker** (sound under ARIES prefix recovery); creates are idempotent, so a crash mid-migration re-runs and a case-variant duplicate config key collapses onto one login instead of erroring. Config auth is then dead: the catalog is authoritative (docs updated).

## Review
Two adversarial multi-agent passes (seam / timing-enumeration / backoff-DoS / migration / crypto lenses, refute-by-default). The first found 4 MEDIUM issues — a concurrency check-then-act throttle bypass, and a non-atomic / non-durable / case-collision migration latch (plus stale config docs) — all fixed here. The second pass over the fixes returned **0 new defects, 0 incomplete fixes**.

## Tests
6 auth + 6 throttle unit; migration idempotency / case-dup / sa-last / disabled and configured-`sa` engine tests; TDS e2e for login success, anti-enumeration state=1 across unknown/wrong-password/disabled, and throttle backoff; a live pytds `CREATE LOGIN` → auth → disable round-trip wired into the existing conformance job. Full workspace green (`cargo test --workspace`), `cargo fmt --check` clean, no new clippy findings on touched lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)