### PR TITLE
Stage 16 permissions: GRANT/DENY/REVOKE, binder enforcement, ownership chaining

### DIFF
--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -7254,6 +7254,270 @@ mod tests {
         let _ = std::fs::remove_file(path);
     }
 
+    /// Opens a restricted (non-dbo, non-sysadmin) session context for `login`,
+    /// so object-permission checks actually bite (unlike the login_sid-0 bypass).
+    fn restricted_ctx(engine: &Engine, login: &str) -> TxnContext {
+        let login_sid = engine.lookup_login(login).unwrap().principal_id;
+        let (user, user_sid) = engine.resolve_session_user(login, login_sid);
+        let mut ctx = TxnContext::default();
+        ctx.set_session_identity("truthdb".into(), login.into(), 9, user, login_sid, user_sid);
+        ctx
+    }
+
+    fn err_num(engine: &Engine, ctx: &mut TxnContext, sql: &str) -> Option<i32> {
+        batch(engine, ctx, sql).error.as_ref().map(|e| e.number)
+    }
+
+    #[test]
+    fn object_permissions_enforce_grant_deny_revoke_and_public() {
+        let path = unique_temp_path("perms");
+        let engine = new_engine(&path);
+        // Admin (login_sid 0 → bypass) sets up objects, a restricted login/user,
+        // and a role.
+        engine
+            .execute("CREATE TABLE t (id INT NOT NULL PRIMARY KEY)")
+            .unwrap();
+        engine.execute("INSERT INTO t VALUES (1), (2)").unwrap();
+        engine
+            .execute("CREATE LOGIN applogin WITH PASSWORD = 'x'")
+            .unwrap();
+        engine
+            .execute("CREATE USER appuser FOR LOGIN applogin")
+            .unwrap();
+        engine.execute("CREATE ROLE readers").unwrap();
+        engine
+            .execute("ALTER ROLE readers ADD MEMBER appuser")
+            .unwrap();
+
+        let mut r = restricted_ctx(&engine, "applogin");
+
+        // Ungranted: SELECT denied 229.
+        assert_eq!(err_num(&engine, &mut r, "SELECT id FROM t"), Some(229));
+        // GRANT SELECT via the role → allowed.
+        engine.execute("GRANT SELECT ON t TO readers").unwrap();
+        assert_eq!(err_num(&engine, &mut r, "SELECT id FROM t"), None);
+        // A direct DENY beats the role's GRANT (both entries present).
+        engine.execute("DENY SELECT ON t TO appuser").unwrap();
+        assert_eq!(err_num(&engine, &mut r, "SELECT id FROM t"), Some(229));
+        // REVOKE the deny → the role GRANT is effective again.
+        engine.execute("REVOKE SELECT ON t FROM appuser").unwrap();
+        assert_eq!(err_num(&engine, &mut r, "SELECT id FROM t"), None);
+        // REVOKE from the role → no grant → denied.
+        engine.execute("REVOKE SELECT ON t FROM readers").unwrap();
+        assert_eq!(err_num(&engine, &mut r, "SELECT id FROM t"), Some(229));
+
+        // GRANT to public covers every user.
+        engine.execute("GRANT SELECT ON t TO public").unwrap();
+        assert_eq!(err_num(&engine, &mut r, "SELECT id FROM t"), None);
+
+        // INSERT/UPDATE/DELETE need their own grants.
+        assert_eq!(
+            err_num(&engine, &mut r, "INSERT INTO t VALUES (3)"),
+            Some(229)
+        );
+        engine.execute("GRANT INSERT ON t TO appuser").unwrap();
+        assert_eq!(err_num(&engine, &mut r, "INSERT INTO t VALUES (3)"), None);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn execute_permission_and_ownership_chaining() {
+        let path = unique_temp_path("perms-chain");
+        let engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE secret (id INT NOT NULL PRIMARY KEY)")
+            .unwrap();
+        engine.execute("INSERT INTO secret VALUES (42)").unwrap();
+        engine
+            .execute("CREATE PROCEDURE read_secret AS SELECT id FROM secret")
+            .unwrap();
+        engine
+            .execute("CREATE LOGIN applogin WITH PASSWORD = 'x'")
+            .unwrap();
+        engine
+            .execute("CREATE USER appuser FOR LOGIN applogin")
+            .unwrap();
+
+        let mut r = restricted_ctx(&engine, "applogin");
+        // No EXECUTE grant: EXEC denied.
+        assert_eq!(err_num(&engine, &mut r, "EXEC read_secret"), Some(229));
+        // GRANT EXECUTE only on the proc — NOT SELECT on the table it reads.
+        engine
+            .execute("GRANT EXECUTE ON read_secret TO appuser")
+            .unwrap();
+        // Ownership chaining: the proc runs, its body's SELECT on secret is not
+        // re-checked (same dbo owner).
+        assert_eq!(err_num(&engine, &mut r, "EXEC read_secret"), None);
+        // But a DIRECT read of the table is still denied.
+        assert_eq!(err_num(&engine, &mut r, "SELECT id FROM secret"), Some(229));
+
+        // Dynamic SQL does NOT ownership-chain: a restricted user cannot escape
+        // the check by wrapping the read (or a write) in sp_executesql.
+        assert_eq!(
+            err_num(
+                &engine,
+                &mut r,
+                "EXEC sp_executesql N'SELECT id FROM secret'"
+            ),
+            Some(229)
+        );
+        assert_eq!(
+            err_num(&engine, &mut r, "EXEC sp_executesql N'DELETE FROM secret'"),
+            Some(229)
+        );
+        assert_eq!(
+            err_num(
+                &engine,
+                &mut r,
+                "EXEC sp_executesql N'INSERT INTO secret VALUES (7)'"
+            ),
+            Some(229)
+        );
+        // A GRANT makes the dynamic read work (proving the check, not a blanket ban).
+        engine.execute("GRANT SELECT ON secret TO appuser").unwrap();
+        assert_eq!(
+            err_num(
+                &engine,
+                &mut r,
+                "EXEC sp_executesql N'SELECT id FROM secret'"
+            ),
+            None
+        );
+        engine
+            .execute("REVOKE SELECT ON secret FROM appuser")
+            .unwrap();
+
+        // Dynamic SQL nested INSIDE a procedure body still does not chain: the
+        // dynamic read is checked as the caller (DynamicScope resets the chaining
+        // depth). Grant EXECUTE on the wrapper proc but NOT SELECT on the table.
+        engine
+            .execute("CREATE PROCEDURE dyn_read AS EXEC sp_executesql N'SELECT id FROM secret'")
+            .unwrap();
+        engine
+            .execute("GRANT EXECUTE ON dyn_read TO appuser")
+            .unwrap();
+        assert_eq!(err_num(&engine, &mut r, "EXEC dyn_read"), Some(229));
+        // Granting the caller SELECT lets the nested dynamic read succeed.
+        engine.execute("GRANT SELECT ON secret TO appuser").unwrap();
+        assert_eq!(err_num(&engine, &mut r, "EXEC dyn_read"), None);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn dropping_a_grantee_scrubs_its_object_permissions() {
+        let path = unique_temp_path("perms-scrub");
+        let engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE t (id INT NOT NULL PRIMARY KEY)")
+            .unwrap();
+        engine.execute("CREATE USER alice").unwrap();
+        engine.execute("GRANT SELECT ON t TO alice").unwrap();
+
+        let perm_count = |engine: &Engine| -> String {
+            let (_c, rows) = sql_rows(
+                engine,
+                "SELECT COUNT(*) FROM sys.database_permissions WHERE major_id = \
+                 (SELECT object_id FROM sys.tables WHERE name = 't')",
+            );
+            rows[0][0].clone().unwrap()
+        };
+        assert_eq!(perm_count(&engine), "1");
+        // Dropping the grantee removes the dangling entry (so a later object_id
+        // reuse after restart cannot re-point it at a new principal).
+        engine.execute("DROP USER alice").unwrap();
+        assert_eq!(perm_count(&engine), "0");
+        // Persisted: the scrub survives a restart.
+        drop(engine);
+        let engine = Engine::new(Storage::open(path.clone()).expect("reopen")).expect("replay");
+        assert_eq!(perm_count(&engine), "0");
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn ddl_and_grant_require_privilege() {
+        let path = unique_temp_path("perms-ddl");
+        let engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE t (id INT NOT NULL PRIMARY KEY)")
+            .unwrap();
+        engine
+            .execute("CREATE LOGIN applogin WITH PASSWORD = 'x'")
+            .unwrap();
+        engine
+            .execute("CREATE USER appuser FOR LOGIN applogin")
+            .unwrap();
+
+        let mut r = restricted_ctx(&engine, "applogin");
+        // A restricted user cannot run DDL...
+        assert_eq!(
+            err_num(
+                &engine,
+                &mut r,
+                "CREATE TABLE hax (id INT NOT NULL PRIMARY KEY)"
+            ),
+            Some(15247)
+        );
+        assert_eq!(err_num(&engine, &mut r, "DROP TABLE t"), Some(15247));
+        assert_eq!(err_num(&engine, &mut r, "CREATE ROLE sneaky"), Some(15247));
+        // ...and cannot grant itself permissions.
+        assert_eq!(
+            err_num(&engine, &mut r, "GRANT SELECT ON t TO appuser"),
+            Some(15247)
+        );
+        // A sysadmin (sa) session bypasses — DDL and GRANT succeed.
+        engine
+            .execute("CREATE LOGIN sa WITH PASSWORD = 'x'")
+            .unwrap();
+        let mut admin = restricted_ctx(&engine, "sa"); // sa → dbo/sysadmin → bypass
+        assert_eq!(
+            err_num(&engine, &mut admin, "GRANT SELECT ON t TO appuser"),
+            None
+        );
+        assert_eq!(
+            err_num(
+                &engine,
+                &mut admin,
+                "CREATE TABLE ok (id INT NOT NULL PRIMARY KEY)"
+            ),
+            None
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn sys_database_permissions_reflects_grants_and_survives_restart() {
+        let path = unique_temp_path("perms-catalog");
+        let engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE t (id INT NOT NULL PRIMARY KEY)")
+            .unwrap();
+        engine.execute("CREATE USER appuser").unwrap();
+        engine.execute("GRANT SELECT ON t TO appuser").unwrap();
+        engine.execute("DENY UPDATE ON t TO appuser").unwrap();
+
+        let check = |engine: &Engine| {
+            let (_c, rows) = sql_rows(
+                engine,
+                "SELECT permission_name, state_desc FROM sys.database_permissions \
+                 WHERE major_id = (SELECT object_id FROM sys.tables WHERE name = 't') \
+                 ORDER BY permission_name",
+            );
+            assert_eq!(
+                rows,
+                vec![
+                    vec![Some("SELECT".into()), Some("GRANT".into())],
+                    vec![Some("UPDATE".into()), Some("DENY".into())],
+                ]
+            );
+        };
+        check(&engine);
+        // Survives restart (permissions ride the object's catalog row).
+        drop(engine);
+        let engine = Engine::new(Storage::open(path.clone()).expect("reopen")).expect("replay");
+        check(&engine);
+        let _ = std::fs::remove_file(path);
+    }
+
     #[test]
     fn showplan_names_a_table_valued_function() {
         let path = unique_temp_path("tvf-showplan");

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -18,12 +18,13 @@ use truthdb_sql::ast::{
     CreateIndex, CreateLogin, CreateProcedure, CreateTable, CreateTrigger, CreateUser, CreateView,
     DataType, DatabaseOption, Declaration, Delete, DropIndex, DropTable, DropView, ExecStatement,
     Expr, ExprKind, ForeignKey, Insert, InsertSource, IsolationLevel, JoinKind, Name, OrderItem,
-    RaiseError, ReturnsClause, RoleMemberAction, Select, SelectItem, SetStatement, Statement,
-    TableRef, ThrowArgs, ThrowStatement, Update,
+    PermissionAction, PermissionKind, PermissionStatement, RaiseError, ReturnsClause,
+    RoleMemberAction, Select, SelectItem, SetStatement, Statement, TableRef, ThrowArgs,
+    ThrowStatement, Update,
 };
 use truthdb_sql::collation::CollationSensitivity;
 use truthdb_sql::error::SqlError;
-use truthdb_sql::eval::{ColumnResolver, EvalContext};
+use truthdb_sql::eval::{ColumnResolver, EvalContext, SecurityContext};
 use truthdb_sql::lexer::Span;
 use truthdb_sql::value::{SqlValue, order_key_cmp};
 use truthdb_sql::{ast, eval};
@@ -33,8 +34,8 @@ use xxhash_rust::xxh64::xxh64;
 use crate::lock::{LockMode, Resource};
 use crate::relstore::btree::ScanCursor;
 use crate::relstore::catalog::{
-    self, FunctionDef, FunctionReturns, PrincipalDef, ProcParamDef, ProcedureDef, TableDef,
-    TriggerDef,
+    self, FunctionDef, FunctionReturns, PermAction, PermissionEntry, PrincipalDef, ProcParamDef,
+    ProcedureDef, TableDef, TriggerDef,
 };
 use crate::relstore::row::{Column, Schema};
 use crate::relstore::types::{ColumnType, Datum};
@@ -125,6 +126,9 @@ pub struct TxnContext {
     /// are refreshed at batch start from the membership cache, so a security DDL
     /// is seen by the next batch (SQL Server's per-batch permission caching).
     session_db_roles: std::collections::HashSet<String>,
+    /// Object-permission enforcement subject (bypass flag + the grant-matching
+    /// principal id set), refreshed at batch start alongside the role sets.
+    security: truthdb_sql::eval::SecurityContext,
     /// The last identity value inserted in this session (SQL Server scope),
     /// surfaced as `SCOPE_IDENTITY()`. Persists across statements until the next
     /// identity INSERT; unaffected by non-identity inserts.
@@ -181,6 +185,7 @@ impl TxnContext {
             user: self.user.clone(),
             server_roles: self.session_server_roles.clone(),
             db_roles: self.session_db_roles.clone(),
+            security: self.security.clone(),
             spid: self.spid,
             rowcount: self.rowcount,
             scope_identity: self.scope_identity,
@@ -254,14 +259,31 @@ impl TxnContext {
     /// `IS_ROLEMEMBER` never answer for the other's namespace. Called at batch
     /// start; a security DDL is therefore visible to the next batch.
     pub fn refresh_session_roles(&mut self, storage: &Storage) {
-        let names = |ids: std::collections::HashSet<u32>| -> std::collections::HashSet<String> {
-            ids.into_iter()
-                .filter_map(|id| storage.principal_name(id))
+        let server_role_ids = storage.effective_roles(self.login_sid);
+        let db_role_ids = storage.effective_roles(self.user_sid);
+        let names = |ids: &std::collections::HashSet<u32>| -> std::collections::HashSet<String> {
+            ids.iter()
+                .filter_map(|&id| storage.principal_name(id))
                 .map(|name| name.to_ascii_lowercase())
                 .collect()
         };
-        self.session_server_roles = names(storage.effective_roles(self.login_sid));
-        self.session_db_roles = names(storage.effective_roles(self.user_sid));
+        self.session_server_roles = names(&server_role_ids);
+        self.session_db_roles = names(&db_role_ids);
+
+        // The object-permission subject. A trusted/internal connection
+        // (login_sid 0 — the native protocol and in-process tests), a sysadmin,
+        // or dbo/db_owner bypasses every object-permission check (owns or
+        // controls the database). Otherwise a GRANT/DENY matches the database
+        // user, its effective roles, or `public`.
+        use crate::storage::{DB_OWNER_ID, DBO_ID, PUBLIC_ID, SYSADMIN_ID};
+        let bypass = self.login_sid == 0
+            || server_role_ids.contains(&SYSADMIN_ID)
+            || self.user_sid == DBO_ID
+            || db_role_ids.contains(&DB_OWNER_ID);
+        let mut principals = db_role_ids;
+        principals.insert(self.user_sid);
+        principals.insert(PUBLIC_ID);
+        self.security = truthdb_sql::eval::SecurityContext { bypass, principals };
     }
 
     /// Clears batch-scoped variables (called at the start of each batch).
@@ -805,6 +827,51 @@ thread_local! {
     /// Nesting depth of EXEC inner batches on this worker (SQL Server caps
     /// procedure nesting at 32, error 217).
     static EXEC_DEPTH: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
+    /// Ownership-chaining depth for object-permission checks: how many OWNED
+    /// stored-object bodies (procedure, scalar UDF, multi-statement TVF, trigger)
+    /// enclose the current statement. Distinct from [`EXEC_DEPTH`] because
+    /// `sp_executesql` bumps that but does NOT chain — dynamic SQL runs in the
+    /// caller's own permission context. Permission checks fire only where this
+    /// (and `VIEW_DEPTH`) is 0.
+    static CHAIN_DEPTH: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
+}
+
+/// RAII guard entered when running an OWNED stored-object body (procedure,
+/// scalar UDF, multi-statement TVF, trigger): it raises the ownership-chaining
+/// depth so the body's object reads are not re-permission-checked (the caller's
+/// permission on the object suffices — single `dbo` owner).
+struct ChainGuard;
+
+impl ChainGuard {
+    fn enter() -> Self {
+        CHAIN_DEPTH.with(|d| d.set(d.get() + 1));
+        ChainGuard
+    }
+}
+
+impl Drop for ChainGuard {
+    fn drop(&mut self) {
+        CHAIN_DEPTH.with(|d| d.set(d.get().saturating_sub(1)));
+    }
+}
+
+/// RAII guard entered when running DYNAMIC SQL (`sp_executesql`): it RESETS the
+/// ownership-chaining depth to 0 for the duration, then restores it — dynamic
+/// SQL never chains, so its statements are permission-checked as the caller's
+/// own, even when the `sp_executesql` call sits inside a procedure body.
+struct DynamicScope(u32);
+
+impl DynamicScope {
+    fn enter() -> Self {
+        let saved = CHAIN_DEPTH.with(|d| d.replace(0));
+        DynamicScope(saved)
+    }
+}
+
+impl Drop for DynamicScope {
+    fn drop(&mut self) {
+        CHAIN_DEPTH.with(|d| d.set(self.0));
+    }
 }
 
 /// Runs `EXEC sp_executesql @stmt [, @params, values...]`: evaluates the
@@ -1040,6 +1107,8 @@ fn run_user_procedure(
     // A procedure called from a trigger body does NOT see the trigger's
     // inserted/deleted (they are visible only in the trigger's own statements).
     let _trigger_shadow = TriggerScope::clear();
+    // A procedure body ownership-chains: its object reads are not re-checked.
+    let _chain = ChainGuard::enter();
     let depth = EXEC_DEPTH.with(|d| {
         let v = d.get() + 1;
         d.set(v);
@@ -1115,6 +1184,8 @@ fn run_user_scalar_function(
     let FunctionReturns::Scalar { type_spec, body } = &function.returns else {
         return Err(function_not_a_table(&def.name));
     };
+    // Invoking a scalar function needs EXECUTE permission.
+    enforce_object_permission(def, &caller.security, PermAction::Execute)?;
     if arg_values.len() < function.params.len() {
         return Err(SqlError::new(
             313,
@@ -1154,6 +1225,7 @@ fn run_user_scalar_function(
     );
     txn_ctx.session_server_roles = caller.server_roles.clone();
     txn_ctx.session_db_roles = caller.db_roles.clone();
+    txn_ctx.security = caller.security.clone();
     for (param, value) in function.params.iter().zip(arg_values) {
         let column_type = ColumnType::parse(&param.type_spec)
             .map_err(|e| SqlError::message_only(245, e.to_string()))?;
@@ -1166,6 +1238,8 @@ fn run_user_scalar_function(
     let statements = truthdb_sql::parse_function_body(body)?;
     // A scalar function called from a trigger body does not see inserted/deleted.
     let _trigger_shadow = TriggerScope::clear();
+    // A function body ownership-chains: its object reads are not re-checked.
+    let _chain = ChainGuard::enter();
     let depth = EXEC_DEPTH.with(|d| {
         let v = d.get() + 1;
         d.set(v);
@@ -1217,6 +1291,8 @@ fn run_exec(
         if let Some(def) = resolve_table(storage, &exec.proc.value)
             && def.is_procedure()
         {
+            enforce_object_permission(&def, &txn_ctx.security, PermAction::Execute)
+                .map_err(|e| ExecError::Own(doom_per_rule(txn_ctx, e.at(exec.proc.span))))?;
             return run_user_procedure(storage, exec, &def, txn_ctx, run, in_try);
         }
         let error = SqlError::new(
@@ -1327,6 +1403,10 @@ fn run_exec(
     }
     // Dynamic SQL run from a trigger body does not see inserted/deleted.
     let _trigger_shadow = TriggerScope::clear();
+    // Dynamic SQL does NOT ownership-chain: reset the chaining depth so its
+    // statements are permission-checked as the caller's own, even when this
+    // sp_executesql sits inside a procedure body.
+    let _dynamic = DynamicScope::enter();
     let depth = EXEC_DEPTH.with(|d| {
         let v = d.get() + 1;
         d.set(v);
@@ -1930,7 +2010,12 @@ pub fn describe_first_result_set(storage: &Storage, tsql: &str) -> Result<RowSet
             // for an execution-path reason describe does not share.
             let mut select = select.clone();
             select.top = None;
-            let ctx = TxnContext::default();
+            let mut ctx = TxnContext::default();
+            // Describe derives column metadata without executing or reading data;
+            // it does not enforce object permissions (and its throwaway context
+            // carries no session identity), so the shared `scan_plan` must not
+            // treat it as a denied read.
+            ctx.security.bypass = true;
             match scan_plan(storage, &select, &ctx.eval_context()) {
                 Some(plan) => plan.columns,
                 None => return Err(undeterminable()),
@@ -2475,6 +2560,7 @@ fn statement_may_commit(statement: &Statement) -> bool {
             | Statement::CreateRole { .. }
             | Statement::DropRole { .. }
             | Statement::AlterRole { .. }
+            | Statement::Permission(_)
             | Statement::Commit { .. }
     )
 }
@@ -3152,7 +3238,8 @@ fn analyze_statements_locks(
             | Statement::DropUser { .. }
             | Statement::CreateRole { .. }
             | Statement::DropRole { .. }
-            | Statement::AlterRole { .. } => {
+            | Statement::AlterRole { .. }
+            | Statement::Permission(_) => {
                 add(Resource::Database, LockMode::Exclusive);
             }
             // IF/WHILE conditions read tables through their subqueries —
@@ -3291,6 +3378,17 @@ fn exec_statement_dispatch(
     statement: &Statement,
     txn_ctx: &mut TxnContext,
 ) -> Result<StatementResult, SqlError> {
+    // DDL (schema + security) requires a privileged principal (sysadmin / dbo /
+    // db_owner / the internal channel). A restricted database user is refused
+    // before any change is made.
+    if !txn_ctx.security.bypass && is_privileged_ddl(statement) {
+        return Err(SqlError::new(
+            15247,
+            16,
+            1,
+            "User does not have permission to perform this action.".to_string(),
+        ));
+    }
     match statement {
         Statement::BeginTransaction { .. } => exec_begin(storage, txn_ctx),
         Statement::Use { database, .. } => exec_use(database, txn_ctx),
@@ -3389,6 +3487,12 @@ fn exec_statement_dispatch(
                 return Err(ddl_in_txn_err());
             }
             exec_alter_role_member(storage, name, *action, member)
+        }
+        Statement::Permission(stmt) => {
+            if txn_ctx.in_txn() {
+                return Err(ddl_in_txn_err());
+            }
+            exec_permission(storage, stmt, &txn_ctx.security)
         }
         // Executed by `run_block`'s own arms; nothing routes them here.
         Statement::Block { .. }
@@ -6034,6 +6138,89 @@ fn exec_alter_role_member(
     Ok(StatementResult::Done)
 }
 
+/// Maps a parsed permission action to its catalog form.
+fn map_perm_action(action: PermissionAction) -> PermAction {
+    match action {
+        PermissionAction::Select => PermAction::Select,
+        PermissionAction::Insert => PermAction::Insert,
+        PermissionAction::Update => PermAction::Update,
+        PermissionAction::Delete => PermAction::Delete,
+        PermissionAction::Execute => PermAction::Execute,
+        PermissionAction::References => PermAction::References,
+        PermissionAction::Alter => PermAction::Alter,
+    }
+}
+
+/// `GRANT|DENY|REVOKE <actions> ON <object> TO|FROM <grantees>`. The authority to
+/// manage permissions is enforced by the DDL privilege gate in the dispatcher
+/// (a bypassing principal — sysadmin / dbo / db_owner / internal). Here we just
+/// resolve the securable and apply each (grantee, action).
+fn exec_permission(
+    storage: &Storage,
+    stmt: &PermissionStatement,
+    _sec: &SecurityContext,
+) -> Result<StatementResult, SqlError> {
+    // The securable must be a schema object (table, view, procedure, function).
+    let Some(def) = resolve_table(storage, &stmt.object.value) else {
+        return Err(SqlError::invalid_object(&stmt.object.value).at(stmt.object.span));
+    };
+    if def.is_trigger() {
+        return Err(SqlError::invalid_object(&stmt.object.value).at(stmt.object.span));
+    }
+    let object = def.name.clone(); // the canonical name = the rel.tables key
+    for grantee in &stmt.grantees {
+        let grantee_bare = strip_schema(&grantee.value);
+        for action in &stmt.actions {
+            let catalog_action = map_perm_action(*action);
+            match stmt.kind {
+                PermissionKind::Grant => {
+                    storage.rel_grant_object(&object, grantee_bare, catalog_action, false)
+                }
+                PermissionKind::Deny => {
+                    storage.rel_grant_object(&object, grantee_bare, catalog_action, true)
+                }
+                PermissionKind::Revoke => {
+                    storage.rel_revoke_object(&object, grantee_bare, catalog_action)
+                }
+            }
+            .map_err(|e| map_storage_err(e, &grantee.value).at(grantee.span))?;
+        }
+    }
+    Ok(StatementResult::Done)
+}
+
+/// Schema and security DDL a non-privileged principal may not run. (GRANT/DENY/
+/// REVOKE — `Permission` — is included: only a privileged principal manages
+/// permissions.) Fine-grained database-scoped CREATE grants and the db_ddladmin
+/// role are deferred: today any DDL requires bypass privilege.
+fn is_privileged_ddl(stmt: &Statement) -> bool {
+    matches!(
+        stmt,
+        Statement::CreateTable(_)
+            | Statement::DropTable(_)
+            | Statement::CreateView(_)
+            | Statement::DropView(_)
+            | Statement::CreateIndex(_)
+            | Statement::DropIndex(_)
+            | Statement::AlterTable(_)
+            | Statement::AlterDatabase(_)
+            | Statement::CreateProcedure(_)
+            | Statement::DropProcedure { .. }
+            | Statement::CreateFunction(_)
+            | Statement::DropFunction { .. }
+            | Statement::CreateTrigger(_)
+            | Statement::DropTrigger { .. }
+            | Statement::CreateLogin(_)
+            | Statement::DropLogin { .. }
+            | Statement::CreateUser(_)
+            | Statement::DropUser { .. }
+            | Statement::CreateRole { .. }
+            | Statement::DropRole { .. }
+            | Statement::AlterRole { .. }
+            | Statement::Permission(_)
+    )
+}
+
 /// Resolves the AFTER triggers to fire for a DML on `target_name` for `event`,
 /// plus the target's definition (for the pseudo-table schema). Empty when no
 /// trigger exists anywhere (the cheap `rel_has_triggers` gate keeps the common
@@ -6164,6 +6351,8 @@ fn fire_one_trigger(
         return Ok(());
     }
     let statements = truthdb_sql::parse_procedure_body(&trigger.body)?;
+    // A trigger body ownership-chains: its object reads are not re-checked.
+    let _chain = ChainGuard::enter();
     let depth = EXEC_DEPTH.with(|d| {
         let v = d.get() + 1;
         d.set(v);
@@ -6696,6 +6885,8 @@ fn exec_insert(
     let def = resolve_table(storage, &insert.table.value)
         .ok_or_else(|| SqlError::invalid_object(&insert.table.value).at(insert.table.span))?;
     reject_dml_on_view(&def)?;
+    enforce_object_permission(&def, &eval_ctx.security, PermAction::Insert)
+        .map_err(|e| e.at(insert.table.span))?;
     let schema = def.schema().map_err(|e| map_storage_err(e, &def.name))?;
     let ncols = schema.columns.len();
     let identity_col = def.identity.map(|s| s.column);
@@ -7107,6 +7298,8 @@ fn exec_update(
     let def = resolve_table(storage, &update.table.value)
         .ok_or_else(|| SqlError::invalid_object(&update.table.value).at(update.table.span))?;
     reject_dml_on_view(&def)?;
+    enforce_object_permission(&def, &eval_ctx.security, PermAction::Update)
+        .map_err(|e| e.at(update.table.span))?;
     let schema = def.schema().map_err(|e| map_storage_err(e, &def.name))?;
     let resolver = SchemaScope { schema: &schema };
     let identity_col = def.identity.map(|s| s.column);
@@ -7271,6 +7464,8 @@ fn exec_delete(
     let def = resolve_table(storage, &delete.table.value)
         .ok_or_else(|| SqlError::invalid_object(&delete.table.value).at(delete.table.span))?;
     reject_dml_on_view(&def)?;
+    enforce_object_permission(&def, &eval_ctx.security, PermAction::Delete)
+        .map_err(|e| e.at(delete.table.span))?;
     let schema = def.schema().map_err(|e| map_storage_err(e, &def.name))?;
     let resolver = SchemaScope { schema: &schema };
 
@@ -9343,6 +9538,10 @@ fn scan_plan(storage: &Storage, select: &Select, eval_ctx: &EvalContext) -> Opti
     if def.view_query.is_some() || def.is_procedure() || def.is_function() || def.is_trigger() {
         return None;
     }
+    // If SELECT is denied, fall back to the collecting path, which resolves the
+    // same table through `build_table_source` and raises the 229 there — keeping
+    // the check on the one path the executor uses to touch the object.
+    enforce_object_permission(&def, &eval_ctx.security, PermAction::Select).ok()?;
     let schema = def.schema().ok()?;
 
     let qualifier = alias
@@ -9590,6 +9789,7 @@ fn is_sys_view(name: &str) -> bool {
             | "sys.configurations"
             | "sys.database_principals"
             | "sys.database_role_members"
+            | "sys.database_permissions"
     )
 }
 
@@ -10993,6 +11193,56 @@ impl Drop for ViewDepthGuard {
     }
 }
 
+/// True where object-permission checks apply — not inside an OWNED stored-object
+/// body (procedure, function, TVF, view, or trigger), whose reads are covered by
+/// ownership chaining (all objects share the single `dbo` owner today), so the
+/// caller's permission on the body suffices (the grant-EXECUTE-only pattern).
+/// Dynamic SQL (`sp_executesql`) resets `CHAIN_DEPTH`, so it is checked here even
+/// when nested in a procedure — matching SQL Server, which does not chain
+/// through dynamic SQL.
+fn at_top_level() -> bool {
+    CHAIN_DEPTH.with(|d| d.get()) == 0 && VIEW_DEPTH.with(|d| d.get()) == 0
+}
+
+/// Whether `sec` permits `action` on an object with these permission entries.
+/// A matching DENY for any of the session's principals wins (DENY beats GRANT);
+/// otherwise a matching GRANT permits; otherwise denied (no implicit grant).
+fn permits(perms: &[PermissionEntry], sec: &SecurityContext, action: PermAction) -> bool {
+    let mut granted = false;
+    for entry in perms {
+        if entry.action == action && sec.principals.contains(&entry.grantee) {
+            if entry.deny {
+                return false;
+            }
+            granted = true;
+        }
+    }
+    granted
+}
+
+/// Enforces `action` on the resolved object `def`, erroring 229 if the session
+/// lacks the permission. A no-op for a bypassing session (sysadmin / dbo /
+/// internal) and inside any stored-object body (ownership chaining).
+fn enforce_object_permission(
+    def: &TableDef,
+    sec: &SecurityContext,
+    action: PermAction,
+) -> Result<(), SqlError> {
+    if sec.bypass || !at_top_level() || permits(&def.permissions, sec, action) {
+        return Ok(());
+    }
+    Err(SqlError::new(
+        229,
+        14,
+        5,
+        format!(
+            "The {} permission was denied on the object '{}', database 'truthdb', schema 'dbo'.",
+            action.name(),
+            def.name
+        ),
+    ))
+}
+
 /// Builds the row source for one base table (or `sys.*` view), stamping every
 /// column with the table's qualifier (its alias, else its name).
 fn build_table_source(
@@ -11053,6 +11303,7 @@ fn build_table_source(
         "sys.sql_logins" => sys_sql_logins(storage),
         "sys.database_principals" => sys_database_principals(storage),
         "sys.database_role_members" => sys_database_role_members(storage),
+        "sys.database_permissions" => sys_database_permissions(storage),
         "sys.parameters" => sys_parameters(storage),
         "sys.objects" => sys_objects(storage),
         "sys.sql_modules" => sys_sql_modules(storage),
@@ -11078,6 +11329,11 @@ fn build_table_source(
             if def.is_function() {
                 return Err(function_not_a_table(&def.name).at(name.span));
             }
+            // SELECT permission on the base table or view (checked here, at the
+            // top level, before a view body expands — the body's own reads are
+            // covered by ownership chaining and not re-checked).
+            enforce_object_permission(&def, &eval_ctx.security, PermAction::Select)
+                .map_err(|e| e.at(name.span))?;
             // A view: run its stored SELECT as a derived table under the view's
             // qualifier. A view over another view expands recursively — building
             // the derived source re-enters `build_table_source` for the inner
@@ -11194,6 +11450,9 @@ fn build_function_source(
         .function
         .as_ref()
         .ok_or_else(|| function_not_a_table(&def.name).at(name.span))?;
+    // A table-valued function in FROM is read like a table: SELECT permission.
+    enforce_object_permission(&def, &eval_ctx.security, PermAction::Select)
+        .map_err(|e| e.at(name.span))?;
     if args.len() < function.params.len() {
         return Err(SqlError::new(
             313,
@@ -11315,6 +11574,7 @@ fn run_multi_statement_tvf(
     );
     txn_ctx.session_server_roles = eval_ctx.server_roles.clone();
     txn_ctx.session_db_roles = eval_ctx.db_roles.clone();
+    txn_ctx.security = eval_ctx.security.clone();
     let no_outer = |_: &str| -> Option<usize> { None };
     for (param, arg) in function.params.iter().zip(args) {
         let column_type = ColumnType::parse(&param.type_spec)
@@ -11341,6 +11601,8 @@ fn run_multi_statement_tvf(
     // A multi-statement TVF called from a trigger body does not see
     // inserted/deleted.
     let _trigger_shadow = TriggerScope::clear();
+    // A multi-statement TVF body ownership-chains: reads are not re-checked.
+    let _chain = ChainGuard::enter();
     // Same nesting cap as a scalar UDF (217), decremented on every exit path.
     let depth = EXEC_DEPTH.with(|d| {
         let v = d.get() + 1;
@@ -12435,6 +12697,47 @@ fn sys_database_role_members(storage: &Storage) -> Source {
                     Datum::Int(def.object_id as i32),
                 ]);
             }
+        }
+    }
+    let collations = vec![None; columns.len()];
+    let qualifiers = vec![None; columns.len()];
+    Source {
+        columns,
+        qualifiers,
+        collations,
+        rows: SourceRows::Materialized(rows),
+    }
+}
+
+fn sys_database_permissions(storage: &Storage) -> Source {
+    let columns = vec![
+        int_col("class"),
+        nvarchar("class_desc", 60),
+        int_col("major_id"),
+        int_col("minor_id"),
+        int_col("grantee_principal_id"),
+        nvarchar("permission_name", 128),
+        nvarchar("state", 1),
+        nvarchar("state_desc", 60),
+    ];
+    let mut rows: Vec<Vec<Datum>> = Vec::new();
+    for def in storage.rel_tables() {
+        for perm in &def.permissions {
+            let (state, state_desc) = if perm.deny {
+                ("D", "DENY")
+            } else {
+                ("G", "GRANT")
+            };
+            rows.push(vec![
+                Datum::Int(1), // class 1 = OBJECT_OR_COLUMN
+                Datum::NVarChar("OBJECT_OR_COLUMN".to_string()),
+                Datum::Int(def.object_id as i32),
+                Datum::Int(0), // minor_id 0 = the whole object (no column-level)
+                Datum::Int(perm.grantee as i32),
+                Datum::NVarChar(perm.action.name().to_string()),
+                Datum::NVarChar(state.to_string()),
+                Datum::NVarChar(state_desc.to_string()),
+            ]);
         }
     }
     let collations = vec![None; columns.len()];

--- a/crates/truthdb-core/src/relstore/catalog.rs
+++ b/crates/truthdb-core/src/relstore/catalog.rs
@@ -141,6 +141,50 @@ pub struct TableDef {
     /// `None` for every schema object.
     #[serde(default)]
     pub principal: Option<PrincipalDef>,
+    /// Object-level permissions (`GRANT`/`DENY` … `ON <this object>`), one entry
+    /// per (grantee, action, state). Rides the object's catalog row, so it is
+    /// WAL-durable, reloads with the object, and is dropped when the object is
+    /// dropped. Empty for a freshly created object.
+    #[serde(default)]
+    pub permissions: Vec<PermissionEntry>,
+}
+
+/// A privilege on a securable, per SQL Server's object permissions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum PermAction {
+    Select,
+    Insert,
+    Update,
+    Delete,
+    Execute,
+    References,
+    Alter,
+}
+
+impl PermAction {
+    /// The SQL Server permission name (`sys.database_permissions.permission_name`).
+    pub fn name(self) -> &'static str {
+        match self {
+            PermAction::Select => "SELECT",
+            PermAction::Insert => "INSERT",
+            PermAction::Update => "UPDATE",
+            PermAction::Delete => "DELETE",
+            PermAction::Execute => "EXECUTE",
+            PermAction::References => "REFERENCES",
+            PermAction::Alter => "ALTER",
+        }
+    }
+}
+
+/// One `GRANT`/`DENY` of an action on the object to a principal. `REVOKE`
+/// removes the matching entry; a `DENY` (`deny = true`) beats a `GRANT`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PermissionEntry {
+    /// The principal_id the grant/deny is to (a user, role, or `public`).
+    pub grantee: u32,
+    pub action: PermAction,
+    /// `true` = DENY, `false` = GRANT.
+    pub deny: bool,
 }
 
 /// Which kind of principal a [`PrincipalDef`] describes. `Login` is the default

--- a/crates/truthdb-core/src/storage.rs
+++ b/crates/truthdb-core/src/storage.rs
@@ -153,6 +153,7 @@ fn principal_table_def(
         function: None,
         trigger: None,
         principal: Some(principal),
+        permissions: Vec::new(),
         counter_page: None,
     }
 }
@@ -844,6 +845,32 @@ impl Storage {
 
     pub fn rel_database_principals(&self) -> Vec<TableDef> {
         self.lock().rel_database_principals()
+    }
+
+    // GRANT/DENY/REVOKE bump the security version so a per-batch security context
+    // is recomputed next batch (like membership DDL).
+    pub fn rel_grant_object(
+        &self,
+        object: &str,
+        grantee: &str,
+        action: crate::relstore::catalog::PermAction,
+        deny: bool,
+    ) -> Result<(), StorageError> {
+        self.lock()
+            .rel_grant_object(object, grantee, action, deny)?;
+        self.bump_security_version();
+        Ok(())
+    }
+
+    pub fn rel_revoke_object(
+        &self,
+        object: &str,
+        grantee: &str,
+        action: crate::relstore::catalog::PermAction,
+    ) -> Result<(), StorageError> {
+        self.lock().rel_revoke_object(object, grantee, action)?;
+        self.bump_security_version();
+        Ok(())
     }
 
     /// The name of the principal with this id — a fixed principal, a login, or a
@@ -1769,6 +1796,7 @@ impl StorageFile {
                 function: None,
                 trigger: None,
                 principal: None,
+                permissions: Vec::new(),
                 counter_page: Some(counter_page),
             };
             catalog::insert_table(ctx, &mut OpMode::Txn(txn), catalog_root, &def)?;
@@ -1824,6 +1852,7 @@ impl StorageFile {
                 function: None,
                 trigger: None,
                 principal: None,
+                permissions: Vec::new(),
                 counter_page: None,
             };
             catalog::insert_table(ctx, &mut OpMode::Txn(txn), catalog_root, &def)?;
@@ -1875,6 +1904,7 @@ impl StorageFile {
                 function: None,
                 trigger: None,
                 principal: None,
+                permissions: Vec::new(),
                 counter_page: None,
             };
             catalog::insert_table(ctx, &mut OpMode::Txn(txn), catalog_root, &def)?;
@@ -1927,6 +1957,7 @@ impl StorageFile {
                 function: Some(function),
                 trigger: None,
                 principal: None,
+                permissions: Vec::new(),
                 counter_page: None,
             };
             catalog::insert_table(ctx, &mut OpMode::Txn(txn), catalog_root, &def)?;
@@ -2044,6 +2075,7 @@ impl StorageFile {
                 function: None,
                 trigger: Some(trigger),
                 principal: None,
+                permissions: Vec::new(),
                 counter_page: None,
             };
             catalog::insert_table(ctx, &mut OpMode::Txn(txn), catalog_root, &def)?;
@@ -2126,6 +2158,7 @@ impl StorageFile {
                 function: None,
                 trigger: None,
                 principal: Some(principal),
+                permissions: Vec::new(),
                 counter_page: None,
             };
             catalog::insert_table(ctx, &mut OpMode::Txn(txn), catalog_root, &def)?;
@@ -2251,11 +2284,37 @@ impl StorageFile {
             .rel
             .catalog_root
             .expect("database principals live in the catalog");
+        // Scrub the principal's object permission entries BEFORE deleting it.
+        // Object_ids can be reused after a restart (next_object_id is recomputed
+        // from the surviving max), so a dangling grantee id must never outlive
+        // its principal. These are separate WAL transactions; doing the scrub
+        // first means a crash mid-drop can leave a still-present principal with
+        // fewer grants (harmless, and a re-run finishes) but never the dangerous
+        // deleted-principal-with-dangling-grant state.
+        self.scrub_grants_for(role_id)?;
         self.rel_statement(move |ctx, txn| {
             catalog::delete_table(ctx, &mut OpMode::Txn(txn), catalog_root, def.object_id)
         })?;
         self.rel.database_principals.remove(&key);
         Ok(true)
+    }
+
+    /// Removes every object permission entry whose grantee is `grantee` (a
+    /// dropped principal), rewriting each affected object's catalog row.
+    fn scrub_grants_for(&mut self, grantee: u32) -> Result<(), StorageError> {
+        let affected: Vec<String> = self
+            .rel
+            .tables
+            .iter()
+            .filter(|(_, def)| def.permissions.iter().any(|p| p.grantee == grantee))
+            .map(|(name, _)| name.clone())
+            .collect();
+        for name in affected {
+            let mut def = self.rel.tables.get(&name).cloned().expect("just listed");
+            def.permissions.retain(|p| p.grantee != grantee);
+            self.persist_object_permissions(&name, def)?;
+        }
+        Ok(())
     }
 
     /// Adds `member` (a user or role) to `role` (a database or fixed role).
@@ -2379,6 +2438,86 @@ impl StorageFile {
             .database_principals
             .values()
             .any(|d| d.object_id == id && d.is_role())
+    }
+
+    /// GRANT or DENY an action on an object to a grantee (a database user/role or
+    /// a fixed database principal, incl. `public`). Replaces any existing entry
+    /// for the same (grantee, action) — a GRANT and a DENY of the same action to
+    /// the same grantee do not coexist. Errors on an unknown grantee or object.
+    pub fn rel_grant_object(
+        &mut self,
+        object: &str,
+        grantee: &str,
+        action: crate::relstore::catalog::PermAction,
+        deny: bool,
+    ) -> Result<(), StorageError> {
+        self.ensure_rel_usable()?;
+        let grantee_id = self.resolve_grantee_id(grantee)?;
+        let Some(mut def) = self.rel.tables.get(object).cloned() else {
+            return Err(StorageError::Constraint(format!(
+                "cannot find the object '{object}', because it does not exist or you do not have permission"
+            )));
+        };
+        def.permissions
+            .retain(|p| !(p.grantee == grantee_id && p.action == action));
+        def.permissions
+            .push(crate::relstore::catalog::PermissionEntry {
+                grantee: grantee_id,
+                action,
+                deny,
+            });
+        self.persist_object_permissions(object, def)
+    }
+
+    /// REVOKE an action on an object from a grantee — removes both the GRANT and
+    /// the DENY of that (grantee, action). Idempotent (no error if absent).
+    pub fn rel_revoke_object(
+        &mut self,
+        object: &str,
+        grantee: &str,
+        action: crate::relstore::catalog::PermAction,
+    ) -> Result<(), StorageError> {
+        self.ensure_rel_usable()?;
+        let grantee_id = self.resolve_grantee_id(grantee)?;
+        let Some(mut def) = self.rel.tables.get(object).cloned() else {
+            return Err(StorageError::Constraint(format!(
+                "cannot find the object '{object}', because it does not exist or you do not have permission"
+            )));
+        };
+        let before = def.permissions.len();
+        def.permissions
+            .retain(|p| !(p.grantee == grantee_id && p.action == action));
+        if def.permissions.len() == before {
+            return Ok(()); // nothing to revoke
+        }
+        self.persist_object_permissions(object, def)
+    }
+
+    /// Resolves a grantee NAME to a database principal_id (a stored user/role or
+    /// a fixed database principal, incl. `public`; NOT the server sysadmin role).
+    fn resolve_grantee_id(&self, grantee: &str) -> Result<u32, StorageError> {
+        self.resolve_db_principal_id(grantee).ok_or_else(|| {
+            StorageError::Constraint(format!(
+                "cannot find the principal '{grantee}', because it does not exist"
+            ))
+        })
+    }
+
+    /// Writes an object's mutated permission list back through the catalog and
+    /// the in-memory cache (one whole-row rewrite, like a role-member edit).
+    fn persist_object_permissions(
+        &mut self,
+        object: &str,
+        def: TableDef,
+    ) -> Result<(), StorageError> {
+        let catalog_root = self.rel.catalog_root.expect("objects live in the catalog");
+        let write = def.clone();
+        self.rel_statement(move |ctx, txn| {
+            catalog::update_table(ctx, &mut OpMode::Txn(txn), catalog_root, &write)?;
+            Ok(())
+        })?;
+        self.rel.tables.insert(object.to_string(), def);
+        Ok(())
     }
 
     /// True if any principal (login or database) is a direct member of `role_id`.

--- a/crates/truthdb-core/tests/slt/permissions.slt
+++ b/crates/truthdb-core/tests/slt/permissions.slt
@@ -1,0 +1,53 @@
+# Stage 16 object permissions: the GRANT/DENY/REVOKE surface and the
+# sys.database_permissions catalog view. The slt harness runs as sa/dbo, which
+# bypasses enforcement, so the ENFORCEMENT behaviour (a restricted user denied a
+# read, DENY beating GRANT, ownership chaining) is pinned in the engine tests;
+# here we pin the DDL and the catalog view.
+
+statement ok
+CREATE TABLE t (id INT NOT NULL PRIMARY KEY)
+
+statement ok
+CREATE USER appuser
+
+# GRANT and DENY produce catalog rows.
+statement ok
+GRANT SELECT, INSERT ON t TO appuser
+
+statement ok
+DENY DELETE ON t TO appuser
+
+query TT
+SELECT permission_name, state_desc FROM sys.database_permissions WHERE grantee_principal_id = (SELECT principal_id FROM sys.database_principals WHERE name = 'appuser') ORDER BY permission_name
+----
+DELETE DENY
+INSERT GRANT
+SELECT GRANT
+
+# REVOKE removes an entry.
+statement ok
+REVOKE INSERT ON t FROM appuser
+
+query TT
+SELECT permission_name, state_desc FROM sys.database_permissions WHERE grantee_principal_id = (SELECT principal_id FROM sys.database_principals WHERE name = 'appuser') ORDER BY permission_name
+----
+DELETE DENY
+SELECT GRANT
+
+# GRANT to public is allowed.
+statement ok
+GRANT SELECT ON t TO public
+
+# GRANT on a non-existent object errors.
+statement error
+GRANT SELECT ON no_such_table TO appuser
+
+# GRANT to a non-existent principal errors.
+statement error
+GRANT SELECT ON t TO no_such_user
+
+statement ok
+DROP TABLE t
+
+statement ok
+DROP USER appuser

--- a/crates/truthdb-sql/src/ast.rs
+++ b/crates/truthdb-sql/src/ast.rs
@@ -171,6 +171,38 @@ pub enum Statement {
         member: Name,
         span: Span,
     },
+    /// `GRANT|DENY|REVOKE <actions> ON <object> TO|FROM <grantees>`.
+    Permission(PermissionStatement),
+}
+
+/// `GRANT` / `DENY` / `REVOKE`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PermissionKind {
+    Grant,
+    Deny,
+    Revoke,
+}
+
+/// An object privilege named in `GRANT`/`DENY`/`REVOKE`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PermissionAction {
+    Select,
+    Insert,
+    Update,
+    Delete,
+    Execute,
+    References,
+    Alter,
+}
+
+/// `GRANT|DENY|REVOKE <actions> ON <object> TO|FROM <grantees>`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PermissionStatement {
+    pub kind: PermissionKind,
+    pub actions: Vec<PermissionAction>,
+    pub object: Name,
+    pub grantees: Vec<Name>,
+    pub span: Span,
 }
 
 /// Whether `ALTER ROLE` adds or removes the named member.

--- a/crates/truthdb-sql/src/eval.rs
+++ b/crates/truthdb-sql/src/eval.rs
@@ -90,6 +90,9 @@ pub struct EvalContext {
     /// `IS_ROLEMEMBER`. Separate from `server_roles` so the two role namespaces
     /// do not cross-answer.
     pub db_roles: std::collections::HashSet<String>,
+    /// Object-permission enforcement subject for this session (bypass flag +
+    /// the principal_ids a grant may match). Computed once per batch.
+    pub security: SecurityContext,
     /// The session process id — `@@SPID`.
     pub spid: i32,
     /// Rows affected/returned by the session's previous statement —
@@ -109,6 +112,17 @@ pub struct EvalContext {
     pub last_error: i32,
     /// `@@NESTLEVEL` — the current procedure nesting depth (0 in a batch).
     pub nestlevel: i32,
+}
+
+/// The object-permission enforcement subject for a session: whether it bypasses
+/// checks (a trusted/internal connection, a sysadmin, or dbo/db_owner), and the
+/// set of principal_ids a `GRANT`/`DENY` may match (the database user, its
+/// effective roles, and `public`). Computed once per batch from the session
+/// identity; read at the read/DML/EXECUTE choke points.
+#[derive(Debug, Clone, Default)]
+pub struct SecurityContext {
+    pub bypass: bool,
+    pub principals: std::collections::HashSet<u32>,
 }
 
 /// The error captured by a `CATCH` block, surfaced by the `ERROR_*()`

--- a/crates/truthdb-sql/src/parser.rs
+++ b/crates/truthdb-sql/src/parser.rs
@@ -189,6 +189,9 @@ impl Parser {
             Some("BREAK") => self.parse_break(),
             Some("CONTINUE") => self.parse_continue(),
             Some("RETURN") => self.parse_return(),
+            Some("GRANT") => self.parse_permission(PermissionKind::Grant),
+            Some("DENY") => self.parse_permission(PermissionKind::Deny),
+            Some("REVOKE") => self.parse_permission(PermissionKind::Revoke),
             _ => {
                 let token = self.peek().clone();
                 Err(SqlError::syntax(self.token_text(&token), token.span))
@@ -1961,6 +1964,58 @@ impl Parser {
             member,
             span,
         })
+    }
+
+    /// `GRANT|DENY|REVOKE <action>[, …] ON <object> TO|FROM <grantee>[, …]`.
+    /// (Column-level, `WITH GRANT OPTION`, and database-scoped grants are not
+    /// parsed here.)
+    fn parse_permission(&mut self, kind: PermissionKind) -> SqlResult<Statement> {
+        let start = self.expect_keyword(match kind {
+            PermissionKind::Grant => "GRANT",
+            PermissionKind::Deny => "DENY",
+            PermissionKind::Revoke => "REVOKE",
+        })?;
+        let mut actions = vec![self.parse_permission_action()?];
+        while self.peek().kind == TokenKind::Comma {
+            self.bump();
+            actions.push(self.parse_permission_action()?);
+        }
+        self.expect_keyword("ON")?;
+        let object = self.parse_name()?;
+        // GRANT/DENY use TO; REVOKE uses FROM.
+        match kind {
+            PermissionKind::Revoke => self.expect_keyword("FROM")?,
+            _ => self.expect_keyword("TO")?,
+        };
+        let mut grantees = vec![self.parse_name()?];
+        while self.peek().kind == TokenKind::Comma {
+            self.bump();
+            grantees.push(self.parse_name()?);
+        }
+        let span = start.to(self.prev_span());
+        Ok(Statement::Permission(PermissionStatement {
+            kind,
+            actions,
+            object,
+            grantees,
+            span,
+        }))
+    }
+
+    fn parse_permission_action(&mut self) -> SqlResult<PermissionAction> {
+        let token = self.peek().clone();
+        let action = match self.peek_keyword().as_deref() {
+            Some("SELECT") => PermissionAction::Select,
+            Some("INSERT") => PermissionAction::Insert,
+            Some("UPDATE") => PermissionAction::Update,
+            Some("DELETE") => PermissionAction::Delete,
+            Some("EXECUTE") | Some("EXEC") => PermissionAction::Execute,
+            Some("REFERENCES") => PermissionAction::References,
+            Some("ALTER") => PermissionAction::Alter,
+            _ => return Err(SqlError::syntax(self.token_text(&token), token.span)),
+        };
+        self.bump();
+        Ok(action)
     }
 
     /// Parses an optional leading `IF EXISTS`.


### PR DESCRIPTION
Third Stage 16 (security) slice: **object-level permissions** on top of principals/roles (#136). Completes the GRANT/DENY/REVOKE + enforcement bullets.

## What changed
- **Catalog**: `TableDef.permissions: Vec<PermissionEntry{grantee, action, deny}>` (serde default); grants ride the object's row (WAL-durable, reload/drop with it). `GRANT/DENY/REVOKE <actions> ON <object> TO|FROM <grantees>` (users, roles, `public`), actions SELECT/INSERT/UPDATE/DELETE/EXECUTE/REFERENCES/ALTER.
- **Enforcement** is a **live bind/execute check** (no plan cache — every batch re-binds, so the plan's "RequiredPermissions + revalidation" is moot). A per-batch `SecurityContext {bypass, principals}` comes from the session identity (`bypass` = native `login_sid 0` / sysadmin / dbo / db_owner; `principals` = the user, its effective roles, `public`). `permits()` gives **DENY-beats-GRANT** with no implicit grant. Checked at the SELECT read (`build_table_source` + the `scan_plan` fast path), INSERT/UPDATE/DELETE targets, EXECUTE on procs and scalar UDFs, and SELECT on TVFs; denial raises **229**.
- **Ownership chaining**: an object reached *through* an owned body (procedure/view/function/TVF/trigger — single `dbo` owner) is not re-checked (the grant-EXECUTE-only pattern works). This uses a dedicated **`CHAIN_DEPTH`**, kept separate from `EXEC_DEPTH` so that **dynamic SQL (`sp_executesql`) — which shares the EXEC nesting counter but does NOT chain — is reset to depth 0 and checked as the caller**, even nested in a procedure.
- **DDL** (schema + security, incl. GRANT) requires bypass privilege; a restricted user is refused **15247**. `sys.database_permissions` view.
- Dropping a principal **scrubs its grant entries before deleting it**, so a reused `object_id` after restart cannot re-point a dangling grant at a new principal.

## Review
Two adversarial multi-agent passes. The first found a **HIGH — dynamic SQL (`sp_executesql`) bypassed every object-permission check** (it bumped the same `EXEC_DEPTH` that gates ownership chaining, so its reads ran suppressed — a restricted user could read/write/execute anything by wrapping it), and a **MEDIUM — dropped-grantee entries could re-point at a reused `object_id` after restart**. Both fixed. The re-review confirmed the fixes correct and complete; its two LOW residuals (drop+scrub crash-atomicity, and a missing test for dynamic-SQL-in-a-proc) are closed here.

## Tests
6 engine tests (grant/deny/revoke/public, INSERT/UPDATE/DELETE, EXECUTE + ownership chaining, dynamic SQL not chained incl. nested in a proc, DDL/GRANT privilege gate, `sys.database_permissions` + restart, grantee-drop scrub) + `permissions.slt`. Full workspace green (717 tests), fmt + clippy clean.

**Deferred (documented):** column-level grants, `WITH GRANT OPTION`, database-scoped CREATE grants, and the `db_ddladmin` role.

🤖 Generated with [Claude Code](https://claude.com/claude-code)