### PR TITLE
Stage 17 slice 1a: online full backup + offline restore round-trip

### DIFF
--- a/crates/truthdb-core/src/allocator.rs
+++ b/crates/truthdb-core/src/allocator.rs
@@ -112,8 +112,6 @@ impl PageAllocator {
     /// ascending order, excluding the temp/spill/version-store extents that a
     /// backup must NOT capture (they vanish on restart). This is both the set of
     /// pages a full backup copies and the allocation map a restore lays down.
-    // `backup_full` (the next Stage 17 slice) is the consumer.
-    #[allow(dead_code)]
     pub fn allocated_runs(&self) -> Vec<(u64, u64)> {
         let bitmap = self.persistable_bitmap();
         let mut runs = Vec::new();

--- a/crates/truthdb-core/src/allocator.rs
+++ b/crates/truthdb-core/src/allocator.rs
@@ -108,6 +108,37 @@ impl PageAllocator {
         !self.is_free(page)
     }
 
+    /// The runs of persistably-allocated pages — `(start_page, count)` pairs in
+    /// ascending order, excluding the temp/spill/version-store extents that a
+    /// backup must NOT capture (they vanish on restart). This is both the set of
+    /// pages a full backup copies and the allocation map a restore lays down.
+    // `backup_full` (the next Stage 17 slice) is the consumer.
+    #[allow(dead_code)]
+    pub fn allocated_runs(&self) -> Vec<(u64, u64)> {
+        let bitmap = self.persistable_bitmap();
+        let mut runs = Vec::new();
+        let mut run_start = 0u64;
+        let mut run_len = 0u64;
+        for page in 0..self.total_pages {
+            let allocated = bitmap
+                .get((page / 8) as usize)
+                .is_some_and(|byte| byte & (1 << (page % 8) as u8) != 0);
+            if allocated {
+                if run_len == 0 {
+                    run_start = page;
+                }
+                run_len += 1;
+            } else if run_len > 0 {
+                runs.push((run_start, run_len));
+                run_len = 0;
+            }
+        }
+        if run_len > 0 {
+            runs.push((run_start, run_len));
+        }
+        runs
+    }
+
     fn scan_range(&self, from: u64, to: u64, num_pages: u64) -> Option<u64> {
         let mut run_start = from;
         let mut run_len = 0u64;
@@ -169,6 +200,28 @@ mod tests {
 
     fn allocator_with_pages(pages: u64) -> PageAllocator {
         PageAllocator::new(pages * PAGE_SIZE as u64)
+    }
+
+    #[test]
+    fn allocated_runs_lists_persistent_runs_excluding_temp_extents() {
+        let mut alloc = allocator_with_pages(1000);
+        let base = alloc.allocate(5).unwrap();
+        // Free two interior pages, splitting the run into two.
+        alloc.free(base + 2, 2);
+        assert_eq!(
+            alloc.allocated_runs(),
+            vec![(base, 2), (base + 4, 1)],
+            "the persistent allocated runs"
+        );
+        // A temp extent is allocated in the live bitmap but excluded from the
+        // persistable set, so it does not appear in the backup's runs.
+        let before = alloc.allocated_runs();
+        let _temp = alloc.allocate_temp_extent().expect("temp extent");
+        assert_eq!(
+            alloc.allocated_runs(),
+            before,
+            "temp extents are excluded from allocated_runs"
+        );
     }
 
     #[test]

--- a/crates/truthdb-core/src/backup.rs
+++ b/crates/truthdb-core/src/backup.rs
@@ -2,21 +2,27 @@
 //! xxh64-checksummed blocks.
 //!
 //! Layout (in order): a [`BlockType::Header`] carrying the parameters needed to
-//! recreate the file and the LSN bracket, one [`BlockType::AllocMap`] listing
-//! every allocated page (so restore can zero-fill the allocation set before
-//! overwriting from data blocks), a sequence of [`BlockType::PageData`] runs of
-//! raw page images, a sequence of [`BlockType::LogChunk`] blocks carrying the
-//! WAL entries `[redo_start_lsn, backup_end_lsn)` verbatim, and a
+//! recreate the destination file and the recovery LSN bracket, one
+//! [`BlockType::AllocMap`] listing every allocated page run (so restore lays the
+//! allocation set back before recovery), a sequence of [`BlockType::PageData`]
+//! runs of raw page images, one or more [`BlockType::LogChunk`] blocks carrying
+//! the WAL bytes of `[redo_start_lsn, backup_end_lsn)` verbatim, and a
 //! [`BlockType::Trailer`]. Every block is framed as `type(u32) | payload_len(u64)
 //! | payload | xxh64(payload)(u64)`, so a torn or tampered block is detected on
 //! read.
 //!
-//! This module owns only the framing and header codec; `storage.rs` assembles
-//! the actual page and log data.
+//! `backup_end_lsn` is not stored in the header: it is only known after the
+//! (fuzzy) page copy finishes, so it is derived on read as
+//! `redo_start_lsn + total LogChunk bytes` — the log covers exactly that range.
+//!
+//! This module owns only the framing and the block codecs; `storage.rs`
+//! assembles the actual page and log data.
 
 use std::io::{self, Read, Write};
 
 use xxhash_rust::xxh64::xxh64;
+
+use crate::storage_layout::PAGE_SIZE;
 
 /// The magic bytes at the start of every `TDBBAK1` file.
 pub const MAGIC: &[u8; 8] = b"TDBBAK1\0";
@@ -27,11 +33,11 @@ pub const FORMAT_VERSION: u32 = 1;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u32)]
 pub enum BlockType {
-    /// The header (recreation parameters + LSN bracket). Exactly one, first.
+    /// The header (recreation parameters + redo-start LSN). Exactly one, first.
     Header = 1,
     /// The allocation map: the full set of allocated page runs.
     AllocMap = 2,
-    /// A run of raw page images (a page number followed by page bytes).
+    /// A run of raw page images (a starting page number followed by page bytes).
     PageData = 3,
     /// A chunk of WAL bytes (a starting LSN followed by the raw entries).
     LogChunk = 4,
@@ -62,25 +68,36 @@ pub struct BackupFlags {
 }
 
 /// The `TDBBAK1` header: everything a restore needs to recreate the file and
-/// bracket the embedded log. Encoded little-endian with an explicit layout so
-/// the format is stable across builds.
+/// seed recovery. Encoded little-endian with an explicit layout so the format
+/// is stable across builds.
+///
+/// The layout sizes reproduce the destination file's regions byte-for-byte (the
+/// offsets are fixed by the region order, so only the sizes travel). The roots
+/// are the source's checkpoint-consistent superblock state as of
+/// `redo_start_lsn`; recovery redoes `[redo_start_lsn, backup_end_lsn)` on top.
 #[derive(Debug, Clone, PartialEq)]
 pub struct BackupHeader {
     pub format_version: u32,
-    /// Storage sizing/layout, to recreate the destination file identically.
-    pub size_gib: u64,
-    pub wal_ratio: f64,
-    pub metadata_ratio: f64,
-    pub snapshot_ratio: f64,
-    pub allocator_ratio: f64,
-    pub reserved_ratio: f64,
-    pub default_collation: Option<String>,
     pub page_size: u32,
-    /// The recovery redo-start LSN (the checkpoint's `wal_head`); restore seeds
-    /// the ring head here and redoes forward.
+    /// Region sizes, in the file's region order; the offsets are derived.
+    pub total_size: u64,
+    pub wal_size: u64,
+    pub data_size: u64,
+    pub metadata_size: u64,
+    pub allocator_size: u64,
+    pub snapshot_size: u64,
+    pub reserved_size: u64,
+    pub default_collation: Option<String>,
+    /// The recovery redo-start LSN (the source's `wal_head`); restore seeds the
+    /// ring head here and redoes forward.
     pub redo_start_lsn: u64,
-    /// The end of the log captured in the backup; restore seeds the ring tail here.
-    pub backup_end_lsn: u64,
+    /// The catalog B+tree root as an absolute file offset (0 = none). The
+    /// restored superblock carries it so recovery starts from the right catalog.
+    pub metadata_root: u64,
+    /// The source's `last_committed_seq` at `redo_start_lsn`.
+    pub last_committed_seq: u64,
+    /// The source's database-options byte (RCSI / ALLOW_SNAPSHOT bits).
+    pub db_options: u8,
     /// Wall-clock time the backup finished, milliseconds since the Unix epoch.
     pub finished_at_millis: u64,
     pub flags: BackupFlags,
@@ -90,16 +107,19 @@ impl BackupHeader {
     fn encode(&self) -> Vec<u8> {
         let mut out = Vec::new();
         out.extend_from_slice(&self.format_version.to_le_bytes());
-        out.extend_from_slice(&self.size_gib.to_le_bytes());
-        out.extend_from_slice(&self.wal_ratio.to_le_bytes());
-        out.extend_from_slice(&self.metadata_ratio.to_le_bytes());
-        out.extend_from_slice(&self.snapshot_ratio.to_le_bytes());
-        out.extend_from_slice(&self.allocator_ratio.to_le_bytes());
-        out.extend_from_slice(&self.reserved_ratio.to_le_bytes());
         out.extend_from_slice(&self.page_size.to_le_bytes());
+        out.extend_from_slice(&self.total_size.to_le_bytes());
+        out.extend_from_slice(&self.wal_size.to_le_bytes());
+        out.extend_from_slice(&self.data_size.to_le_bytes());
+        out.extend_from_slice(&self.metadata_size.to_le_bytes());
+        out.extend_from_slice(&self.allocator_size.to_le_bytes());
+        out.extend_from_slice(&self.snapshot_size.to_le_bytes());
+        out.extend_from_slice(&self.reserved_size.to_le_bytes());
         out.extend_from_slice(&self.redo_start_lsn.to_le_bytes());
-        out.extend_from_slice(&self.backup_end_lsn.to_le_bytes());
+        out.extend_from_slice(&self.metadata_root.to_le_bytes());
+        out.extend_from_slice(&self.last_committed_seq.to_le_bytes());
         out.extend_from_slice(&self.finished_at_millis.to_le_bytes());
+        out.push(self.db_options);
         let flag_bits = (self.flags.checksum as u8) | ((self.flags.copy_only as u8) << 1);
         out.push(flag_bits);
         // Default collation as a length-prefixed UTF-8 string (u32 len, or
@@ -117,16 +137,19 @@ impl BackupHeader {
     fn decode(bytes: &[u8]) -> io::Result<Self> {
         let mut cursor = Cursor { bytes, pos: 0 };
         let format_version = cursor.u32()?;
-        let size_gib = cursor.u64()?;
-        let wal_ratio = cursor.f64()?;
-        let metadata_ratio = cursor.f64()?;
-        let snapshot_ratio = cursor.f64()?;
-        let allocator_ratio = cursor.f64()?;
-        let reserved_ratio = cursor.f64()?;
         let page_size = cursor.u32()?;
+        let total_size = cursor.u64()?;
+        let wal_size = cursor.u64()?;
+        let data_size = cursor.u64()?;
+        let metadata_size = cursor.u64()?;
+        let allocator_size = cursor.u64()?;
+        let snapshot_size = cursor.u64()?;
+        let reserved_size = cursor.u64()?;
         let redo_start_lsn = cursor.u64()?;
-        let backup_end_lsn = cursor.u64()?;
+        let metadata_root = cursor.u64()?;
+        let last_committed_seq = cursor.u64()?;
         let finished_at_millis = cursor.u64()?;
+        let db_options = cursor.u8()?;
         let flag_bits = cursor.u8()?;
         let collation_len = cursor.u32()?;
         let default_collation = if collation_len == u32::MAX {
@@ -140,16 +163,19 @@ impl BackupHeader {
         };
         Ok(BackupHeader {
             format_version,
-            size_gib,
-            wal_ratio,
-            metadata_ratio,
-            snapshot_ratio,
-            allocator_ratio,
-            reserved_ratio,
-            default_collation,
             page_size,
+            total_size,
+            wal_size,
+            data_size,
+            metadata_size,
+            allocator_size,
+            snapshot_size,
+            reserved_size,
+            default_collation,
             redo_start_lsn,
-            backup_end_lsn,
+            metadata_root,
+            last_committed_seq,
+            db_options,
             finished_at_millis,
             flags: BackupFlags {
                 checksum: flag_bits & 1 != 0,
@@ -157,6 +183,83 @@ impl BackupHeader {
             },
         })
     }
+}
+
+/// What a completed [`crate::storage::Storage::backup_full`] reports back.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BackupSummary {
+    pub redo_start_lsn: u64,
+    pub backup_end_lsn: u64,
+    pub pages_copied: u64,
+    pub log_bytes: u64,
+    pub finished_at_millis: u64,
+}
+
+/// Encodes an allocation map: a `u64` run count, then `(start_page, count)`
+/// pairs.
+pub fn encode_alloc_map(runs: &[(u64, u64)]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(8 + runs.len() * 16);
+    out.extend_from_slice(&(runs.len() as u64).to_le_bytes());
+    for (start, count) in runs {
+        out.extend_from_slice(&start.to_le_bytes());
+        out.extend_from_slice(&count.to_le_bytes());
+    }
+    out
+}
+
+/// Decodes an allocation map produced by [`encode_alloc_map`].
+pub fn decode_alloc_map(payload: &[u8]) -> io::Result<Vec<(u64, u64)>> {
+    let mut cursor = Cursor {
+        bytes: payload,
+        pos: 0,
+    };
+    let count = cursor.u64()? as usize;
+    let mut runs = Vec::with_capacity(count);
+    for _ in 0..count {
+        let start = cursor.u64()?;
+        let run = cursor.u64()?;
+        runs.push((start, run));
+    }
+    Ok(runs)
+}
+
+/// Encodes a page-data run: the starting page number, then `page_bytes`
+/// (a whole number of pages).
+pub fn encode_page_run(start_page: u64, page_bytes: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(8 + page_bytes.len());
+    out.extend_from_slice(&start_page.to_le_bytes());
+    out.extend_from_slice(page_bytes);
+    out
+}
+
+/// Decodes a page-data run into `(start_page, page_count, page_bytes)`.
+pub fn decode_page_run(payload: &[u8]) -> io::Result<(u64, u64, &[u8])> {
+    if payload.len() < 8 {
+        return Err(corrupt("page run block too short"));
+    }
+    let start_page = u64::from_le_bytes(payload[..8].try_into().unwrap());
+    let bytes = &payload[8..];
+    if !bytes.len().is_multiple_of(PAGE_SIZE) {
+        return Err(corrupt("page run is not a whole number of pages"));
+    }
+    Ok((start_page, (bytes.len() / PAGE_SIZE) as u64, bytes))
+}
+
+/// Encodes a log chunk: the starting LSN, then the raw WAL bytes.
+pub fn encode_log_chunk(start_lsn: u64, bytes: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(8 + bytes.len());
+    out.extend_from_slice(&start_lsn.to_le_bytes());
+    out.extend_from_slice(bytes);
+    out
+}
+
+/// Decodes a log chunk into `(start_lsn, raw_bytes)`.
+pub fn decode_log_chunk(payload: &[u8]) -> io::Result<(u64, &[u8])> {
+    if payload.len() < 8 {
+        return Err(corrupt("log chunk block too short"));
+    }
+    let start_lsn = u64::from_le_bytes(payload[..8].try_into().unwrap());
+    Ok((start_lsn, &payload[8..]))
 }
 
 /// Writes framed, checksummed `TDBBAK1` blocks to an underlying writer.
@@ -293,7 +396,7 @@ impl Cursor<'_> {
             .pos
             .checked_add(n)
             .filter(|&e| e <= self.bytes.len())
-            .ok_or_else(|| corrupt("truncated backup header"))?;
+            .ok_or_else(|| corrupt("truncated backup block"))?;
         let slice = &self.bytes[self.pos..end];
         self.pos = end;
         Ok(slice)
@@ -307,9 +410,6 @@ impl Cursor<'_> {
     fn u64(&mut self) -> io::Result<u64> {
         Ok(u64::from_le_bytes(self.take(8)?.try_into().unwrap()))
     }
-    fn f64(&mut self) -> io::Result<f64> {
-        Ok(f64::from_le_bytes(self.take(8)?.try_into().unwrap()))
-    }
 }
 
 #[cfg(test)]
@@ -319,16 +419,19 @@ mod tests {
     fn sample_header() -> BackupHeader {
         BackupHeader {
             format_version: FORMAT_VERSION,
-            size_gib: 4,
-            wal_ratio: 0.05,
-            metadata_ratio: 0.08,
-            snapshot_ratio: 0.02,
-            allocator_ratio: 0.02,
-            reserved_ratio: 0.17,
-            default_collation: Some("Finnish_Swedish_CI_AS".to_string()),
             page_size: 4096,
+            total_size: 1 << 30,
+            wal_size: 64 * 1024,
+            data_size: 512 * 1024,
+            metadata_size: 128 * 1024,
+            allocator_size: 4096,
+            snapshot_size: 8192,
+            reserved_size: 16384,
+            default_collation: Some("Finnish_Swedish_CI_AS".to_string()),
             redo_start_lsn: 12_345,
-            backup_end_lsn: 67_890,
+            metadata_root: 4096 * 40,
+            last_committed_seq: 7,
+            db_options: 0b01,
             finished_at_millis: 1_700_000_000_000,
             flags: BackupFlags {
                 checksum: true,
@@ -369,6 +472,32 @@ mod tests {
                 (BlockType::LogChunk, b"logbytes".to_vec()),
             ]
         );
+    }
+
+    #[test]
+    fn block_codecs_round_trip() {
+        let runs = vec![(0u64, 3u64), (7, 1), (100, 64)];
+        assert_eq!(decode_alloc_map(&encode_alloc_map(&runs)).unwrap(), runs);
+
+        let pages = vec![0x5au8; 2 * PAGE_SIZE];
+        let encoded_pages = encode_page_run(9, &pages);
+        let (start, count, bytes) = decode_page_run(&encoded_pages).unwrap();
+        assert_eq!((start, count), (9, 2));
+        assert_eq!(bytes, &pages[..]);
+
+        let log = b"raw-wal-entry-bytes";
+        let encoded_log = encode_log_chunk(4096, log);
+        let (lsn, bytes) = decode_log_chunk(&encoded_log).unwrap();
+        assert_eq!(lsn, 4096);
+        assert_eq!(bytes, log);
+    }
+
+    #[test]
+    fn a_partial_page_run_is_rejected() {
+        // 8-byte start prefix + 100 bytes: not a whole page.
+        let mut payload = 3u64.to_le_bytes().to_vec();
+        payload.extend_from_slice(&[0u8; 100]);
+        assert!(decode_page_run(&payload).is_err());
     }
 
     #[test]

--- a/crates/truthdb-core/src/backup.rs
+++ b/crates/truthdb-core/src/backup.rs
@@ -1,0 +1,415 @@
+//! The `TDBBAK1` backup file format: a self-describing stream of typed,
+//! xxh64-checksummed blocks.
+//!
+//! Layout (in order): a [`BlockType::Header`] carrying the parameters needed to
+//! recreate the file and the LSN bracket, one [`BlockType::AllocMap`] listing
+//! every allocated page (so restore can zero-fill the allocation set before
+//! overwriting from data blocks), a sequence of [`BlockType::PageData`] runs of
+//! raw page images, a sequence of [`BlockType::LogChunk`] blocks carrying the
+//! WAL entries `[redo_start_lsn, backup_end_lsn)` verbatim, and a
+//! [`BlockType::Trailer`]. Every block is framed as `type(u32) | payload_len(u64)
+//! | payload | xxh64(payload)(u64)`, so a torn or tampered block is detected on
+//! read.
+//!
+//! This module owns only the framing and header codec; `storage.rs` assembles
+//! the actual page and log data.
+
+use std::io::{self, Read, Write};
+
+use xxhash_rust::xxh64::xxh64;
+
+/// The magic bytes at the start of every `TDBBAK1` file.
+pub const MAGIC: &[u8; 8] = b"TDBBAK1\0";
+/// Format version — bumped on any incompatible framing/header change.
+pub const FORMAT_VERSION: u32 = 1;
+
+/// The kind of a framed block.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u32)]
+pub enum BlockType {
+    /// The header (recreation parameters + LSN bracket). Exactly one, first.
+    Header = 1,
+    /// The allocation map: the full set of allocated page runs.
+    AllocMap = 2,
+    /// A run of raw page images (a page number followed by page bytes).
+    PageData = 3,
+    /// A chunk of WAL bytes (a starting LSN followed by the raw entries).
+    LogChunk = 4,
+    /// The trailer (block count). Exactly one, last.
+    Trailer = 5,
+}
+
+impl BlockType {
+    fn from_u32(value: u32) -> Option<Self> {
+        Some(match value {
+            1 => BlockType::Header,
+            2 => BlockType::AllocMap,
+            3 => BlockType::PageData,
+            4 => BlockType::LogChunk,
+            5 => BlockType::Trailer,
+            _ => return None,
+        })
+    }
+}
+
+/// Backup options that travel in the header (subset of `WITH ...`).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct BackupFlags {
+    /// `WITH CHECKSUM` (default on): every page was checksum-verified as copied.
+    pub checksum: bool,
+    /// `WITH COPY_ONLY`: the backup did not disturb the log-backup chain.
+    pub copy_only: bool,
+}
+
+/// The `TDBBAK1` header: everything a restore needs to recreate the file and
+/// bracket the embedded log. Encoded little-endian with an explicit layout so
+/// the format is stable across builds.
+#[derive(Debug, Clone, PartialEq)]
+pub struct BackupHeader {
+    pub format_version: u32,
+    /// Storage sizing/layout, to recreate the destination file identically.
+    pub size_gib: u64,
+    pub wal_ratio: f64,
+    pub metadata_ratio: f64,
+    pub snapshot_ratio: f64,
+    pub allocator_ratio: f64,
+    pub reserved_ratio: f64,
+    pub default_collation: Option<String>,
+    pub page_size: u32,
+    /// The recovery redo-start LSN (the checkpoint's `wal_head`); restore seeds
+    /// the ring head here and redoes forward.
+    pub redo_start_lsn: u64,
+    /// The end of the log captured in the backup; restore seeds the ring tail here.
+    pub backup_end_lsn: u64,
+    /// Wall-clock time the backup finished, milliseconds since the Unix epoch.
+    pub finished_at_millis: u64,
+    pub flags: BackupFlags,
+}
+
+impl BackupHeader {
+    fn encode(&self) -> Vec<u8> {
+        let mut out = Vec::new();
+        out.extend_from_slice(&self.format_version.to_le_bytes());
+        out.extend_from_slice(&self.size_gib.to_le_bytes());
+        out.extend_from_slice(&self.wal_ratio.to_le_bytes());
+        out.extend_from_slice(&self.metadata_ratio.to_le_bytes());
+        out.extend_from_slice(&self.snapshot_ratio.to_le_bytes());
+        out.extend_from_slice(&self.allocator_ratio.to_le_bytes());
+        out.extend_from_slice(&self.reserved_ratio.to_le_bytes());
+        out.extend_from_slice(&self.page_size.to_le_bytes());
+        out.extend_from_slice(&self.redo_start_lsn.to_le_bytes());
+        out.extend_from_slice(&self.backup_end_lsn.to_le_bytes());
+        out.extend_from_slice(&self.finished_at_millis.to_le_bytes());
+        let flag_bits = (self.flags.checksum as u8) | ((self.flags.copy_only as u8) << 1);
+        out.push(flag_bits);
+        // Default collation as a length-prefixed UTF-8 string (u32 len, or
+        // u32::MAX for None).
+        match &self.default_collation {
+            Some(collation) => {
+                out.extend_from_slice(&(collation.len() as u32).to_le_bytes());
+                out.extend_from_slice(collation.as_bytes());
+            }
+            None => out.extend_from_slice(&u32::MAX.to_le_bytes()),
+        }
+        out
+    }
+
+    fn decode(bytes: &[u8]) -> io::Result<Self> {
+        let mut cursor = Cursor { bytes, pos: 0 };
+        let format_version = cursor.u32()?;
+        let size_gib = cursor.u64()?;
+        let wal_ratio = cursor.f64()?;
+        let metadata_ratio = cursor.f64()?;
+        let snapshot_ratio = cursor.f64()?;
+        let allocator_ratio = cursor.f64()?;
+        let reserved_ratio = cursor.f64()?;
+        let page_size = cursor.u32()?;
+        let redo_start_lsn = cursor.u64()?;
+        let backup_end_lsn = cursor.u64()?;
+        let finished_at_millis = cursor.u64()?;
+        let flag_bits = cursor.u8()?;
+        let collation_len = cursor.u32()?;
+        let default_collation = if collation_len == u32::MAX {
+            None
+        } else {
+            let bytes = cursor.take(collation_len as usize)?;
+            Some(
+                String::from_utf8(bytes.to_vec())
+                    .map_err(|e| corrupt(&format!("collation not UTF-8: {e}")))?,
+            )
+        };
+        Ok(BackupHeader {
+            format_version,
+            size_gib,
+            wal_ratio,
+            metadata_ratio,
+            snapshot_ratio,
+            allocator_ratio,
+            reserved_ratio,
+            default_collation,
+            page_size,
+            redo_start_lsn,
+            backup_end_lsn,
+            finished_at_millis,
+            flags: BackupFlags {
+                checksum: flag_bits & 1 != 0,
+                copy_only: flag_bits & 2 != 0,
+            },
+        })
+    }
+}
+
+/// Writes framed, checksummed `TDBBAK1` blocks to an underlying writer.
+pub struct BackupWriter<W: Write> {
+    writer: W,
+    blocks: u64,
+}
+
+impl<W: Write> BackupWriter<W> {
+    /// Starts a backup stream: writes the magic, then the header block.
+    pub fn new(mut writer: W, header: &BackupHeader) -> io::Result<Self> {
+        writer.write_all(MAGIC)?;
+        let mut this = BackupWriter { writer, blocks: 0 };
+        this.write_block(BlockType::Header, &header.encode())?;
+        Ok(this)
+    }
+
+    /// Writes one framed block: `type | len | payload | xxh64(payload)`.
+    pub fn write_block(&mut self, block_type: BlockType, payload: &[u8]) -> io::Result<()> {
+        self.writer.write_all(&(block_type as u32).to_le_bytes())?;
+        self.writer
+            .write_all(&(payload.len() as u64).to_le_bytes())?;
+        self.writer.write_all(payload)?;
+        self.writer.write_all(&xxh64(payload, 0).to_le_bytes())?;
+        self.blocks += 1;
+        Ok(())
+    }
+
+    /// Writes the trailer (the block count for a completeness check) and returns
+    /// the underlying writer.
+    pub fn finish(mut self) -> io::Result<W> {
+        // +1: the trailer counts itself, so a reader can verify it saw them all.
+        let count = (self.blocks + 1).to_le_bytes();
+        self.write_block(BlockType::Trailer, &count)?;
+        self.writer.flush()?;
+        Ok(self.writer)
+    }
+}
+
+/// Reads and verifies framed `TDBBAK1` blocks.
+pub struct BackupReader<R: Read> {
+    reader: R,
+    blocks: u64,
+    done: bool,
+}
+
+impl<R: Read> BackupReader<R> {
+    /// Opens a backup stream: checks the magic and reads the header block.
+    pub fn new(mut reader: R) -> io::Result<(Self, BackupHeader)> {
+        let mut magic = [0u8; 8];
+        reader.read_exact(&mut magic)?;
+        if &magic != MAGIC {
+            return Err(corrupt("not a TDBBAK1 backup (bad magic)"));
+        }
+        let mut this = BackupReader {
+            reader,
+            blocks: 0,
+            done: false,
+        };
+        let (block_type, payload) = this.read_block()?;
+        if block_type != BlockType::Header {
+            return Err(corrupt("first block is not the header"));
+        }
+        let header = BackupHeader::decode(&payload)?;
+        if header.format_version != FORMAT_VERSION {
+            return Err(corrupt(&format!(
+                "unsupported backup format version {}",
+                header.format_version
+            )));
+        }
+        Ok((this, header))
+    }
+
+    /// Reads the next data block, or `None` at the trailer. The trailer's block
+    /// count is verified against the number actually read.
+    pub fn next_block(&mut self) -> io::Result<Option<(BlockType, Vec<u8>)>> {
+        if self.done {
+            return Ok(None);
+        }
+        let (block_type, payload) = self.read_block()?;
+        if block_type == BlockType::Trailer {
+            self.done = true;
+            let expected = u64::from_le_bytes(
+                payload
+                    .as_slice()
+                    .try_into()
+                    .map_err(|_| corrupt("malformed trailer"))?,
+            );
+            if expected != self.blocks {
+                return Err(corrupt(&format!(
+                    "backup is incomplete: trailer expected {expected} blocks, read {}",
+                    self.blocks
+                )));
+            }
+            return Ok(None);
+        }
+        Ok(Some((block_type, payload)))
+    }
+
+    fn read_block(&mut self) -> io::Result<(BlockType, Vec<u8>)> {
+        let mut type_bytes = [0u8; 4];
+        self.reader.read_exact(&mut type_bytes)?;
+        let block_type = BlockType::from_u32(u32::from_le_bytes(type_bytes))
+            .ok_or_else(|| corrupt("unknown block type"))?;
+        let mut len_bytes = [0u8; 8];
+        self.reader.read_exact(&mut len_bytes)?;
+        let len = u64::from_le_bytes(len_bytes) as usize;
+        let mut payload = vec![0u8; len];
+        self.reader.read_exact(&mut payload)?;
+        let mut checksum_bytes = [0u8; 8];
+        self.reader.read_exact(&mut checksum_bytes)?;
+        let stored = u64::from_le_bytes(checksum_bytes);
+        if xxh64(&payload, 0) != stored {
+            return Err(corrupt("block checksum mismatch (corrupt backup)"));
+        }
+        self.blocks += 1;
+        Ok((block_type, payload))
+    }
+}
+
+fn corrupt(message: &str) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, message.to_string())
+}
+
+/// A tiny little-endian byte cursor for header decoding.
+struct Cursor<'a> {
+    bytes: &'a [u8],
+    pos: usize,
+}
+
+impl Cursor<'_> {
+    fn take(&mut self, n: usize) -> io::Result<&[u8]> {
+        let end = self
+            .pos
+            .checked_add(n)
+            .filter(|&e| e <= self.bytes.len())
+            .ok_or_else(|| corrupt("truncated backup header"))?;
+        let slice = &self.bytes[self.pos..end];
+        self.pos = end;
+        Ok(slice)
+    }
+    fn u8(&mut self) -> io::Result<u8> {
+        Ok(self.take(1)?[0])
+    }
+    fn u32(&mut self) -> io::Result<u32> {
+        Ok(u32::from_le_bytes(self.take(4)?.try_into().unwrap()))
+    }
+    fn u64(&mut self) -> io::Result<u64> {
+        Ok(u64::from_le_bytes(self.take(8)?.try_into().unwrap()))
+    }
+    fn f64(&mut self) -> io::Result<f64> {
+        Ok(f64::from_le_bytes(self.take(8)?.try_into().unwrap()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_header() -> BackupHeader {
+        BackupHeader {
+            format_version: FORMAT_VERSION,
+            size_gib: 4,
+            wal_ratio: 0.05,
+            metadata_ratio: 0.08,
+            snapshot_ratio: 0.02,
+            allocator_ratio: 0.02,
+            reserved_ratio: 0.17,
+            default_collation: Some("Finnish_Swedish_CI_AS".to_string()),
+            page_size: 4096,
+            redo_start_lsn: 12_345,
+            backup_end_lsn: 67_890,
+            finished_at_millis: 1_700_000_000_000,
+            flags: BackupFlags {
+                checksum: true,
+                copy_only: false,
+            },
+        }
+    }
+
+    #[test]
+    fn header_and_blocks_round_trip() {
+        let header = sample_header();
+        let mut buf = Vec::new();
+        {
+            let mut writer = BackupWriter::new(&mut buf, &header).unwrap();
+            writer
+                .write_block(BlockType::AllocMap, &[1, 2, 3, 4])
+                .unwrap();
+            writer
+                .write_block(BlockType::PageData, &vec![0xab; 4096])
+                .unwrap();
+            writer
+                .write_block(BlockType::LogChunk, b"logbytes")
+                .unwrap();
+            writer.finish().unwrap();
+        }
+
+        let (mut reader, read_header) = BackupReader::new(&buf[..]).unwrap();
+        assert_eq!(read_header, header, "header round-trips exactly");
+        let mut seen = Vec::new();
+        while let Some((block_type, payload)) = reader.next_block().unwrap() {
+            seen.push((block_type, payload));
+        }
+        assert_eq!(
+            seen,
+            vec![
+                (BlockType::AllocMap, vec![1, 2, 3, 4]),
+                (BlockType::PageData, vec![0xab; 4096]),
+                (BlockType::LogChunk, b"logbytes".to_vec()),
+            ]
+        );
+    }
+
+    #[test]
+    fn a_tampered_block_is_detected() {
+        let header = sample_header();
+        let mut buf = Vec::new();
+        {
+            let mut writer = BackupWriter::new(&mut buf, &header).unwrap();
+            writer
+                .write_block(BlockType::PageData, b"important")
+                .unwrap();
+            writer.finish().unwrap();
+        }
+        // Flip a byte inside the PageData payload.
+        let flip = buf.windows(9).position(|w| w == b"important").unwrap();
+        buf[flip] ^= 0xff;
+        let (mut reader, _) = BackupReader::new(&buf[..]).unwrap();
+        let err = reader.next_block().unwrap_err();
+        assert_eq!(
+            err.kind(),
+            io::ErrorKind::InvalidData,
+            "corruption detected"
+        );
+    }
+
+    #[test]
+    fn a_truncated_backup_is_detected_by_the_trailer_count() {
+        // A stream missing its trailer (truncated mid-write) fails to read to end.
+        let header = sample_header();
+        let mut buf = Vec::new();
+        {
+            let mut writer = BackupWriter::new(&mut buf, &header).unwrap();
+            writer.write_block(BlockType::PageData, b"data").unwrap();
+            // NOTE: no finish() → no trailer.
+        }
+        let (mut reader, _) = BackupReader::new(&buf[..]).unwrap();
+        assert!(
+            reader.next_block().unwrap().is_some(),
+            "the data block reads"
+        );
+        // The next read hits EOF where the trailer should be.
+        assert!(reader.next_block().is_err(), "missing trailer is an error");
+    }
+}

--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -83,6 +83,13 @@ impl Engine {
         })
     }
 
+    /// The underlying storage handle, so a test can drive an online backup
+    /// while the engine is live.
+    #[cfg(test)]
+    pub(crate) fn storage(&self) -> &Storage {
+        &self.storage
+    }
+
     pub fn execute(&self, input: &str) -> Result<String, EngineError> {
         // Routing: the legacy ES commands all carry a `{` JSON body; that
         // shape routes to the frozen search path. Everything else is SQL.
@@ -1802,6 +1809,86 @@ mod tests {
         let (_, rows) = sql_rows(&engine, "SELECT id FROM t WHERE name = 'e'");
         assert_eq!(rows, vec![vec![Some("5".into())]]);
         let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn full_backup_and_offline_restore_round_trips_relational_data() {
+        let src = unique_temp_path("backup-src");
+        let bak = unique_temp_path("backup-bak");
+        let restored = unique_temp_path("backup-restored");
+
+        let engine = new_engine(&src);
+        engine
+            .execute("CREATE TABLE t (id INT NOT NULL PRIMARY KEY, name NVARCHAR(20))")
+            .expect("create t");
+        engine
+            .execute("CREATE INDEX ix_name ON t (name)")
+            .expect("create index");
+        // Enough rows to spread the heap and the secondary index over several
+        // B+tree pages, so the copy is more than a single catalog page.
+        for i in 1..=200 {
+            engine
+                .execute(&format!("INSERT INTO t (id, name) VALUES ({i}, 'row{i}')"))
+                .expect("insert into t");
+        }
+        engine
+            .execute("CREATE TABLE u (k INT NOT NULL PRIMARY KEY, v INT)")
+            .expect("create u");
+        engine
+            .execute("INSERT INTO u (k, v) VALUES (1, 10), (2, 20)")
+            .expect("insert into u");
+
+        let expected_t = sql_rows(&engine, "SELECT id, name FROM t ORDER BY id").1;
+
+        // Online backup while the engine is live.
+        let summary = engine
+            .storage()
+            .backup_full(&bak)
+            .expect("online full backup");
+        assert!(summary.pages_copied > 0, "the backup copied data pages");
+        assert!(
+            summary.backup_end_lsn >= summary.redo_start_lsn,
+            "the log bracket is well-formed"
+        );
+        drop(engine);
+
+        // Offline restore into a fresh file, then open it and compare.
+        Storage::restore_full(&restored, &bak).expect("offline restore");
+        let engine2 = Engine::new(Storage::open(restored.clone()).expect("open restored"))
+            .expect("engine on restored file");
+
+        assert_eq!(
+            sql_rows(&engine2, "SELECT id, name FROM t ORDER BY id").1,
+            expected_t,
+            "table t round-trips row-for-row"
+        );
+        assert_eq!(
+            sql_rows(&engine2, "SELECT k, v FROM u ORDER BY k").1,
+            vec![
+                vec![Some("1".into()), Some("10".into())],
+                vec![Some("2".into()), Some("20".into())],
+            ],
+            "table u round-trips"
+        );
+        // The secondary index round-trips: a seek by name finds the row.
+        assert_eq!(
+            sql_rows(&engine2, "SELECT id FROM t WHERE name = 'row150'").1,
+            vec![vec![Some("150".into())]],
+            "the secondary index is intact after restore"
+        );
+        // The catalog round-trips: further DML on the restored database works.
+        engine2
+            .execute("INSERT INTO u (k, v) VALUES (3, 30)")
+            .expect("insert into restored u");
+        assert_eq!(
+            sql_rows(&engine2, "SELECT v FROM u WHERE k = 3").1,
+            vec![vec![Some("30".into())]]
+        );
+        drop(engine2);
+
+        let _ = std::fs::remove_file(src);
+        let _ = std::fs::remove_file(bak);
+        let _ = std::fs::remove_file(restored);
     }
 
     /// Runs SQL expected to error and returns the SQL error message.

--- a/crates/truthdb-core/src/lib.rs
+++ b/crates/truthdb-core/src/lib.rs
@@ -1,5 +1,6 @@
 mod allocator;
 pub mod auth;
+pub mod backup;
 pub mod client_listener;
 mod direct_io;
 pub mod dispatcher;

--- a/crates/truthdb-core/src/storage.rs
+++ b/crates/truthdb-core/src/storage.rs
@@ -575,6 +575,129 @@ impl Storage {
         self.lock().wal_tail()
     }
 
+    /// Online full backup: writes a self-describing `TDBBAK1` file at `dst`
+    /// capturing the database as of a consistent recovery point.
+    ///
+    /// The copy is fuzzy: pages are read in bounded chunks, each under the
+    /// storage lock but releasing it between chunks so writers proceed. A
+    /// truncation hold pins the WAL at `redo_start` for the duration, and the
+    /// log `[redo_start, backup_end)` is shipped into the backup. `backup_end`
+    /// is captured *after* the page copy, so it is at least the latest-change
+    /// LSN of every page copied; ARIES redo therefore heals every page image —
+    /// however stale, or with a future change already baked in — to the single
+    /// `backup_end` point on restore, then undoes the transactions in flight
+    /// there. `dst` is created; an existing file is truncated.
+    pub fn backup_full(&self, dst: &Path) -> Result<crate::backup::BackupSummary, StorageError> {
+        let plan = self.lock().begin_backup(true, false)?;
+        // The hold must be released on every path: a stale hold freezes WAL
+        // truncation for the life of the process.
+        let result = self.write_backup(dst, &plan);
+        self.lock().release_backup_hold();
+        result
+    }
+
+    fn write_backup(
+        &self,
+        dst: &Path,
+        plan: &BackupPlan,
+    ) -> Result<crate::backup::BackupSummary, StorageError> {
+        use crate::backup::{BlockType, encode_alloc_map, encode_log_chunk, encode_page_run};
+        let file = std::fs::File::create(dst)?;
+        let mut writer =
+            crate::backup::BackupWriter::new(std::io::BufWriter::new(file), &plan.header())?;
+        writer.write_block(BlockType::AllocMap, &encode_alloc_map(&plan.runs))?;
+
+        let mut pages_copied = 0u64;
+        let mut buf = vec![0u8; BACKUP_CHUNK_PAGES as usize * PAGE_SIZE];
+        for &(run_start, run_count) in &plan.runs {
+            let mut page = run_start;
+            let end = run_start + run_count;
+            while page < end {
+                let chunk = (end - page).min(BACKUP_CHUNK_PAGES);
+                let bytes = &mut buf[..chunk as usize * PAGE_SIZE];
+                self.lock()
+                    .read_pages_for_backup(page, chunk, bytes, plan.checksum)?;
+                writer.write_block(BlockType::PageData, &encode_page_run(page, bytes))?;
+                pages_copied += chunk;
+                page += chunk;
+            }
+        }
+
+        let (backup_end, log) = self.lock().ship_backup_log(plan.redo_start)?;
+        writer.write_block(
+            BlockType::LogChunk,
+            &encode_log_chunk(plan.redo_start, &log),
+        )?;
+        writer.finish()?;
+        Ok(crate::backup::BackupSummary {
+            redo_start_lsn: plan.redo_start,
+            backup_end_lsn: backup_end,
+            pages_copied,
+            log_bytes: log.len() as u64,
+            finished_at_millis: plan.finished_at_millis,
+        })
+    }
+
+    /// Offline restore: rebuilds a fresh database file at `dst_path` from the
+    /// `TDBBAK1` backup at `bak_path`, then opens it once to run ARIES recovery,
+    /// validating that the restored file is recoverable. `dst_path` must not
+    /// already exist.
+    pub fn restore_full(dst_path: &Path, bak_path: &Path) -> Result<(), StorageError> {
+        use crate::backup::{BlockType, decode_alloc_map, decode_log_chunk, decode_page_run};
+        assert_layout_invariants();
+        let reader = std::io::BufReader::new(std::fs::File::open(bak_path)?);
+        let (mut backup, header) = crate::backup::BackupReader::new(reader)?;
+        if header.page_size as usize != PAGE_SIZE {
+            return Err(StorageError::InvalidFile(
+                "backup page size mismatch".to_string(),
+            ));
+        }
+        let layout = layout_from_backup_header(&header);
+        let mut file = StorageFile::create_from_layout(
+            dst_path.to_path_buf(),
+            layout,
+            header.default_collation.clone(),
+        )?;
+
+        let mut runs: Vec<(u64, u64)> = Vec::new();
+        let mut log: Option<(u64, Vec<u8>)> = None;
+        while let Some((block_type, payload)) = backup.next_block()? {
+            match block_type {
+                BlockType::AllocMap => runs = decode_alloc_map(&payload)?,
+                BlockType::PageData => {
+                    let (start, count, bytes) = decode_page_run(&payload)?;
+                    file.restore_pages(start, count, bytes)?;
+                }
+                BlockType::LogChunk => {
+                    let (start_lsn, bytes) = decode_log_chunk(&payload)?;
+                    // One chunk today; multiple must be emitted contiguously in
+                    // LSN order so appending reconstructs the range.
+                    match &mut log {
+                        Some((_, acc)) => acc.extend_from_slice(bytes),
+                        None => log = Some((start_lsn, bytes.to_vec())),
+                    }
+                }
+                BlockType::Header | BlockType::Trailer => {}
+            }
+        }
+
+        file.restore_allocator_bitmap(&runs)?;
+        let backup_end = match &log {
+            Some((start_lsn, bytes)) => file.seed_ring(*start_lsn, bytes)?,
+            None => header.redo_start_lsn,
+        };
+        file.restore_superblock(&header, backup_end)?;
+        file.sync_file()?;
+        drop(file);
+
+        // Validate: opening reruns allocator recovery + ARIES relational
+        // recovery over the seeded ring, failing loudly if the restored file is
+        // not recoverable.
+        let storage = Storage::open(dst_path.to_path_buf())?;
+        drop(storage);
+        Ok(())
+    }
+
     /// Wedges the relational store after a durability (fsync) failure so no
     /// further op serves state the log does not back. See `ensure_rel_usable`.
     pub(crate) fn wedge(&self) {
@@ -4302,12 +4425,25 @@ impl StorageFile {
         wal_max_bytes: u64,
     ) -> Result<Self, StorageError> {
         let layout = compute_layout(opts.clone(), wal_min_bytes, wal_max_bytes)?;
+        Self::create_from_layout(path, layout, opts.default_collation)
+    }
+
+    /// Creates a fresh file with an explicit layout. The restore path
+    /// reconstructs the source's exact region sizes from the backup header
+    /// rather than recomputing them from ratios, so it lays regions back
+    /// byte-for-byte. Mirrors [`Self::create_new`] from
+    /// `validate_allocator_region` onward.
+    fn create_from_layout(
+        path: PathBuf,
+        layout: StorageLayout,
+        default_collation: Option<String>,
+    ) -> Result<Self, StorageError> {
         validate_allocator_region(&layout)?;
         let mut header = FileHeader::default();
         // Stamp the database's default collation into the file. Every character
         // column declared without an explicit COLLATE is keyed under it, so it
         // belongs to the data, not to whatever the config says at the next boot.
-        if let Some(name) = opts.default_collation.as_deref() {
+        if let Some(name) = default_collation.as_deref() {
             header
                 .set_default_collation(name)
                 .map_err(StorageError::InvalidConfig)?;
@@ -4799,14 +4935,11 @@ impl StorageFile {
     /// Registers an in-progress backup's `redo_start_lsn` as a truncation hold,
     /// so a concurrent checkpoint cannot reclaim log the backup still has to ship.
     /// Paired with [`Self::release_backup_hold`].
-    // `backup_full` (the next Stage 17 slice) is the caller.
-    #[allow(dead_code)]
     fn register_backup_hold(&mut self, redo_start_lsn: u64) {
         self.truncation_gate.backup = Some(redo_start_lsn);
     }
 
     /// Releases the backup truncation hold (the backup finished or failed).
-    #[allow(dead_code)]
     fn release_backup_hold(&mut self) {
         self.truncation_gate.backup = None;
     }
@@ -4973,6 +5106,225 @@ impl StorageFile {
         let offset = self.layout.data_offset + page * PAGE_SIZE as u64;
         self.file.read_page_into(offset, &mut frame)?;
         out.copy_from_slice(frame.as_slice());
+        Ok(())
+    }
+
+    // --- Backup / restore (Stage 17) ---
+
+    /// Captures a backup plan under the storage lock and registers the WAL
+    /// truncation hold. The caller MUST release the hold (via
+    /// [`Self::release_backup_hold`]) on every exit path once the backup
+    /// finishes or fails.
+    fn begin_backup(
+        &mut self,
+        checksum: bool,
+        copy_only: bool,
+    ) -> Result<BackupPlan, StorageError> {
+        self.ensure_rel_usable()?;
+        let redo_start = self.wal.head();
+        self.register_backup_hold(redo_start);
+
+        // The active superblock is the checkpoint whose head is redo_start, so
+        // its roots are the checkpoint-consistent state recovery redoes onto.
+        let (metadata_root, last_committed_seq, db_options) = {
+            let active = match self.active_superblock {
+                ActiveSuperblock::A => &self.superblock_a,
+                ActiveSuperblock::B => &self.superblock_b,
+            };
+            debug_assert_eq!(
+                redo_start, active.wal_head,
+                "redo_start must equal the active checkpoint's wal_head"
+            );
+            (
+                active.metadata_root,
+                active.last_committed_seq,
+                active.db_options(),
+            )
+        };
+
+        let mut runs = self.allocator.allocated_runs();
+        // The search-snapshot extent is a durable allocation (so allocated_runs
+        // includes it) but holds raw, non-page-formatted bytes. This slice does
+        // not preserve the search snapshot (Stage 19 retires it), so drop its
+        // extent from the backup rather than copy pages that would fail checksum
+        // verification and dangle unreferenced on restore.
+        if let Some(desc) = self.load_active_snapshot_descriptor()? {
+            let (start, pages) = self.descriptor_page_range(&desc)?;
+            runs = subtract_run(runs, start, pages);
+        }
+
+        Ok(BackupPlan {
+            layout: self.layout,
+            default_collation: self.default_collation.clone(),
+            redo_start,
+            metadata_root,
+            last_committed_seq,
+            db_options,
+            runs,
+            checksum,
+            copy_only,
+            finished_at_millis: now_millis(),
+        })
+    }
+
+    /// Reads `count` data pages starting at `start_page` into `out`, verifying
+    /// each page's checksum unless `checksum` is off (an all-zero page is an
+    /// unwritten allocation and always passes).
+    fn read_pages_for_backup(
+        &mut self,
+        start_page: u64,
+        count: u64,
+        out: &mut [u8],
+        checksum: bool,
+    ) -> Result<(), StorageError> {
+        debug_assert_eq!(out.len(), count as usize * PAGE_SIZE);
+        for i in 0..count as usize {
+            let page = start_page + i as u64;
+            let slot = &mut out[i * PAGE_SIZE..(i + 1) * PAGE_SIZE];
+            self.spill_read_page(page, slot)?;
+            if checksum
+                && !crate::relstore::page::is_zero_page(slot)
+                && !crate::relstore::page::verify_checksum(slot)
+            {
+                return Err(StorageError::InvalidFile(format!(
+                    "backup aborted: data page {page} failed checksum (corrupt source page)"
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    /// Forces the log durable, captures `backup_end = tail`, and returns the raw
+    /// ring bytes for `[redo_start, backup_end)`. The physical copy handles the
+    /// ring wrap; the range never exceeds one ring lap (the truncation hold
+    /// keeps `tail - head <= wal_size`).
+    fn ship_backup_log(&mut self, redo_start: u64) -> Result<(u64, Vec<u8>), StorageError> {
+        self.wal.sync_all()?;
+        let backup_end = self.wal.tail();
+        debug_assert!(backup_end >= redo_start);
+        let len = backup_end - redo_start;
+        if len > self.layout.wal_size {
+            return Err(StorageError::WalFull(
+                "backup log range exceeds the WAL ring size".to_string(),
+            ));
+        }
+        let mut out = vec![0u8; len as usize];
+        if len > 0 {
+            let wal_offset = self.layout.wal_offset;
+            let wal_size = self.layout.wal_size;
+            let start_phys = redo_start % wal_size;
+            let first = ((wal_size - start_phys).min(len)) as usize;
+            self.wal
+                .file_mut()
+                .read_exact_at(wal_offset + start_phys, &mut out[..first])?;
+            if first < out.len() {
+                self.wal
+                    .file_mut()
+                    .read_exact_at(wal_offset, &mut out[first..])?;
+            }
+        }
+        Ok((backup_end, out))
+    }
+
+    /// Lays a run of page images back at their page numbers (restore).
+    fn restore_pages(
+        &mut self,
+        start_page: u64,
+        count: u64,
+        bytes: &[u8],
+    ) -> Result<(), StorageError> {
+        debug_assert_eq!(bytes.len(), count as usize * PAGE_SIZE);
+        for i in 0..count as usize {
+            let page = start_page + i as u64;
+            self.spill_write_page(page, &bytes[i * PAGE_SIZE..(i + 1) * PAGE_SIZE])?;
+        }
+        Ok(())
+    }
+
+    /// Rebuilds and persists the allocation bitmap from the shipped run list
+    /// (restore).
+    fn restore_allocator_bitmap(&mut self, runs: &[(u64, u64)]) -> Result<(), StorageError> {
+        let mut allocator = PageAllocator::new(self.layout.data_size);
+        for &(start, count) in runs {
+            allocator.mark_used(start, count);
+        }
+        let bitmap = allocator.persistable_bitmap();
+        if bitmap.len() as u64 > self.layout.allocator_size {
+            return Err(StorageError::InvalidFile(
+                "restored allocator bitmap exceeds allocator region".to_string(),
+            ));
+        }
+        self.file
+            .write_all_at(self.layout.allocator_offset, &bitmap)?;
+        self.allocator = allocator;
+        Ok(())
+    }
+
+    /// Writes the shipped WAL bytes into the ring at their physical positions,
+    /// handling the ring wrap (restore). Returns `start_lsn + bytes.len()`, the
+    /// restored `backup_end`.
+    fn seed_ring(&mut self, start_lsn: u64, bytes: &[u8]) -> Result<u64, StorageError> {
+        let wal_size = self.layout.wal_size;
+        if bytes.len() as u64 > wal_size {
+            return Err(StorageError::WalFull(
+                "restored log exceeds the WAL ring size".to_string(),
+            ));
+        }
+        if !bytes.is_empty() {
+            let wal_offset = self.layout.wal_offset;
+            let start_phys = start_lsn % wal_size;
+            let first = ((wal_size - start_phys) as usize).min(bytes.len());
+            self.file
+                .write_all_at(wal_offset + start_phys, &bytes[..first])?;
+            if first < bytes.len() {
+                self.file.write_all_at(wal_offset, &bytes[first..])?;
+            }
+        }
+        Ok(start_lsn + bytes.len() as u64)
+    }
+
+    /// Writes the restored superblock: the source's catalog root and options as
+    /// of `redo_start`, the ring bracketed at `[redo_start, backup_end)`. Slot A
+    /// is active; slot B is a valid lower-generation mirror. The search-related
+    /// roots are cleared — this slice does not restore the search snapshot.
+    fn restore_superblock(
+        &mut self,
+        header: &crate::backup::BackupHeader,
+        backup_end: u64,
+    ) -> Result<(), StorageError> {
+        let mut base = Superblock {
+            wal_head: header.redo_start_lsn,
+            wal_tail: backup_end,
+            last_committed_seq: header.last_committed_seq,
+            metadata_root: header.metadata_root,
+            ..Superblock::default()
+        };
+        base.set_db_options(header.db_options);
+
+        let mut a = base;
+        a.generation = 1;
+        a.active = SUPERBLOCK_ACTIVE_A;
+        a.checksum = a.compute_checksum();
+
+        let mut b = base;
+        b.generation = 0;
+        b.active = SUPERBLOCK_ACTIVE_B;
+        b.checksum = b.compute_checksum();
+
+        self.file.write_all_at(
+            self.layout.superblock_a_offset,
+            &a.to_le_bytes_with_checksum(),
+        )?;
+        self.file.write_all_at(
+            self.layout.superblock_b_offset,
+            &b.to_le_bytes_with_checksum(),
+        )?;
+        Ok(())
+    }
+
+    /// Fsyncs the restored file's data handle.
+    fn sync_file(&mut self) -> Result<(), StorageError> {
+        self.file.sync_data()?;
         Ok(())
     }
 
@@ -5585,6 +5937,109 @@ fn compute_layout(
         reserved_offset,
         reserved_size,
     })
+}
+
+/// Pages copied per storage-lock acquisition during a backup (1 MiB at 4 KiB
+/// pages): bounds both the lock hold and the in-flight copy buffer.
+const BACKUP_CHUNK_PAGES: u64 = 256;
+
+/// Everything captured under the storage lock at the start of a backup, so the
+/// bulk page copy can proceed while releasing the lock between chunks.
+struct BackupPlan {
+    layout: StorageLayout,
+    default_collation: Option<String>,
+    redo_start: u64,
+    metadata_root: u64,
+    last_committed_seq: u64,
+    db_options: u8,
+    runs: Vec<(u64, u64)>,
+    checksum: bool,
+    copy_only: bool,
+    finished_at_millis: u64,
+}
+
+impl BackupPlan {
+    fn header(&self) -> crate::backup::BackupHeader {
+        crate::backup::BackupHeader {
+            format_version: crate::backup::FORMAT_VERSION,
+            page_size: PAGE_SIZE as u32,
+            total_size: self.layout.total_size,
+            wal_size: self.layout.wal_size,
+            data_size: self.layout.data_size,
+            metadata_size: self.layout.metadata_size,
+            allocator_size: self.layout.allocator_size,
+            snapshot_size: self.layout.snapshot_size,
+            reserved_size: self.layout.reserved_size,
+            default_collation: self.default_collation.clone(),
+            redo_start_lsn: self.redo_start,
+            metadata_root: self.metadata_root,
+            last_committed_seq: self.last_committed_seq,
+            db_options: self.db_options,
+            finished_at_millis: self.finished_at_millis,
+            flags: crate::backup::BackupFlags {
+                checksum: self.checksum,
+                copy_only: self.copy_only,
+            },
+        }
+    }
+}
+
+fn now_millis() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// Rebuilds a [`StorageLayout`] from a backup header's region sizes. The
+/// offsets follow the fixed region order (see [`compute_layout`]).
+fn layout_from_backup_header(header: &crate::backup::BackupHeader) -> StorageLayout {
+    let page = PAGE_SIZE as u64;
+    let wal_offset = page * 3;
+    let data_offset = wal_offset + header.wal_size;
+    let metadata_offset = data_offset + header.data_size;
+    let allocator_offset = metadata_offset + header.metadata_size;
+    let snapshot_offset = allocator_offset + header.allocator_size;
+    let reserved_offset = snapshot_offset + header.snapshot_size;
+    StorageLayout {
+        total_size: header.total_size,
+        header_offset: 0,
+        superblock_a_offset: page,
+        superblock_b_offset: page * 2,
+        wal_offset,
+        wal_size: header.wal_size,
+        data_offset,
+        data_size: header.data_size,
+        metadata_offset,
+        metadata_size: header.metadata_size,
+        allocator_offset,
+        allocator_size: header.allocator_size,
+        snapshot_offset,
+        snapshot_size: header.snapshot_size,
+        reserved_offset,
+        reserved_size: header.reserved_size,
+    }
+}
+
+/// Removes the page range `[start, start + len)` from a set of ascending,
+/// disjoint allocated runs, splitting a run that straddles it.
+fn subtract_run(runs: Vec<(u64, u64)>, start: u64, len: u64) -> Vec<(u64, u64)> {
+    let cut_end = start + len;
+    let mut out = Vec::with_capacity(runs.len());
+    for (run_start, run_count) in runs {
+        let run_end = run_start + run_count;
+        if run_end <= start || run_start >= cut_end {
+            out.push((run_start, run_count)); // disjoint
+            continue;
+        }
+        if run_start < start {
+            out.push((run_start, start - run_start)); // left remainder
+        }
+        if run_end > cut_end {
+            out.push((cut_end, run_end - cut_end)); // right remainder
+        }
+    }
+    out
 }
 
 #[cfg(test)]

--- a/crates/truthdb-core/src/storage.rs
+++ b/crates/truthdb-core/src/storage.rs
@@ -257,6 +257,11 @@ pub enum StorageError {
     /// Maps to SQL Server's 3961.
     #[error("schema of '{0}' changed under the snapshot")]
     SnapshotSchemaChange(String),
+
+    /// A full backup was requested while one is already running. Only one
+    /// backup may hold the WAL truncation gate's single backup slot at a time.
+    #[error("a backup is already in progress")]
+    BackupInProgress,
 }
 
 /// Thread-safe handle to the storage engine. All mutable state lives in a
@@ -589,11 +594,11 @@ impl Storage {
     /// there. `dst` is created; an existing file is truncated.
     pub fn backup_full(&self, dst: &Path) -> Result<crate::backup::BackupSummary, StorageError> {
         let plan = self.lock().begin_backup(true, false)?;
-        // The hold must be released on every path: a stale hold freezes WAL
-        // truncation for the life of the process.
-        let result = self.write_backup(dst, &plan);
-        self.lock().release_backup_hold();
-        result
+        // Release the hold on EVERY exit — normal return, an early `?` error out
+        // of write_backup, or an unwind — via the guard's Drop. A leaked hold
+        // permanently freezes WAL truncation and eventually wedges writes.
+        let _hold = BackupHoldGuard { storage: self };
+        self.write_backup(dst, &plan)
     }
 
     fn write_backup(
@@ -653,6 +658,19 @@ impl Storage {
             ));
         }
         let layout = layout_from_backup_header(&header);
+        // The header is only integrity-checked (xxh64), not authenticated, so a
+        // tampered-but-valid backup could carry inconsistent sizes or drive
+        // writes outside the data region. Reject a header whose regions do not
+        // tile the file exactly before creating anything (a bogus total_size
+        // would otherwise `set_len` a huge sparse file).
+        if layout.reserved_offset.checked_add(layout.reserved_size) != Some(layout.total_size)
+            || layout.data_size == 0
+        {
+            return Err(StorageError::InvalidFile(
+                "backup header region sizes are inconsistent".to_string(),
+            ));
+        }
+        let data_pages = header.data_size / PAGE_SIZE as u64;
         let mut file = StorageFile::create_from_layout(
             dst_path.to_path_buf(),
             layout,
@@ -663,17 +681,39 @@ impl Storage {
         let mut log: Option<(u64, Vec<u8>)> = None;
         while let Some((block_type, payload)) = backup.next_block()? {
             match block_type {
-                BlockType::AllocMap => runs = decode_alloc_map(&payload)?,
+                BlockType::AllocMap => {
+                    runs = decode_alloc_map(&payload)?;
+                    for &(start, count) in &runs {
+                        if start.checked_add(count).is_none_or(|end| end > data_pages) {
+                            return Err(StorageError::InvalidFile(
+                                "backup allocation run is outside the data region".to_string(),
+                            ));
+                        }
+                    }
+                }
                 BlockType::PageData => {
                     let (start, count, bytes) = decode_page_run(&payload)?;
+                    if start.checked_add(count).is_none_or(|end| end > data_pages) {
+                        return Err(StorageError::InvalidFile(
+                            "backup page run is outside the data region".to_string(),
+                        ));
+                    }
                     file.restore_pages(start, count, bytes)?;
                 }
                 BlockType::LogChunk => {
                     let (start_lsn, bytes) = decode_log_chunk(&payload)?;
-                    // One chunk today; multiple must be emitted contiguously in
-                    // LSN order so appending reconstructs the range.
+                    // One chunk today; a future split emitter must produce them
+                    // contiguously in LSN order — enforce it so a gap or a
+                    // reorder fails loudly rather than seeding a wrong range.
                     match &mut log {
-                        Some((_, acc)) => acc.extend_from_slice(bytes),
+                        Some((first_start, acc)) => {
+                            if start_lsn != *first_start + acc.len() as u64 {
+                                return Err(StorageError::InvalidFile(
+                                    "backup log chunks are not contiguous".to_string(),
+                                ));
+                            }
+                            acc.extend_from_slice(bytes);
+                        }
                         None => log = Some((start_lsn, bytes.to_vec())),
                     }
                 }
@@ -5111,18 +5151,24 @@ impl StorageFile {
 
     // --- Backup / restore (Stage 17) ---
 
-    /// Captures a backup plan under the storage lock and registers the WAL
-    /// truncation hold. The caller MUST release the hold (via
-    /// [`Self::release_backup_hold`]) on every exit path once the backup
-    /// finishes or fails.
+    /// Captures a backup plan under the storage lock, rejecting a second
+    /// concurrent backup, and registers the WAL truncation hold LAST (after all
+    /// fallible work) so a failure here leaves no stale hold. On success the
+    /// caller arms a [`BackupHoldGuard`] to release the hold on every exit.
     fn begin_backup(
         &mut self,
         checksum: bool,
         copy_only: bool,
     ) -> Result<BackupPlan, StorageError> {
         self.ensure_rel_usable()?;
+        // Single-flight: the gate has one backup hold slot. A second concurrent
+        // backup would overwrite the first's hold (and its release would clear
+        // the survivor's), leaving a backup with a wrong or absent truncation
+        // floor — a silently truncated restore. Reject it.
+        if self.truncation_gate.backup.is_some() {
+            return Err(StorageError::BackupInProgress);
+        }
         let redo_start = self.wal.head();
-        self.register_backup_hold(redo_start);
 
         // The active superblock is the checkpoint whose head is redo_start, so
         // its roots are the checkpoint-consistent state recovery redoes onto.
@@ -5153,6 +5199,11 @@ impl StorageFile {
             runs = subtract_run(runs, start, pages);
         }
 
+        // Register the hold LAST, after every fallible step above: a failure
+        // here must leave no stale hold behind (a leaked hold freezes WAL
+        // truncation for the life of the process). We are still under the same
+        // lock, so redo_start is unchanged.
+        self.register_backup_hold(redo_start);
         Ok(BackupPlan {
             layout: self.layout,
             default_collation: self.default_collation.clone(),
@@ -5185,6 +5236,7 @@ impl StorageFile {
             if checksum
                 && !crate::relstore::page::is_zero_page(slot)
                 && !crate::relstore::page::verify_checksum(slot)
+                && self.page_is_live_regular(page)?
             {
                 return Err(StorageError::InvalidFile(format!(
                     "backup aborted: data page {page} failed checksum (corrupt source page)"
@@ -5192,6 +5244,25 @@ impl StorageFile {
             }
         }
         Ok(())
+    }
+
+    /// True iff `page` is still a live, page-formatted data page — so a checksum
+    /// failure genuinely means source corruption. A page that has been freed
+    /// since the backup began, or reused as the raw (non-page-formatted)
+    /// search-snapshot extent by a between-chunk checkpoint, legitimately fails
+    /// page-checksum verification and is NOT corrupt: on restore its stale
+    /// image is irrelevant because redo frees or overwrites it.
+    fn page_is_live_regular(&mut self, page: u64) -> Result<bool, StorageError> {
+        if !self.allocator.is_allocated(page) {
+            return Ok(false); // freed since the backup began
+        }
+        if let Some(desc) = self.load_active_snapshot_descriptor()? {
+            let (start, pages) = self.descriptor_page_range(&desc)?;
+            if page >= start && page < start + pages {
+                return Ok(false); // reused as the raw snapshot extent
+            }
+        }
+        Ok(true)
     }
 
     /// Forces the log durable, captures `backup_end = tail`, and returns the raw
@@ -5203,9 +5274,18 @@ impl StorageFile {
         let backup_end = self.wal.tail();
         debug_assert!(backup_end >= redo_start);
         let len = backup_end - redo_start;
-        if len > self.layout.wal_size {
+        // Cap the shipped range so the restored ring leaves the reserve free:
+        // restore's undo pass appends its own compensation records into that
+        // reserve. Because head is pinned at redo_start for the whole backup,
+        // a rollback storm can push the tail into the reserve (forward appends
+        // stop short of it, but undo CLRs use it), which would otherwise yield
+        // a backup that fails only at restore time. Fail cleanly here instead.
+        let max_len = self.layout.wal_size.saturating_sub(self.wal.reserve());
+        if len > max_len {
             return Err(StorageError::WalFull(
-                "backup log range exceeds the WAL ring size".to_string(),
+                "backup log range fills the WAL reserve (ring under pressure); \
+                 checkpoint and retry the backup"
+                    .to_string(),
             ));
         }
         let mut out = vec![0u8; len as usize];
@@ -5943,6 +6023,19 @@ fn compute_layout(
 /// pages): bounds both the lock hold and the in-flight copy buffer.
 const BACKUP_CHUNK_PAGES: u64 = 256;
 
+/// Releases the WAL truncation hold registered by `begin_backup` when the
+/// backup ends — on every path, including an early error return or a panic
+/// unwind. A leaked hold freezes WAL truncation for the life of the process.
+struct BackupHoldGuard<'a> {
+    storage: &'a Storage,
+}
+
+impl Drop for BackupHoldGuard<'_> {
+    fn drop(&mut self) {
+        self.storage.lock().release_backup_hold();
+    }
+}
+
 /// Everything captured under the storage lock at the start of a backup, so the
 /// bulk page copy can proceed while releasing the lock between chunks.
 struct BackupPlan {
@@ -6066,6 +6159,66 @@ mod tests {
             reserved_ratio: 0.17,
             default_collation: None,
         }
+    }
+
+    #[test]
+    fn backup_is_single_flight_and_releases_its_hold() {
+        let path = unique_temp_path("backup-hold");
+        let bak = unique_temp_path("backup-hold-bak");
+        let bak2 = unique_temp_path("backup-hold-bak2");
+        let storage = Storage::create(path.clone(), test_storage_options()).expect("create");
+
+        // A second backup while a hold is set is rejected, and — critically —
+        // must NOT clear the in-flight backup's hold (the guard arms only after
+        // begin_backup succeeds, so a rejected backup touches nothing).
+        storage.lock().register_backup_hold(42);
+        assert!(matches!(
+            storage.backup_full(&bak),
+            Err(StorageError::BackupInProgress)
+        ));
+        assert_eq!(
+            storage.lock().truncation_gate.backup,
+            Some(42),
+            "a rejected backup leaves the existing hold intact"
+        );
+        storage.lock().release_backup_hold();
+
+        // A successful backup releases its own hold, so a second one succeeds.
+        storage.backup_full(&bak).expect("first backup");
+        assert_eq!(
+            storage.lock().truncation_gate.backup,
+            None,
+            "the hold is released after a successful backup"
+        );
+        storage
+            .backup_full(&bak2)
+            .expect("second backup after release");
+
+        drop(storage);
+        let _ = std::fs::remove_file(path);
+        let _ = std::fs::remove_file(bak);
+        let _ = std::fs::remove_file(bak2);
+    }
+
+    #[test]
+    fn a_page_freed_since_the_backup_began_is_not_treated_as_corrupt() {
+        let path = unique_temp_path("backup-freed");
+        let storage = Storage::create(path.clone(), test_storage_options()).expect("create");
+        {
+            let mut file = storage.lock();
+            let page = file.allocator.allocate(1).expect("allocate a page");
+            assert!(
+                file.page_is_live_regular(page).unwrap(),
+                "a live, allocated data page is regular (a checksum failure there is real corruption)"
+            );
+            file.allocator.free(page, 1);
+            assert!(
+                !file.page_is_live_regular(page).unwrap(),
+                "a page freed since the backup began is tolerated, not flagged corrupt"
+            );
+        }
+        drop(storage);
+        let _ = std::fs::remove_file(path);
     }
 
     /// ALTER TABLE ADD survives a restart — the widened schema and the frozen

--- a/crates/truthdb-core/src/storage.rs
+++ b/crates/truthdb-core/src/storage.rs
@@ -1616,12 +1616,37 @@ pub struct SnapshotData {
     pub next_doc_id: u64,
 }
 
+/// Holds that pin the WAL ring's truncation floor below what a checkpoint would
+/// otherwise reclaim, so a subsystem that still needs a stretch of log keeps it.
+/// The floor is `min` over all active holds; the active-transaction hold (the
+/// oldest open `BEGIN` LSN) is computed separately from `active_txn_begins` and
+/// combined in [`StorageFile::checkpoint_wal_head`]. Built for Stage 17 backup
+/// and reused by Stage 18 replication slots.
+#[derive(Debug, Default)]
+struct LogTruncationGate {
+    /// An in-progress full backup's `redo_start_lsn` — the log it must ship
+    /// before the ring can reclaim it. `None` when no backup is running.
+    backup: Option<u64>,
+    // Later: `log_backup` (FULL recovery model, Stage 17 slice 2) and
+    // `repl_slots` (Stage 18) join the same `min`.
+}
+
+impl LogTruncationGate {
+    /// The lowest LSN any hold pins, or `None` if no hold is registered.
+    fn min_hold(&self) -> Option<u64> {
+        self.backup
+    }
+}
+
 struct StorageFile {
     /// Handle for data-region, superblock and descriptor I/O.
     file: DirectFile,
     /// WAL writer with its own dedicated file handle, so log writes do not
     /// serialize behind page flushes.
     wal: WalWriter,
+    /// Holds that keep the WAL ring from truncating log a backup (or, later, a
+    /// replication slot) still needs.
+    truncation_gate: LogTruncationGate,
     layout: StorageLayout,
     superblock_a: Superblock,
     superblock_b: Superblock,
@@ -4235,6 +4260,7 @@ impl StorageFile {
             default_collation: header.default_collation(),
             file,
             wal,
+            truncation_gate: LogTruncationGate::default(),
             layout,
             superblock_a,
             superblock_b,
@@ -4327,6 +4353,7 @@ impl StorageFile {
             default_collation: header.default_collation(),
             file,
             wal,
+            truncation_gate: LogTruncationGate::default(),
             layout,
             superblock_a,
             superblock_b,
@@ -4755,12 +4782,33 @@ impl StorageFile {
     /// The WAL LSN a checkpoint may truncate up to: the oldest open transaction's
     /// BEGIN LSN (so its undo records survive), or the WAL tail if none is open.
     fn checkpoint_wal_head(&self) -> u64 {
-        self.rel
-            .active_txn_begins
-            .values()
-            .min()
-            .copied()
-            .map_or(self.wal.tail(), |oldest| oldest.min(self.wal.tail()))
+        // The floor is the min over every truncation hold, clamped to the tail:
+        // the oldest open transaction's BEGIN (so its undo survives a crash), and
+        // any gate hold (an in-progress backup's redo_start_lsn, later also log
+        // backup and replication slots). A checkpoint never truncates past this.
+        let mut floor = self.wal.tail();
+        if let Some(oldest_txn) = self.rel.active_txn_begins.values().min().copied() {
+            floor = floor.min(oldest_txn);
+        }
+        if let Some(hold) = self.truncation_gate.min_hold() {
+            floor = floor.min(hold);
+        }
+        floor
+    }
+
+    /// Registers an in-progress backup's `redo_start_lsn` as a truncation hold,
+    /// so a concurrent checkpoint cannot reclaim log the backup still has to ship.
+    /// Paired with [`Self::release_backup_hold`].
+    // `backup_full` (the next Stage 17 slice) is the caller.
+    #[allow(dead_code)]
+    fn register_backup_hold(&mut self, redo_start_lsn: u64) {
+        self.truncation_gate.backup = Some(redo_start_lsn);
+    }
+
+    /// Releases the backup truncation hold (the backup finished or failed).
+    #[allow(dead_code)]
+    fn release_backup_hold(&mut self) {
+        self.truncation_gate.backup = None;
     }
 
     fn ensure_rel_usable(&self) -> Result<(), StorageError> {

--- a/crates/truthdb-core/src/wal/mod.rs
+++ b/crates/truthdb-core/src/wal/mod.rs
@@ -148,6 +148,14 @@ impl WalWriter {
         self.flushed
     }
 
+    /// Ring bytes reserved for compensation records (rollback and recovery
+    /// undo). Forward appends stop `reserve` bytes short of a full ring so undo
+    /// always has room; a backup uses this to keep the shipped log range small
+    /// enough that a restore's undo pass still fits.
+    pub fn reserve(&self) -> u64 {
+        self.reserve
+    }
+
     /// Makes the log durable at least up to and including the record that
     /// STARTS at `lsn` (page writes always happen at append time; this only
     /// issues the missing fsync). `flushed` counts covered bytes, so a


### PR DESCRIPTION
First slice of Stage 17 (backup & restore): the crash-critical core, `Storage::backup_full` + `Storage::restore_full`, with a working round-trip. No SQL/CLI surface yet (that is slice 1b).

## What it does
- **`backup_full(dst)`** — online, fuzzy full backup to a self-describing `TDBBAK1` file. Captures `redo_start = wal.head()`, registers a WAL truncation hold, copies the allocated data pages in bounded chunks (releasing the storage lock between chunks so writers proceed), checksum-verifies each page, forces the log durable and captures `backup_end = wal.tail()` **after** the copy, then ships the raw ring bytes for `[redo_start, backup_end)`.
- **`restore_full(dst, bak)`** — offline rebuild: reconstruct the exact layout from the header's region sizes, lay the page images back, rebuild the allocator bitmap, seed the ring with the shipped log (wrap-aware), write a superblock carrying the source's catalog root + options bracketed at `[redo_start, backup_end)`, then reuse the existing `recover_allocator` + `recover_rel` (via `Storage::open`) to run ARIES recovery.

## Why it's correct (fuzzy consistency)
Because `backup_end` is captured after the page copy, it is at least the latest-change LSN of every page copied. ARIES redo is page-LSN-gated, so replaying `[redo_start, backup_end)` heals every page image — however stale, or with a future change already baked in — to the single `backup_end` state; undo then removes transactions in flight there. This is exactly ARIES restore from a fuzzy page image + log.

## Review
Three adversarial review passes confirmed the fuzzy-copy/ARIES core sound (page-LSN < backup_end proven; wrap math correct; no committed-write loss; restore layout byte-identical; double-open recovery idempotent). Six defects found and fixed — see the second commit: concurrent-backup hold collision (now single-flight), hold leak on setup failure (register last), panic-unsafe release (RAII guard), spurious checksum abort on since-freed pages, restore-undo `WalFull` on a full ring (cap the range + fail clean), and tampered-backup bounds checks.

## Tests
- Online backup of a live engine (two tables, 200 rows, a secondary index) → offline restore → data round-trips row-for-row, the index seeks, DML works on the restored file.
- TDBBAK1 format/codec unit tests; single-flight + hold-release; freed-page tolerance.
- Full workspace suite green; fmt + clippy `-D warnings` clean.

## Deferred to later slices
Slice 1b: `BACKUP DATABASE` T-SQL + offline CLI `restore` + `sys.backupset`. Slice 2: recovery models + `BACKUP LOG` + PITR. Slice 3: backup-under-write-load / kill-mid-backup exit matrices, buffer-pool torn-read fallback. The search-snapshot extent is excluded from the backup (raw bytes; Stage 19 retires it), so relational data round-trips cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)