### PR TITLE
Stage 17 slice 2a-i: recovery model FULL/SIMPLE

### DIFF
--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -1959,6 +1959,48 @@ mod tests {
         let _ = std::fs::remove_file(path);
     }
 
+    #[test]
+    fn recovery_model_sets_persists_and_reports() {
+        let path = unique_temp_path("recovery-model");
+        let engine = new_engine(&path);
+        let model = |e: &Engine| sql_rows(e, "SELECT recovery_model_desc FROM sys.databases").1;
+
+        // SIMPLE is the default.
+        assert_eq!(model(&engine), vec![vec![Some("SIMPLE".into())]]);
+
+        engine
+            .execute("ALTER DATABASE CURRENT SET RECOVERY FULL")
+            .expect("set full");
+        assert_eq!(model(&engine), vec![vec![Some("FULL".into())]]);
+
+        // An unrelated option in the same statement family leaves it untouched.
+        engine
+            .execute("ALTER DATABASE CURRENT SET READ_COMMITTED_SNAPSHOT ON")
+            .expect("rcsi on");
+        assert_eq!(model(&engine), vec![vec![Some("FULL".into())]]);
+        drop(engine);
+
+        // FULL persists across a reopen (the set is itself durable).
+        let engine2 = Engine::new(Storage::open(path.clone()).expect("reopen")).expect("engine");
+        assert_eq!(model(&engine2), vec![vec![Some("FULL".into())]]);
+        assert_eq!(
+            sql_rows(
+                &engine2,
+                "SELECT is_read_committed_snapshot_on FROM sys.databases"
+            )
+            .1,
+            vec![vec![Some("1".into())]],
+            "RCSI survived alongside the recovery model"
+        );
+
+        engine2
+            .execute("ALTER DATABASE CURRENT SET RECOVERY SIMPLE")
+            .expect("set simple");
+        assert_eq!(model(&engine2), vec![vec![Some("SIMPLE".into())]]);
+        drop(engine2);
+        let _ = std::fs::remove_file(path);
+    }
+
     /// Runs SQL expected to error and returns the SQL error message.
     fn sql_error_message(engine: &Engine, text: &str) -> String {
         let env = sql(engine, text);

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -6622,14 +6622,17 @@ fn exec_alter_database(
     }
     let mut rcsi = None;
     let mut allow_snapshot = None;
+    let mut recovery_full = None;
     for (option, on) in &alter.options {
         match option {
             DatabaseOption::ReadCommittedSnapshot => rcsi = Some(*on),
             DatabaseOption::AllowSnapshotIsolation => allow_snapshot = Some(*on),
+            // For Recovery the bool is the mode: true = FULL, false = SIMPLE.
+            DatabaseOption::Recovery => recovery_full = Some(*on),
         }
     }
     storage
-        .rel_set_db_options(rcsi, allow_snapshot)
+        .rel_set_db_options(rcsi, allow_snapshot, recovery_full)
         .map_err(|err| map_storage_err(err, &txn_ctx.database))?;
     Ok(StatementResult::Done)
 }
@@ -12354,7 +12357,14 @@ fn sys_databases(storage: &Storage, eval_ctx: &EvalContext) -> Source {
         Datum::NVarChar("SQL_Latin1_General_CP1_CI_AS".into()),
         Datum::NVarChar("MULTI_USER".into()),
         Datum::NVarChar("ONLINE".into()),
-        Datum::NVarChar("SIMPLE".into()),
+        Datum::NVarChar(
+            if storage.recovery_model_full() {
+                "FULL"
+            } else {
+                "SIMPLE"
+            }
+            .into(),
+        ),
         Datum::Int(storage.snapshot_isolation_allowed() as i32),
         Datum::Bit(storage.rcsi_enabled()),
         Datum::Bit(false),

--- a/crates/truthdb-core/src/relstore/version.rs
+++ b/crates/truthdb-core/src/relstore/version.rs
@@ -113,6 +113,9 @@ pub(crate) struct VersionState {
     /// Database options (mirrored to the superblock's reserved area).
     pub rcsi: bool,
     pub allow_snapshot: bool,
+    /// FULL recovery model (vs SIMPLE, the default). Independent of the
+    /// version store — it does not affect `publishing()`.
+    pub recovery_full: bool,
     /// Committed transactions -> commit sequence. Entries live until no chain
     /// references them and the watermark has passed (pruned together with the
     /// chains). A transaction absent here is running or rolled back — either
@@ -147,12 +150,20 @@ impl VersionState {
     /// Applies `ALTER DATABASE` option changes. Turning the last option off
     /// resets the store: the ALTER holds Database X, so no snapshot can be
     /// live and no chain can be needed again.
-    pub fn set_options(&mut self, rcsi: Option<bool>, allow_snapshot: Option<bool>) {
+    pub fn set_options(
+        &mut self,
+        rcsi: Option<bool>,
+        allow_snapshot: Option<bool>,
+        recovery_full: Option<bool>,
+    ) {
         if let Some(on) = rcsi {
             self.rcsi = on;
         }
         if let Some(on) = allow_snapshot {
             self.allow_snapshot = on;
+        }
+        if let Some(on) = recovery_full {
+            self.recovery_full = on;
         }
         if !self.publishing() {
             debug_assert!(self.snapshots.is_empty());
@@ -182,14 +193,16 @@ impl VersionState {
             .is_some_and(|&seq| seq > snap.seq)
     }
 
-    /// The two option bits as persisted in the superblock reserved area.
+    /// The option bits as persisted in the superblock reserved area: bit 0 =
+    /// RCSI, bit 1 = ALLOW_SNAPSHOT_ISOLATION, bit 2 = FULL recovery model.
     pub fn options_byte(&self) -> u8 {
-        (self.rcsi as u8) | ((self.allow_snapshot as u8) << 1)
+        (self.rcsi as u8) | ((self.allow_snapshot as u8) << 1) | ((self.recovery_full as u8) << 2)
     }
 
     pub fn set_options_byte(&mut self, byte: u8) {
         self.rcsi = byte & 1 != 0;
         self.allow_snapshot = byte & 2 != 0;
+        self.recovery_full = byte & 4 != 0;
     }
 
     /// Records a commit, assigning its sequence. Called under the storage
@@ -548,7 +561,7 @@ mod tests {
 
     fn on() -> VersionState {
         let mut v = VersionState::default();
-        v.set_options(Some(true), None);
+        v.set_options(Some(true), None, None);
         v
     }
 
@@ -816,7 +829,7 @@ mod tests {
             10,
         );
         v.record_commit(10, 100);
-        v.set_options(Some(false), None);
+        v.set_options(Some(false), None, None);
         assert!(!v.publishing());
         assert_eq!(v.chain_count(OID), 0);
         assert_eq!(v.options_byte(), 0);

--- a/crates/truthdb-core/src/storage.rs
+++ b/crates/truthdb-core/src/storage.rs
@@ -283,6 +283,9 @@ pub struct Storage {
     /// analysis and the per-statement snapshot gate are on the hot path).
     rcsi: std::sync::atomic::AtomicBool,
     allow_snapshot: std::sync::atomic::AtomicBool,
+    /// FULL recovery model mirror (vs SIMPLE). Read without the mutex by
+    /// `sys.databases` and (later) the log-backup hold / 9002 decision.
+    recovery_full: std::sync::atomic::AtomicBool,
     /// Bumped whenever the options change: a parked batch whose lock set was
     /// analyzed under an older epoch is re-analyzed before it can be granted
     /// (its versioned-read decision may no longer match execution).
@@ -364,6 +367,7 @@ impl Storage {
         let (gc, log_writer) = GroupCommit::start(wal_fd);
         let rcsi = file.version.rcsi;
         let allow_snapshot = file.version.allow_snapshot;
+        let recovery_full = file.version.recovery_full;
         Ok(Storage {
             path,
             inner: std::sync::Mutex::new(file),
@@ -371,6 +375,7 @@ impl Storage {
             log_writer: Some(log_writer),
             rcsi: std::sync::atomic::AtomicBool::new(rcsi),
             allow_snapshot: std::sync::atomic::AtomicBool::new(allow_snapshot),
+            recovery_full: std::sync::atomic::AtomicBool::new(recovery_full),
             lock_epoch: std::sync::atomic::AtomicU64::new(0),
             security_version: std::sync::atomic::AtomicU64::new(0),
             membership: std::sync::Mutex::new(MembershipCache::default()),
@@ -1178,6 +1183,12 @@ impl Storage {
             .load(std::sync::atomic::Ordering::Relaxed)
     }
 
+    /// Whether the database is in the FULL recovery model (vs SIMPLE).
+    pub(crate) fn recovery_model_full(&self) -> bool {
+        self.recovery_full
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+
     /// Applies `ALTER DATABASE SET` option changes: updates the version
     /// store, persists the options in the superblocks, and refreshes the
     /// lock-free mirrors. The caller holds Database X, so no snapshot is live
@@ -1186,15 +1197,22 @@ impl Storage {
         &self,
         rcsi: Option<bool>,
         allow_snapshot: Option<bool>,
+        recovery_full: Option<bool>,
     ) -> Result<(), StorageError> {
         let mut guard = self.lock();
-        guard.set_db_options(rcsi, allow_snapshot)?;
-        let (rcsi_now, allow_now) = (guard.version.rcsi, guard.version.allow_snapshot);
+        guard.set_db_options(rcsi, allow_snapshot, recovery_full)?;
+        let (rcsi_now, allow_now, recovery_now) = (
+            guard.version.rcsi,
+            guard.version.allow_snapshot,
+            guard.version.recovery_full,
+        );
         drop(guard);
         self.rcsi
             .store(rcsi_now, std::sync::atomic::Ordering::Relaxed);
         self.allow_snapshot
             .store(allow_now, std::sync::atomic::Ordering::Relaxed);
+        self.recovery_full
+            .store(recovery_now, std::sync::atomic::Ordering::Relaxed);
         // After the mirrors, so a batch analyzed against a stale epoch is
         // always re-analyzed against the settled options.
         self.lock_epoch
@@ -5427,6 +5445,7 @@ impl StorageFile {
         &mut self,
         rcsi: Option<bool>,
         allow_snapshot: Option<bool>,
+        recovery_full: Option<bool>,
     ) -> Result<(), StorageError> {
         self.ensure_rel_usable()?;
         // Build the new superblocks in LOCALS and write them BEFORE mutating
@@ -5443,6 +5462,9 @@ impl StorageFile {
             }
             if let Some(on) = allow_snapshot {
                 next = (next & !2) | ((on as u8) << 1);
+            }
+            if let Some(on) = recovery_full {
+                next = (next & !4) | ((on as u8) << 2);
             }
             next
         };
@@ -5494,7 +5516,8 @@ impl StorageFile {
                 self.superblock_a = backup;
             }
         }
-        self.version.set_options(rcsi, allow_snapshot);
+        self.version
+            .set_options(rcsi, allow_snapshot, recovery_full);
         Ok(())
     }
 

--- a/crates/truthdb-core/tests/slt/alter_database.slt
+++ b/crates/truthdb-core/tests/slt/alter_database.slt
@@ -9,10 +9,19 @@ ALTER DATABASE CURRENT SET READ_COMMITTED_SNAPSHOT ON
 statement ok
 ALTER DATABASE CURRENT SET ALLOW_SNAPSHOT_ISOLATION ON, READ_COMMITTED_SNAPSHOT ON
 
-# Only the recognized options are accepted; anything else is a syntax error,
-# never a silent no-op (these options change what concurrent readers see).
-statement error
+# RECOVERY {FULL|SIMPLE} is recognized and persists (engine tests cover
+# sys.databases reporting and reopen durability).
+statement ok
+ALTER DATABASE CURRENT SET RECOVERY FULL
+
+statement ok
 ALTER DATABASE CURRENT SET RECOVERY SIMPLE
+
+# Only the recognized options are accepted; anything else is a syntax error,
+# never a silent no-op (these options change what concurrent readers see). An
+# unsupported RECOVERY mode and a non-ON/OFF value both error.
+statement error
+ALTER DATABASE CURRENT SET RECOVERY BULK_LOGGED
 
 statement error
 ALTER DATABASE CURRENT SET READ_COMMITTED_SNAPSHOT MAYBE

--- a/crates/truthdb-sql/src/ast.rs
+++ b/crates/truthdb-sql/src/ast.rs
@@ -423,6 +423,9 @@ pub struct AlterDatabase {
 pub enum DatabaseOption {
     ReadCommittedSnapshot,
     AllowSnapshotIsolation,
+    /// `SET RECOVERY {FULL | SIMPLE}`. Unlike the ON/OFF options, the paired
+    /// bool carries the mode: `true` = FULL, `false` = SIMPLE.
+    Recovery,
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/crates/truthdb-sql/src/parser.rs
+++ b/crates/truthdb-sql/src/parser.rs
@@ -1536,17 +1536,35 @@ impl Parser {
         let mut options = Vec::new();
         let mut end;
         loop {
-            let option = match self.peek_keyword().as_deref() {
-                Some("READ_COMMITTED_SNAPSHOT") => DatabaseOption::ReadCommittedSnapshot,
-                Some("ALLOW_SNAPSHOT_ISOLATION") => DatabaseOption::AllowSnapshotIsolation,
+            let (option, value) = match self.peek_keyword().as_deref() {
+                Some("READ_COMMITTED_SNAPSHOT") => {
+                    end = self.bump().span;
+                    (DatabaseOption::ReadCommittedSnapshot, self.parse_on_off()?)
+                }
+                Some("ALLOW_SNAPSHOT_ISOLATION") => {
+                    end = self.bump().span;
+                    (DatabaseOption::AllowSnapshotIsolation, self.parse_on_off()?)
+                }
+                // `SET RECOVERY {FULL | SIMPLE}` — a mode keyword, not ON/OFF.
+                Some("RECOVERY") => {
+                    self.bump();
+                    let is_full = match self.peek_keyword().as_deref() {
+                        Some("FULL") => true,
+                        Some("SIMPLE") => false,
+                        _ => {
+                            let token = self.peek().clone();
+                            return Err(SqlError::syntax(self.token_text(&token), token.span));
+                        }
+                    };
+                    end = self.bump().span;
+                    (DatabaseOption::Recovery, is_full)
+                }
                 _ => {
                     let token = self.peek().clone();
                     return Err(SqlError::syntax(self.token_text(&token), token.span));
                 }
             };
-            end = self.bump().span;
-            let on = self.parse_on_off()?;
-            options.push((option, on));
+            options.push((option, value));
             if !self.eat(&TokenKind::Comma) {
                 break;
             }
@@ -3620,6 +3638,30 @@ fn is_reserved(keyword: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn alter_database_set_recovery_parses() {
+        let full = Parser::parse_str("ALTER DATABASE CURRENT SET RECOVERY FULL").expect("parse");
+        assert!(matches!(
+            &full[0],
+            Statement::AlterDatabase(a) if a.options == vec![(DatabaseOption::Recovery, true)]
+        ));
+        let simple = Parser::parse_str("ALTER DATABASE d SET RECOVERY SIMPLE").expect("parse");
+        assert!(matches!(
+            &simple[0],
+            Statement::AlterDatabase(a) if a.options == vec![(DatabaseOption::Recovery, false)]
+        ));
+        // Only FULL/SIMPLE are supported; any other mode is a syntax error.
+        assert!(Parser::parse_str("ALTER DATABASE d SET RECOVERY BULK_LOGGED").is_err());
+        // The existing ON/OFF options still parse alongside.
+        let rcsi =
+            Parser::parse_str("ALTER DATABASE d SET READ_COMMITTED_SNAPSHOT ON").expect("parse");
+        assert!(matches!(
+            &rcsi[0],
+            Statement::AlterDatabase(a)
+                if a.options == vec![(DatabaseOption::ReadCommittedSnapshot, true)]
+        ));
+    }
 
     #[test]
     fn backup_database_parses_with_options() {


### PR DESCRIPTION
The foundation for BACKUP LOG and the FULL-model log-truncation hold (both key on this flag). Low-risk: a stored per-database bit, no WAL or durability change.

- `ALTER DATABASE ... SET RECOVERY {FULL | SIMPLE}` — new `DatabaseOption::Recovery` (bool carries the mode, since RECOVERY isn't ON/OFF), threaded through `exec_alter_database` → `rel_set_db_options` → `set_db_options`.
- Persisted in `db_options` bit 2, riding the existing dual-write / checkpoint / restore / open / backup-header paths for free. SIMPLE is the zero default.
- `recovery_full` AtomicBool mirror + `recovery_model_full()`; `sys.databases.recovery_model_desc` reports it.

Tests: parser (modes + bad-mode rejection + ON/OFF coexistence); the model sets, persists across reopen, coexists with RCSI, reports through `sys.databases`. RCSI/snapshot suite unchanged. fmt + clippy `-D warnings` clean.

Next in slice 2: BACKUP LOG + the `log_backup` hold + 9002 (2a-ii), then PITR (2b).

🤖 Generated with [Claude Code](https://claude.com/claude-code)