### PR TITLE
Stage 17 slice 2a-ii: FULL-model log hold + BACKUP LOG + 9002

### DIFF
--- a/crates/truthdb-core/src/backup.rs
+++ b/crates/truthdb-core/src/backup.rs
@@ -65,6 +65,11 @@ pub struct BackupFlags {
     pub checksum: bool,
     /// `WITH COPY_ONLY`: the backup did not disturb the log-backup chain.
     pub copy_only: bool,
+    /// This is a `BACKUP LOG` archive (log records only, no page data): the
+    /// header's `redo_start_lsn` is the archived range's start and the region
+    /// sizes / roots are unused. Restore applies its `LogChunk` on top of a
+    /// full-backup base.
+    pub log_backup: bool,
 }
 
 /// The `TDBBAK1` header: everything a restore needs to recreate the file and
@@ -120,7 +125,9 @@ impl BackupHeader {
         out.extend_from_slice(&self.last_committed_seq.to_le_bytes());
         out.extend_from_slice(&self.finished_at_millis.to_le_bytes());
         out.push(self.db_options);
-        let flag_bits = (self.flags.checksum as u8) | ((self.flags.copy_only as u8) << 1);
+        let flag_bits = (self.flags.checksum as u8)
+            | ((self.flags.copy_only as u8) << 1)
+            | ((self.flags.log_backup as u8) << 2);
         out.push(flag_bits);
         // Default collation as a length-prefixed UTF-8 string (u32 len, or
         // u32::MAX for None).
@@ -180,6 +187,7 @@ impl BackupHeader {
             flags: BackupFlags {
                 checksum: flag_bits & 1 != 0,
                 copy_only: flag_bits & 2 != 0,
+                log_backup: flag_bits & 4 != 0,
             },
         })
     }
@@ -436,6 +444,7 @@ mod tests {
             flags: BackupFlags {
                 checksum: true,
                 copy_only: false,
+                log_backup: false,
             },
         }
     }

--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -2001,6 +2001,216 @@ mod tests {
         let _ = std::fs::remove_file(path);
     }
 
+    #[test]
+    fn backup_log_ships_the_log_advances_the_marker_and_chains() {
+        use crate::backup::{BackupReader, BlockType};
+        let src = unique_temp_path("backuplog-src");
+        let trn1 = unique_temp_path("backuplog-1");
+        let trn2 = unique_temp_path("backuplog-2");
+        let engine = new_engine(&src);
+        engine
+            .execute("ALTER DATABASE CURRENT SET RECOVERY FULL")
+            .expect("full");
+        // Enabling FULL starts the log chain at the current tail and pins it.
+        let chain_start = engine.storage().last_log_backup_lsn();
+        assert_eq!(engine.storage().log_backup_hold(), Some(chain_start));
+        engine
+            .execute("CREATE TABLE t (id INT NOT NULL PRIMARY KEY, v INT)")
+            .expect("create");
+        for i in 1..=20 {
+            engine
+                .execute(&format!("INSERT INTO t VALUES ({i}, {i})"))
+                .expect("insert");
+        }
+
+        let read_log_archive = |path: &std::path::Path| -> (crate::backup::BackupHeader, u64) {
+            let (mut r, header) =
+                BackupReader::new(std::io::BufReader::new(std::fs::File::open(path).unwrap()))
+                    .unwrap();
+            let mut log_bytes = 0u64;
+            while let Some((bt, payload)) = r.next_block().unwrap() {
+                if bt == BlockType::LogChunk {
+                    log_bytes += payload.len().saturating_sub(8) as u64; // minus the start-LSN prefix
+                }
+            }
+            (header, log_bytes)
+        };
+
+        // First BACKUP LOG ships [chain_start, tail) and advances the marker.
+        let lit1 = trn1.to_str().unwrap().replace('\'', "''");
+        assert!(
+            sql(&engine, &format!("BACKUP LOG truthdb TO DISK = '{lit1}'"))["error"].is_null(),
+            "BACKUP LOG succeeded"
+        );
+        let marker1 = engine.storage().last_log_backup_lsn();
+        assert!(marker1 > chain_start, "the marker advanced");
+        assert_eq!(
+            engine.storage().log_backup_hold(),
+            Some(marker1),
+            "the hold moved to the new marker"
+        );
+        let (header1, bytes1) = read_log_archive(&trn1);
+        assert!(header1.flags.log_backup, "flagged as a log-only archive");
+        assert_eq!(header1.redo_start_lsn, chain_start);
+        assert_eq!(
+            chain_start + bytes1,
+            marker1,
+            "the shipped range ends at the marker"
+        );
+
+        // A second BACKUP LOG chains contiguously from the first.
+        engine
+            .execute("INSERT INTO t VALUES (99, 99)")
+            .expect("more");
+        let lit2 = trn2.to_str().unwrap().replace('\'', "''");
+        assert!(sql(&engine, &format!("BACKUP LOG truthdb TO DISK = '{lit2}'"))["error"].is_null());
+        let (header2, _) = read_log_archive(&trn2);
+        assert_eq!(
+            header2.redo_start_lsn, marker1,
+            "the second archive starts where the first ended"
+        );
+        drop(engine);
+        for p in [src, trn1, trn2] {
+            let _ = std::fs::remove_file(p);
+        }
+    }
+
+    #[test]
+    fn backup_log_requires_the_full_recovery_model() {
+        let path = unique_temp_path("backuplog-simple");
+        let engine = new_engine(&path);
+        // SIMPLE (the default): BACKUP LOG is 4208.
+        assert_eq!(
+            sql_error_number(
+                &engine,
+                "BACKUP LOG truthdb TO DISK = '/tmp/truthdb-never.trn'"
+            ),
+            4208
+        );
+        drop(engine);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn full_recovery_holds_the_log_until_backup_log() {
+        let path = unique_temp_path("backuplog-hold");
+        let trn = unique_temp_path("backuplog-hold-trn");
+        let engine = new_engine(&path);
+        engine
+            .execute("ALTER DATABASE CURRENT SET RECOVERY FULL")
+            .expect("full");
+        let marker = engine.storage().last_log_backup_lsn();
+        engine
+            .execute("CREATE TABLE t (id INT NOT NULL PRIMARY KEY, v INT)")
+            .expect("create");
+        for i in 1..=50 {
+            engine
+                .execute(&format!("INSERT INTO t VALUES ({i}, {i})"))
+                .expect("insert");
+        }
+        // A checkpoint cannot truncate past the log-backup floor under FULL.
+        engine
+            .storage()
+            .write_checkpoint(b"cp", 1, 2, 1)
+            .expect("checkpoint");
+        assert!(
+            engine.storage().wal_head() <= marker,
+            "FULL pins the head at the log-backup floor"
+        );
+
+        // BACKUP LOG advances the floor, so a later checkpoint reclaims the log.
+        let lit = trn.to_str().unwrap().replace('\'', "''");
+        assert!(sql(&engine, &format!("BACKUP LOG truthdb TO DISK = '{lit}'"))["error"].is_null());
+        assert!(engine.storage().last_log_backup_lsn() > marker);
+        engine
+            .storage()
+            .write_checkpoint(b"cp2", 2, 3, 2)
+            .expect("checkpoint");
+        assert!(
+            engine.storage().wal_head() > marker,
+            "after BACKUP LOG the checkpoint reclaims past the old floor"
+        );
+        drop(engine);
+        for p in [path, trn] {
+            let _ = std::fs::remove_file(p);
+        }
+    }
+
+    #[test]
+    fn log_backup_marker_and_hold_survive_reopen() {
+        let path = unique_temp_path("backuplog-reopen");
+        let trn = unique_temp_path("backuplog-reopen-trn");
+        let engine = new_engine(&path);
+        engine
+            .execute("ALTER DATABASE CURRENT SET RECOVERY FULL")
+            .expect("full");
+        engine
+            .execute("CREATE TABLE t (id INT NOT NULL PRIMARY KEY)")
+            .expect("create");
+        engine.execute("INSERT INTO t VALUES (1)").expect("insert");
+        let lit = trn.to_str().unwrap().replace('\'', "''");
+        assert!(sql(&engine, &format!("BACKUP LOG truthdb TO DISK = '{lit}'"))["error"].is_null());
+        let marker = engine.storage().last_log_backup_lsn();
+        drop(engine);
+
+        let engine2 = Engine::new(Storage::open(path.clone()).expect("reopen")).expect("engine");
+        assert_eq!(
+            engine2.storage().last_log_backup_lsn(),
+            marker,
+            "the marker persisted"
+        );
+        assert_eq!(
+            engine2.storage().log_backup_hold(),
+            Some(marker),
+            "the hold re-registered on open"
+        );
+        assert_eq!(
+            sql_rows(&engine2, "SELECT recovery_model_desc FROM sys.databases").1,
+            vec![vec![Some("FULL".into())]]
+        );
+        drop(engine2);
+        for p in [path, trn] {
+            let _ = std::fs::remove_file(p);
+        }
+    }
+
+    #[test]
+    fn full_recovery_ring_full_reports_9002() {
+        let path = unique_temp_path("backuplog-9002");
+        // A small ring so the un-backed-up log fills it quickly.
+        let storage = Storage::create_with_wal_bounds(
+            path.clone(),
+            test_storage_options(),
+            128 * 1024,
+            128 * 1024,
+        )
+        .expect("create");
+        let engine = Engine::new(storage).expect("engine");
+        engine
+            .execute("ALTER DATABASE CURRENT SET RECOVERY FULL")
+            .expect("full");
+        engine
+            .execute("CREATE TABLE t (id INT NOT NULL PRIMARY KEY, v NVARCHAR(120))")
+            .expect("create");
+        // FULL pins the head at the enable point, so with no BACKUP LOG the ring
+        // fills and a write eventually reports 9002 (log full).
+        let mut hit_9002 = false;
+        for i in 0..4000 {
+            let env = sql(
+                &engine,
+                &format!("INSERT INTO t VALUES ({i}, '{}')", "x".repeat(100)),
+            );
+            if let Some(n) = env["error"]["number"].as_i64() {
+                assert_eq!(n, 9002, "ring-full under FULL reports 9002, got {env}");
+                hit_9002 = true;
+                break;
+            }
+        }
+        assert!(hit_9002, "the ring filled and reported 9002");
+        drop(engine);
+        let _ = std::fs::remove_file(path);
+    }
+
     /// Runs SQL expected to error and returns the SQL error message.
     fn sql_error_message(engine: &Engine, text: &str) -> String {
         let env = sql(engine, text);

--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -2076,6 +2076,62 @@ mod tests {
     }
 
     #[test]
+    fn restoring_a_full_recovery_database_opens_and_checkpoints_cleanly() {
+        let src = unique_temp_path("restore-full-src");
+        let bak = unique_temp_path("restore-full-bak");
+        let restored = unique_temp_path("restore-full-restored");
+        let trn = unique_temp_path("restore-full-trn");
+        let engine = new_engine(&src);
+        engine
+            .execute("ALTER DATABASE CURRENT SET RECOVERY FULL")
+            .expect("full");
+        engine
+            .execute("CREATE TABLE t (id INT NOT NULL PRIMARY KEY, v INT)")
+            .expect("create");
+        for i in 1..=30 {
+            engine
+                .execute(&format!("INSERT INTO t VALUES ({i}, {i})"))
+                .expect("insert");
+        }
+        let expected = sql_rows(&engine, "SELECT id, v FROM t ORDER BY id").1;
+        engine
+            .storage()
+            .backup_full(&bak)
+            .expect("full backup of a FULL-model db");
+        drop(engine);
+
+        Storage::restore_full(&restored, &bak).expect("restore");
+        let engine2 = Engine::new(Storage::open(restored.clone()).expect("open")).expect("engine");
+        assert_eq!(
+            sql_rows(&engine2, "SELECT id, v FROM t ORDER BY id").1,
+            expected
+        );
+        // The restored DB is FULL and its log-backup floor is seeded at the
+        // restore point (backup_end), so the on-open hold sits at/above wal_head.
+        assert_eq!(
+            sql_rows(&engine2, "SELECT recovery_model_desc FROM sys.databases").1,
+            vec![vec![Some("FULL".into())]]
+        );
+        assert!(
+            engine2.storage().log_backup_hold().is_some(),
+            "FULL-model hold re-registered on the restored db"
+        );
+        // A checkpoint would panic (set_head with a floor below the head) if the
+        // marker had been left at 0 — the Fix-3 regression guard.
+        engine2
+            .storage()
+            .write_checkpoint(b"cp", 1, 2, 1)
+            .expect("checkpoint on the restored db");
+        // And BACKUP LOG works on the restored (fresh) log chain.
+        let lit = trn.to_str().unwrap().replace('\'', "''");
+        assert!(sql(&engine2, &format!("BACKUP LOG truthdb TO DISK = '{lit}'"))["error"].is_null());
+        drop(engine2);
+        for p in [src, bak, restored, trn] {
+            let _ = std::fs::remove_file(p);
+        }
+    }
+
+    #[test]
     fn backup_log_requires_the_full_recovery_model() {
         let path = unique_temp_path("backuplog-simple");
         let engine = new_engine(&path);

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -3288,7 +3288,8 @@ fn analyze_statements_locks(
             // BACKUP takes no batch lock: it is online and manages its own
             // per-chunk storage locking. A Database X here would serialize it
             // against every writer and defeat the fuzzy design.
-            | Statement::BackupDatabase { .. } => {}
+            | Statement::BackupDatabase { .. }
+            | Statement::BackupLog { .. } => {}
         }
     }
     // Batch-level lock escalation: if a table accumulated more than the
@@ -3524,6 +3525,43 @@ fn exec_statement_dispatch(
                         16,
                         1,
                         format!("BACKUP DATABASE is terminating abnormally. {e}"),
+                    )
+                })?;
+            Ok(StatementResult::Done)
+        }
+        Statement::BackupLog {
+            path,
+            checksum,
+            copy_only,
+            ..
+        } => {
+            if txn_ctx.in_txn() {
+                return Err(SqlError::new(
+                    3021,
+                    16,
+                    1,
+                    "Cannot perform a backup or restore operation within a transaction."
+                        .to_string(),
+                ));
+            }
+            if !storage.recovery_model_full() {
+                return Err(SqlError::new(
+                    4208,
+                    16,
+                    1,
+                    "The statement BACKUP LOG is not allowed while the recovery model is SIMPLE. \
+                     Use BACKUP DATABASE or change the recovery model to FULL with ALTER DATABASE."
+                        .to_string(),
+                ));
+            }
+            storage
+                .backup_log(std::path::Path::new(path), *checksum, *copy_only)
+                .map_err(|e| {
+                    SqlError::new(
+                        3013,
+                        16,
+                        1,
+                        format!("BACKUP LOG is terminating abnormally. {e}"),
                     )
                 })?;
             Ok(StatementResult::Done)
@@ -6253,6 +6291,7 @@ fn is_privileged_ddl(stmt: &Statement) -> bool {
             | Statement::AlterRole { .. }
             | Statement::Permission(_)
             | Statement::BackupDatabase { .. }
+            | Statement::BackupLog { .. }
     )
 }
 
@@ -13392,6 +13431,15 @@ fn map_storage_err(err: StorageError, table: &str) -> SqlError {
             ),
         ),
         StorageError::InvalidConfig(msg) => SqlError::new(1701, 16, 1, msg),
+        // The WAL ring is full — under FULL recovery this is typically because
+        // un-backed-up log pins truncation (run BACKUP LOG); under SIMPLE it is
+        // an oversized active transaction. SQL Server reports 9002 either way.
+        StorageError::WalFull(msg) => SqlError::new(
+            9002,
+            17,
+            2,
+            format!("The transaction log for the database is full. {msg}"),
+        ),
         other => SqlError::new(
             3621,
             16,

--- a/crates/truthdb-core/src/storage.rs
+++ b/crates/truthdb-core/src/storage.rs
@@ -649,18 +649,17 @@ impl Storage {
         // pins `[start, ...)`, so no checkpoint can truncate the range we are
         // about to ship, even after we release the lock.
         let (header, start, end, log) = self.lock().begin_log_backup(checksum, copy_only)?;
+        // Release the single-flight guard on EVERY exit — an early `?` out of
+        // write_log_archive, a panic, or normal completion.
+        let _guard = LogBackupGuard { storage: self };
         // Phase 2 (UNLOCKED): write and fsync the archive — including its parent
         // directory — so concurrent DML proceeds during the copy-out (BACKUP LOG
-        // is online, like BACKUP DATABASE). On failure, release the single-flight
-        // guard without advancing the marker.
-        if let Err(e) = write_log_archive(dst, &header, start, &log) {
-            self.lock().cancel_log_backup();
-            return Err(e);
-        }
+        // is online, like BACKUP DATABASE).
+        write_log_archive(dst, &header, start, &log)?;
         // Phase 3 (locked): the archive is durable — durably advance the marker
-        // and the hold, releasing `[start, end)` for reclamation. Copy-out
-        // strictly before truncate.
-        self.lock().finish_log_backup(end)?;
+        // and the hold (unless the FULL-model state changed meanwhile), releasing
+        // `[start, end)` for reclamation. Copy-out strictly before truncate.
+        self.lock().finish_log_backup(start, end)?;
         Ok(crate::backup::BackupSummary {
             redo_start_lsn: start,
             backup_end_lsn: end,
@@ -5493,18 +5492,27 @@ impl StorageFile {
 
     /// Phase 3 of `BACKUP LOG`: the archive at `end` is durable, so durably
     /// advance the persisted marker then the in-memory marker and hold, letting
-    /// the ring reclaim `[old_marker, end)`. Clears the single-flight guard
-    /// first, so a persist failure still frees the next backup.
-    fn finish_log_backup(&mut self, end: u64) -> Result<(), StorageError> {
-        self.log_backup_in_progress = false;
+    /// the ring reclaim `[start, end)`.
+    ///
+    /// ORPHANS the backup (no marker/hold change) if the FULL-model state
+    /// changed during the unlocked archive write — a concurrent `ALTER DATABASE
+    /// SET RECOVERY SIMPLE` released the hold (and a checkpoint then advanced
+    /// the head), or a re-enable moved the marker. Re-arming the hold at `end`
+    /// in those cases could sit it below the advanced head, which `set_head`
+    /// forbids. The single-flight guard is released by `LogBackupGuard` on every
+    /// exit path, not here.
+    fn finish_log_backup(&mut self, start: u64, end: u64) -> Result<(), StorageError> {
+        if !self.version.recovery_full || self.last_log_backup_lsn != start {
+            return Ok(());
+        }
         self.persist_last_log_backup_lsn(end)?;
         self.last_log_backup_lsn = end;
         self.register_log_backup_hold(end);
         Ok(())
     }
 
-    /// Aborts an in-progress `BACKUP LOG` (the archive write failed) without
-    /// advancing the marker.
+    /// Releases the `BACKUP LOG` single-flight guard (idempotent). Called by
+    /// [`LogBackupGuard`] on every exit — error, panic, or success.
     fn cancel_log_backup(&mut self) {
         self.log_backup_in_progress = false;
     }
@@ -6290,6 +6298,19 @@ impl Drop for BackupHoldGuard<'_> {
     }
 }
 
+/// Releases the `BACKUP LOG` single-flight guard when the operation ends — on
+/// every path, including an early error return or a panic during the unlocked
+/// archive write. A leaked guard would reject every later `BACKUP LOG`.
+struct LogBackupGuard<'a> {
+    storage: &'a Storage,
+}
+
+impl Drop for LogBackupGuard<'_> {
+    fn drop(&mut self) {
+        self.storage.lock().cancel_log_backup();
+    }
+}
+
 /// Everything captured under the storage lock at the start of a backup, so the
 /// bulk page copy can proceed while releasing the lock between chunks.
 struct BackupPlan {
@@ -6485,6 +6506,58 @@ mod tests {
         let _ = std::fs::remove_file(path);
         let _ = std::fs::remove_file(bak);
         let _ = std::fs::remove_file(bak2);
+    }
+
+    #[test]
+    fn log_backup_orphans_when_recovery_flips_to_simple_mid_flight() {
+        // Reproduces the race the lock-dance opened: BACKUP LOG releases the
+        // storage lock to write its archive; a concurrent ALTER ... SET RECOVERY
+        // SIMPLE releases the log hold and a checkpoint advances the head; phase
+        // 3 must then ORPHAN the backup rather than re-arm the hold below head.
+        let path = unique_temp_path("backuplog-orphan");
+        let storage = Storage::create(path.clone(), test_storage_options()).expect("create");
+        storage
+            .rel_set_db_options(None, None, Some(true))
+            .expect("enable FULL");
+        for seq in 0..8 {
+            storage
+                .append_wal_entry(WAL_ENTRY_TYPE_RECORD, 1, seq, b"logbytes")
+                .expect("append");
+        }
+        // Phase 1: capture the range under the lock (marker = start).
+        let (_, start, end, _log) = storage.lock().begin_log_backup(true, false).expect("begin");
+        assert!(end > start);
+        // The concurrent ALTER SET RECOVERY SIMPLE during the unlocked window.
+        storage
+            .rel_set_db_options(None, None, Some(false))
+            .expect("disable FULL");
+        assert_eq!(storage.log_backup_hold(), None, "SIMPLE released the hold");
+        // A checkpoint now advances the head to the tail (no hold pins it).
+        storage
+            .write_checkpoint(b"cp", 1, 2, 1)
+            .expect("checkpoint after SIMPLE");
+        assert!(
+            storage.wal_head() > start,
+            "the head advanced past the old marker"
+        );
+        // Phase 3: finish must orphan (recovery_full is false) — no re-arm.
+        storage
+            .lock()
+            .finish_log_backup(start, end)
+            .expect("finish orphans cleanly");
+        assert_eq!(
+            storage.log_backup_hold(),
+            None,
+            "finish did not re-arm the hold on the now-SIMPLE database"
+        );
+        // The next checkpoint must not move the head backward (would panic
+        // without the orphan guard).
+        storage
+            .write_checkpoint(b"cp2", 2, 3, 2)
+            .expect("checkpoint after orphan does not panic");
+        storage.lock().cancel_log_backup();
+        drop(storage);
+        let _ = std::fs::remove_file(path);
     }
 
     #[test]

--- a/crates/truthdb-core/src/storage.rs
+++ b/crates/truthdb-core/src/storage.rs
@@ -585,6 +585,25 @@ impl Storage {
         self.lock().wal_tail()
     }
 
+    /// The current WAL head (the reclaim floor) — for tests that verify the
+    /// FULL-model log-backup hold pins truncation.
+    #[cfg(test)]
+    pub(crate) fn wal_head(&self) -> u64 {
+        self.lock().wal.head()
+    }
+
+    /// The persisted log-backup floor (tests).
+    #[cfg(test)]
+    pub(crate) fn last_log_backup_lsn(&self) -> u64 {
+        self.lock().last_log_backup_lsn
+    }
+
+    /// The active FULL-model log-backup truncation hold, if any (tests).
+    #[cfg(test)]
+    pub(crate) fn log_backup_hold(&self) -> Option<u64> {
+        self.lock().truncation_gate.log_backup
+    }
+
     /// Online full backup: writes a self-describing `TDBBAK1` file at `dst`
     /// capturing the database as of a consistent recovery point.
     ///
@@ -615,6 +634,18 @@ impl Storage {
         // permanently freezes WAL truncation and eventually wedges writes.
         let _hold = BackupHoldGuard { storage: self };
         self.write_backup(dst, &plan)
+    }
+
+    /// `BACKUP LOG`: ships the FULL-model log tail to a `TDBBAK1` log archive
+    /// and advances the log-backup floor, releasing the ring it held. Requires
+    /// the FULL recovery model.
+    pub fn backup_log(
+        &self,
+        dst: &Path,
+        checksum: bool,
+        copy_only: bool,
+    ) -> Result<crate::backup::BackupSummary, StorageError> {
+        self.lock().backup_log(dst, checksum, copy_only)
     }
 
     fn write_backup(
@@ -1819,14 +1850,18 @@ struct LogTruncationGate {
     /// An in-progress full backup's `redo_start_lsn` — the log it must ship
     /// before the ring can reclaim it. `None` when no backup is running.
     backup: Option<u64>,
-    // Later: `log_backup` (FULL recovery model, Stage 17 slice 2) and
-    // `repl_slots` (Stage 18) join the same `min`.
+    /// The FULL-recovery-model log-backup floor: `last_log_backup_lsn`, the log
+    /// past which nothing has been shipped to a log archive yet. Held so a
+    /// checkpoint cannot truncate log a future `BACKUP LOG` still owes. `None`
+    /// in the SIMPLE model (log is reclaimable as soon as it is checkpointed).
+    log_backup: Option<u64>,
+    // Later: `repl_slots` (Stage 18) joins the same `min`.
 }
 
 impl LogTruncationGate {
     /// The lowest LSN any hold pins, or `None` if no hold is registered.
     fn min_hold(&self) -> Option<u64> {
-        self.backup
+        [self.backup, self.log_backup].into_iter().flatten().min()
     }
 }
 
@@ -1839,6 +1874,10 @@ struct StorageFile {
     /// Holds that keep the WAL ring from truncating log a backup (or, later, a
     /// replication slot) still needs.
     truncation_gate: LogTruncationGate,
+    /// FULL-model log-backup floor (mirrors the active superblock's
+    /// `last_log_backup_lsn`): the LSN up to which the log has been shipped to
+    /// a log archive. `0` in the SIMPLE model / before the first log backup.
+    last_log_backup_lsn: u64,
     layout: StorageLayout,
     superblock_a: Superblock,
     superblock_b: Superblock,
@@ -4448,11 +4487,14 @@ impl StorageFile {
 
         let mut version = crate::relstore::version::VersionState::default();
         version.set_options_byte(active_sb.db_options());
+        let last_log_backup_lsn = active_sb.last_log_backup_lsn();
+        let recovery_full = version.recovery_full;
         let mut storage = StorageFile {
             default_collation: header.default_collation(),
             file,
             wal,
             truncation_gate: LogTruncationGate::default(),
+            last_log_backup_lsn,
             layout,
             superblock_a,
             superblock_b,
@@ -4462,6 +4504,13 @@ impl StorageFile {
             replay_cache: scan.records,
             version,
         };
+        // Re-establish the FULL-model log-backup hold so a checkpoint cannot
+        // reclaim un-backed-up log. The floor is >= the persisted wal_head
+        // (checkpoints were already clamped to it), so it never moves the head
+        // backward.
+        if recovery_full {
+            storage.register_log_backup_hold(last_log_backup_lsn);
+        }
         storage.recover_allocator()?;
 
         // A tail below the superblock's recorded one means part of the
@@ -4559,6 +4608,7 @@ impl StorageFile {
             file,
             wal,
             truncation_gate: LogTruncationGate::default(),
+            last_log_backup_lsn: 0,
             layout,
             superblock_a,
             superblock_b,
@@ -5013,6 +5063,19 @@ impl StorageFile {
         self.truncation_gate.backup = None;
     }
 
+    /// Pins the FULL-model log-backup floor at `last_log_backup_lsn` so a
+    /// checkpoint cannot reclaim log a `BACKUP LOG` still has to ship. Set when
+    /// FULL is enabled and re-set (advanced) after each `BACKUP LOG`.
+    fn register_log_backup_hold(&mut self, last_log_backup_lsn: u64) {
+        self.truncation_gate.log_backup = Some(last_log_backup_lsn);
+    }
+
+    /// Drops the log-backup floor (recovery model set back to SIMPLE): log is
+    /// reclaimable as soon as it is checkpointed.
+    fn release_log_backup_hold(&mut self) {
+        self.truncation_gate.log_backup = None;
+    }
+
     fn ensure_rel_usable(&self) -> Result<(), StorageError> {
         if self.rel.wedged {
             return Err(StorageError::InvalidFile(
@@ -5317,11 +5380,21 @@ impl StorageFile {
                     .to_string(),
             ));
         }
+        let out = self.read_ring_range(redo_start, backup_end)?;
+        Ok((backup_end, out))
+    }
+
+    /// Reads the raw WAL ring bytes for the logical range `[start, end)`,
+    /// handling the physical wrap. The caller must have synced the log to at
+    /// least `end` first (`DirectFile` bypasses the page cache).
+    fn read_ring_range(&mut self, start: u64, end: u64) -> Result<Vec<u8>, StorageError> {
+        debug_assert!(end >= start);
+        let len = end - start;
         let mut out = vec![0u8; len as usize];
         if len > 0 {
             let wal_offset = self.layout.wal_offset;
             let wal_size = self.layout.wal_size;
-            let start_phys = redo_start % wal_size;
+            let start_phys = start % wal_size;
             let first = ((wal_size - start_phys).min(len)) as usize;
             self.wal
                 .file_mut()
@@ -5332,7 +5405,77 @@ impl StorageFile {
                     .read_exact_at(wal_offset, &mut out[first..])?;
             }
         }
-        Ok((backup_end, out))
+        Ok(out)
+    }
+
+    /// Ships the FULL-model log tail `[last_log_backup_lsn, tail)` to a
+    /// `TDBBAK1` log archive, then durably advances the marker and the hold —
+    /// copy-out strictly before truncate, so a crash after the archive write
+    /// but before the marker advance simply re-ships the (idempotent) range.
+    fn backup_log(
+        &mut self,
+        dst: &Path,
+        checksum: bool,
+        copy_only: bool,
+    ) -> Result<crate::backup::BackupSummary, StorageError> {
+        use crate::backup::{BackupFlags, BackupHeader, BackupWriter, BlockType, encode_log_chunk};
+        self.ensure_rel_usable()?;
+        if !self.version.recovery_full {
+            return Err(StorageError::InvalidConfig(
+                "BACKUP LOG requires the FULL recovery model".to_string(),
+            ));
+        }
+        self.wal.sync_all()?;
+        let start = self.last_log_backup_lsn;
+        let end = self.wal.tail();
+        debug_assert!(end >= start);
+        let log = self.read_ring_range(start, end)?;
+        let finished_at_millis = now_millis();
+
+        // A log-only archive: no page/region data — the header carries the
+        // range start in `redo_start_lsn` and the `log_backup` flag; the end is
+        // derived from the LogChunk length on read.
+        let header = BackupHeader {
+            format_version: crate::backup::FORMAT_VERSION,
+            page_size: PAGE_SIZE as u32,
+            total_size: 0,
+            wal_size: self.layout.wal_size,
+            data_size: 0,
+            metadata_size: 0,
+            allocator_size: 0,
+            snapshot_size: 0,
+            reserved_size: 0,
+            default_collation: None,
+            redo_start_lsn: start,
+            metadata_root: 0,
+            last_committed_seq: 0,
+            db_options: self.version.options_byte(),
+            finished_at_millis,
+            flags: BackupFlags {
+                checksum,
+                copy_only,
+                log_backup: true,
+            },
+        };
+        // Write the archive fully and fsync it BEFORE advancing the marker.
+        let file = std::fs::File::create(dst)?;
+        let mut writer = BackupWriter::new(file, &header)?;
+        writer.write_block(BlockType::LogChunk, &encode_log_chunk(start, &log))?;
+        writer.finish()?.sync_all()?;
+
+        // Copy-out done and durable → advance the persisted marker, then the
+        // in-memory marker and hold, so the ring may now reclaim `[start, end)`.
+        self.persist_last_log_backup_lsn(end)?;
+        self.last_log_backup_lsn = end;
+        self.register_log_backup_hold(end);
+
+        Ok(crate::backup::BackupSummary {
+            redo_start_lsn: start,
+            backup_end_lsn: end,
+            pages_copied: 0,
+            log_bytes: log.len() as u64,
+            finished_at_millis,
+        })
     }
 
     /// Lays a run of page images back at their page numbers (restore).
@@ -5448,6 +5591,19 @@ impl StorageFile {
         recovery_full: Option<bool>,
     ) -> Result<(), StorageError> {
         self.ensure_rel_usable()?;
+        // Enabling FULL starts a fresh log chain at the current tail; the
+        // marker (and its hold) advance only via BACKUP LOG thereafter. An
+        // already-FULL ALTER, or one that disables FULL / touches only the
+        // snapshot options, leaves the marker where it was. Computed against
+        // the OLD recovery model (before `version.set_options` below) and
+        // stamped into the same durable superblock write as the option byte,
+        // so a crash never leaves FULL set with a stale/zero marker.
+        let enabling_full = recovery_full == Some(true) && !self.version.recovery_full;
+        let new_marker = if enabling_full {
+            self.wal.tail()
+        } else {
+            self.last_log_backup_lsn
+        };
         // Build the new superblocks in LOCALS and write them BEFORE mutating
         // any in-memory state: a failed write must leave the version store,
         // the option mirrors, and the cached superblocks exactly as they
@@ -5468,15 +5624,35 @@ impl StorageFile {
             }
             next
         };
+        self.commit_superblock(|sb| {
+            sb.set_db_options(byte);
+            sb.set_last_log_backup_lsn(new_marker);
+        })?;
+        self.version
+            .set_options(rcsi, allow_snapshot, recovery_full);
+        // Now that the model byte and marker are durable, sync the in-memory
+        // marker and the FULL-model log-truncation hold. FULL pins the ring at
+        // the marker; SIMPLE releases it.
+        self.last_log_backup_lsn = new_marker;
+        if self.version.recovery_full {
+            self.register_log_backup_hold(new_marker);
+        } else {
+            self.release_log_backup_hold();
+        }
+        Ok(())
+    }
+
+    /// Rebuilds both superblocks from the active slot, applies `mutate` to each,
+    /// bumps the generation, and dual-writes them durably (active slot first,
+    /// fsync between — a torn first write falls back to the other slot with the
+    /// old state). Commits the new superblocks to memory only after both are
+    /// durable. The single discipline behind every reserved-field update.
+    fn commit_superblock(&mut self, mutate: impl Fn(&mut Superblock)) -> Result<(), StorageError> {
         let generation = self
             .superblock_a
             .generation
             .max(self.superblock_b.generation)
             .saturating_add(1);
-        // The lazy active-slot rewrite leaves the backup's dynamic fields
-        // stale; both slots get the same generation here, so equalize them
-        // from the active slot (whichever wins at open must carry the
-        // freshest recovery hints).
         let (active, backup_flag) = match self.active_superblock {
             ActiveSuperblock::A => (self.superblock_a, SUPERBLOCK_ACTIVE_B),
             ActiveSuperblock::B => (self.superblock_b, SUPERBLOCK_ACTIVE_A),
@@ -5485,7 +5661,7 @@ impl StorageFile {
         let mut backup = active;
         backup.active = backup_flag;
         for sb in [&mut primary, &mut backup] {
-            sb.set_db_options(byte);
+            mutate(sb);
             sb.generation = generation;
             sb.checksum = sb.compute_checksum();
         }
@@ -5505,7 +5681,6 @@ impl StorageFile {
         self.file
             .write_all_at(backup_offset, &backup.to_le_bytes_with_checksum())?;
         self.file.sync_data()?;
-        // Durable on disk — now commit to memory.
         match self.active_superblock {
             ActiveSuperblock::A => {
                 self.superblock_a = primary;
@@ -5516,9 +5691,13 @@ impl StorageFile {
                 self.superblock_a = backup;
             }
         }
-        self.version
-            .set_options(rcsi, allow_snapshot, recovery_full);
         Ok(())
+    }
+
+    /// Durably advances the persisted log-backup floor in both superblocks —
+    /// the copy-out-before-truncate commit point for `BACKUP LOG`.
+    fn persist_last_log_backup_lsn(&mut self, lsn: u64) -> Result<(), StorageError> {
+        self.commit_superblock(|sb| sb.set_last_log_backup_lsn(lsn))
     }
 
     /// Lazily rewrites the active superblock in place (no fsync: it is a
@@ -5738,6 +5917,10 @@ impl StorageFile {
             .map(|page| self.layout.data_offset + page * PAGE_SIZE as u64)
             .unwrap_or(0);
         let db_options = self.version.options_byte();
+        // The closure builds from Superblock::default() (reserved zeroed), so
+        // the log-backup floor must be stamped back in or a checkpoint would
+        // silently reset it to 0 and drop the FULL-model hold across a restart.
+        let last_log_backup_lsn = self.last_log_backup_lsn;
         let new_sb = |active_flag: u8| -> Superblock {
             let mut sb = Superblock {
                 generation,
@@ -5751,6 +5934,7 @@ impl StorageFile {
                 ..Superblock::default()
             };
             sb.set_db_options(db_options);
+            sb.set_last_log_backup_lsn(last_log_backup_lsn);
             sb.checksum = sb.compute_checksum();
             sb
         };
@@ -6106,6 +6290,7 @@ impl BackupPlan {
             flags: crate::backup::BackupFlags {
                 checksum: self.checksum,
                 copy_only: self.copy_only,
+                log_backup: false,
             },
         }
     }

--- a/crates/truthdb-core/src/storage.rs
+++ b/crates/truthdb-core/src/storage.rs
@@ -645,7 +645,29 @@ impl Storage {
         checksum: bool,
         copy_only: bool,
     ) -> Result<crate::backup::BackupSummary, StorageError> {
-        self.lock().backup_log(dst, checksum, copy_only)
+        // Phase 1 (locked): capture the log range + header. The OLD marker still
+        // pins `[start, ...)`, so no checkpoint can truncate the range we are
+        // about to ship, even after we release the lock.
+        let (header, start, end, log) = self.lock().begin_log_backup(checksum, copy_only)?;
+        // Phase 2 (UNLOCKED): write and fsync the archive — including its parent
+        // directory — so concurrent DML proceeds during the copy-out (BACKUP LOG
+        // is online, like BACKUP DATABASE). On failure, release the single-flight
+        // guard without advancing the marker.
+        if let Err(e) = write_log_archive(dst, &header, start, &log) {
+            self.lock().cancel_log_backup();
+            return Err(e);
+        }
+        // Phase 3 (locked): the archive is durable — durably advance the marker
+        // and the hold, releasing `[start, end)` for reclamation. Copy-out
+        // strictly before truncate.
+        self.lock().finish_log_backup(end)?;
+        Ok(crate::backup::BackupSummary {
+            redo_start_lsn: start,
+            backup_end_lsn: end,
+            pages_copied: 0,
+            log_bytes: log.len() as u64,
+            finished_at_millis: header.finished_at_millis,
+        })
     }
 
     fn write_backup(
@@ -1878,6 +1900,10 @@ struct StorageFile {
     /// `last_log_backup_lsn`): the LSN up to which the log has been shipped to
     /// a log archive. `0` in the SIMPLE model / before the first log backup.
     last_log_backup_lsn: u64,
+    /// Single-flight guard: set for the duration of a `BACKUP LOG` (which
+    /// releases the storage lock while writing the archive), so a second one
+    /// cannot begin from the same marker and produce an overlapping archive.
+    log_backup_in_progress: bool,
     layout: StorageLayout,
     superblock_a: Superblock,
     superblock_b: Superblock,
@@ -4495,6 +4521,7 @@ impl StorageFile {
             wal,
             truncation_gate: LogTruncationGate::default(),
             last_log_backup_lsn,
+            log_backup_in_progress: false,
             layout,
             superblock_a,
             superblock_b,
@@ -4609,6 +4636,7 @@ impl StorageFile {
             wal,
             truncation_gate: LogTruncationGate::default(),
             last_log_backup_lsn: 0,
+            log_backup_in_progress: false,
             layout,
             superblock_a,
             superblock_b,
@@ -5408,34 +5436,37 @@ impl StorageFile {
         Ok(out)
     }
 
-    /// Ships the FULL-model log tail `[last_log_backup_lsn, tail)` to a
-    /// `TDBBAK1` log archive, then durably advances the marker and the hold —
-    /// copy-out strictly before truncate, so a crash after the archive write
-    /// but before the marker advance simply re-ships the (idempotent) range.
-    fn backup_log(
+    /// Phase 1 of `BACKUP LOG`: under the storage lock, capture the log range
+    /// `[last_log_backup_lsn, tail)` and its bytes plus the archive header. Does
+    /// NOT advance the marker or hold, so the old marker keeps pinning the range
+    /// while the caller writes the archive with the lock released. Returns
+    /// `(header, start, end, log_bytes)`. Requires the FULL recovery model.
+    fn begin_log_backup(
         &mut self,
-        dst: &Path,
         checksum: bool,
         copy_only: bool,
-    ) -> Result<crate::backup::BackupSummary, StorageError> {
-        use crate::backup::{BackupFlags, BackupHeader, BackupWriter, BlockType, encode_log_chunk};
+    ) -> Result<(crate::backup::BackupHeader, u64, u64, Vec<u8>), StorageError> {
         self.ensure_rel_usable()?;
         if !self.version.recovery_full {
             return Err(StorageError::InvalidConfig(
                 "BACKUP LOG requires the FULL recovery model".to_string(),
             ));
         }
+        if self.log_backup_in_progress {
+            return Err(StorageError::BackupInProgress);
+        }
         self.wal.sync_all()?;
         let start = self.last_log_backup_lsn;
         let end = self.wal.tail();
         debug_assert!(end >= start);
         let log = self.read_ring_range(start, end)?;
-        let finished_at_millis = now_millis();
-
-        // A log-only archive: no page/region data — the header carries the
-        // range start in `redo_start_lsn` and the `log_backup` flag; the end is
-        // derived from the LogChunk length on read.
-        let header = BackupHeader {
+        // Reserve the single-flight slot only after the fallible reads above, so
+        // a failure never strands the guard.
+        self.log_backup_in_progress = true;
+        // A log-only archive: no page/region data — the header carries the range
+        // start in `redo_start_lsn` and the `log_backup` flag; the end is derived
+        // from the LogChunk length on read.
+        let header = crate::backup::BackupHeader {
             format_version: crate::backup::FORMAT_VERSION,
             page_size: PAGE_SIZE as u32,
             total_size: 0,
@@ -5450,32 +5481,32 @@ impl StorageFile {
             metadata_root: 0,
             last_committed_seq: 0,
             db_options: self.version.options_byte(),
-            finished_at_millis,
-            flags: BackupFlags {
+            finished_at_millis: now_millis(),
+            flags: crate::backup::BackupFlags {
                 checksum,
                 copy_only,
                 log_backup: true,
             },
         };
-        // Write the archive fully and fsync it BEFORE advancing the marker.
-        let file = std::fs::File::create(dst)?;
-        let mut writer = BackupWriter::new(file, &header)?;
-        writer.write_block(BlockType::LogChunk, &encode_log_chunk(start, &log))?;
-        writer.finish()?.sync_all()?;
+        Ok((header, start, end, log))
+    }
 
-        // Copy-out done and durable → advance the persisted marker, then the
-        // in-memory marker and hold, so the ring may now reclaim `[start, end)`.
+    /// Phase 3 of `BACKUP LOG`: the archive at `end` is durable, so durably
+    /// advance the persisted marker then the in-memory marker and hold, letting
+    /// the ring reclaim `[old_marker, end)`. Clears the single-flight guard
+    /// first, so a persist failure still frees the next backup.
+    fn finish_log_backup(&mut self, end: u64) -> Result<(), StorageError> {
+        self.log_backup_in_progress = false;
         self.persist_last_log_backup_lsn(end)?;
         self.last_log_backup_lsn = end;
         self.register_log_backup_hold(end);
+        Ok(())
+    }
 
-        Ok(crate::backup::BackupSummary {
-            redo_start_lsn: start,
-            backup_end_lsn: end,
-            pages_copied: 0,
-            log_bytes: log.len() as u64,
-            finished_at_millis,
-        })
+    /// Aborts an in-progress `BACKUP LOG` (the archive write failed) without
+    /// advancing the marker.
+    fn cancel_log_backup(&mut self) {
+        self.log_backup_in_progress = false;
     }
 
     /// Lays a run of page images back at their page numbers (restore).
@@ -5552,6 +5583,11 @@ impl StorageFile {
             ..Superblock::default()
         };
         base.set_db_options(header.db_options);
+        // Seed the log-backup floor at the restore point (`backup_end`), not 0:
+        // a restored FULL-model database starts a fresh log chain here. Leaving
+        // it 0 would make the on-open log-backup hold sit BELOW wal_head, which
+        // `set_head` forbids (the floor can only move forward).
+        base.set_last_log_backup_lsn(backup_end);
 
         let mut a = base;
         a.generation = 1;
@@ -6301,6 +6337,38 @@ fn now_millis() -> u64 {
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_millis() as u64)
         .unwrap_or(0)
+}
+
+/// Writes a log-only `TDBBAK1` archive (one `LogChunk`) at `dst` and makes it
+/// FULLY durable — data, then the parent directory's entry — before returning.
+/// Called with the storage lock RELEASED. Directory durability matters because
+/// the caller then advances the log-backup marker, which makes the shipped log
+/// range reclaimable; if the archive's directory entry were not durable, a crash
+/// could reclaim the log while the only archive copy lost its name.
+fn write_log_archive(
+    dst: &Path,
+    header: &crate::backup::BackupHeader,
+    start: u64,
+    log: &[u8],
+) -> Result<(), StorageError> {
+    use crate::backup::{BackupWriter, BlockType, encode_log_chunk};
+    let file = std::fs::File::create(dst)?;
+    let mut writer = BackupWriter::new(file, header)?;
+    writer.write_block(BlockType::LogChunk, &encode_log_chunk(start, log))?;
+    writer.finish()?.sync_all()?;
+    fsync_parent_dir(dst)?;
+    Ok(())
+}
+
+/// Fsyncs the parent directory of `path` so a newly created file's name is
+/// durable (POSIX: `fsync` on a file does not persist its directory entry).
+fn fsync_parent_dir(path: &Path) -> Result<(), StorageError> {
+    let parent = path
+        .parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    std::fs::File::open(parent)?.sync_all()?;
+    Ok(())
 }
 
 /// Rebuilds a [`StorageLayout`] from a backup header's region sizes. The

--- a/crates/truthdb-core/src/storage_layout.rs
+++ b/crates/truthdb-core/src/storage_layout.rs
@@ -322,6 +322,19 @@ impl Superblock {
     pub fn set_db_options(&mut self, byte: u8) {
         self.reserved[0] = byte;
     }
+
+    /// FULL-recovery-model log-backup floor: the LSN up to which the log has
+    /// been shipped to a log archive (`0` = none). Stored in the reserved area
+    /// (bytes 8..16; byte 0 is `db_options`, 1..8 are padding) and covered by
+    /// the superblock checksum. Persisted so the log-truncation hold is
+    /// re-established on open.
+    pub fn last_log_backup_lsn(&self) -> u64 {
+        u64::from_le_bytes(self.reserved[8..16].try_into().unwrap())
+    }
+
+    pub fn set_last_log_backup_lsn(&mut self, lsn: u64) {
+        self.reserved[8..16].copy_from_slice(&lsn.to_le_bytes());
+    }
 }
 
 #[repr(C)]

--- a/crates/truthdb-sql/src/ast.rs
+++ b/crates/truthdb-sql/src/ast.rs
@@ -182,6 +182,15 @@ pub enum Statement {
         copy_only: bool,
         span: Span,
     },
+    /// `BACKUP LOG <name> TO DISK = '<path>' [WITH <opt>[, ...]]` — a
+    /// transaction-log backup (FULL recovery model only).
+    BackupLog {
+        database: Name,
+        path: String,
+        checksum: bool,
+        copy_only: bool,
+        span: Span,
+    },
 }
 
 /// `GRANT` / `DENY` / `REVOKE`.

--- a/crates/truthdb-sql/src/parser.rs
+++ b/crates/truthdb-sql/src/parser.rs
@@ -1843,7 +1843,15 @@ impl Parser {
                 SqlError::new(156, 15, 1, "Incorrect syntax near the keyword 'BACKUP'.").at(start),
             );
         }
-        self.expect_keyword("DATABASE")?;
+        let is_log = match self.peek_keyword().as_deref() {
+            Some("DATABASE") => false,
+            Some("LOG") => true,
+            _ => {
+                let token = self.peek().clone();
+                return Err(SqlError::syntax(self.token_text(&token), token.span));
+            }
+        };
+        self.bump(); // DATABASE | LOG
         let database = self.parse_name()?;
         self.expect_keyword("TO")?;
         self.expect_keyword("DISK")?;
@@ -1889,13 +1897,23 @@ impl Parser {
             }
         }
         let span = start.to(self.prev_span());
-        Ok(Statement::BackupDatabase {
-            database,
-            path,
-            checksum,
-            copy_only,
-            span,
-        })
+        if is_log {
+            Ok(Statement::BackupLog {
+                database,
+                path,
+                checksum,
+                copy_only,
+                span,
+            })
+        } else {
+            Ok(Statement::BackupDatabase {
+                database,
+                path,
+                checksum,
+                copy_only,
+                span,
+            })
+        }
     }
 
     fn parse_create_login(&mut self, start: Span, alter: bool) -> SqlResult<Statement> {


### PR DESCRIPTION
FULL recovery model now holds the WAL ring until `BACKUP LOG` ships the log out, and a FULL-model ring that fills with un-backed-up log stalls with 9002.

- **`LogTruncationGate` gains a `log_backup` hold** folded into `min_hold` alongside the backup hold, so `checkpoint_wal_head`/`set_head` (unchanged) can never truncate past the log-backup floor. Invariant `marker >= head` holds (enabling FULL sets `marker = tail`; the hold then pins `head <= marker`).
- **`last_log_backup_lsn`** lives in the superblock reserved area (bytes 8..16, checksum-covered) + on `StorageFile`. Enabling FULL starts the chain at the current tail, stamped into the **same durable superblock write** as the recovery bit (crash-atomic); re-read + hold re-registered on open; carried forward by `finish_checkpoint`.
- **`BACKUP LOG <db> TO DISK = '<path>'`** — new AST variant, shared parser branch, privileged executor arm (no batch lock, 3021 in a txn, 4208 in SIMPLE). `Storage::backup_log` ships `[last_log_backup_lsn, tail)` to a log-only `TDBBAK1` archive (new `BackupFlags::log_backup`), fsyncs it, then durably advances the marker + hold — **copy-out strictly before truncate**.
- **`WalFull` maps to 9002** (was 3621) — faithful for both models.
- Refactored the superblock dual-write into a shared **`commit_superblock`** helper (reused by `persist_last_log_backup_lsn`); extracted **`read_ring_range`** from `ship_backup_log`.

## Tests
BACKUP LOG ships + advances + chains contiguously; the archive is a valid log-only TDBBAK1; a checkpoint under FULL holds the head at the floor and reclaims past it only after BACKUP LOG; marker + hold survive reopen; SIMPLE→4208; a full FULL-model ring→9002. Full workspace green; fmt + clippy `-D warnings` clean.

Restore of a log chain (`restore --log`) is slice 2b (with PITR). This slice is the source-side FULL model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)