### PR TITLE
Stage 17 slice 2b (restore-of-log): restore --full --log chain

### DIFF
--- a/crates/truthdb-cli/src/main.rs
+++ b/crates/truthdb-cli/src/main.rs
@@ -52,8 +52,9 @@ enum Command {
         #[arg(long)]
         add_gib: u64,
     },
-    /// OFFLINE: restore a database file from a `TDBBAK1` full backup. The
-    /// destination must not exist and the server must not be running.
+    /// OFFLINE: restore a database file from a `TDBBAK1` full backup, optionally
+    /// followed by an ordered chain of `BACKUP LOG` archives. The destination
+    /// must not exist and the server must not be running.
     Restore {
         /// Path to the `TDBBAK1` full-backup file.
         #[arg(long)]
@@ -61,6 +62,10 @@ enum Command {
         /// Destination path for the restored database file (must not exist).
         #[arg(long)]
         to: std::path::PathBuf,
+        /// A `BACKUP LOG` archive to apply after the full backup. Repeat in
+        /// chain order (oldest first).
+        #[arg(long = "log")]
+        log: Vec<std::path::PathBuf>,
     },
 }
 
@@ -87,10 +92,19 @@ async fn main() -> Result<()> {
                 Err(err) => Err(anyhow::anyhow!("grow failed: {err}")),
             }
         }
-        Command::Restore { full, to } => {
-            match truthdb_core::storage::Storage::restore_full(&full, &to) {
+        Command::Restore { full, to, log } => {
+            match truthdb_core::storage::Storage::restore_full_with_logs(&full, &to, &log) {
                 Ok(()) => {
-                    println!("restored {} from {}", to.display(), full.display());
+                    println!(
+                        "restored {} from {}{}",
+                        to.display(),
+                        full.display(),
+                        if log.is_empty() {
+                            String::new()
+                        } else {
+                            format!(" + {} log archive(s)", log.len())
+                        }
+                    );
                     Ok(())
                 }
                 Err(err) => Err(anyhow::anyhow!("restore failed: {err}")),

--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -2197,11 +2197,18 @@ mod tests {
             "the full backup alone is the point-in-time it was taken"
         );
 
-        // A gap in the chain (apply only the second log) is rejected (4305).
+        // A gap in the chain (apply only the second log) is rejected (4305), and
+        // the partial destination is removed so a retry can reuse the path.
         assert!(
             Storage::restore_full_with_logs(&restored_gap, &bak, &[trn2.clone()]).is_err(),
             "a log-chain gap is rejected"
         );
+        assert!(
+            !restored_gap.exists(),
+            "the partial destination is cleaned up on error"
+        );
+        Storage::restore_full_with_logs(&restored_gap, &bak, &[trn1.clone(), trn2.clone()])
+            .expect("retry with the full chain to the same path succeeds after cleanup");
 
         drop(engine2);
         drop(engine3);

--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -2132,6 +2132,93 @@ mod tests {
     }
 
     #[test]
+    fn restore_full_plus_log_chain_recovers_post_backup_changes() {
+        let src = unique_temp_path("restlog-src");
+        let bak = unique_temp_path("restlog-bak");
+        let trn1 = unique_temp_path("restlog-1");
+        let trn2 = unique_temp_path("restlog-2");
+        let restored = unique_temp_path("restlog-restored");
+        let restored_full_only = unique_temp_path("restlog-fullonly");
+        let restored_gap = unique_temp_path("restlog-gap");
+
+        let engine = new_engine(&src);
+        engine
+            .execute("ALTER DATABASE CURRENT SET RECOVERY FULL")
+            .expect("full");
+        engine
+            .execute("CREATE TABLE t (id INT NOT NULL PRIMARY KEY, v INT)")
+            .expect("create");
+        for i in 1..=20 {
+            engine
+                .execute(&format!("INSERT INTO t VALUES ({i}, {i})"))
+                .expect("insert");
+        }
+        // Full backup captures rows 1..=20.
+        engine.storage().backup_full(&bak).expect("full backup");
+        // Changes AFTER the full backup, then a first log backup.
+        for i in 21..=40 {
+            engine
+                .execute(&format!("INSERT INTO t VALUES ({i}, {i})"))
+                .expect("insert");
+        }
+        let lit1 = trn1.to_str().unwrap().replace('\'', "''");
+        assert!(sql(&engine, &format!("BACKUP LOG truthdb TO DISK = '{lit1}'"))["error"].is_null());
+        // More changes, then a second (chained) log backup.
+        engine
+            .execute("UPDATE t SET v = v + 100 WHERE id <= 5")
+            .expect("update");
+        for i in 41..=50 {
+            engine
+                .execute(&format!("INSERT INTO t VALUES ({i}, {i})"))
+                .expect("insert");
+        }
+        let lit2 = trn2.to_str().unwrap().replace('\'', "''");
+        assert!(sql(&engine, &format!("BACKUP LOG truthdb TO DISK = '{lit2}'"))["error"].is_null());
+        let expected = sql_rows(&engine, "SELECT id, v FROM t ORDER BY id").1;
+        drop(engine);
+
+        // Full + the whole log chain recovers EVERY committed change.
+        Storage::restore_full_with_logs(&restored, &bak, &[trn1.clone(), trn2.clone()])
+            .expect("restore full + log chain");
+        let engine2 = Engine::new(Storage::open(restored.clone()).expect("open")).expect("engine");
+        assert_eq!(
+            sql_rows(&engine2, "SELECT id, v FROM t ORDER BY id").1,
+            expected,
+            "restore + log chain recovers all post-full-backup changes"
+        );
+
+        // The full backup alone recovers only the 20 rows at its point.
+        Storage::restore_full(&restored_full_only, &bak).expect("restore full only");
+        let engine3 =
+            Engine::new(Storage::open(restored_full_only.clone()).expect("open")).expect("engine");
+        assert_eq!(
+            sql_rows(&engine3, "SELECT COUNT(*) FROM t").1,
+            vec![vec![Some("20".into())]],
+            "the full backup alone is the point-in-time it was taken"
+        );
+
+        // A gap in the chain (apply only the second log) is rejected (4305).
+        assert!(
+            Storage::restore_full_with_logs(&restored_gap, &bak, &[trn2.clone()]).is_err(),
+            "a log-chain gap is rejected"
+        );
+
+        drop(engine2);
+        drop(engine3);
+        for p in [
+            src,
+            bak,
+            trn1,
+            trn2,
+            restored,
+            restored_full_only,
+            restored_gap,
+        ] {
+            let _ = std::fs::remove_file(p);
+        }
+    }
+
+    #[test]
     fn backup_log_requires_the_full_recovery_model() {
         let path = unique_temp_path("backuplog-simple");
         let engine = new_engine(&path);

--- a/crates/truthdb-core/src/storage.rs
+++ b/crates/truthdb-core/src/storage.rs
@@ -731,10 +731,9 @@ impl Storage {
         bak_path: &Path,
         log_paths: &[std::path::PathBuf],
     ) -> Result<(), StorageError> {
-        use crate::backup::{BlockType, decode_alloc_map, decode_log_chunk, decode_page_run};
         assert_layout_invariants();
         let reader = std::io::BufReader::new(std::fs::File::open(bak_path)?);
-        let (mut backup, header) = crate::backup::BackupReader::new(reader)?;
+        let (backup, header) = crate::backup::BackupReader::new(reader)?;
         if header.page_size as usize != PAGE_SIZE {
             return Err(StorageError::InvalidFile(
                 "backup page size mismatch".to_string(),
@@ -753,13 +752,34 @@ impl Storage {
                 "backup header region sizes are inconsistent".to_string(),
             ));
         }
-        let data_pages = header.data_size / PAGE_SIZE as u64;
-        let mut file = StorageFile::create_from_layout(
+        let file = StorageFile::create_from_layout(
             dst_path.to_path_buf(),
             layout,
             header.default_collation.clone(),
         )?;
+        // The destination now exists and is ours: remove the partial file if any
+        // later step fails, so a retry (which requires a fresh destination) can
+        // proceed. Everything ABOVE this point errors without having created it.
+        let outcome = Self::restore_body(file, backup, &header, log_paths, dst_path);
+        if outcome.is_err() {
+            let _ = std::fs::remove_file(dst_path);
+        }
+        outcome
+    }
 
+    /// The part of a restore that owns the (already-created) destination: lays
+    /// down page images + the log, applies the log chain, writes the superblock,
+    /// and validates by opening (running recovery). A failure here leaves a
+    /// partial file the caller removes.
+    fn restore_body(
+        mut file: StorageFile,
+        mut backup: crate::backup::BackupReader<std::io::BufReader<std::fs::File>>,
+        header: &crate::backup::BackupHeader,
+        log_paths: &[std::path::PathBuf],
+        dst_path: &Path,
+    ) -> Result<(), StorageError> {
+        use crate::backup::{BlockType, decode_alloc_map, decode_log_chunk, decode_page_run};
+        let data_pages = header.data_size / PAGE_SIZE as u64;
         let mut runs: Vec<(u64, u64)> = Vec::new();
         let mut log: Option<(u64, Vec<u8>)> = None;
         while let Some((block_type, payload)) = backup.next_block()? {
@@ -817,7 +837,7 @@ impl Storage {
         }
         // The restored superblock brackets the ring at `[redo_start, tail)`; the
         // log-backup floor is the end of the applied chain (a fresh chain).
-        file.restore_superblock(&header, tail)?;
+        file.restore_superblock(header, tail)?;
         file.sync_file()?;
         drop(file);
 
@@ -6434,6 +6454,17 @@ fn apply_log_archive(
             path.display()
         )));
     }
+    // Partial identity guard: a log archive whose page or ring geometry differs
+    // was taken against a differently-configured database and cannot belong to
+    // this chain. (A full database-identity match — a persisted DB uuid checked
+    // against the full backup — is future work; today the LSN-continuity check
+    // and geometry are the only cross-database guards.)
+    if header.page_size as usize != PAGE_SIZE || header.wal_size != file.layout.wal_size {
+        return Err(StorageError::InvalidFile(format!(
+            "{}: log archive geometry does not match the restored database",
+            path.display()
+        )));
+    }
     // Concatenate the archive's (contiguous) log chunks.
     let mut chunk: Option<(u64, Vec<u8>)> = None;
     while let Some((block_type, payload)) = r.next_block()? {
@@ -6463,9 +6494,15 @@ fn apply_log_archive(
         )));
     }
     let new_end = start_lsn + bytes.len() as u64;
-    if new_end.saturating_sub(head) > file.layout.wal_size {
+    // Leave the CLR reserve free: on open, ARIES undo appends compensation
+    // records for the transactions in flight at the chain end (use_reserve), so
+    // the recoverable range must fit `wal_size - reserve`, exactly as the full
+    // backup caps its own shipped log. Otherwise a legitimate long chain fills
+    // the ring and recovery's first undo append hits WalFull.
+    let max_range = file.layout.wal_size.saturating_sub(file.wal.reserve());
+    if new_end.saturating_sub(head) > max_range {
         return Err(StorageError::InvalidFile(
-            "the full backup plus its log chain exceed the WAL ring size; \
+            "the full backup plus its log chain exceed the WAL ring's usable size; \
              incremental restore is not yet supported"
                 .to_string(),
         ));

--- a/crates/truthdb-core/src/storage.rs
+++ b/crates/truthdb-core/src/storage.rs
@@ -715,7 +715,22 @@ impl Storage {
     /// `TDBBAK1` backup at `bak_path`, then opens it once to run ARIES recovery,
     /// validating that the restored file is recoverable. `dst_path` must not
     /// already exist.
+    /// Offline restore of a full backup with no log chain (recover to the full
+    /// backup's own end).
     pub fn restore_full(dst_path: &Path, bak_path: &Path) -> Result<(), StorageError> {
+        Self::restore_full_with_logs(dst_path, bak_path, &[])
+    }
+
+    /// Offline restore of a full backup followed by an ordered chain of
+    /// `BACKUP LOG` archives (recover to the end of the last log). Each archive
+    /// must continue from where the previous coverage ended (no gap, error
+    /// 4305); the whole recoverable range must fit in the WAL ring (a longer
+    /// chain needs incremental restore, not yet supported).
+    pub fn restore_full_with_logs(
+        dst_path: &Path,
+        bak_path: &Path,
+        log_paths: &[std::path::PathBuf],
+    ) -> Result<(), StorageError> {
         use crate::backup::{BlockType, decode_alloc_map, decode_log_chunk, decode_page_run};
         assert_layout_invariants();
         let reader = std::io::BufReader::new(std::fs::File::open(bak_path)?);
@@ -790,11 +805,19 @@ impl Storage {
         }
 
         file.restore_allocator_bitmap(&runs)?;
-        let backup_end = match &log {
+        let mut tail = match &log {
             Some((start_lsn, bytes)) => file.seed_ring(*start_lsn, bytes)?,
             None => header.redo_start_lsn,
         };
-        file.restore_superblock(&header, backup_end)?;
+        // Apply the log chain in order, extending the seeded ring past the full
+        // backup's end. Each archive continues from the current coverage (no
+        // gap) and the whole range must fit the ring.
+        for log_path in log_paths {
+            apply_log_archive(&mut file, log_path, header.redo_start_lsn, &mut tail)?;
+        }
+        // The restored superblock brackets the ring at `[redo_start, tail)`; the
+        // log-backup floor is the end of the applied chain (a fresh chain).
+        file.restore_superblock(&header, tail)?;
         file.sync_file()?;
         drop(file);
 
@@ -6389,6 +6412,66 @@ fn fsync_parent_dir(path: &Path) -> Result<(), StorageError> {
         .filter(|p| !p.as_os_str().is_empty())
         .unwrap_or_else(|| Path::new("."));
     std::fs::File::open(parent)?.sync_all()?;
+    Ok(())
+}
+
+/// Applies one `BACKUP LOG` archive to a restore in progress: reads its log
+/// range, verifies it continues from the current coverage (no gap — error 4305)
+/// and that the whole recoverable range still fits the ring, then seeds it and
+/// extends `tail`. Overlap with already-seeded log is harmless (same bytes).
+fn apply_log_archive(
+    file: &mut StorageFile,
+    path: &Path,
+    head: u64,
+    tail: &mut u64,
+) -> Result<(), StorageError> {
+    use crate::backup::{BlockType, decode_log_chunk};
+    let reader = std::io::BufReader::new(std::fs::File::open(path)?);
+    let (mut r, header) = crate::backup::BackupReader::new(reader)?;
+    if !header.flags.log_backup {
+        return Err(StorageError::InvalidFile(format!(
+            "{}: --log expects a BACKUP LOG archive, but this is a full backup",
+            path.display()
+        )));
+    }
+    // Concatenate the archive's (contiguous) log chunks.
+    let mut chunk: Option<(u64, Vec<u8>)> = None;
+    while let Some((block_type, payload)) = r.next_block()? {
+        if block_type == BlockType::LogChunk {
+            let (start_lsn, bytes) = decode_log_chunk(&payload)?;
+            match &mut chunk {
+                Some((first, acc)) => {
+                    if start_lsn != *first + acc.len() as u64 {
+                        return Err(StorageError::InvalidFile(
+                            "log archive chunks are not contiguous".to_string(),
+                        ));
+                    }
+                    acc.extend_from_slice(bytes);
+                }
+                None => chunk = Some((start_lsn, bytes.to_vec())),
+            }
+        }
+    }
+    let Some((start_lsn, bytes)) = chunk else {
+        return Ok(()); // an empty log backup contributes nothing
+    };
+    // Continuity: a start LATER than the current tail is a broken chain (4305).
+    if start_lsn > *tail {
+        return Err(StorageError::InvalidFile(format!(
+            "log chain gap (4305): {} begins at LSN {start_lsn} but the restore has reached {tail}",
+            path.display()
+        )));
+    }
+    let new_end = start_lsn + bytes.len() as u64;
+    if new_end.saturating_sub(head) > file.layout.wal_size {
+        return Err(StorageError::InvalidFile(
+            "the full backup plus its log chain exceed the WAL ring size; \
+             incremental restore is not yet supported"
+                .to_string(),
+        ));
+    }
+    file.seed_ring(start_lsn, &bytes)?;
+    *tail = (*tail).max(new_end);
     Ok(())
 }
 


### PR DESCRIPTION
Makes the BACKUP LOG archives usable — an offline restore applies an ordered chain of log backups on a full backup and recovers to the end of the chain.

- `Storage::restore_full_with_logs(dst, bak, &[log...])`: seed the full backup, then apply each log archive in order (log-only check, contiguous chunks, continuity/gap 4305, ring-bound, seed + extend tail). Superblock brackets [redo_start, final_tail).
- CLI: `restore --full <bak> --to <db> [--log <l.trn> ...]`.

Test: full (rows 1..20) + two chained log backups (through row 50 + an update) → restore recovers all changes; full-only recovers the 20-row point; a chain gap is rejected. Full workspace + clippy clean.

Limitation: a chain whose recoverable range exceeds the ring needs incremental restore (future). PITR (`--stopat` + commit timestamps) is the next slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)