### PR TITLE
Stage 17 slice 2b: commit-record timestamp (WAL entry v2)

### DIFF
--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -2226,6 +2226,54 @@ mod tests {
     }
 
     #[test]
+    fn commit_records_carry_a_recent_wall_clock_timestamp() {
+        use crate::storage_layout::WAL_ENTRY_TYPE_REL;
+        use crate::wal::records::{REL_KIND_TXN_COMMIT, RelRecord};
+        let now_ms = || {
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_millis() as u64
+        };
+        let path = unique_temp_path("commit-ts");
+        let before = now_ms();
+        {
+            let engine = new_engine(&path);
+            engine
+                .execute("CREATE TABLE t (id INT NOT NULL PRIMARY KEY)")
+                .expect("create");
+            engine.execute("INSERT INTO t VALUES (1)").expect("insert"); // autocommits
+        }
+        let after = now_ms();
+
+        // Reopen so recovery's ring scan populates the replay cache; some
+        // committed transaction's record carries a v2 entry with a wall-clock
+        // timestamp in [before, after] (for point-in-time restore).
+        let storage = Storage::open(path.clone()).expect("reopen");
+        let records = storage.replay_wal_entries().expect("replay");
+        let mut found = false;
+        for r in records {
+            if r.entry_type != WAL_ENTRY_TYPE_REL {
+                continue;
+            }
+            let rec = RelRecord::decode(&r.payload).expect("decode");
+            if rec.kind == REL_KIND_TXN_COMMIT && rec.redo.len() >= 8 {
+                assert_eq!(r.entry_version, 2, "new commit records are entry version 2");
+                let ts = u64::from_le_bytes(rec.redo[..8].try_into().unwrap());
+                if before <= ts && ts <= after {
+                    found = true;
+                }
+            }
+        }
+        assert!(
+            found,
+            "a commit record carried a timestamp in [{before}, {after}]"
+        );
+        drop(storage);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
     fn backup_log_requires_the_full_recovery_model() {
         let path = unique_temp_path("backuplog-simple");
         let engine = new_engine(&path);

--- a/crates/truthdb-core/src/relstore/ctx.rs
+++ b/crates/truthdb-core/src/relstore/ctx.rs
@@ -23,7 +23,9 @@ use crate::storage_layout::{PAGE_SIZE, WAL_ENTRY_TYPE_REL};
 use crate::wal::WalWriter;
 use crate::wal::records::{PageOpRedo, PageOpUndo, RelRecord};
 
-const REL_WAL_ENTRY_VERSION: u16 = 1;
+// v2 adds a commit-record timestamp (in the commit's `redo`) for point-in-time
+// restore. Nothing gates on the version, so v1 records decode unchanged.
+const REL_WAL_ENTRY_VERSION: u16 = 2;
 
 /// Raw page I/O + WAL watermark for the buffer pool, over the data region.
 pub(crate) struct PoolIo<'a> {
@@ -223,7 +225,14 @@ impl RelCtx<'_> {
         // `Storage::ensure_durable` at the end of the batch, so one fsync serves
         // every commit in the window. The record must reach the disk before the
         // batch is acknowledged; nothing before that ack depends on it.
-        let commit_lsn = self.append(&RelRecord::txn_commit(txn.txn_id, txn.last_lsn), false)?;
+        let timestamp_millis = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or(0);
+        let commit_lsn = self.append(
+            &RelRecord::txn_commit(txn.txn_id, txn.last_lsn, timestamp_millis),
+            false,
+        )?;
         let _ = self.append(&RelRecord::txn_end(txn.txn_id, commit_lsn), false);
         Ok(commit_lsn)
     }

--- a/crates/truthdb-core/src/storage.rs
+++ b/crates/truthdb-core/src/storage.rs
@@ -40,8 +40,9 @@ impl From<TypeError> for StorageError {
 }
 
 /// Version stamped in REL wal entries (entry-level, distinct from the record
-/// kinds inside).
-const REL_WAL_ENTRY_VERSION: u16 = 1;
+/// kinds inside). v2 adds a commit-record timestamp for point-in-time restore;
+/// v1 records decode unchanged (nothing gates on the version).
+const REL_WAL_ENTRY_VERSION: u16 = 2;
 
 // Fixed (built-in) principals are SYNTHESIZED at read time, never stored. Their
 // principal_ids sit in a reserved band far above any real `object_id` (which

--- a/crates/truthdb-core/src/wal/records.rs
+++ b/crates/truthdb-core/src/wal/records.rs
@@ -451,13 +451,18 @@ impl RelRecord {
         }
     }
 
-    pub fn txn_commit(txn_id: u64, prev_lsn: u64) -> Self {
+    pub fn txn_commit(txn_id: u64, prev_lsn: u64, timestamp_millis: u64) -> Self {
         RelRecord {
             prev_lsn,
             txn_id,
             kind: REL_KIND_TXN_COMMIT,
             flags: 0,
-            redo: Vec::new(),
+            // The commit wall-clock time (millis since the Unix epoch), for
+            // point-in-time restore. It rides in `redo` so the record stays
+            // length-self-describing; recovery never redoes a commit record, so
+            // these bytes are inert to redo. Entry-version-1 commit records have
+            // an empty `redo` (no timestamp) and decode unchanged.
+            redo: timestamp_millis.to_le_bytes().to_vec(),
             undo: Vec::new(),
         }
     }
@@ -831,13 +836,21 @@ mod tests {
     fn txn_and_catalog_records_round_trip() {
         for record in [
             RelRecord::txn_begin(7),
-            RelRecord::txn_commit(7, 123),
+            RelRecord::txn_commit(7, 123, 1_700_000_000_000),
             RelRecord::txn_end(7, 456),
             RelRecord::set_catalog_root(99),
         ] {
             let decoded = RelRecord::decode(&record.encode()).expect("decode");
             assert_eq!(decoded, record);
         }
+        // The commit timestamp survives the encode/decode round-trip and lands
+        // in the commit record's redo.
+        let commit = RelRecord::txn_commit(7, 123, 1_700_000_000_000);
+        let decoded = RelRecord::decode(&commit.encode()).expect("decode");
+        assert_eq!(
+            u64::from_le_bytes(decoded.redo[..8].try_into().unwrap()),
+            1_700_000_000_000
+        );
         assert_eq!(
             RelRecord::set_catalog_root(99)
                 .decode_catalog_root()


### PR DESCRIPTION
The foundation for point-in-time restore. A commit record now carries the wall-clock time it committed (in the commit's `redo`, 8 bytes; `REL_WAL_ENTRY_VERSION` 1→2).

Pure format extension: nothing gates on the entry version, v1 records decode unchanged, and recovery never reads a commit record's redo (analysis only removes the txn from the ATT; the redo phase never matches TXN_COMMIT) — so the timestamp is inert to recovery. 22 recovery/reopen tests + the full suite pass unchanged.

Tests: encode/decode round-trip; a real autocommit's record carries a v2 entry with a timestamp between two now() reads.

Split redo (`stop_at`) + `restore --stopat` consume it in the next slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)