### PR TITLE
Stage 17 slice 2b (PITR): restore --stopat point-in-time recovery

### DIFF
--- a/crates/truthdb-cli/src/main.rs
+++ b/crates/truthdb-cli/src/main.rs
@@ -66,6 +66,11 @@ enum Command {
         /// chain order (oldest first).
         #[arg(long = "log")]
         log: Vec<std::path::PathBuf>,
+        /// Point-in-time restore: stop recovery at this wall-clock time
+        /// (milliseconds since the Unix epoch). Transactions that committed
+        /// after it are undone.
+        #[arg(long = "stopat")]
+        stopat: Option<u64>,
     },
 }
 
@@ -92,17 +97,26 @@ async fn main() -> Result<()> {
                 Err(err) => Err(anyhow::anyhow!("grow failed: {err}")),
             }
         }
-        Command::Restore { full, to, log } => {
-            match truthdb_core::storage::Storage::restore_full_with_logs(&full, &to, &log) {
+        Command::Restore {
+            full,
+            to,
+            log,
+            stopat,
+        } => {
+            match truthdb_core::storage::Storage::restore_full_with_logs(&full, &to, &log, stopat) {
                 Ok(()) => {
                     println!(
-                        "restored {} from {}{}",
+                        "restored {} from {}{}{}",
                         to.display(),
                         full.display(),
                         if log.is_empty() {
                             String::new()
                         } else {
                             format!(" + {} log archive(s)", log.len())
+                        },
+                        match stopat {
+                            Some(ts) => format!(" (stopped at {ts})"),
+                            None => String::new(),
                         }
                     );
                     Ok(())

--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -2178,7 +2178,7 @@ mod tests {
         drop(engine);
 
         // Full + the whole log chain recovers EVERY committed change.
-        Storage::restore_full_with_logs(&restored, &bak, &[trn1.clone(), trn2.clone()])
+        Storage::restore_full_with_logs(&restored, &bak, &[trn1.clone(), trn2.clone()], None)
             .expect("restore full + log chain");
         let engine2 = Engine::new(Storage::open(restored.clone()).expect("open")).expect("engine");
         assert_eq!(
@@ -2200,14 +2200,14 @@ mod tests {
         // A gap in the chain (apply only the second log) is rejected (4305), and
         // the partial destination is removed so a retry can reuse the path.
         assert!(
-            Storage::restore_full_with_logs(&restored_gap, &bak, &[trn2.clone()]).is_err(),
+            Storage::restore_full_with_logs(&restored_gap, &bak, &[trn2.clone()], None).is_err(),
             "a log-chain gap is rejected"
         );
         assert!(
             !restored_gap.exists(),
             "the partial destination is cleaned up on error"
         );
-        Storage::restore_full_with_logs(&restored_gap, &bak, &[trn1.clone(), trn2.clone()])
+        Storage::restore_full_with_logs(&restored_gap, &bak, &[trn1.clone(), trn2.clone()], None)
             .expect("retry with the full chain to the same path succeeds after cleanup");
 
         drop(engine2);
@@ -2221,6 +2221,83 @@ mod tests {
             restored_full_only,
             restored_gap,
         ] {
+            let _ = std::fs::remove_file(p);
+        }
+    }
+
+    #[test]
+    fn point_in_time_restore_stops_at_a_commit_timestamp() {
+        use crate::storage_layout::WAL_ENTRY_TYPE_REL;
+        use crate::wal::records::{REL_KIND_TXN_COMMIT, RelRecord};
+
+        let src = unique_temp_path("pitr-src");
+        let bak = unique_temp_path("pitr-bak");
+        let restored = unique_temp_path("pitr-restored");
+
+        let engine = new_engine(&src);
+        engine
+            .execute("CREATE TABLE t (id INT NOT NULL PRIMARY KEY)")
+            .expect("create");
+        // Three autocommitted inserts, spaced so their commit records land in
+        // distinct milliseconds; the sleeps make the timestamps separable.
+        engine.execute("INSERT INTO t VALUES (1)").expect("ins 1");
+        std::thread::sleep(std::time::Duration::from_millis(15));
+        engine.execute("INSERT INTO t VALUES (2)").expect("ins 2");
+        std::thread::sleep(std::time::Duration::from_millis(15));
+        engine.execute("INSERT INTO t VALUES (3)").expect("ins 3");
+        // The online full backup captures all three commits in its embedded log.
+        engine.storage().backup_full(&bak).expect("full backup");
+        drop(engine);
+
+        // Reopen the source so recovery's ring scan fills the replay cache, then
+        // read the commit timestamps in LSN order: create, insert-1, insert-2,
+        // insert-3. Stopping at insert-1's timestamp must keep row 1 (ts == stop
+        // is not "after") and undo rows 2 and 3 (ts > stop).
+        let storage = Storage::open(src.clone()).expect("reopen src");
+        let mut commit_ts: Vec<u64> = Vec::new();
+        for r in storage.replay_wal_entries().expect("replay") {
+            if r.entry_type != WAL_ENTRY_TYPE_REL {
+                continue;
+            }
+            let rec = RelRecord::decode(&r.payload).expect("decode");
+            if let Some(ts) = rec.commit_timestamp_millis() {
+                commit_ts.push(ts);
+            }
+        }
+        drop(storage);
+        assert!(
+            commit_ts.len() >= 4,
+            "create + three inserts commit; got {commit_ts:?}"
+        );
+        let stop_at = commit_ts[1]; // insert-1's commit timestamp
+        assert!(
+            commit_ts[2] > stop_at,
+            "insert-2 must commit strictly after insert-1 for a clean stop point: {commit_ts:?}"
+        );
+
+        // Point-in-time restore of the full backup, stopping after insert-1.
+        Storage::restore_full_with_logs(&restored, &bak, &[], Some(stop_at)).expect("pitr restore");
+        let engine2 = Engine::new(Storage::open(restored.clone()).expect("open")).expect("engine");
+        assert_eq!(
+            sql_rows(&engine2, "SELECT id FROM t ORDER BY id").1,
+            vec![vec![Some("1".into())]],
+            "only the commit at-or-before the stop point survives"
+        );
+        drop(engine2);
+
+        // The undo persists: a plain reopen (no stop point) still shows only
+        // row 1 — the losers were rolled back durably via CLRs, not re-derived
+        // from stop_at.
+        let engine3 =
+            Engine::new(Storage::open(restored.clone()).expect("reopen")).expect("engine");
+        assert_eq!(
+            sql_rows(&engine3, "SELECT id FROM t ORDER BY id").1,
+            vec![vec![Some("1".into())]],
+            "point-in-time state survives a normal restart"
+        );
+        drop(engine3);
+
+        for p in [src, bak, restored] {
             let _ = std::fs::remove_file(p);
         }
     }

--- a/crates/truthdb-core/src/relstore/recovery.rs
+++ b/crates/truthdb-core/src/relstore/recovery.rs
@@ -36,22 +36,55 @@ pub(crate) struct AnalysisRedoOutcome {
 }
 
 /// Analysis + redo over the recovered records (`(lsn, record)`, log order).
+///
+/// `stop_at` drives point-in-time restore. Recovery keeps a log *prefix*: the
+/// first commit (in log order) whose wall-clock timestamp is past `stop_at`
+/// marks the cut, and that commit plus every later or still-uncommitted
+/// transaction is a loser. Redo still repeats ALL history and undo rolls those
+/// losers back with CLRs, so the point-in-time state persists across a later
+/// normal reopen. Cutting by LSN — not by each commit's own timestamp — keeps
+/// the restore internally consistent even when commit timestamps run backwards
+/// across increasing LSN (a non-monotonic clock): a transaction is never kept
+/// while an earlier one it depended on is dropped. `None` recovers to the end of
+/// the log (normal open).
 pub(crate) fn analyze_and_redo(
     ctx: &mut RelCtx<'_>,
     records: &[(u64, RelRecord)],
+    stop_at: Option<u64>,
 ) -> Result<AnalysisRedoOutcome, StorageError> {
+    // The point-in-time cut: every transaction committed at or after this LSN is
+    // undone. `u64::MAX` (no stop, or a stop past every commit) keeps them all.
+    let cut_lsn = match stop_at {
+        Some(limit) => first_commit_past(records, limit)?,
+        None => u64::MAX,
+    };
+
     // Analysis: rebuild the active-transaction table.
     let mut att: HashMap<u64, u64> = HashMap::new();
     let mut catalog_root = None;
     let mut max_txn_id = 0u64;
+    // Transactions committed at or past the cut: losers whose later TXN_END must
+    // not clear them from the ATT.
+    let mut forced_losers: std::collections::HashSet<u64> = std::collections::HashSet::new();
     for (lsn, record) in records {
         max_txn_id = max_txn_id.max(record.txn_id);
         match record.kind {
             REL_KIND_TXN_BEGIN => {
                 att.insert(record.txn_id, *lsn);
             }
-            REL_KIND_TXN_COMMIT | REL_KIND_TXN_END => {
-                att.remove(&record.txn_id);
+            REL_KIND_TXN_COMMIT => {
+                // A commit at or after the point-in-time cut does not count: keep
+                // the txn in the ATT so undo rolls it back.
+                if *lsn >= cut_lsn {
+                    forced_losers.insert(record.txn_id);
+                } else {
+                    att.remove(&record.txn_id);
+                }
+            }
+            REL_KIND_TXN_END => {
+                if !forced_losers.contains(&record.txn_id) {
+                    att.remove(&record.txn_id);
+                }
             }
             REL_KIND_PAGE_OP | REL_KIND_PAGE_IMAGE | REL_KIND_PAGE_IMAGES | REL_KIND_CLR => {
                 if record.txn_id != 0 {
@@ -101,6 +134,36 @@ pub(crate) fn analyze_and_redo(
         catalog_root,
         max_txn_id,
     })
+}
+
+/// The LSN of the first commit record (lowest LSN) whose wall-clock timestamp is
+/// strictly past `limit`, or `u64::MAX` when none is. Errors if any commit record
+/// carries no timestamp (a pre-timestamp WAL entry): point-in-time restore cannot
+/// place such a commit relative to the stop point, and silently treating it as a
+/// winner would keep post-stop data.
+fn first_commit_past(records: &[(u64, RelRecord)], limit: u64) -> Result<u64, StorageError> {
+    let mut cut = u64::MAX;
+    for (lsn, record) in records {
+        if record.kind != REL_KIND_TXN_COMMIT {
+            continue;
+        }
+        match record.commit_timestamp_millis() {
+            Some(ts) => {
+                if ts > limit && *lsn < cut {
+                    cut = *lsn;
+                }
+            }
+            None => {
+                return Err(StorageError::InvalidFile(
+                    "point-in-time restore requires timestamped commit records, but the \
+                     recoverable log contains a commit without a timestamp (the backup \
+                     predates the timestamped-commit WAL format)"
+                        .to_string(),
+                ));
+            }
+        }
+    }
+    Ok(cut)
 }
 
 /// Full-image redo: replaces the page wholesale when its LSN is older —
@@ -381,4 +444,63 @@ fn heap_slot_occupied(ctx: &mut RelCtx<'_>, page_no: u64, slot: u16) -> Result<b
     let occupied = (slot as usize) < page.slot_count() && page.get(slot as usize).is_some();
     ctx.pool.unpin(frame);
     Ok(occupied)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A version-2 commit record at `lsn` carrying `ts`.
+    fn commit(lsn: u64, ts: u64) -> (u64, RelRecord) {
+        (lsn, RelRecord::txn_commit(1, 0, ts))
+    }
+
+    /// A begin record at `lsn` (no timestamp) — the cut ignores non-commits.
+    fn begin(lsn: u64) -> (u64, RelRecord) {
+        (lsn, RelRecord::txn_begin(1))
+    }
+
+    #[test]
+    fn cut_is_the_first_commit_over_the_limit() {
+        let records = [
+            begin(5),
+            commit(10, 100),
+            begin(15),
+            commit(20, 200),
+            commit(30, 300),
+        ];
+        assert_eq!(first_commit_past(&records, 150).unwrap(), 20);
+        // A limit at a commit's exact timestamp keeps that commit (strictly past).
+        assert_eq!(first_commit_past(&records, 200).unwrap(), 30);
+    }
+
+    #[test]
+    fn cut_is_the_lowest_lsn_past_the_limit_under_a_backward_clock() {
+        // The clock stepped back: LSN 20 committed at ts 100, earlier than LSN
+        // 10's ts 300. The cut must be the lowest LSN whose ts is past the limit
+        // (10), so that the later-LSN, lower-ts commit at 20 is also undone —
+        // a log prefix, never a non-suffix loser set.
+        let records = [commit(10, 300), commit(20, 100)];
+        assert_eq!(first_commit_past(&records, 100).unwrap(), 10);
+    }
+
+    #[test]
+    fn no_cut_when_every_commit_is_within_the_limit() {
+        let records = [commit(10, 100), commit(20, 200)];
+        assert_eq!(first_commit_past(&records, 500).unwrap(), u64::MAX);
+    }
+
+    #[test]
+    fn a_timestampless_commit_is_rejected() {
+        let v1_commit = RelRecord {
+            prev_lsn: 0,
+            txn_id: 1,
+            kind: REL_KIND_TXN_COMMIT,
+            flags: 0,
+            redo: Vec::new(),
+            undo: Vec::new(),
+        };
+        let records = [commit(10, 100), (20, v1_commit)];
+        assert!(first_commit_past(&records, 50).is_err());
+    }
 }

--- a/crates/truthdb-core/src/storage.rs
+++ b/crates/truthdb-core/src/storage.rs
@@ -444,7 +444,16 @@ impl Storage {
 
     pub fn open(path: PathBuf) -> Result<Self, StorageError> {
         assert_layout_invariants();
-        let file = StorageFile::open_existing(path.clone())?;
+        let file = StorageFile::open_existing(path.clone(), None)?;
+        Self::with_log_writer(path, file)
+    }
+
+    /// Opens with recovery stopped at a point in time: transactions whose commit
+    /// timestamp is past `stop_at` are undone (point-in-time restore). Used by
+    /// the restore path to validate + finalize a `--stopat` recovery.
+    fn open_with_stop_at(path: PathBuf, stop_at: u64) -> Result<Self, StorageError> {
+        assert_layout_invariants();
+        let file = StorageFile::open_existing(path.clone(), Some(stop_at))?;
         Self::with_log_writer(path, file)
     }
 
@@ -719,18 +728,21 @@ impl Storage {
     /// Offline restore of a full backup with no log chain (recover to the full
     /// backup's own end).
     pub fn restore_full(dst_path: &Path, bak_path: &Path) -> Result<(), StorageError> {
-        Self::restore_full_with_logs(dst_path, bak_path, &[])
+        Self::restore_full_with_logs(dst_path, bak_path, &[], None)
     }
 
     /// Offline restore of a full backup followed by an ordered chain of
-    /// `BACKUP LOG` archives (recover to the end of the last log). Each archive
-    /// must continue from where the previous coverage ended (no gap, error
-    /// 4305); the whole recoverable range must fit in the WAL ring (a longer
-    /// chain needs incremental restore, not yet supported).
+    /// `BACKUP LOG` archives. Recovers to the end of the last log, or — when
+    /// `stop_at` is set — to that wall-clock point in time (transactions that
+    /// committed past it are undone). Each archive must continue from where the
+    /// previous coverage ended (no gap, error 4305); the whole recoverable range
+    /// must fit in the WAL ring (a longer chain needs incremental restore, not
+    /// yet supported).
     pub fn restore_full_with_logs(
         dst_path: &Path,
         bak_path: &Path,
         log_paths: &[std::path::PathBuf],
+        stop_at: Option<u64>,
     ) -> Result<(), StorageError> {
         assert_layout_invariants();
         let reader = std::io::BufReader::new(std::fs::File::open(bak_path)?);
@@ -761,7 +773,7 @@ impl Storage {
         // The destination now exists and is ours: remove the partial file if any
         // later step fails, so a retry (which requires a fresh destination) can
         // proceed. Everything ABOVE this point errors without having created it.
-        let outcome = Self::restore_body(file, backup, &header, log_paths, dst_path);
+        let outcome = Self::restore_body(file, backup, &header, log_paths, dst_path, stop_at);
         if outcome.is_err() {
             let _ = std::fs::remove_file(dst_path);
         }
@@ -778,6 +790,7 @@ impl Storage {
         header: &crate::backup::BackupHeader,
         log_paths: &[std::path::PathBuf],
         dst_path: &Path,
+        stop_at: Option<u64>,
     ) -> Result<(), StorageError> {
         use crate::backup::{BlockType, decode_alloc_map, decode_log_chunk, decode_page_run};
         let data_pages = header.data_size / PAGE_SIZE as u64;
@@ -842,10 +855,16 @@ impl Storage {
         file.sync_file()?;
         drop(file);
 
-        // Validate: opening reruns allocator recovery + ARIES relational
-        // recovery over the seeded ring, failing loudly if the restored file is
-        // not recoverable.
-        let storage = Storage::open(dst_path.to_path_buf())?;
+        // Validate + finalize: opening reruns allocator recovery + ARIES
+        // relational recovery over the seeded ring. For a point-in-time restore,
+        // recovery stops at `stop_at`, undoing later transactions with CLRs that
+        // persist the point-in-time state across a normal reopen (their undo is
+        // replayed and each undone txn is sealed with a TXN_END). Failing loudly
+        // if the restored file is not recoverable.
+        let storage = match stop_at {
+            Some(ts) => Storage::open_with_stop_at(dst_path.to_path_buf(), ts)?,
+            None => Storage::open(dst_path.to_path_buf())?,
+        };
         drop(storage);
         Ok(())
     }
@@ -4461,7 +4480,7 @@ impl StorageFile {
         Ok((def, schema))
     }
 
-    fn open_existing(path: PathBuf) -> Result<Self, StorageError> {
+    fn open_existing(path: PathBuf, stop_at: Option<u64>) -> Result<Self, StorageError> {
         let mut file = DirectFile::open_existing(path.clone())?;
         let mut header_bytes = [0u8; crate::storage_layout::FILE_HEADER_SIZE];
         file.read_exact_at(0, &mut header_bytes)?;
@@ -4602,7 +4621,7 @@ impl StorageFile {
 
         // ARIES restart for the relational store: analysis + redo, catalog
         // reload, undo of losers with compensation logging.
-        storage.recover_rel()?;
+        storage.recover_rel(stop_at)?;
         Ok(storage)
     }
 
@@ -4721,7 +4740,7 @@ impl StorageFile {
     /// loser transactions with CLRs. The catalog is loaded between redo and
     /// undo (undo needs tree roots) and reloaded after (undo may have
     /// removed catalog rows).
-    fn recover_rel(&mut self) -> Result<(), StorageError> {
+    fn recover_rel(&mut self, stop_at: Option<u64>) -> Result<(), StorageError> {
         let records = self.rel_records()?;
         if records.is_empty() && self.rel.catalog_root.is_none() {
             return Ok(());
@@ -4729,7 +4748,7 @@ impl StorageFile {
 
         let outcome = {
             let mut ctx = self.rel_ctx();
-            rel_recovery::analyze_and_redo(&mut ctx, &records)?
+            rel_recovery::analyze_and_redo(&mut ctx, &records, stop_at)?
         };
         if let Some(root) = outcome.catalog_root {
             self.rel.catalog_root = Some(root);

--- a/crates/truthdb-core/src/wal/records.rs
+++ b/crates/truthdb-core/src/wal/records.rs
@@ -467,6 +467,17 @@ impl RelRecord {
         }
     }
 
+    /// The commit wall-clock time (millis since the Unix epoch) for a
+    /// `TXN_COMMIT` record, or `None` for other kinds or a version-1 commit
+    /// record (which carried no timestamp). Used by point-in-time restore.
+    pub fn commit_timestamp_millis(&self) -> Option<u64> {
+        if self.kind == REL_KIND_TXN_COMMIT && self.redo.len() >= 8 {
+            Some(u64::from_le_bytes(self.redo[..8].try_into().unwrap()))
+        } else {
+            None
+        }
+    }
+
     pub fn txn_end(txn_id: u64, prev_lsn: u64) -> Self {
         RelRecord {
             prev_lsn,


### PR DESCRIPTION
## What

Point-in-time restore: `truthdb-cli restore --full f.bak [--log l.trn ...] --stopat <ms>` stops ARIES recovery at a wall-clock point in time, undoing transactions that committed after it. Consumes the commit-record timestamps added in #144.

## How

Recovery keeps a log **prefix** by LSN. `analyze_and_redo` computes `cut_lsn` = the first commit (in log order) whose timestamp is strictly past the stop point; that commit plus every later or still-uncommitted transaction is a loser. Redo repeats **all** history and undo rolls the losers back with CLRs, so the point-in-time state persists across a later normal reopen (each undone loser is sealed with a TXN_END; `recover_rel` fsyncs the WAL before the restore returns).

Cutting by **LSN** — not by each commit's own timestamp — keeps the restore internally consistent even if commit timestamps run backwards across increasing LSN (a non-monotonic clock): a transaction is never kept while an earlier one it depended on is dropped. This matches SQL Server STOPAT, which stops roll-forward at a single log point.

A `--stopat` restore whose recoverable log contains a commit record without a timestamp (a pre-#144 WAL entry) is **rejected**, rather than silently treating it as a winner and keeping post-stop data.

## Changes

- `RelRecord::commit_timestamp_millis()` — read the timestamp off a v2 commit record.
- `analyze_and_redo(stop_at)` + `first_commit_past` — the LSN-prefix cut and the timestampless-commit guard.
- `recover_rel` / `open_existing` thread `stop_at`; new **private** `Storage::open_with_stop_at` (restore-only — a live server can never boot at a stop point).
- `restore_full_with_logs(..., stop_at)` and the CLI `restore --stopat`.

## Tests

- Unit tests for the cut: first-past-limit, lowest-LSN under a backward clock, no-cut-in-the-future, timestampless-commit rejected.
- Engine round-trip: back up three timestamp-spaced inserts, restore stopping after the first, assert only row 1 survives — and survives a normal restart.

## Review

Adversarial review (4 lenses) found two MEDIUMs, both fixed here and re-verified:
1. Per-transaction stop was inconsistent under a non-monotonic clock → switched to the LSN-prefix cut.
2. `--stopat` silently kept post-stop data for pre-#144 (timestampless) commits → now rejected.

Durability, prefix-consistency, normal-recovery regression, and the fsync-before-return were re-verified with throwaway round-trip tests (reverted).

## Known limitation

PITR undoes *committed* post-cut transactions, so it can emit more CLRs than a normal restore. The ring-fit check sizes for the recoverable log, not the extra undo CLRs, so a large-enough `--stopat` window can exceed the WAL ring and fail the restore loudly (the partial destination is removed). A capacity limit, not corruption; large PITR needs incremental restore (deferred).

🤖 Generated with [Claude Code](https://claude.com/claude-code)