### PR TITLE
Stage 17 slice 2c: RESTORE VERIFYONLY/HEADERONLY/FILELISTONLY over TDS

### DIFF
--- a/crates/truthdb-core/src/backup.rs
+++ b/crates/truthdb-core/src/backup.rs
@@ -374,9 +374,24 @@ impl<R: Read> BackupReader<R> {
             .ok_or_else(|| corrupt("unknown block type"))?;
         let mut len_bytes = [0u8; 8];
         self.reader.read_exact(&mut len_bytes)?;
-        let len = u64::from_le_bytes(len_bytes) as usize;
-        let mut payload = vec![0u8; len];
-        self.reader.read_exact(&mut payload)?;
+        let len = u64::from_le_bytes(len_bytes);
+        // The length field is outside the per-block checksum, so a corrupt length
+        // must not drive a `vec![0u8; len]` allocation: a flipped high byte yields
+        // a length near u64::MAX and aborts or panics the process instead of
+        // surfacing as a clean corruption error. Grow the buffer only by bytes
+        // actually read; a bogus length then hits EOF and fails the length check.
+        let mut payload = Vec::new();
+        let mut buf = [0u8; 16 * 1024];
+        let mut remaining = len;
+        while remaining > 0 {
+            let want = remaining.min(buf.len() as u64) as usize;
+            let n = self.reader.read(&mut buf[..want])?;
+            if n == 0 {
+                return Err(corrupt("block truncated (corrupt backup)"));
+            }
+            payload.extend_from_slice(&buf[..n]);
+            remaining -= n as u64;
+        }
         let mut checksum_bytes = [0u8; 8];
         self.reader.read_exact(&mut checksum_bytes)?;
         let stored = u64::from_le_bytes(checksum_bytes);
@@ -386,6 +401,24 @@ impl<R: Read> BackupReader<R> {
         self.blocks += 1;
         Ok((block_type, payload))
     }
+}
+
+/// Reads a backup's header without restoring it (`RESTORE HEADERONLY` /
+/// `FILELISTONLY`). Fails if the file is not a readable `TDBBAK1` backup.
+pub fn read_header(path: &std::path::Path) -> io::Result<BackupHeader> {
+    let reader = io::BufReader::new(std::fs::File::open(path)?);
+    let (_, header) = BackupReader::new(reader)?;
+    Ok(header)
+}
+
+/// Verifies a backup end to end (`RESTORE VERIFYONLY`): the magic, the header,
+/// every block's checksum, and that the trailer's block count matches. A
+/// truncated file fails when a block read hits EOF. Returns the header.
+pub fn verify(path: &std::path::Path) -> io::Result<BackupHeader> {
+    let reader = io::BufReader::new(std::fs::File::open(path)?);
+    let (mut reader, header) = BackupReader::new(reader)?;
+    while reader.next_block()?.is_some() {}
+    Ok(header)
 }
 
 fn corrupt(message: &str) -> io::Error {

--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -2303,6 +2303,140 @@ mod tests {
     }
 
     #[test]
+    fn restore_inspect_verbs_read_a_backup_without_restoring() {
+        let src = unique_temp_path("restinspect-src");
+        let bak = unique_temp_path("restinspect-bak");
+
+        let engine = new_engine(&src);
+        engine
+            .execute("CREATE TABLE t (id INT NOT NULL PRIMARY KEY, v INT)")
+            .expect("create");
+        for i in 1..=10 {
+            engine
+                .execute(&format!("INSERT INTO t VALUES ({i}, {i})"))
+                .expect("insert");
+        }
+        let baklit = bak.to_str().unwrap().replace('\'', "''");
+        assert!(
+            sql(
+                &engine,
+                &format!("BACKUP DATABASE truthdb TO DISK = '{baklit}'")
+            )["error"]
+                .is_null()
+        );
+
+        // HEADERONLY: exactly one metadata row; a full backup is BackupType 1.
+        let (cols, rows) = sql_rows(
+            &engine,
+            &format!("RESTORE HEADERONLY FROM DISK = '{baklit}'"),
+        );
+        assert_eq!(rows.len(), 1, "one header row");
+        assert!(cols.contains(&"BackupType".to_string()));
+        assert!(cols.contains(&"Checksum".to_string()));
+        let col = |name: &str| rows[0][cols.iter().position(|c| c == name).unwrap()].clone();
+        assert_eq!(col("BackupType"), Some("1".to_string()), "full backup");
+        assert_eq!(col("FormatVersion"), Some("1".to_string()));
+        assert_eq!(col("PageSize"), Some("4096".to_string()));
+
+        // FILELISTONLY: a data row ('D') and a log row ('L').
+        let (fcols, frows) = sql_rows(
+            &engine,
+            &format!("RESTORE FILELISTONLY FROM DISK = '{baklit}'"),
+        );
+        assert_eq!(fcols, vec!["LogicalName", "Type", "Size"]);
+        let types: Vec<Option<String>> = frows.iter().map(|r| r[1].clone()).collect();
+        assert_eq!(types, vec![Some("D".to_string()), Some("L".to_string())]);
+
+        // VERIFYONLY: a valid backup verifies with no error and opens no rowset.
+        let env = sql(
+            &engine,
+            &format!("RESTORE VERIFYONLY FROM DISK = '{baklit}'"),
+        );
+        assert!(env["error"].is_null(), "valid backup verifies: {env}");
+
+        // RESTORE DATABASE is offline-only: online it errors (3101).
+        assert_eq!(
+            sql_error_number(
+                &engine,
+                &format!("RESTORE DATABASE truthdb FROM DISK = '{baklit}'")
+            ),
+            3101
+        );
+
+        // Inside a transaction, restore is refused (3021), like BACKUP.
+        assert_eq!(
+            sql_error_number(
+                &engine,
+                &format!("BEGIN TRANSACTION; RESTORE VERIFYONLY FROM DISK = '{baklit}'")
+            ),
+            3021
+        );
+        drop(engine);
+
+        for p in [src, bak] {
+            let _ = std::fs::remove_file(p);
+        }
+    }
+
+    #[test]
+    fn restore_verifyonly_rejects_a_corrupt_or_missing_backup() {
+        let src = unique_temp_path("restverify-src");
+        let bak = unique_temp_path("restverify-bak");
+        let engine = new_engine(&src);
+        engine
+            .execute("CREATE TABLE t (id INT NOT NULL PRIMARY KEY)")
+            .expect("create");
+        engine.execute("INSERT INTO t VALUES (1)").expect("insert");
+        let baklit = bak.to_str().unwrap().replace('\'', "''");
+        assert!(
+            sql(
+                &engine,
+                &format!("BACKUP DATABASE truthdb TO DISK = '{baklit}'")
+            )["error"]
+                .is_null()
+        );
+
+        let pristine = std::fs::read(&bak).expect("read bak");
+        let verify = |bytes: &[u8]| {
+            std::fs::write(&bak, bytes).expect("write");
+            sql_error_number(
+                &engine,
+                &format!("RESTORE VERIFYONLY FROM DISK = '{baklit}'"),
+            )
+        };
+
+        // Flip a payload byte mid-file: it no longer matches its xxh64, so
+        // VERIFYONLY reports the restore terminating abnormally (3013).
+        let mut payload_flip = pristine.clone();
+        let mid = payload_flip.len() / 2;
+        payload_flip[mid] ^= 0xFF;
+        assert_eq!(verify(&payload_flip), 3013, "a flipped payload byte");
+
+        // Corrupt the header block's length field (its high byte, outside the
+        // checksum): recovery must report 3013, not allocate ~u64::MAX and crash.
+        let mut len_flip = pristine.clone();
+        len_flip[19] = 0xFF;
+        assert_eq!(
+            verify(&len_flip),
+            3013,
+            "a corrupt block length is not a crash"
+        );
+
+        // A missing file errors cleanly, not a panic.
+        assert_eq!(
+            sql_error_number(
+                &engine,
+                "RESTORE VERIFYONLY FROM DISK = '/nonexistent/nope.bak'"
+            ),
+            3013
+        );
+        drop(engine);
+        for p in [src, bak] {
+            let _ = std::fs::remove_file(p);
+        }
+    }
+
+    #[test]
     fn commit_records_carry_a_recent_wall_clock_timestamp() {
         use crate::storage_layout::WAL_ENTRY_TYPE_REL;
         use crate::wal::records::{REL_KIND_TXN_COMMIT, RelRecord};

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -18,7 +18,7 @@ use truthdb_sql::ast::{
     CreateIndex, CreateLogin, CreateProcedure, CreateTable, CreateTrigger, CreateUser, CreateView,
     DataType, DatabaseOption, Declaration, Delete, DropIndex, DropTable, DropView, ExecStatement,
     Expr, ExprKind, ForeignKey, Insert, InsertSource, IsolationLevel, JoinKind, Name, OrderItem,
-    PermissionAction, PermissionKind, PermissionStatement, RaiseError, ReturnsClause,
+    PermissionAction, PermissionKind, PermissionStatement, RaiseError, RestoreMode, ReturnsClause,
     RoleMemberAction, Select, SelectItem, SetStatement, Statement, TableRef, ThrowArgs,
     ThrowStatement, Update,
 };
@@ -2116,6 +2116,11 @@ fn produces_rowset(statement: &Statement) -> bool {
         // sets; conservative.
         Statement::Exec(_) => true,
         Statement::Block { .. } | Statement::If { .. } | Statement::While { .. } => true,
+        // The header/file-list restore verbs return a rowset; VERIFYONLY and the
+        // offline DATABASE/LOG forms do not.
+        Statement::Restore { mode, .. } => {
+            matches!(mode, RestoreMode::HeaderOnly | RestoreMode::FileListOnly)
+        }
         _ => false,
     }
 }
@@ -3289,7 +3294,10 @@ fn analyze_statements_locks(
             // per-chunk storage locking. A Database X here would serialize it
             // against every writer and defeat the fuzzy design.
             | Statement::BackupDatabase { .. }
-            | Statement::BackupLog { .. } => {}
+            | Statement::BackupLog { .. }
+            // RESTORE VERIFYONLY/HEADERONLY/FILELISTONLY only read a backup file;
+            // they touch no database object, so they take no lock.
+            | Statement::Restore { .. } => {}
         }
     }
     // Batch-level lock escalation: if a table accumulated more than the
@@ -3566,6 +3574,7 @@ fn exec_statement_dispatch(
                 })?;
             Ok(StatementResult::Done)
         }
+        Statement::Restore { mode, path, .. } => exec_restore(*mode, path, txn_ctx),
         // Executed by `run_block`'s own arms; nothing routes them here.
         Statement::Block { .. }
         | Statement::If { .. }
@@ -6292,6 +6301,7 @@ fn is_privileged_ddl(stmt: &Statement) -> bool {
             | Statement::Permission(_)
             | Statement::BackupDatabase { .. }
             | Statement::BackupLog { .. }
+            | Statement::Restore { .. }
     )
 }
 
@@ -12342,6 +12352,134 @@ fn int_col(name: &str) -> ResultColumn {
         name: name.to_string(),
         column_type: ColumnType::Int,
     }
+}
+
+fn bigint_col(name: &str) -> ResultColumn {
+    ResultColumn {
+        name: name.to_string(),
+        column_type: ColumnType::BigInt,
+    }
+}
+
+fn bit_col(name: &str) -> ResultColumn {
+    ResultColumn {
+        name: name.to_string(),
+        column_type: ColumnType::Bit,
+    }
+}
+
+/// `RESTORE VERIFYONLY/HEADERONLY/FILELISTONLY` (online, read-only), plus a clear
+/// error for the offline-only `RESTORE DATABASE`/`LOG`. Like BACKUP, restore is
+/// illegal inside a transaction (3021).
+fn exec_restore(
+    mode: RestoreMode,
+    path: &str,
+    txn_ctx: &TxnContext,
+) -> Result<StatementResult, SqlError> {
+    if txn_ctx.in_txn() {
+        return Err(SqlError::new(
+            3021,
+            16,
+            1,
+            "Cannot perform a backup or restore operation within a transaction.".to_string(),
+        ));
+    }
+    let file = std::path::Path::new(path);
+    let terminating = |verb: &str, e: std::io::Error| {
+        SqlError::new(
+            3013,
+            16,
+            1,
+            format!("RESTORE {verb} is terminating abnormally. {e}"),
+        )
+    };
+    match mode {
+        RestoreMode::VerifyOnly => {
+            crate::backup::verify(file).map_err(|e| terminating("VERIFYONLY", e))?;
+            Ok(StatementResult::Done)
+        }
+        RestoreMode::HeaderOnly => {
+            let header =
+                crate::backup::read_header(file).map_err(|e| terminating("HEADERONLY", e))?;
+            Ok(StatementResult::Rows(restore_headeronly_rows(&header)))
+        }
+        RestoreMode::FileListOnly => {
+            let header =
+                crate::backup::read_header(file).map_err(|e| terminating("FILELISTONLY", e))?;
+            Ok(StatementResult::Rows(restore_filelist_rows(&header)))
+        }
+        RestoreMode::Database | RestoreMode::Log => Err(SqlError::new(
+            3101,
+            16,
+            1,
+            "Exclusive access could not be obtained because the database is in use. TruthDB \
+             restores a database offline: stop the server and run `truthdb-cli restore`."
+                .to_string(),
+        )),
+    }
+}
+
+/// One metadata row for `RESTORE HEADERONLY`.
+fn restore_headeronly_rows(header: &crate::backup::BackupHeader) -> RowSet {
+    let columns = vec![
+        int_col("BackupType"),
+        int_col("FormatVersion"),
+        int_col("PageSize"),
+        bigint_col("DatabaseSize"),
+        bit_col("Checksum"),
+        bit_col("CopyOnly"),
+        bigint_col("RedoStartLSN"),
+        bigint_col("LastCommittedSeq"),
+        int_col("DbOptions"),
+        nvarchar("Collation", 128),
+        bigint_col("BackupFinishDate"),
+    ];
+    // BackupType: 1 = full database, 2 = transaction log (SQL Server's coding).
+    let backup_type = if header.flags.log_backup { 2 } else { 1 };
+    let row = vec![
+        Datum::Int(backup_type),
+        Datum::Int(header.format_version as i32),
+        Datum::Int(header.page_size as i32),
+        Datum::BigInt(header.total_size as i64),
+        Datum::Bit(header.flags.checksum),
+        Datum::Bit(header.flags.copy_only),
+        Datum::BigInt(header.redo_start_lsn as i64),
+        Datum::BigInt(header.last_committed_seq as i64),
+        Datum::Int(header.db_options as i32),
+        match &header.default_collation {
+            Some(c) => Datum::NVarChar(c.clone()),
+            None => Datum::Null,
+        },
+        Datum::BigInt(header.finished_at_millis as i64),
+    ];
+    RowSet {
+        columns,
+        rows: vec![row],
+    }
+}
+
+/// The data + log "files" for `RESTORE FILELISTONLY`. A log-only archive reports
+/// a zero data size (it holds no page data) but keeps its WAL region size;
+/// `HEADERONLY`'s BackupType = 2 marks it as a log backup.
+fn restore_filelist_rows(header: &crate::backup::BackupHeader) -> RowSet {
+    let columns = vec![
+        nvarchar("LogicalName", 128),
+        nvarchar("Type", 1),
+        bigint_col("Size"),
+    ];
+    let rows = vec![
+        vec![
+            Datum::NVarChar("truthdb_data".to_string()),
+            Datum::NVarChar("D".to_string()),
+            Datum::BigInt(header.data_size as i64),
+        ],
+        vec![
+            Datum::NVarChar("truthdb_log".to_string()),
+            Datum::NVarChar("L".to_string()),
+            Datum::BigInt(header.wal_size as i64),
+        ],
+    ];
+    RowSet { columns, rows }
 }
 
 fn sys_tables(storage: &Storage) -> Source {

--- a/crates/truthdb-sql/src/ast.rs
+++ b/crates/truthdb-sql/src/ast.rs
@@ -191,6 +191,29 @@ pub enum Statement {
         copy_only: bool,
         span: Span,
     },
+    /// `RESTORE {VERIFYONLY|HEADERONLY|FILELISTONLY|DATABASE <name>|LOG <name>}
+    /// FROM DISK = '<path>'` — the online, read-only restore verbs. Actual
+    /// `RESTORE DATABASE`/`LOG` is offline (the CLI); online it errors.
+    Restore {
+        mode: RestoreMode,
+        path: String,
+        span: Span,
+    },
+}
+
+/// The `RESTORE` verb.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RestoreMode {
+    /// `RESTORE VERIFYONLY` — validate the whole backup file.
+    VerifyOnly,
+    /// `RESTORE HEADERONLY` — one row of backup metadata.
+    HeaderOnly,
+    /// `RESTORE FILELISTONLY` — one row per file in the backup.
+    FileListOnly,
+    /// `RESTORE DATABASE` — offline only (errors online).
+    Database,
+    /// `RESTORE LOG` — offline only (errors online).
+    Log,
 }
 
 /// `GRANT` / `DENY` / `REVOKE`.

--- a/crates/truthdb-sql/src/parser.rs
+++ b/crates/truthdb-sql/src/parser.rs
@@ -193,6 +193,7 @@ impl Parser {
             Some("DENY") => self.parse_permission(PermissionKind::Deny),
             Some("REVOKE") => self.parse_permission(PermissionKind::Revoke),
             Some("BACKUP") => self.parse_backup(),
+            Some("RESTORE") => self.parse_restore(),
             _ => {
                 let token = self.peek().clone();
                 Err(SqlError::syntax(self.token_text(&token), token.span))
@@ -1914,6 +1915,60 @@ impl Parser {
                 span,
             })
         }
+    }
+
+    /// `RESTORE {VERIFYONLY|HEADERONLY|FILELISTONLY|DATABASE <name>|LOG <name>}
+    /// FROM DISK = '<path>'`. The three inspect verbs run online; DATABASE/LOG
+    /// parse (so the error is semantic, not a syntax error) but restore offline.
+    fn parse_restore(&mut self) -> SqlResult<Statement> {
+        let start = self.peek().span;
+        self.bump(); // RESTORE
+        // Like BACKUP, RESTORE is side-effecting/privileged and illegal inside a
+        // function or table-valued-function body.
+        if self.in_function || self.in_table_function {
+            return Err(
+                SqlError::new(156, 15, 1, "Incorrect syntax near the keyword 'RESTORE'.").at(start),
+            );
+        }
+        let mode = match self.peek_keyword().as_deref() {
+            Some("VERIFYONLY") => {
+                self.bump();
+                RestoreMode::VerifyOnly
+            }
+            Some("HEADERONLY") => {
+                self.bump();
+                RestoreMode::HeaderOnly
+            }
+            Some("FILELISTONLY") => {
+                self.bump();
+                RestoreMode::FileListOnly
+            }
+            Some("DATABASE") => {
+                self.bump();
+                let _ = self.parse_name()?;
+                RestoreMode::Database
+            }
+            Some("LOG") => {
+                self.bump();
+                let _ = self.parse_name()?;
+                RestoreMode::Log
+            }
+            _ => {
+                let token = self.peek().clone();
+                return Err(SqlError::syntax(self.token_text(&token), token.span));
+            }
+        };
+        self.expect_keyword("FROM")?;
+        self.expect_keyword("DISK")?;
+        self.expect(&TokenKind::Eq)?;
+        let token = self.peek().clone();
+        let TokenKind::String(path) = &token.kind else {
+            return Err(SqlError::syntax(self.token_text(&token), token.span));
+        };
+        let path = path.clone();
+        self.bump();
+        let span = start.to(self.prev_span());
+        Ok(Statement::Restore { mode, path, span })
     }
 
     fn parse_create_login(&mut self, start: Span, alter: bool) -> SqlResult<Statement> {


### PR DESCRIPTION
## What

The online, read-only `RESTORE` verbs — inspect a `TDBBAK1` backup file without restoring it. Completes the RESTORE surface of **17.3**.

- `RESTORE VERIFYONLY FROM DISK = '<path>'` — walks the whole archive (magic, header, every block's xxh64, trailer block-count); errors (3013) on any corruption/truncation, success on a valid backup.
- `RESTORE HEADERONLY FROM DISK = '<path>'` — one metadata row (BackupType, FormatVersion, PageSize, DatabaseSize, Checksum, CopyOnly, RedoStartLSN, LastCommittedSeq, DbOptions, Collation, BackupFinishDate).
- `RESTORE FILELISTONLY FROM DISK = '<path>'` — the data (`D`) and log (`L`) file rows with region sizes.
- `RESTORE DATABASE`/`LOG` parse but restore is offline only → online they return 3101 pointing at `truthdb-cli restore`.

All verbs are privileged (`is_privileged_ddl`, so a non-privileged user gets 15247 before any file is opened — no filesystem probing), take no batch lock, and are refused inside a transaction (3021), like BACKUP.

## Hardening (found by review)

The block length field sits outside the per-block xxh64, so a corrupt length drove a `vec![0u8; len]` allocation that **panicked (capacity overflow) or aborted (alloc failure)** the process instead of a clean error. `read_block` now grows the buffer only by bytes actually read, so a bogus length hits EOF and returns 3013. Reachable before this change via the offline CLI restore; `RESTORE VERIFYONLY` exposed it to an online, client-supplied path. Regression-tested.

## Review

Two adversarial lenses (parser/grammar, exec/rowsets):
- Parser: no defect — `RESTORE` is a contextual dispatch keyword (not reserved, like BACKUP), all five forms parse, mis-parses error cleanly.
- Exec: found the length-field crash (fixed here). Privilege gate, lock/txn handling, rowset shape (columns==row widths), numeric casts, and log-archive inputs all verified clean.

The shared `read_block` fix (also on the real-restore path) is separately re-verified.

## Tests

Inspect verbs over a real backup (header row, file list, verify ok, offline 3101, in-txn 3021); VERIFYONLY rejecting a flipped-payload byte, a corrupt block length (no crash), and a missing file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)