### PR TITLE
Stage 18 slice 1: extract the resumable redo core (redo_records)

### DIFF
--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -2560,6 +2560,44 @@ mod tests {
     }
 
     #[test]
+    fn recovery_redo_is_idempotent_across_repeated_reopens() {
+        // Redo is the resumable core of replication (a standby applies it as
+        // records arrive): re-running it must be a no-op, gated by each page's
+        // LSN. Reopening the same database repeatedly re-runs redo over the whole
+        // log each time; the committed state must survive unchanged.
+        let path = unique_temp_path("redo-idempotent");
+        {
+            let engine = new_engine(&path);
+            engine
+                .execute("CREATE TABLE t (id INT NOT NULL PRIMARY KEY, v INT)")
+                .expect("create");
+            for i in 1..=30 {
+                engine
+                    .execute(&format!("INSERT INTO t VALUES ({i}, {i})"))
+                    .expect("insert");
+            }
+            engine
+                .execute("UPDATE t SET v = v + 100 WHERE id <= 10")
+                .expect("update");
+        }
+        let expected = {
+            let engine = Engine::new(Storage::open(path.clone()).expect("open")).expect("engine");
+            sql_rows(&engine, "SELECT id, v FROM t ORDER BY id").1
+        };
+        // Reopen several more times: each reopen re-runs redo over the full log.
+        // The state is invariant — proving redo re-application is idempotent.
+        for _ in 0..3 {
+            let engine = Engine::new(Storage::open(path.clone()).expect("reopen")).expect("engine");
+            assert_eq!(
+                sql_rows(&engine, "SELECT id, v FROM t ORDER BY id").1,
+                expected,
+                "redo re-application over the whole log is a no-op"
+            );
+        }
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
     fn commit_records_carry_a_recent_wall_clock_timestamp() {
         use crate::storage_layout::WAL_ENTRY_TYPE_REL;
         use crate::wal::records::{REL_KIND_TXN_COMMIT, RelRecord};

--- a/crates/truthdb-core/src/relstore/recovery.rs
+++ b/crates/truthdb-core/src/relstore/recovery.rs
@@ -103,7 +103,26 @@ pub(crate) fn analyze_and_redo(
         }
     }
 
-    // Redo: repeat history in log order, gated by each page's LSN.
+    redo_records(ctx, records)?;
+
+    Ok(AnalysisRedoOutcome {
+        losers: att,
+        catalog_root,
+        max_txn_id,
+    })
+}
+
+/// The redo pass on its own: repeat history in log order, each page write gated
+/// by that page's on-disk LSN (`page_lsn >= lsn` skips). This is the resumable
+/// core of ARIES recovery — it consults no active-transaction table and appends
+/// nothing to the WAL, so it is idempotent and safe to re-run over overlapping
+/// or extending record ranges. A streaming standby applies redo this way as
+/// records arrive; analysis (loser detection) and `undo_losers` — which need the
+/// whole log and mutate the WAL — run only at final recovery / promotion.
+pub(crate) fn redo_records(
+    ctx: &mut RelCtx<'_>,
+    records: &[(u64, RelRecord)],
+) -> Result<(), StorageError> {
     for (lsn, record) in records {
         match record.kind {
             REL_KIND_PAGE_IMAGE => {
@@ -128,12 +147,7 @@ pub(crate) fn analyze_and_redo(
             _ => {}
         }
     }
-
-    Ok(AnalysisRedoOutcome {
-        losers: att,
-        catalog_root,
-        max_txn_id,
-    })
+    Ok(())
 }
 
 /// The LSN of the first commit record (lowest LSN) whose wall-clock timestamp is


### PR DESCRIPTION
First slice of **Stage 18** (replication/HA). Physical replication ships WAL and a standby applies ARIES **redo verbatim**, incrementally and repeatedly.

The redo pass is already the resumable core: it repeats history gated by each page's on-disk LSN (`page_lsn >= lsn` skips), consults no active-transaction table, and appends nothing to the WAL — so it is **idempotent** and safe to re-run over overlapping/extending ranges. Analysis (loser detection) needs the whole log and `undo_losers` mutates the WAL, so both run only at final recovery / promotion — never during streaming.

This slice extracts that pass into `pub(crate) fn redo_records(ctx, records)` (called by `analyze_and_redo` after its analysis pass) and documents the contract. Behaviour-preserving — the full crash/recovery suite proves it; a new test (`recovery_redo_is_idempotent_across_repeated_reopens`) locks in the re-run-is-a-no-op property that the streaming standby will depend on.

Foundation for the next slices (in-process WAL apply → slots → transport → failover), mapped in the design note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)