### PR TITLE
Stage 15.1: scalar UDFs in ORDER BY / GROUP BY / HAVING / aggregate-arg / join-ON / CHECK

### DIFF
--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -6755,6 +6755,102 @@ mod tests {
     }
 
     #[test]
+    fn user_scalar_function_works_in_all_query_clause_positions() {
+        let path = unique_temp_path("udf-clauses");
+        let engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE t (id INT NOT NULL PRIMARY KEY)")
+            .expect("create");
+        for i in 1..=5 {
+            engine
+                .execute(&format!("INSERT INTO t VALUES ({i})"))
+                .expect("insert");
+        }
+        engine
+            .execute("CREATE FUNCTION dbo.dbl (@x INT) RETURNS INT AS BEGIN RETURN @x * 2 END")
+            .expect("create fn");
+
+        // ORDER BY a UDF (descending by dbl(id) == descending by id).
+        assert_eq!(
+            sql_rows(&engine, "SELECT id FROM t ORDER BY dbo.dbl(id) DESC").1,
+            vec![
+                vec![Some("5".into())],
+                vec![Some("4".into())],
+                vec![Some("3".into())],
+                vec![Some("2".into())],
+                vec![Some("1".into())],
+            ],
+            "UDF in ORDER BY"
+        );
+
+        // GROUP BY a UDF key: five distinct dbl(id) groups.
+        assert_eq!(
+            sql_rows(&engine, "SELECT COUNT(*) FROM t GROUP BY dbo.dbl(id)")
+                .1
+                .len(),
+            5,
+            "UDF in GROUP BY key"
+        );
+
+        // A UDF over an aggregate in the grouped SELECT list (dbl(count)=2 per id).
+        assert_eq!(
+            sql_rows(&engine, "SELECT dbo.dbl(COUNT(*)) FROM t GROUP BY id").1,
+            vec![vec![Some("2".into())]; 5],
+            "UDF over an aggregate in the grouped output"
+        );
+
+        // HAVING a UDF over the grouping column: dbl(id) > 6 keeps id 4 and 5.
+        assert_eq!(
+            sql_rows(
+                &engine,
+                "SELECT id FROM t GROUP BY id HAVING dbo.dbl(id) > 6 ORDER BY id"
+            )
+            .1,
+            vec![vec![Some("4".into())], vec![Some("5".into())]],
+            "UDF in HAVING"
+        );
+
+        // A UDF as an aggregate argument: SUM(dbl(id)) = 2*(1+2+3+4+5) = 30.
+        assert_eq!(
+            sql_rows(&engine, "SELECT SUM(dbo.dbl(id)) FROM t").1,
+            vec![vec![Some("30".into())]],
+            "UDF as an aggregate argument"
+        );
+
+        // A UDF in a join ON predicate: dbl(t.id) matches u.x for id 2 and 5.
+        engine
+            .execute("CREATE TABLE u (x INT NOT NULL PRIMARY KEY)")
+            .expect("create u");
+        engine.execute("INSERT INTO u VALUES (4)").expect("ins u");
+        engine.execute("INSERT INTO u VALUES (10)").expect("ins u");
+        assert_eq!(
+            sql_rows(
+                &engine,
+                "SELECT t.id FROM t JOIN u ON dbo.dbl(t.id) = u.x ORDER BY t.id"
+            )
+            .1,
+            vec![vec![Some("2".into())], vec![Some("5".into())]],
+            "UDF in join ON"
+        );
+
+        // A UDF in a CHECK constraint: dbl(v) <= 10 rejects v = 6 (dbl = 12) with 547.
+        engine
+            .execute("CREATE TABLE c (v INT CHECK (dbo.dbl(v) <= 10))")
+            .expect("create c");
+        engine
+            .execute("INSERT INTO c VALUES (5)")
+            .expect("dbl(5)=10 passes the check");
+        assert_eq!(
+            sql_error_number(&engine, "INSERT INTO c VALUES (6)"),
+            547,
+            "UDF in CHECK: dbl(6)=12 > 10 conflicts (547)"
+        );
+
+        drop(engine);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
     fn scalar_function_snapshot_scope_covers_body_reads() {
         // The snapshot-scope determination must recurse into a called UDF's
         // body exactly as lock analysis does: under SNAPSHOT isolation with

--- a/crates/truthdb-core/src/rel/aggregate.rs
+++ b/crates/truthdb-core/src/rel/aggregate.rs
@@ -10,13 +10,35 @@
 use truthdb_sql::ast::{AggFunc, BinaryOp, Expr, ExprKind, Name, Select, SelectItem};
 use truthdb_sql::collation::CollationSensitivity;
 use truthdb_sql::error::SqlError;
-use truthdb_sql::eval::{self, EvalContext};
+use truthdb_sql::eval::{self, ColumnResolver, EvalContext};
 use truthdb_sql::value::{SqlValue, order_key_cmp};
 
 use crate::relstore::types::{ColumnType, Datum};
 
 use super::value;
 use super::{JoinScope, ResultColumn, RowSet, row_values};
+
+/// Evaluate an expression that may hold a subquery or user scalar function: fold
+/// it against `row` (its columns resolved by `resolver`) before the pure
+/// evaluator runs, mirroring the SELECT-list / WHERE rewrite. Used for GROUP BY
+/// keys and aggregate arguments, where a UDF would otherwise reach the pure
+/// evaluator and raise 195.
+fn eval_bound(
+    storage: &crate::storage::Storage,
+    expr: &Expr,
+    row: &[SqlValue],
+    resolver: &JoinScope,
+    eval_ctx: &EvalContext,
+) -> Result<SqlValue, SqlError> {
+    if crate::rel::expr_needs_binding(storage, expr) {
+        let outer = |name: &str| resolver.resolve(name);
+        let bound =
+            crate::rel::substitute_correlated_in_expr(storage, expr, &outer, row, eval_ctx)?;
+        eval::eval(&bound, row, resolver, eval_ctx)
+    } else {
+        eval::eval(expr, row, resolver, eval_ctx)
+    }
+}
 
 /// True if the query aggregates: it has a GROUP BY, a HAVING, or any aggregate
 /// in its SELECT list.
@@ -216,13 +238,13 @@ fn aggregate_partition(
     out_exprs: &[Expr],
     synth: &SynthScope,
 ) -> Result<Vec<Vec<SqlValue>>, SqlError> {
-    let groups = group_rows(select, rows, types, resolver, eval_ctx)?;
+    let groups = group_rows(storage, select, rows, types, resolver, eval_ctx)?;
     let mut out_rows: Vec<Vec<SqlValue>> = Vec::new();
     for (keys, members) in &groups {
         let mut group_row = keys.clone();
         for spec in aggs {
             group_row.push(compute_aggregate(
-                spec, rows, types, resolver, members, eval_ctx,
+                storage, spec, rows, types, resolver, members, eval_ctx,
             )?);
         }
         if let Some(having) = having {
@@ -232,13 +254,15 @@ fn aggregate_partition(
             // A reference to a non-grouped column stays unresolved and errors
             // inside the subquery, as SQL Server rejects it too.
             let bound;
-            let having = if crate::rel::expr_has_subquery(having) {
+            let having = if crate::rel::expr_needs_binding(storage, having) {
+                // A user function's args were rewritten to the synthetic group
+                // columns ($gk/$agg), which `synth` resolves; a subquery keeps its
+                // original grouping-column names, which `group_key_resolver`
+                // resolves. Both index into `group_row`, so try synth first.
+                let gkr = group_key_resolver(select, resolver);
+                let outer = |name: &str| synth.resolve(name).or_else(|| gkr(name));
                 bound = crate::rel::substitute_correlated_in_expr(
-                    storage,
-                    having,
-                    &group_key_resolver(select, resolver),
-                    &group_row,
-                    eval_ctx,
+                    storage, having, &outer, &group_row, eval_ctx,
                 )?;
                 &bound
             } else {
@@ -262,13 +286,11 @@ fn aggregate_partition(
             // A subquery here is correlated to a grouping column (the
             // rewrite left it): bind the group row, exactly as HAVING does.
             let bound;
-            let expr = if crate::rel::expr_has_subquery(expr) {
+            let expr = if crate::rel::expr_needs_binding(storage, expr) {
+                let gkr = group_key_resolver(select, resolver);
+                let outer = |name: &str| synth.resolve(name).or_else(|| gkr(name));
                 bound = crate::rel::substitute_correlated_in_expr(
-                    storage,
-                    expr,
-                    &group_key_resolver(select, resolver),
-                    &group_row,
-                    eval_ctx,
+                    storage, expr, &outer, &group_row, eval_ctx,
                 )?;
                 &bound
             } else {
@@ -305,7 +327,7 @@ fn grace_hash_aggregate(
         .map(|_| crate::relstore::spill::RowSpool::new(storage))
         .collect();
     for row in rows {
-        let key = group_key(select, row, types, resolver, eval_ctx)?;
+        let key = group_key(storage, select, row, types, resolver, eval_ctx)?;
         let index = partition_index(&key, partitions);
         spools[index]
             .write_row(row)
@@ -338,6 +360,7 @@ fn grace_hash_aggregate(
 /// in-memory `group_rows` — so case-insensitive-equal keys route to the same
 /// partition and are not split across partitions on a spilling GROUP BY.
 fn group_key(
+    storage: &crate::storage::Storage,
     select: &Select,
     row: &[Datum],
     types: &[ColumnType],
@@ -353,7 +376,7 @@ fn group_key(
     let raw = select
         .group_by
         .iter()
-        .map(|expr| eval::eval(expr, &sql_row, resolver, eval_ctx))
+        .map(|expr| eval_bound(storage, expr, &sql_row, resolver, eval_ctx))
         .collect::<Result<Vec<_>, _>>()?;
     Ok(super::hash::fold_hash_key(&raw, &key_sens))
 }
@@ -372,6 +395,7 @@ fn partition_index(key: &[SqlValue], partitions: usize) -> usize {
 /// yields one row. NULL keys group together.
 #[allow(clippy::type_complexity)]
 fn group_rows(
+    storage: &crate::storage::Storage,
     select: &Select,
     rows: &[Vec<Datum>],
     types: &[ColumnType],
@@ -404,7 +428,7 @@ fn group_rows(
         let key = select
             .group_by
             .iter()
-            .map(|expr| eval::eval(expr, &sql_row, resolver, eval_ctx))
+            .map(|expr| eval_bound(storage, expr, &sql_row, resolver, eval_ctx))
             .collect::<Result<Vec<_>, _>>()?;
         let folded = fold_hash_key(&key, &key_sens);
         match index_of.get(&HashKey(folded.clone())) {
@@ -419,6 +443,7 @@ fn group_rows(
 }
 
 fn compute_aggregate(
+    storage: &crate::storage::Storage,
     spec: &AggSpec,
     rows: &[Vec<Datum>],
     types: &[ColumnType],
@@ -437,7 +462,7 @@ fn compute_aggregate(
     let mut values: Vec<SqlValue> = Vec::new();
     for &index in members {
         let sql_row = row_values(&rows[index], types);
-        let value = eval::eval(arg, &sql_row, resolver, eval_ctx)?;
+        let value = eval_bound(storage, arg, &sql_row, resolver, eval_ctx)?;
         if !value.is_null() {
             values.push(value);
         }

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -5050,6 +5050,7 @@ fn parse_checks(def: &TableDef) -> Result<Vec<(String, Expr)>, SqlError> {
 /// Enforces CHECK constraints against a fully-built row (schema order). A
 /// constraint passes on TRUE or UNKNOWN (NULL); FALSE is error 547.
 fn enforce_checks(
+    storage: &Storage,
     checks: &[(String, Expr)],
     row: &[SqlValue],
     resolver: &impl ColumnResolver,
@@ -5058,6 +5059,16 @@ fn enforce_checks(
     table: &str,
 ) -> Result<(), SqlError> {
     for (name, expr) in checks {
+        // A user scalar function (or subquery) in the CHECK is folded against the
+        // row before the pure evaluator runs, like the other clause positions.
+        let bound;
+        let expr = if expr_needs_binding(storage, expr) {
+            let outer = |n: &str| resolver.resolve(n);
+            bound = substitute_correlated_in_expr(storage, expr, &outer, row, eval_ctx)?;
+            &bound
+        } else {
+            expr
+        };
         match eval::eval(expr, row, resolver, eval_ctx)? {
             SqlValue::Bool(false) => {
                 return Err(SqlError::new(
@@ -6896,6 +6907,7 @@ fn alter_add_check(
     for row in &rows {
         let scope = row_values(row, &types);
         enforce_checks(
+            storage,
             &compiled,
             &scope,
             &resolver,
@@ -7082,6 +7094,7 @@ fn exec_insert(
         if !checks.is_empty() {
             let scope = row_values(&values, &check_types);
             enforce_checks(
+                storage,
                 &checks,
                 &scope,
                 &check_resolver,
@@ -7456,7 +7469,9 @@ fn exec_update(
         }
         if !checks.is_empty() {
             let scope = row_values(&new_row, &types);
-            enforce_checks(&checks, &scope, &resolver, eval_ctx, "UPDATE", &def.name)?;
+            enforce_checks(
+                storage, &checks, &scope, &resolver, eval_ctx, "UPDATE", &def.name,
+            )?;
         }
         updates.push((locator, old_values, new_row));
     }
@@ -9408,7 +9423,7 @@ fn exec_select(
                 .collect();
             dedup_rows(storage, &mut out, &out_sens)?;
         }
-        order_output(&mut out, &select.order_by, eval_ctx)?;
+        order_output(storage, &mut out, &select.order_by, eval_ctx)?;
         if let Some(top) = select.top {
             out.rows.truncate(top as usize);
         }
@@ -10204,6 +10219,7 @@ fn dedup_rows(
 /// evaluated against the output row (its columns are the resolver). Uses
 /// code-point ordering (NULLs first), stable.
 fn order_output(
+    storage: &Storage,
     rowset: &mut RowSet,
     order_by: &[OrderItem],
     eval_ctx: &EvalContext,
@@ -10234,7 +10250,7 @@ fn order_output(
                     })?;
                 sql_row[ordinal].clone()
             } else {
-                eval::eval(&item.expr, &sql_row, &scope, eval_ctx)?
+                eval_maybe_bound(storage, &item.expr, &sql_row, &scope, eval_ctx)?
             };
             key.push(value);
         }
@@ -10409,7 +10425,29 @@ fn sort_collators(
 }
 
 /// The ORDER BY key of one row.
+/// Evaluate an expression that may hold a subquery or user scalar function: fold
+/// it against `row` (its columns resolved by `resolver`) before the pure
+/// evaluator, mirroring the SELECT-list / WHERE rewrite. Lets a UDF appear in
+/// ORDER BY / join-ON / CHECK etc. rather than reaching the pure evaluator and
+/// raising 195.
+fn eval_maybe_bound(
+    storage: &Storage,
+    expr: &Expr,
+    row: &[SqlValue],
+    resolver: &impl ColumnResolver,
+    eval_ctx: &EvalContext,
+) -> Result<SqlValue, SqlError> {
+    if expr_needs_binding(storage, expr) {
+        let outer = |name: &str| resolver.resolve(name);
+        let bound = substitute_correlated_in_expr(storage, expr, &outer, row, eval_ctx)?;
+        eval::eval(&bound, row, resolver, eval_ctx)
+    } else {
+        eval::eval(expr, row, resolver, eval_ctx)
+    }
+}
+
 fn sort_key(
+    storage: &Storage,
     row: &[Datum],
     order_by: &[OrderItem],
     types: &[ColumnType],
@@ -10419,7 +10457,7 @@ fn sort_key(
     let values = row_values(row, types);
     order_by
         .iter()
-        .map(|item| eval::eval(&item.expr, &values, resolver, eval_ctx))
+        .map(|item| eval_maybe_bound(storage, &item.expr, &values, resolver, eval_ctx))
         .collect()
 }
 
@@ -10482,7 +10520,7 @@ fn order_rows_budgeted<'a>(
     let mut current_bytes = 0usize;
     for row in rows {
         check_cancelled()?;
-        let key = sort_key(&row, order_by, types, resolver, eval_ctx)?;
+        let key = sort_key(storage, &row, order_by, types, resolver, eval_ctx)?;
         current_bytes += approx_row_bytes(&row);
         current.push((key, row));
         if current_bytes >= budget {
@@ -10498,7 +10536,7 @@ fn order_rows_budgeted<'a>(
     // Sort the final partial run and merge every run.
     current.sort_by(|(a, _), (b, _)| cmp(a, b));
     merge_runs(
-        &runs, current, order_by, types, resolver, eval_ctx, &collators,
+        storage, &runs, current, order_by, types, resolver, eval_ctx, &collators,
     )
 }
 
@@ -10528,6 +10566,7 @@ fn sort_and_spill<'a>(
 /// (spilled runs hold earlier input rows than the in-memory tail).
 #[allow(clippy::too_many_arguments)]
 fn merge_runs(
+    storage: &Storage,
     runs: &[crate::relstore::spill::RowSpool<'_>],
     tail: Vec<KeyedRow>,
     order_by: &[OrderItem],
@@ -10544,7 +10583,9 @@ fn merge_runs(
     let source_count = readers.len() + 1;
     let mut heads: Vec<Option<(Vec<SqlValue>, Vec<Datum>)>> = Vec::with_capacity(source_count);
     for reader in &mut readers {
-        heads.push(read_head(reader, order_by, types, resolver, eval_ctx)?);
+        heads.push(read_head(
+            storage, reader, order_by, types, resolver, eval_ctx,
+        )?);
     }
     heads.push(tail_iter.next());
 
@@ -10572,7 +10613,14 @@ fn merge_runs(
         out.push(row);
         // Advance the chosen source.
         heads[i] = if i < readers.len() {
-            read_head(&mut readers[i], order_by, types, resolver, eval_ctx)?
+            read_head(
+                storage,
+                &mut readers[i],
+                order_by,
+                types,
+                resolver,
+                eval_ctx,
+            )?
         } else {
             tail_iter.next()
         };
@@ -10582,6 +10630,7 @@ fn merge_runs(
 
 /// Reads the next row from a spool reader and pairs it with its ORDER BY key.
 fn read_head(
+    storage: &Storage,
     reader: &mut crate::relstore::spill::RowSpoolReader,
     order_by: &[OrderItem],
     types: &[ColumnType],
@@ -10593,7 +10642,7 @@ fn read_head(
         .map_err(|e| map_storage_err(e, "<sort spill>"))?
     {
         Some(row) => {
-            let key = sort_key(&row, order_by, types, resolver, eval_ctx)?;
+            let key = sort_key(storage, &row, order_by, types, resolver, eval_ctx)?;
             Ok(Some((key, row)))
         }
         None => Ok(None),
@@ -11862,13 +11911,24 @@ fn join_sources(
     let left_nulls = vec![Datum::Null; left.columns.len()];
     let right_nulls = vec![Datum::Null; right.columns.len()];
 
+    // A subquery or user scalar function in the ON predicate is folded against
+    // the joined row before the pure evaluator runs (per candidate pair).
+    let on_needs_binding = on.is_some_and(|pred| expr_needs_binding(storage, pred));
     let concat = |l: &[Datum], r: &[Datum]| -> Vec<Datum> { l.iter().chain(r).cloned().collect() };
     let matches = |l: &[Datum], r: &[Datum]| -> Result<bool, SqlError> {
         match on {
             None => Ok(true),
             Some(pred) => {
-                let row = concat(l, r);
-                match eval::eval(pred, &row_values(&row, &types), &scope, eval_ctx)? {
+                let vals = row_values(&concat(l, r), &types);
+                let value = if on_needs_binding {
+                    let outer = |name: &str| scope.resolve(name);
+                    let bound =
+                        substitute_correlated_in_expr(storage, pred, &outer, &vals, eval_ctx)?;
+                    eval::eval(&bound, &vals, &scope, eval_ctx)?
+                } else {
+                    eval::eval(pred, &vals, &scope, eval_ctx)?
+                };
+                match value {
                     SqlValue::Bool(b) => Ok(b),
                     SqlValue::Null => Ok(false),
                     _ => Err(SqlError::new(


### PR DESCRIPTION
Part of finishing **Stage 15.1**. A user scalar function was folded to a literal (the per-row rewrite-to-literal used by subqueries) only in the SELECT list, WHERE, and IF/WHILE conditions; elsewhere it reached the pure evaluator and raised 195. This extends the same rewrite to the remaining clause positions:

- **ORDER BY** — both the in-memory `order_output` and the streamed/spill sort (`sort_key`/`merge_runs`/`read_head` now thread `storage`), via a shared `eval_maybe_bound` helper.
- **join-ON** — folded per candidate pair; residual to any hash-join equi-key, so the result set is unchanged.
- **GROUP BY key + aggregate argument** — `group_key`/`group_rows`/`compute_aggregate` thread `storage` and fold via `eval_bound`.
- **HAVING + grouped SELECT-list exprs** — gate widened from subquery-only to `expr_needs_binding`; UDF args resolve against the synthetic group row (`$gk`/`$agg` via `synth`), falling back to `group_key_resolver` for a subquery's original grouping-column names (both index into the same group row).
- **CHECK constraints** — `enforce_checks` threads `storage` and folds each check.

Everything is gated on `expr_needs_binding`, so a query with no UDF or subquery is evaluated exactly as before (the full suite confirms no regression). One test drives a UDF through all six positions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)