### PR TITLE
Stage 15.1: ENABLE / DISABLE TRIGGER

### DIFF
--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -6755,6 +6755,79 @@ mod tests {
     }
 
     #[test]
+    fn disable_and_enable_trigger_controls_firing() {
+        let path = unique_temp_path("trigger-disable");
+        let engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE t (id INT NOT NULL PRIMARY KEY)")
+            .expect("create t");
+        engine
+            .execute("CREATE TABLE log (n INT NOT NULL PRIMARY KEY)")
+            .expect("create log");
+        engine
+            .execute(
+                "CREATE TRIGGER trg ON t AFTER INSERT AS INSERT INTO log SELECT id FROM inserted",
+            )
+            .expect("create trigger");
+        let log_count = |e: &Engine| sql_rows(e, "SELECT COUNT(*) FROM log").1;
+
+        // Enabled by default: the insert fires the trigger.
+        engine
+            .execute("INSERT INTO t VALUES (1)")
+            .expect("insert 1");
+        assert_eq!(
+            log_count(&engine),
+            vec![vec![Some("1".into())]],
+            "trigger fired"
+        );
+
+        // DISABLE: the trigger no longer fires.
+        engine.execute("DISABLE TRIGGER trg ON t").expect("disable");
+        engine
+            .execute("INSERT INTO t VALUES (2)")
+            .expect("insert 2");
+        assert_eq!(
+            log_count(&engine),
+            vec![vec![Some("1".into())]],
+            "a disabled trigger does not fire"
+        );
+
+        // ENABLE: it fires again.
+        engine.execute("ENABLE TRIGGER trg ON t").expect("enable");
+        engine
+            .execute("INSERT INTO t VALUES (3)")
+            .expect("insert 3");
+        assert_eq!(
+            log_count(&engine),
+            vec![vec![Some("2".into())]],
+            "a re-enabled trigger fires"
+        );
+
+        // DISABLE TRIGGER ALL ON <table> disables every trigger on the table.
+        engine
+            .execute("DISABLE TRIGGER ALL ON t")
+            .expect("disable all");
+        engine
+            .execute("INSERT INTO t VALUES (4)")
+            .expect("insert 4");
+        assert_eq!(
+            log_count(&engine),
+            vec![vec![Some("2".into())]],
+            "DISABLE TRIGGER ALL stopped firing"
+        );
+
+        // A trigger that is not on the named table (or does not exist) errors.
+        assert_eq!(
+            sql_error_number(&engine, "DISABLE TRIGGER nope ON t"),
+            3701,
+            "a missing trigger errors"
+        );
+
+        drop(engine);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
     fn user_scalar_function_works_in_all_query_clause_positions() {
         let path = unique_temp_path("udf-clauses");
         let engine = new_engine(&path);

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -2566,6 +2566,7 @@ fn statement_may_commit(statement: &Statement) -> bool {
             | Statement::DropRole { .. }
             | Statement::AlterRole { .. }
             | Statement::Permission(_)
+            | Statement::SetTriggerState { .. }
             | Statement::Commit { .. }
     )
 }
@@ -3244,7 +3245,8 @@ fn analyze_statements_locks(
             | Statement::CreateRole { .. }
             | Statement::DropRole { .. }
             | Statement::AlterRole { .. }
-            | Statement::Permission(_) => {
+            | Statement::Permission(_)
+            | Statement::SetTriggerState { .. } => {
                 add(Resource::Database, LockMode::Exclusive);
             }
             // IF/WHILE conditions read tables through their subqueries —
@@ -3447,6 +3449,17 @@ fn exec_statement_dispatch(
                 return Err(ddl_in_txn_err());
             }
             exec_drop_trigger(storage, name, *if_exists)
+        }
+        Statement::SetTriggerState {
+            trigger,
+            table,
+            enable,
+            ..
+        } => {
+            if txn_ctx.in_txn() {
+                return Err(ddl_in_txn_err());
+            }
+            exec_set_trigger_state(storage, trigger, table, *enable)
         }
         Statement::CreateLogin(create) => {
             if txn_ctx.in_txn() {
@@ -6044,6 +6057,64 @@ fn exec_drop_trigger(
     }
 }
 
+/// `{ENABLE | DISABLE} TRIGGER {<name> | ALL} ON <table>`: flips the disabled
+/// flag on one trigger (or every trigger on the table). A disabled trigger stays
+/// in the catalog but does not fire.
+fn exec_set_trigger_state(
+    storage: &Storage,
+    trigger: &Option<Name>,
+    table: &Name,
+    enable: bool,
+) -> Result<StatementResult, SqlError> {
+    let target = resolve_table(storage, &table.value)
+        .ok_or_else(|| SqlError::invalid_object(&table.value).at(table.span))?;
+    if target.is_view() || target.is_procedure() || target.is_function() || target.is_trigger() {
+        return Err(SqlError::invalid_object(&table.value).at(table.span));
+    }
+    let set_one = |def: &TableDef| -> Result<(), SqlError> {
+        let mut td = def.trigger.clone().expect("is_trigger");
+        td.is_disabled = !enable;
+        storage
+            .rel_alter_trigger(&def.name, td)
+            .map_err(|e| map_storage_err(e, &def.name))
+    };
+    match trigger {
+        Some(name) => {
+            let def = resolve_table(storage, &name.value)
+                .filter(|d| d.is_trigger())
+                .filter(|d| {
+                    d.trigger.as_ref().map(|t| t.parent_object_id) == Some(target.object_id)
+                })
+                .ok_or_else(|| {
+                    SqlError::new(
+                        3701,
+                        11,
+                        5,
+                        format!(
+                            "Cannot {} the trigger '{}', because it does not exist on table \
+                             '{}' or you do not have permission.",
+                            if enable { "enable" } else { "disable" },
+                            name.value,
+                            table.value
+                        ),
+                    )
+                    .at(name.span)
+                })?;
+            set_one(&def)?;
+        }
+        None => {
+            for def in storage.rel_tables() {
+                if def.is_trigger()
+                    && def.trigger.as_ref().map(|t| t.parent_object_id) == Some(target.object_id)
+                {
+                    set_one(&def)?;
+                }
+            }
+        }
+    }
+    Ok(StatementResult::Done)
+}
+
 /// `CREATE|ALTER LOGIN <name> WITH PASSWORD = '<pw>'` / `ALTER LOGIN <name>
 /// {ENABLE | DISABLE}`. Logins are server principals in their own namespace
 /// (disjoint from schema objects); the password is hashed here (on the worker —
@@ -6310,6 +6381,7 @@ fn is_privileged_ddl(stmt: &Statement) -> bool {
             | Statement::DropRole { .. }
             | Statement::AlterRole { .. }
             | Statement::Permission(_)
+            | Statement::SetTriggerState { .. }
             | Statement::BackupDatabase { .. }
             | Statement::BackupLog { .. }
             | Statement::Restore { .. }

--- a/crates/truthdb-sql/src/ast.rs
+++ b/crates/truthdb-sql/src/ast.rs
@@ -136,6 +136,15 @@ pub enum Statement {
         if_exists: bool,
         span: Span,
     },
+    /// `{ENABLE | DISABLE} TRIGGER {<name> | ALL} ON <table>` — flips a trigger's
+    /// disabled flag (a disabled trigger does not fire). `trigger` is `None` for
+    /// `ALL` (every trigger on the table).
+    SetTriggerState {
+        trigger: Option<Name>,
+        table: Name,
+        enable: bool,
+        span: Span,
+    },
     /// `CREATE|ALTER LOGIN <name> WITH PASSWORD = '<pw>'` or `ALTER LOGIN <name>
     /// {ENABLE | DISABLE}` — a SQL-authentication server login.
     CreateLogin(CreateLogin),

--- a/crates/truthdb-sql/src/parser.rs
+++ b/crates/truthdb-sql/src/parser.rs
@@ -194,6 +194,7 @@ impl Parser {
             Some("REVOKE") => self.parse_permission(PermissionKind::Revoke),
             Some("BACKUP") => self.parse_backup(),
             Some("RESTORE") => self.parse_restore(),
+            Some("ENABLE") | Some("DISABLE") => self.parse_trigger_state(),
             _ => {
                 let token = self.peek().clone();
                 Err(SqlError::syntax(self.token_text(&token), token.span))
@@ -1969,6 +1970,28 @@ impl Parser {
         self.bump();
         let span = start.to(self.prev_span());
         Ok(Statement::Restore { mode, path, span })
+    }
+
+    /// `{ENABLE | DISABLE} TRIGGER {<name> | ALL} ON <table>`.
+    fn parse_trigger_state(&mut self) -> SqlResult<Statement> {
+        let start = self.peek().span;
+        let enable = self.peek_keyword().as_deref() == Some("ENABLE");
+        self.bump(); // ENABLE | DISABLE
+        self.expect_keyword("TRIGGER")?;
+        let trigger = if self.eat_keyword("ALL") {
+            None
+        } else {
+            Some(self.parse_name()?)
+        };
+        self.expect_keyword("ON")?;
+        let table = self.parse_name()?;
+        let span = start.to(self.prev_span());
+        Ok(Statement::SetTriggerState {
+            trigger,
+            table,
+            enable,
+            span,
+        })
     }
 
     fn parse_create_login(&mut self, start: Span, alter: bool) -> SqlResult<Statement> {


### PR DESCRIPTION
Part of finishing **Stage 15.1**. The trigger firing path already skipped triggers whose catalog `is_disabled` flag was set, but nothing could set it. This adds the SQL surface:

`{ENABLE | DISABLE} TRIGGER {<name> | ALL} ON <table>`

- **ast**: `Statement::SetTriggerState { trigger: Option<Name> (None = ALL), table, enable, span }`.
- **parser**: `parse_trigger_state`, dispatched from `ENABLE`/`DISABLE` at statement start (previously a syntax error there — no regression).
- **exec**: `exec_set_trigger_state` resolves the table, then flips `is_disabled` on the named trigger (verifying it belongs to that table) or every trigger on the table (`ALL`), reusing `rel_alter_trigger`. Privileged DDL, Database exclusive lock like other catalog DDL, refused in a transaction; a missing/wrong-table trigger errors 3701.

Test: fire → DISABLE stops → ENABLE resumes → DISABLE ALL stops → missing-trigger errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)