### PR TITLE
Stage 15.1: GOTO and labels

### DIFF
--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -6755,6 +6755,91 @@ mod tests {
     }
 
     #[test]
+    fn goto_jumps_forward_backward_and_errors_on_missing_label() {
+        let path = unique_temp_path("goto");
+        let engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE t (n INT NOT NULL PRIMARY KEY)")
+            .expect("create");
+
+        // Forward GOTO skips the statement it jumps over.
+        engine
+            .execute(
+                "INSERT INTO t VALUES (1); GOTO skip; INSERT INTO t VALUES (2); \
+                 skip: INSERT INTO t VALUES (3)",
+            )
+            .expect("forward goto");
+        assert_eq!(
+            sql_rows(&engine, "SELECT n FROM t ORDER BY n").1,
+            vec![vec![Some("1".into())], vec![Some("3".into())]],
+            "forward GOTO skipped VALUES(2)"
+        );
+
+        // Backward GOTO from inside an IF drives a counting loop (10, 11, 12).
+        engine.execute("DELETE FROM t").expect("clear");
+        engine
+            .execute(
+                "DECLARE @i INT = 10; \
+                 loop: INSERT INTO t VALUES (@i); SET @i = @i + 1; IF @i <= 12 GOTO loop",
+            )
+            .expect("backward goto loop");
+        assert_eq!(
+            sql_rows(&engine, "SELECT n FROM t ORDER BY n").1,
+            vec![
+                vec![Some("10".into())],
+                vec![Some("11".into())],
+                vec![Some("12".into())],
+            ],
+            "backward GOTO from an IF looped"
+        );
+
+        // A GOTO to a label defined nowhere in scope errors 133.
+        assert_eq!(
+            sql_error_number(&engine, "GOTO nowhere"),
+            133,
+            "a GOTO to an undefined label errors 133"
+        );
+
+        // A label inside a BEGIN...END block (no semicolon after the label).
+        engine.execute("DELETE FROM t").expect("clear");
+        engine
+            .execute("BEGIN GOTO d; INSERT INTO t VALUES (7); d: INSERT INTO t VALUES (8) END")
+            .expect("label in a block");
+        assert_eq!(
+            sql_rows(&engine, "SELECT n FROM t ORDER BY n").1,
+            vec![vec![Some("8".into())]],
+            "GOTO skipped VALUES(7) inside the block"
+        );
+
+        // A label inside a stored procedure body.
+        engine.execute("DELETE FROM t").expect("clear");
+        assert!(
+            sql(
+                &engine,
+                "CREATE PROCEDURE fill AS BEGIN GOTO d; INSERT INTO t VALUES (20); d: INSERT INTO t VALUES (21) END"
+            )["error"]
+                .is_null(),
+            "a procedure body with a label creates cleanly"
+        );
+        engine.execute("EXEC fill").expect("exec proc");
+        assert_eq!(
+            sql_rows(&engine, "SELECT n FROM t ORDER BY n").1,
+            vec![vec![Some("21".into())]],
+            "GOTO inside a procedure body skipped VALUES(20)"
+        );
+
+        // A label repeated in the same list errors 132.
+        assert_eq!(
+            sql_error_number(&engine, "d: SELECT 1; d: SELECT 2"),
+            132,
+            "a duplicate label errors 132"
+        );
+
+        drop(engine);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
     fn disable_and_enable_trigger_controls_firing() {
         let path = unique_temp_path("trigger-disable");
         let engine = new_engine(&path);

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -508,7 +508,9 @@ pub fn execute_batch_streamed(
     // `run_block` returns Err only when the batch must terminate (a cancel, or a
     // dooming/uncaught error outside any TRY); a non-dooming error under
     // `XACT_ABORT OFF` is recorded in `run.last_error` and the batch continues.
-    let terminating = run_block(storage, &statements, txn_ctx, &mut run, false).err();
+    let terminating = run_block(storage, &statements, txn_ctx, &mut run, false)
+        .and_then(end_of_scope)
+        .err();
     // The batch-end durability point, and the DONEs it was holding back. A
     // durability failure outranks any statement error: a lost commit is more
     // severe than an error the client asked about, and a benign continued error
@@ -1124,7 +1126,7 @@ fn run_user_procedure(
         Err(ExecError::Own(doom_per_rule(txn_ctx, error)))
     } else {
         run_block(storage, &statements, txn_ctx, run, in_try)
-            .map(|_| ())
+            .and_then(end_of_scope)
             .map_err(ExecError::Inner)
     };
     EXEC_DEPTH.with(|d| d.set(d.get() - 1));
@@ -1263,7 +1265,7 @@ fn run_user_scalar_function(
             last_error: None,
             function_return_type: Some(return_type),
         };
-        run_block(storage, &statements, &mut txn_ctx, &mut run, false).map(|_| ())
+        run_block(storage, &statements, &mut txn_ctx, &mut run, false).and_then(end_of_scope)
     };
     EXEC_DEPTH.with(|d| d.set(d.get() - 1));
     result?;
@@ -1426,7 +1428,7 @@ fn run_exec(
         // error crossing out already carries every decision: dooming, and by
         // crossing at all, termination of the whole nest.
         run_block(storage, &statements, txn_ctx, run, in_try)
-            .map(|_| ())
+            .and_then(end_of_scope)
             .map_err(ExecError::Inner)
     };
     EXEC_DEPTH.with(|d| d.set(d.get() - 1));
@@ -1605,14 +1607,58 @@ fn eval_condition(
 
 /// How a statement block ended: normally, or via a control-flow statement
 /// that must propagate to the construct that absorbs it (`WHILE` for
-/// Break/Continue, the batch — later the procedure — for Return). TRY/CATCH
-/// and plain blocks pass every non-Normal flow straight through.
-#[derive(Clone, Copy, PartialEq, Eq)]
+/// Break/Continue, the batch — later the procedure — for Return, the nearest
+/// block holding the target label for `Goto`). TRY/CATCH and plain blocks pass
+/// every non-Normal flow straight through (a `Goto` is first checked against the
+/// current block's labels, then propagated).
+#[derive(Clone, PartialEq, Eq)]
 enum Flow {
     Normal,
     Break,
     Continue,
     Return,
+    /// A `GOTO <label>` still looking for its target label.
+    Goto(String),
+}
+
+/// What `run_block`'s loop should do with a flow bubbling up from a nested
+/// construct: a `GOTO` to a label in this block jumps there; anything else
+/// propagates to the enclosing block.
+enum GotoAction {
+    /// Resume at this statement index (a resolved `GOTO`).
+    Jump(usize),
+    /// The nested construct ended normally — fall through.
+    Fall,
+    /// Return this flow to the caller (Break/Continue/Return, or a `GOTO` to a
+    /// label not defined in this block).
+    Propagate(Flow),
+}
+
+fn resolve_goto(flow: Flow, labels: &std::collections::HashMap<String, usize>) -> GotoAction {
+    match flow {
+        Flow::Normal => GotoAction::Fall,
+        Flow::Goto(label) => match labels.get(&label.to_ascii_lowercase()) {
+            Some(&target) => GotoAction::Jump(target),
+            None => GotoAction::Propagate(Flow::Goto(label)),
+        },
+        other => GotoAction::Propagate(other),
+    }
+}
+
+/// A statement list run as its own scope — a batch, or a procedure / function /
+/// trigger body — cannot be a GOTO target from outside and a GOTO cannot jump
+/// out of it. A GOTO that reaches the end of such a scope unresolved references
+/// a label defined nowhere in scope: error 133.
+fn end_of_scope(flow: Flow) -> Result<(), SqlError> {
+    match flow {
+        Flow::Goto(label) => Err(SqlError::new(
+            133,
+            15,
+            1,
+            format!("A GOTO statement references the label '{label}:' which has not been defined."),
+        )),
+        _ => Ok(()),
+    }
 }
 
 fn run_block(
@@ -1622,7 +1668,29 @@ fn run_block(
     run: &mut BatchRun<'_>,
     in_try: bool,
 ) -> Result<Flow, SqlError> {
-    for statement in statements {
+    // Label positions for GOTO. A jump sets the index to the label's position;
+    // execution resumes there (the label statement itself is a no-op). A label
+    // repeated in the same list is error 132.
+    let mut labels: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
+    for (idx, s) in statements.iter().enumerate() {
+        if let Statement::Label { name, .. } = s
+            && labels.insert(name.to_ascii_lowercase(), idx).is_some()
+        {
+            return Err(SqlError::new(
+                132,
+                15,
+                1,
+                format!(
+                    "The label '{name}:' has already been declared. Label names must be unique \
+                     within a query batch or stored procedure."
+                ),
+            ));
+        }
+    }
+    let mut i = 0;
+    'stmts: while i < statements.len() {
+        let statement = &statements[i];
+        i += 1;
         // A TDS Attention (cancel) aborts the batch before the next statement.
         // It is never catchable — it propagates straight out, past any TRY.
         check_cancelled()?;
@@ -1690,9 +1758,13 @@ fn run_block(
         }
         match statement {
             Statement::Block { body, .. } => {
-                match run_block(storage, body, txn_ctx, run, in_try)? {
-                    Flow::Normal => {}
-                    flow => return Ok(flow),
+                match resolve_goto(run_block(storage, body, txn_ctx, run, in_try)?, &labels) {
+                    GotoAction::Jump(t) => {
+                        i = t;
+                        continue 'stmts;
+                    }
+                    GotoAction::Propagate(flow) => return Ok(flow),
+                    GotoAction::Fall => {}
                 }
                 continue;
             }
@@ -1726,9 +1798,15 @@ fn run_block(
                     else_branch.as_ref()
                 };
                 if let Some(branch) = branch {
-                    match run_block(storage, std::slice::from_ref(branch), txn_ctx, run, in_try)? {
-                        Flow::Normal => {}
-                        flow => return Ok(flow),
+                    let flow =
+                        run_block(storage, std::slice::from_ref(branch), txn_ctx, run, in_try)?;
+                    match resolve_goto(flow, &labels) {
+                        GotoAction::Jump(t) => {
+                            i = t;
+                            continue 'stmts;
+                        }
+                        GotoAction::Propagate(flow) => return Ok(flow),
+                        GotoAction::Fall => {}
                     }
                 }
                 continue;
@@ -1758,10 +1836,21 @@ fn run_block(
                     if !taken {
                         break;
                     }
-                    match run_block(storage, std::slice::from_ref(body), txn_ctx, run, in_try)? {
+                    let flow =
+                        run_block(storage, std::slice::from_ref(body), txn_ctx, run, in_try)?;
+                    match flow {
                         Flow::Normal | Flow::Continue => {}
                         Flow::Break => break,
-                        Flow::Return => return Ok(Flow::Return),
+                        // RETURN or a GOTO leaves the loop: a GOTO to a label in
+                        // this block jumps out of the WHILE to it, else propagate.
+                        other => match resolve_goto(other, &labels) {
+                            GotoAction::Jump(t) => {
+                                i = t;
+                                continue 'stmts;
+                            }
+                            GotoAction::Propagate(flow) => return Ok(flow),
+                            GotoAction::Fall => {}
+                        },
                     }
                 }
                 continue;
@@ -1854,6 +1943,17 @@ fn run_block(
                 }
                 return Ok(Flow::Return);
             }
+            // A label is a no-op when reached in sequence.
+            Statement::Label { .. } => continue,
+            // GOTO jumps to a label in this block, or propagates to an enclosing
+            // one (the batch top turns an unresolved GOTO into error 133).
+            Statement::Goto { label, .. } => match labels.get(&label.to_ascii_lowercase()) {
+                Some(&target) => {
+                    i = target;
+                    continue 'stmts;
+                }
+                None => return Ok(Flow::Goto(label.clone())),
+            },
             _ => {}
         }
         if let Statement::TryCatch {
@@ -1864,8 +1964,16 @@ fn run_block(
         {
             match run_block(storage, try_block, txn_ctx, run, true) {
                 Ok(Flow::Normal) => {}
-                // BREAK/CONTINUE/RETURN cross a TRY without running its CATCH.
-                Ok(flow) => return Ok(flow),
+                // BREAK/CONTINUE/RETURN/GOTO cross a TRY without running its
+                // CATCH; a GOTO to a label in this block jumps there.
+                Ok(flow) => match resolve_goto(flow, &labels) {
+                    GotoAction::Jump(t) => {
+                        i = t;
+                        continue 'stmts;
+                    }
+                    GotoAction::Propagate(flow) => return Ok(flow),
+                    GotoAction::Fall => {}
+                },
                 // An Attention that landed inside the TRY block is not caught.
                 Err(cancel) if cancel.number == CANCEL_ERROR => return Err(cancel),
                 // A durability failure wedged the store: no CATCH swallows a
@@ -1888,9 +1996,13 @@ fn run_block(
                     // outer CATCH (or end the batch) per `in_try`.
                     let caught = run_block(storage, catch_block, txn_ctx, run, in_try);
                     txn_ctx.pop_error();
-                    match caught? {
-                        Flow::Normal => {}
-                        flow => return Ok(flow),
+                    match resolve_goto(caught?, &labels) {
+                        GotoAction::Jump(t) => {
+                            i = t;
+                            continue 'stmts;
+                        }
+                        GotoAction::Propagate(flow) => return Ok(flow),
+                        GotoAction::Fall => {}
                     }
                 }
             }
@@ -3281,6 +3393,8 @@ fn analyze_statements_locks(
             | Statement::Break { .. }
             | Statement::Continue { .. }
             | Statement::Return { .. }
+            | Statement::Goto { .. }
+            | Statement::Label { .. }
             | Statement::BeginTransaction { .. }
             | Statement::Commit { .. }
             | Statement::Rollback { .. }
@@ -3594,7 +3708,9 @@ fn exec_statement_dispatch(
         | Statement::While { .. }
         | Statement::Break { .. }
         | Statement::Continue { .. }
-        | Statement::Return { .. } => {
+        | Statement::Return { .. }
+        | Statement::Goto { .. }
+        | Statement::Label { .. } => {
             unreachable!("control flow is executed by run_block")
         }
         // Handled in `exec_statement_streamed_inner` (severity <= 10 emits an
@@ -6557,10 +6673,11 @@ fn fire_one_trigger(
         // aborts the firing statement: SQL Server rolls back the DML and returns
         // the error. (A successful CATCH clears last_error, so a trigger that
         // handles its own error still succeeds.)
-        flow.map(|_| ()).and_then(|()| match run.last_error.take() {
-            Some(err) => Err(err),
-            None => Ok(()),
-        })
+        flow.and_then(end_of_scope)
+            .and_then(|()| match run.last_error.take() {
+                Some(err) => Err(err),
+                None => Ok(()),
+            })
     };
     FIRING_TRIGGERS.with(|f| {
         f.borrow_mut().pop();
@@ -11836,7 +11953,7 @@ fn run_multi_statement_tvf(
             // A multi-statement TVF's RETURN carries no value.
             function_return_type: None,
         };
-        run_block(storage, &statements, &mut txn_ctx, &mut run, false).map(|_| ())
+        run_block(storage, &statements, &mut txn_ctx, &mut run, false).and_then(end_of_scope)
     };
     EXEC_DEPTH.with(|d| d.set(d.get() - 1));
     result?;

--- a/crates/truthdb-sql/src/ast.rs
+++ b/crates/truthdb-sql/src/ast.rs
@@ -108,6 +108,17 @@ pub enum Statement {
         value: Option<Expr>,
         span: Span,
     },
+    /// `GOTO <label>` — an unconditional jump to a label in the same statement
+    /// list or an enclosing one.
+    Goto {
+        label: String,
+        span: Span,
+    },
+    /// `<label>:` — a `GOTO` target. Executed in sequence it is a no-op.
+    Label {
+        name: String,
+        span: Span,
+    },
     /// `CREATE PROCEDURE` / `ALTER PROCEDURE` — the body is stored as source
     /// text (the view posture) and re-parsed at EXEC.
     CreateProcedure(CreateProcedure),

--- a/crates/truthdb-sql/src/lexer.rs
+++ b/crates/truthdb-sql/src/lexer.rs
@@ -43,6 +43,7 @@ pub enum TokenKind {
     // Operators / punctuation.
     Comma,
     Semicolon,
+    Colon,
     LParen,
     RParen,
     Dot,
@@ -190,6 +191,10 @@ impl<'a> Lexer<'a> {
             b';' => {
                 self.pos += 1;
                 Ok(single(TokenKind::Semicolon, 1))
+            }
+            b':' => {
+                self.pos += 1;
+                Ok(single(TokenKind::Colon, 1))
             }
             b'(' => {
                 self.pos += 1;

--- a/crates/truthdb-sql/src/parser.rs
+++ b/crates/truthdb-sql/src/parser.rs
@@ -157,7 +157,11 @@ impl Parser {
             self.nodes = 0;
             self.statement_index = statements.len();
             statements.push(self.parse_statement()?);
-            if !self.at_eof() && !self.check(&TokenKind::Semicolon) {
+            // A label (`<name>:`) prefixes the statement that follows it, so no
+            // separator is required after it; every other statement needs `;` or
+            // end-of-batch before the next one.
+            let after_label = matches!(statements.last(), Some(Statement::Label { .. }));
+            if !after_label && !self.at_eof() && !self.check(&TokenKind::Semicolon) {
                 let token = self.peek().clone();
                 return Err(SqlError::syntax(self.token_text(&token), token.span));
             }
@@ -166,6 +170,17 @@ impl Parser {
     }
 
     fn parse_statement(&mut self) -> SqlResult<Statement> {
+        // A label `<identifier>:` at statement start (a GOTO target). At the
+        // start of a statement, an identifier immediately followed by `:` can
+        // only be a label — no statement begins that way.
+        if matches!(self.peek().kind, TokenKind::Word { .. })
+            && matches!(
+                self.tokens.get(self.pos + 1).map(|t| &t.kind),
+                Some(TokenKind::Colon)
+            )
+        {
+            return self.parse_label();
+        }
         match self.peek_keyword().as_deref() {
             Some("CREATE") => self.parse_create(),
             Some("ALTER") => self.parse_alter(),
@@ -195,6 +210,7 @@ impl Parser {
             Some("BACKUP") => self.parse_backup(),
             Some("RESTORE") => self.parse_restore(),
             Some("ENABLE") | Some("DISABLE") => self.parse_trigger_state(),
+            Some("GOTO") => self.parse_goto(),
             _ => {
                 let token = self.peek().clone();
                 Err(SqlError::syntax(self.token_text(&token), token.span))
@@ -481,7 +497,11 @@ impl Parser {
                 break;
             }
             statements.push(self.parse_statement()?);
-            if !self.at_eof()
+            // A label prefixes the next statement, so it needs no separator after
+            // it (matching `parse_statements`).
+            let after_label = matches!(statements.last(), Some(Statement::Label { .. }));
+            if !after_label
+                && !self.at_eof()
                 && !matches!(self.peek_keyword().as_deref(), Some("END"))
                 && !self.check(&TokenKind::Semicolon)
             {
@@ -1687,8 +1707,8 @@ impl Parser {
                     return Ok(());
                 }
                 self.nodes = 0;
-                self.parse_statement()?;
-                if !self.at_eof() && !self.check(&TokenKind::Semicolon) {
+                let after_label = matches!(self.parse_statement()?, Statement::Label { .. });
+                if !after_label && !self.at_eof() && !self.check(&TokenKind::Semicolon) {
                     let token = self.peek().clone();
                     return Err(SqlError::syntax(self.token_text(&token), token.span));
                 }
@@ -1794,8 +1814,8 @@ impl Parser {
                     return Ok(());
                 }
                 self.nodes = 0;
-                self.parse_statement()?;
-                if !self.at_eof() && !self.check(&TokenKind::Semicolon) {
+                let after_label = matches!(self.parse_statement()?, Statement::Label { .. });
+                if !after_label && !self.at_eof() && !self.check(&TokenKind::Semicolon) {
                     let token = self.peek().clone();
                     return Err(SqlError::syntax(self.token_text(&token), token.span));
                 }
@@ -1992,6 +2012,23 @@ impl Parser {
             enable,
             span,
         })
+    }
+
+    /// `<label>:` — a GOTO target.
+    fn parse_label(&mut self) -> SqlResult<Statement> {
+        let start = self.peek().span;
+        let name = self.parse_ident()?.value;
+        self.expect(&TokenKind::Colon)?;
+        let span = start.to(self.prev_span());
+        Ok(Statement::Label { name, span })
+    }
+
+    /// `GOTO <label>`.
+    fn parse_goto(&mut self) -> SqlResult<Statement> {
+        let start = self.bump().span; // GOTO
+        let label = self.parse_ident()?.value;
+        let span = start.to(self.prev_span());
+        Ok(Statement::Goto { label, span })
     }
 
     fn parse_create_login(&mut self, start: Span, alter: bool) -> SqlResult<Statement> {
@@ -2309,8 +2346,8 @@ impl Parser {
                         return Ok(());
                     }
                     self.nodes = 0;
-                    self.parse_statement()?;
-                    if !self.at_eof() && !self.check(&TokenKind::Semicolon) {
+                    let after_label = matches!(self.parse_statement()?, Statement::Label { .. });
+                    if !after_label && !self.at_eof() && !self.check(&TokenKind::Semicolon) {
                         let token = self.peek().clone();
                         return Err(SqlError::syntax(self.token_text(&token), token.span));
                     }
@@ -2375,8 +2412,8 @@ impl Parser {
                     return Ok(());
                 }
                 self.nodes = 0;
-                self.parse_statement()?;
-                if !self.at_eof() && !self.check(&TokenKind::Semicolon) {
+                let after_label = matches!(self.parse_statement()?, Statement::Label { .. });
+                if !after_label && !self.at_eof() && !self.check(&TokenKind::Semicolon) {
                     let token = self.peek().clone();
                     return Err(SqlError::syntax(self.token_text(&token), token.span));
                 }


### PR DESCRIPTION
Part of finishing **Stage 15.1**. Adds `GOTO <label>` and `<label>:` targets. `run_block` (the statement-list executor) changes from a `for` loop to an indexed loop with a per-block label→index map.

- **lexer**: a `:` token.
- **ast**: `Statement::Goto { label }`, `Statement::Label { name }`.
- **parser**: a label is `<identifier>:` at statement start (unambiguous), and prefixes the next statement (no `;` required after it).
- **executor**: `Flow` gains `Goto(String)` (no longer `Copy`). `resolve_goto` handles a flow bubbling out of a nested Block/If/While/TRY-CATCH — a GOTO to a label in the current block jumps there, anything else (incl. a GOTO to an outer label) propagates. A GOTO leaves a WHILE/TRY without further iterations/the CATCH, like SQL Server. `end_of_scope` turns an unresolved GOTO reaching the end of a self-contained scope (batch / procedure / function / trigger / TVF body) into error 133.

Test: forward skip, backward loop from inside an IF, and undefined-label 133. Full suite green (this is in the core control-flow path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)