### PR TITLE
Stage 15.1: INSTEAD OF triggers

### DIFF
--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -6840,6 +6840,92 @@ mod tests {
     }
 
     #[test]
+    fn instead_of_triggers_replace_the_dml() {
+        let path = unique_temp_path("instead-of");
+        let engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE ilog (n INT NOT NULL PRIMARY KEY)")
+            .expect("ilog");
+
+        // INSTEAD OF INSERT: the base insert is bypassed; the body logs `inserted`.
+        engine
+            .execute("CREATE TABLE ti (id INT NOT NULL PRIMARY KEY)")
+            .expect("ti");
+        engine
+            .execute("CREATE TRIGGER trg_i ON ti INSTEAD OF INSERT AS INSERT INTO ilog SELECT id FROM inserted")
+            .expect("io insert");
+        engine.execute("INSERT INTO ti VALUES (5)").expect("insert");
+        assert_eq!(
+            sql_rows(&engine, "SELECT COUNT(*) FROM ti").1,
+            vec![vec![Some("0".into())]],
+            "INSTEAD OF INSERT bypassed the base insert"
+        );
+
+        // INSTEAD OF DELETE: base delete bypassed; body logs `deleted` (+100).
+        engine
+            .execute("CREATE TABLE td (id INT NOT NULL PRIMARY KEY)")
+            .expect("td");
+        engine
+            .execute("INSERT INTO td VALUES (7)")
+            .expect("seed td");
+        engine
+            .execute("CREATE TRIGGER trg_d ON td INSTEAD OF DELETE AS INSERT INTO ilog SELECT id + 100 FROM deleted")
+            .expect("io delete");
+        engine
+            .execute("DELETE FROM td WHERE id = 7")
+            .expect("delete");
+        assert_eq!(
+            sql_rows(&engine, "SELECT COUNT(*) FROM td").1,
+            vec![vec![Some("1".into())]],
+            "INSTEAD OF DELETE bypassed the base delete"
+        );
+
+        // INSTEAD OF UPDATE: base update bypassed; body logs `inserted` (new v).
+        engine
+            .execute("CREATE TABLE tu (id INT NOT NULL PRIMARY KEY, v INT)")
+            .expect("tu");
+        engine
+            .execute("INSERT INTO tu VALUES (1, 3)")
+            .expect("seed tu");
+        engine
+            .execute("CREATE TRIGGER trg_u ON tu INSTEAD OF UPDATE AS INSERT INTO ilog SELECT v FROM inserted")
+            .expect("io update");
+        engine
+            .execute("UPDATE tu SET v = 42 WHERE id = 1")
+            .expect("update");
+        assert_eq!(
+            sql_rows(&engine, "SELECT v FROM tu").1,
+            vec![vec![Some("3".into())]],
+            "INSTEAD OF UPDATE bypassed the base update"
+        );
+
+        // Every INSTEAD OF body ran over the proposed images: 5 (ins), 42 (upd new
+        // value), 107 (del id + 100).
+        assert_eq!(
+            sql_rows(&engine, "SELECT n FROM ilog ORDER BY n").1,
+            vec![
+                vec![Some("5".into())],
+                vec![Some("42".into())],
+                vec![Some("107".into())],
+            ],
+            "the INSTEAD OF bodies ran over inserted/deleted"
+        );
+
+        // A second INSTEAD OF trigger for the same action errors 2113.
+        assert_eq!(
+            sql_error_number(
+                &engine,
+                "CREATE TRIGGER trg_i2 ON ti INSTEAD OF INSERT AS SELECT 1"
+            ),
+            2113,
+            "only one INSTEAD OF trigger per action"
+        );
+
+        drop(engine);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
     fn disable_and_enable_trigger_controls_firing() {
         let path = unique_temp_path("trigger-disable");
         let engine = new_engine(&path);

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -3791,8 +3791,8 @@ fn exec_statement_dispatch(
                 let eval_ctx = txn_ctx.eval_context();
                 return exec_insert_table_var(storage, insert, txn_ctx, &eval_ctx);
             }
-            let (target, triggers) =
-                after_triggers_for(storage, &insert.table.value, catalog::TriggerEvent::Insert);
+            let (target, after, instead_of) =
+                triggers_for(storage, &insert.table.value, catalog::TriggerEvent::Insert);
             let run_insert = |txn_ctx: &mut TxnContext| -> Result<StatementResult, SqlError> {
                 let eval_ctx = txn_ctx.eval_context();
                 let (result, identity) = {
@@ -3807,40 +3807,64 @@ fn exec_statement_dispatch(
                 Ok(result)
             };
             match target {
-                Some(target) if !triggers.is_empty() => {
-                    run_dml_with_triggers(storage, txn_ctx, &target, triggers, run_insert)
+                Some(target) => {
+                    if let Some(io) = instead_of {
+                        run_instead_of(storage, txn_ctx, &target, io, |eval_ctx| {
+                            instead_of_insert_images(storage, insert, &target, eval_ctx)
+                        })
+                    } else if !after.is_empty() {
+                        run_dml_with_triggers(storage, txn_ctx, &target, after, run_insert)
+                    } else {
+                        run_insert(txn_ctx)
+                    }
                 }
-                _ => run_insert(txn_ctx),
+                None => run_insert(txn_ctx),
             }
         }
         Statement::Update(update) => {
-            let (target, triggers) =
-                after_triggers_for(storage, &update.table.value, catalog::TriggerEvent::Update);
+            let (target, after, instead_of) =
+                triggers_for(storage, &update.table.value, catalog::TriggerEvent::Update);
             let run_update = |txn_ctx: &mut TxnContext| -> Result<StatementResult, SqlError> {
                 let eval_ctx = txn_ctx.eval_context();
                 let mut scope = txn_ctx.scope();
                 exec_update(storage, update, &mut scope, &eval_ctx)
             };
             match target {
-                Some(target) if !triggers.is_empty() => {
-                    run_dml_with_triggers(storage, txn_ctx, &target, triggers, run_update)
+                Some(target) => {
+                    if let Some(io) = instead_of {
+                        run_instead_of(storage, txn_ctx, &target, io, |eval_ctx| {
+                            instead_of_update_images(storage, update, &target, eval_ctx)
+                        })
+                    } else if !after.is_empty() {
+                        run_dml_with_triggers(storage, txn_ctx, &target, after, run_update)
+                    } else {
+                        run_update(txn_ctx)
+                    }
                 }
-                _ => run_update(txn_ctx),
+                None => run_update(txn_ctx),
             }
         }
         Statement::Delete(delete) => {
-            let (target, triggers) =
-                after_triggers_for(storage, &delete.table.value, catalog::TriggerEvent::Delete);
+            let (target, after, instead_of) =
+                triggers_for(storage, &delete.table.value, catalog::TriggerEvent::Delete);
             let run_delete = |txn_ctx: &mut TxnContext| -> Result<StatementResult, SqlError> {
                 let eval_ctx = txn_ctx.eval_context();
                 let mut scope = txn_ctx.scope();
                 exec_delete(storage, delete, &mut scope, &eval_ctx)
             };
             match target {
-                Some(target) if !triggers.is_empty() => {
-                    run_dml_with_triggers(storage, txn_ctx, &target, triggers, run_delete)
+                Some(target) => {
+                    if let Some(io) = instead_of {
+                        run_instead_of(storage, txn_ctx, &target, io, |eval_ctx| {
+                            instead_of_delete_images(storage, delete, &target, eval_ctx)
+                        })
+                    } else if !after.is_empty() {
+                        run_dml_with_triggers(storage, txn_ctx, &target, after, run_delete)
+                    } else {
+                        run_delete(txn_ctx)
+                    }
                 }
-                _ => run_delete(txn_ctx),
+                None => run_delete(txn_ctx),
             }
         }
         Statement::Select(select) => {
@@ -6114,11 +6138,35 @@ fn exec_create_trigger(
             ast::TriggerEvent::Delete => catalog::TriggerEvent::Delete,
         })
         .collect();
+    // A table may have at most one INSTEAD OF trigger per action (SQL Server).
+    if create.instead_of {
+        for def in storage.rel_tables() {
+            if let Some(t) = &def.trigger
+                && t.is_instead_of
+                && t.parent_object_id == target.object_id
+                && !def.name.eq_ignore_ascii_case(bare)
+                && t.events.iter().any(|e| events.contains(e))
+            {
+                return Err(SqlError::new(
+                    2113,
+                    16,
+                    1,
+                    format!(
+                        "Cannot create INSTEAD OF trigger '{bare}' on table '{}' because there is \
+                         already an INSTEAD OF trigger '{}' for the same action.",
+                        target.name, def.name
+                    ),
+                )
+                .at(create.name.span));
+            }
+        }
+    }
     let trigger = TriggerDef {
         parent_object_id: target.object_id,
         events,
         body: create.body.clone(),
         is_disabled: false,
+        is_instead_of: create.instead_of,
     };
     if create.alter {
         match resolve_table(storage, &create.name.value) {
@@ -6508,13 +6556,15 @@ fn is_privileged_ddl(stmt: &Statement) -> bool {
 /// plus the target's definition (for the pseudo-table schema). Empty when no
 /// trigger exists anywhere (the cheap `rel_has_triggers` gate keeps the common
 /// path free) or the target is not a base table.
-fn after_triggers_for(
+/// The triggers on `target_name` for `event`, split into AFTER triggers (fired
+/// after the DML) and the at-most-one INSTEAD OF trigger (fired in place of it).
+fn triggers_for(
     storage: &Storage,
     target_name: &str,
     event: catalog::TriggerEvent,
-) -> (Option<TableDef>, Vec<TableDef>) {
+) -> (Option<TableDef>, Vec<TableDef>, Option<TableDef>) {
     if !storage.rel_has_triggers() {
-        return (None, Vec::new());
+        return (None, Vec::new(), None);
     }
     match resolve_table(storage, target_name) {
         Some(def)
@@ -6523,10 +6573,13 @@ fn after_triggers_for(
                 && def.function.is_none()
                 && def.view_query.is_none() =>
         {
-            let triggers = storage.rel_triggers_for(def.object_id, event);
-            (Some(def), triggers)
+            let (instead, after): (Vec<TableDef>, Vec<TableDef>) = storage
+                .rel_triggers_for(def.object_id, event)
+                .into_iter()
+                .partition(|t| t.trigger.as_ref().is_some_and(|d| d.is_instead_of));
+            (Some(def), after, instead.into_iter().next())
         }
-        _ => (None, Vec::new()),
+        _ => (None, Vec::new(), None),
     }
 }
 
@@ -6612,6 +6665,148 @@ fn run_dml_with_triggers(
         exec_commit(storage, txn_ctx)?;
     }
     Ok(result)
+}
+
+/// The `(inserted, deleted)` row images an INSTEAD OF trigger's body sees.
+type TriggerImages = (Vec<Vec<Datum>>, Vec<Vec<Datum>>);
+
+/// Fires an INSTEAD OF trigger in place of the DML: it runs the trigger body over
+/// the *proposed* `inserted`/`deleted` images (the base operation and its
+/// constraints are bypassed — the body decides what actually happens). Reuses the
+/// DML+trigger transaction/firing/error machinery with a DML step that only
+/// computes and captures the images, writing nothing.
+fn run_instead_of(
+    storage: &Storage,
+    txn_ctx: &mut TxnContext,
+    target: &TableDef,
+    trigger: TableDef,
+    images: impl FnOnce(&EvalContext) -> Result<TriggerImages, SqlError>,
+) -> Result<StatementResult, SqlError> {
+    run_dml_with_triggers(storage, txn_ctx, target, vec![trigger], |txn_ctx| {
+        let eval_ctx = txn_ctx.eval_context();
+        let (inserted, deleted) = images(&eval_ctx)?;
+        let count = inserted.len().max(deleted.len()) as u64;
+        capture_trigger_images(|| (inserted, deleted));
+        Ok(StatementResult::RowsAffected(count))
+    })
+}
+
+/// The `inserted` image an INSTEAD OF INSERT trigger sees: the proposed rows with
+/// DEFAULTs applied and the identity column left NULL (the body's own insert
+/// generates it). Constraints are not enforced here.
+fn instead_of_insert_images(
+    storage: &Storage,
+    insert: &Insert,
+    def: &TableDef,
+    eval_ctx: &EvalContext,
+) -> Result<TriggerImages, SqlError> {
+    enforce_object_permission(def, &eval_ctx.security, PermAction::Insert)
+        .map_err(|e| e.at(insert.table.span))?;
+    let schema = def.schema().map_err(|e| map_storage_err(e, &def.name))?;
+    let ncols = schema.columns.len();
+    let identity_col = def.identity.map(|s| s.column);
+    let target: Vec<usize> = match &insert.columns {
+        Some(names) => {
+            let mut indices = Vec::with_capacity(names.len());
+            for n in names {
+                indices.push(
+                    column_index(&schema, &n.value)
+                        .ok_or_else(|| SqlError::invalid_column(&n.value).at(n.span))?,
+                );
+            }
+            indices
+        }
+        None => (0..ncols).filter(|i| Some(*i) != identity_col).collect(),
+    };
+    let input_rows = insert_input_rows(storage, &insert.source, target.len(), eval_ctx)?;
+    let mut inserted = Vec::with_capacity(input_rows.len());
+    for input in &input_rows {
+        let mut values = vec![Datum::Null; ncols];
+        for (position, sql_value) in target.iter().zip(input) {
+            let column = &schema.columns[*position];
+            values[*position] = value::sql_to_datum(sql_value, &column.column_type, &column.name)?;
+        }
+        for (index, column) in schema.columns.iter().enumerate() {
+            if !values[index].is_null() || target.contains(&index) || Some(index) == identity_col {
+                continue;
+            }
+            if let Some(text) = def.default_for(index) {
+                let sql_value = eval_default(text, eval_ctx)?;
+                values[index] = value::sql_to_datum(&sql_value, &column.column_type, &column.name)?;
+            }
+        }
+        inserted.push(values);
+    }
+    Ok((inserted, Vec::new()))
+}
+
+/// The (`inserted` = post-update, `deleted` = pre-update) images an INSTEAD OF
+/// UPDATE trigger sees for the rows matching the WHERE clause. Constraints are
+/// not enforced here.
+fn instead_of_update_images(
+    storage: &Storage,
+    update: &Update,
+    def: &TableDef,
+    eval_ctx: &EvalContext,
+) -> Result<TriggerImages, SqlError> {
+    enforce_object_permission(def, &eval_ctx.security, PermAction::Update)
+        .map_err(|e| e.at(update.table.span))?;
+    let schema = def.schema().map_err(|e| map_storage_err(e, &def.name))?;
+    let resolver = SchemaScope { schema: &schema };
+    let types = schema_types(&schema);
+    let mut assignments: Vec<(usize, &Expr)> = Vec::with_capacity(update.assignments.len());
+    for a in &update.assignments {
+        let index = column_index(&schema, &a.column.value)
+            .ok_or_else(|| SqlError::invalid_column(&a.column.value).at(a.column.span))?;
+        assignments.push((index, &a.value));
+    }
+    let mut old_rows = Vec::new();
+    let mut new_rows = Vec::new();
+    for row in storage
+        .rel_scan(&def.name)
+        .map_err(|e| map_storage_err(e, &def.name))?
+    {
+        check_cancelled()?;
+        if !predicate_true(&update.where_clause, &row, &types, &resolver, eval_ctx)? {
+            continue;
+        }
+        let old_scope = row_values(&row, &types);
+        let mut new_row = row.clone();
+        for (index, expr) in &assignments {
+            let column = &schema.columns[*index];
+            let value = eval::eval(expr, &old_scope, &resolver, eval_ctx)?;
+            new_row[*index] = value::sql_to_datum(&value, &column.column_type, &column.name)?;
+        }
+        old_rows.push(row);
+        new_rows.push(new_row);
+    }
+    Ok((new_rows, old_rows))
+}
+
+/// The `deleted` image an INSTEAD OF DELETE trigger sees: the rows matching the
+/// WHERE clause (none are actually removed).
+fn instead_of_delete_images(
+    storage: &Storage,
+    delete: &Delete,
+    def: &TableDef,
+    eval_ctx: &EvalContext,
+) -> Result<TriggerImages, SqlError> {
+    enforce_object_permission(def, &eval_ctx.security, PermAction::Delete)
+        .map_err(|e| e.at(delete.table.span))?;
+    let schema = def.schema().map_err(|e| map_storage_err(e, &def.name))?;
+    let resolver = SchemaScope { schema: &schema };
+    let types = schema_types(&schema);
+    let mut deleted = Vec::new();
+    for row in storage
+        .rel_scan(&def.name)
+        .map_err(|e| map_storage_err(e, &def.name))?
+    {
+        check_cancelled()?;
+        if predicate_true(&delete.where_clause, &row, &types, &resolver, eval_ctx)? {
+            deleted.push(row);
+        }
+    }
+    Ok((Vec::new(), deleted))
 }
 
 /// Fires one trigger body: parses it, runs it in the firing statement's
@@ -12973,8 +13168,7 @@ fn sys_triggers(storage: &Storage) -> Source {
                 Datum::Int(trigger.parent_object_id as i32),
                 Datum::NVarChar("TR".to_string()),
                 Datum::Int(i32::from(trigger.is_disabled)),
-                // Only AFTER triggers exist here (INSTEAD OF is not supported).
-                Datum::Int(0),
+                Datum::Int(i32::from(trigger.is_instead_of)),
             ])
         })
         .collect();

--- a/crates/truthdb-core/src/relstore/catalog.rs
+++ b/crates/truthdb-core/src/relstore/catalog.rs
@@ -282,6 +282,10 @@ pub struct TriggerDef {
     pub body: String,
     /// `DISABLE TRIGGER` sets this; a disabled trigger does not fire.
     pub is_disabled: bool,
+    /// An `INSTEAD OF` trigger fires in place of the DML (the base operation and
+    /// its constraints are bypassed); a plain `AFTER` trigger fires after it.
+    #[serde(default)]
+    pub is_instead_of: bool,
 }
 
 /// A stored procedure's catalog payload: declared parameters and body text.

--- a/crates/truthdb-core/tests/slt/triggers.slt
+++ b/crates/truthdb-core/tests/slt/triggers.slt
@@ -73,8 +73,8 @@ CREATE VIEW v AS SELECT id FROM t
 statement error
 CREATE TRIGGER trg_bad ON v AFTER INSERT AS INSERT INTO audit SELECT id, 'x' FROM inserted
 
-# INSTEAD OF triggers are not supported.
-statement error
+# INSTEAD OF triggers fire in place of the DML.
+statement ok
 CREATE TRIGGER trg_io ON t INSTEAD OF INSERT AS INSERT INTO audit SELECT id, 'io' FROM inserted
 
 # DROP TRIGGER IF EXISTS on a missing trigger is a no-op.

--- a/crates/truthdb-sql/src/ast.rs
+++ b/crates/truthdb-sql/src/ast.rs
@@ -305,6 +305,8 @@ pub struct CreateTrigger {
     pub target: Name,
     /// The DML events it fires on (at least one; deduplicated by the parser).
     pub events: Vec<TriggerEvent>,
+    /// `INSTEAD OF` (fires in place of the DML) rather than `AFTER`/`FOR`.
+    pub instead_of: bool,
     /// The body source text (everything after `AS`), re-parsed per firing.
     pub body: String,
     /// `ALTER TRIGGER` replaces an existing definition.

--- a/crates/truthdb-sql/src/parser.rs
+++ b/crates/truthdb-sql/src/parser.rs
@@ -1765,16 +1765,22 @@ impl Parser {
         let name = self.parse_name()?;
         self.expect_keyword("ON")?;
         let target = self.parse_name()?;
-        // AFTER (or its FOR synonym) is the only supported timing.
-        match self.peek_keyword().as_deref() {
+        // Timing: AFTER (its FOR synonym) or INSTEAD OF.
+        let instead_of = match self.peek_keyword().as_deref() {
             Some("AFTER") | Some("FOR") => {
                 self.bump();
+                false
+            }
+            Some("INSTEAD") => {
+                self.bump();
+                self.expect_keyword("OF")?;
+                true
             }
             _ => {
                 let token = self.peek().clone();
                 return Err(SqlError::syntax(self.token_text(&token), token.span));
             }
-        }
+        };
         // The event list: INSERT/UPDATE/DELETE, comma-separated, at least one,
         // deduplicated.
         let mut events = Vec::new();
@@ -1828,6 +1834,7 @@ impl Parser {
             name,
             target,
             events,
+            instead_of,
             body,
             alter,
             span,


### PR DESCRIPTION
Part of finishing **Stage 15.1**. Adds `CREATE TRIGGER ... INSTEAD OF {INSERT|UPDATE|DELETE}`. An INSTEAD OF trigger fires *in place of* the DML — the base operation and its constraints are bypassed; the body (reading `inserted`/`deleted`) decides what happens.

- **ast/catalog**: an `instead_of` flag (serde default → existing catalogs read as AFTER).
- **parser**: `INSTEAD OF` timing alongside AFTER/FOR.
- **exec**: store the flag; reject a second INSTEAD OF per action (2113); `sys.triggers.is_instead_of_trigger` reports it.
- **dispatch**: `triggers_for` splits AFTER vs the at-most-one INSTEAD OF. `run_instead_of` reuses the existing DML+trigger transaction/firing/error machinery (`run_dml_with_triggers`) with a DML step that **only computes and captures** the proposed `inserted`/`deleted` images — writing nothing, so the base op/constraints/identity are bypassed. Images via `instead_of_{insert,update,delete}_images` (defaults applied, identity NULL).

Normal DML and AFTER triggers are untouched (image computation is separate from the write path). Test: each verb bypasses its base op and runs the body over `inserted`/`deleted`; second-INSTEAD-OF-per-action → 2113. slt corpus updated (the old "INSTEAD OF unsupported" negative assertion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)