### PR TITLE
Stage 15.1: UPDATE() and COLUMNS_UPDATED() in triggers

### DIFF
--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -6840,6 +6840,59 @@ mod tests {
     }
 
     #[test]
+    fn update_function_reports_touched_columns_in_a_trigger() {
+        let path = unique_temp_path("update-fn");
+        let engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE t (id INT NOT NULL PRIMARY KEY, a INT, b INT)")
+            .expect("t");
+        engine
+            .execute("CREATE TABLE tlog (which VARCHAR(20) NOT NULL PRIMARY KEY)")
+            .expect("tlog");
+        engine
+            .execute("CREATE TRIGGER trg ON t AFTER UPDATE AS IF UPDATE(a) INSERT INTO tlog VALUES ('a'); IF UPDATE(b) INSERT INTO tlog VALUES ('b')")
+            .expect("trigger");
+        engine
+            .execute("INSERT INTO t VALUES (1, 10, 20)")
+            .expect("seed");
+
+        // Update only column a: UPDATE(a) is true, UPDATE(b) is false.
+        engine
+            .execute("UPDATE t SET a = 99 WHERE id = 1")
+            .expect("update a");
+        assert_eq!(
+            sql_rows(&engine, "SELECT which FROM tlog ORDER BY which").1,
+            vec![vec![Some("a".into())]],
+            "only column a is reported updated"
+        );
+
+        // Now update column b: UPDATE(b) is true (a is not in this SET list).
+        engine
+            .execute("UPDATE t SET b = 30 WHERE id = 1")
+            .expect("update b");
+        assert_eq!(
+            sql_rows(&engine, "SELECT which FROM tlog ORDER BY which").1,
+            vec![vec![Some("a".into())], vec![Some("b".into())]],
+            "column b is now reported updated"
+        );
+
+        // Outside a trigger, UPDATE()/COLUMNS_UPDATED() error 4101.
+        assert_eq!(
+            sql_error_number(&engine, "SELECT UPDATE(a)"),
+            4101,
+            "UPDATE() outside a trigger errors"
+        );
+        assert_eq!(
+            sql_error_number(&engine, "SELECT COLUMNS_UPDATED()"),
+            4101,
+            "COLUMNS_UPDATED() outside a trigger errors"
+        );
+
+        drop(engine);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
     fn instead_of_triggers_replace_the_dml() {
         let path = unique_temp_path("instead-of");
         let engine = new_engine(&path);

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -193,6 +193,7 @@ impl TxnContext {
             xact_state: self.xact_state(),
             last_error: self.last_error,
             nestlevel: EXEC_DEPTH.with(|d| d.get()) as i32,
+            updated_columns: current_trigger_updated_columns(),
         }
     }
 
@@ -2322,6 +2323,8 @@ struct TriggerTables {
     schema: Schema,
     inserted: Vec<Vec<Datum>>,
     deleted: Vec<Vec<Datum>>,
+    /// The 0-based indices of the columns the firing statement touched.
+    updated: Vec<usize>,
 }
 
 thread_local! {
@@ -2413,11 +2416,13 @@ thread_local! {
 }
 
 /// New (`inserted`) and old (`deleted`) row images collected during a DML that
-/// has AFTER triggers to fire.
+/// has triggers to fire, plus the indices of the columns the statement touched
+/// (its SET list, or every inserted column) for `UPDATE()`/`COLUMNS_UPDATED()`.
 #[derive(Default)]
 struct CapturedImages {
     inserted: Vec<Vec<Datum>>,
     deleted: Vec<Vec<Datum>>,
+    updated: Vec<usize>,
 }
 
 /// Records row images into the active capture, if one is armed. `f` builds the
@@ -2432,6 +2437,35 @@ fn capture_trigger_images(f: impl FnOnce() -> (Vec<Vec<Datum>>, Vec<Vec<Datum>>)
             images.deleted.extend(del);
         }
     });
+}
+
+/// Records the indices of the columns a firing UPDATE's SET list (or an INSERT's
+/// target columns) touched, for `UPDATE()`/`COLUMNS_UPDATED()`, if capture is on.
+fn capture_trigger_updated(indices: Vec<usize>) {
+    TRIGGER_CAPTURE.with(|c| {
+        if let Some(images) = c.borrow_mut().as_mut() {
+            images.updated = indices;
+        }
+    });
+}
+
+/// The columns the firing trigger's statement touched, resolved against the
+/// parent table's schema — the value behind `UPDATE()`/`COLUMNS_UPDATED()` in a
+/// trigger body. `None` outside a trigger.
+fn current_trigger_updated_columns() -> Option<truthdb_sql::eval::UpdatedColumns> {
+    CURRENT_TRIGGER_TABLES.with(|c| {
+        let borrow = c.borrow();
+        let tables = borrow.as_ref()?;
+        Some(truthdb_sql::eval::UpdatedColumns {
+            columns: tables
+                .schema
+                .columns
+                .iter()
+                .map(|col| col.name.clone())
+                .collect(),
+            touched: tables.updated.iter().copied().collect(),
+        })
+    })
 }
 
 thread_local! {
@@ -6622,6 +6656,7 @@ fn run_dml_with_triggers(
         schema,
         inserted: images.inserted,
         deleted: images.deleted,
+        updated: images.updated,
     });
     // Fire each trigger once, in creation order, even for an empty image set.
     for trig_def in &triggers {
@@ -6737,6 +6772,7 @@ fn instead_of_insert_images(
         }
         inserted.push(values);
     }
+    capture_trigger_updated((0..ncols).collect());
     Ok((inserted, Vec::new()))
 }
 
@@ -6780,6 +6816,7 @@ fn instead_of_update_images(
         old_rows.push(row);
         new_rows.push(new_row);
     }
+    capture_trigger_updated(assignments.iter().map(|(i, _)| *i).collect());
     Ok((new_rows, old_rows))
 }
 
@@ -7499,8 +7536,10 @@ fn exec_insert(
     }
 
     // Capture the new row images for an AFTER trigger's `inserted` table (only
-    // when a capture is armed — the no-trigger path clones nothing).
+    // when a capture is armed — the no-trigger path clones nothing). Every column
+    // counts as updated for an INSERT (SQL Server's UPDATE() semantics).
     capture_trigger_images(|| (rows.clone(), Vec::new()));
+    capture_trigger_updated((0..ncols).collect());
     let inserted = rows.len() as u64;
     storage
         .rel_insert_many(&def.name, rows, scope)
@@ -7935,6 +7974,7 @@ fn exec_update(
             updates.iter().map(|(_, old, _)| old.clone()).collect(),
         )
     });
+    capture_trigger_updated(assignments.iter().map(|(i, _)| *i).collect());
     let count = storage
         .rel_update_located(&def.name, updates, scope)
         .map_err(|e| map_storage_err(e, &def.name))?;

--- a/crates/truthdb-sql/src/eval.rs
+++ b/crates/truthdb-sql/src/eval.rs
@@ -112,6 +112,18 @@ pub struct EvalContext {
     pub last_error: i32,
     /// `@@NESTLEVEL` — the current procedure nesting depth (0 in a batch).
     pub nestlevel: i32,
+    /// Inside a trigger body: which columns the firing UPDATE/INSERT touched,
+    /// for `UPDATE(<col>)` and `COLUMNS_UPDATED()`. `None` outside a trigger.
+    pub updated_columns: Option<UpdatedColumns>,
+}
+
+/// The columns a trigger's firing statement touched: the parent table's column
+/// names and the 0-based indices that were set (the UPDATE `SET` list, or every
+/// inserted column for an INSERT; empty for a DELETE).
+#[derive(Clone, Debug)]
+pub struct UpdatedColumns {
+    pub columns: Vec<String>,
+    pub touched: std::collections::HashSet<usize>,
 }
 
 /// The object-permission enforcement subject for a session: whether it bypasses
@@ -450,6 +462,13 @@ fn eval_case_expr<R: ColumnResolver>(
 }
 
 #[inline(never)]
+fn trigger_function_outside_trigger() -> SqlError {
+    SqlError::message_only(
+        4101,
+        "UPDATE() and COLUMNS_UPDATED() may be used only inside a trigger body.".to_string(),
+    )
+}
+
 fn eval_call<R: ColumnResolver>(
     name: &str,
     args: &[Expr],
@@ -458,6 +477,49 @@ fn eval_call<R: ColumnResolver>(
     ctx: &EvalContext,
     depth: usize,
 ) -> SqlResult<SqlValue> {
+    // Trigger-only column-change functions. UPDATE(<col>) takes a column NAME
+    // (not a value), so it is handled before the arguments are evaluated.
+    if name.eq_ignore_ascii_case("UPDATE") {
+        let col = match args {
+            [arg] => match &arg.kind {
+                ExprKind::Column(n) => &n.value,
+                _ => {
+                    return Err(SqlError::message_only(
+                        174,
+                        "The UPDATE function requires one column-name argument.".to_string(),
+                    ));
+                }
+            },
+            _ => {
+                return Err(SqlError::message_only(
+                    174,
+                    "The UPDATE function requires one column-name argument.".to_string(),
+                ));
+            }
+        };
+        let u = ctx
+            .updated_columns
+            .as_ref()
+            .ok_or_else(trigger_function_outside_trigger)?;
+        let index = u
+            .columns
+            .iter()
+            .position(|c| c.eq_ignore_ascii_case(col))
+            .ok_or_else(|| SqlError::message_only(207, format!("Invalid column name '{col}'.")))?;
+        return Ok(SqlValue::Bool(u.touched.contains(&index)));
+    }
+    if name.eq_ignore_ascii_case("COLUMNS_UPDATED") {
+        let u = ctx
+            .updated_columns
+            .as_ref()
+            .ok_or_else(trigger_function_outside_trigger)?;
+        // A varbinary bitmask: column c (1-based) sets bit (c-1)%8 of byte (c-1)/8.
+        let mut bytes = vec![0u8; u.columns.len().div_ceil(8).max(1)];
+        for &i in &u.touched {
+            bytes[i / 8] |= 1 << (i % 8);
+        }
+        return Ok(SqlValue::Binary(bytes));
+    }
     // Session-context functions read the EvalContext, which the pure
     // functions::eval_function does not receive.
     if let Some(value) = eval_session_function(name, args) {


### PR DESCRIPTION
Part of finishing **Stage 15.1**. Adds the trigger-only column-change built-ins. `UPDATE(<col>)` = was the column in the firing statement's SET list (or, for INSERT, always); `COLUMNS_UPDATED()` = a varbinary bitmask of the same.

- **eval**: `EvalContext.updated_columns` (parent-table column names + touched index set). `eval_call` handles `UPDATE` (argument is a column *name*, read before args are evaluated) and `COLUMNS_UPDATED`; both error 4101 outside a trigger, `UPDATE` errors 207 for an unknown column.
- **parser**: `UPDATE(` in expression position parses as the function — it collides with the UPDATE statement keyword, which is dispatched separately at statement start, so the UPDATE **statement** is unaffected.
- **capture**: touched-column indices captured at the DML site alongside inserted/deleted (SET list for UPDATE, all columns for INSERT, none for DELETE), on both the AFTER and INSTEAD OF paths, threaded through `TriggerTables` into the body's `EvalContext`.

Test: a trigger's `UPDATE(a)`/`UPDATE(b)` reflect the SET list across two updates; both functions error 4101 outside a trigger. Full suite (incl. slt corpus) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)