### PR TITLE
Stage 18 slice 3: persistent replication slots + retain-cap reap

### DIFF
--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -2304,6 +2304,79 @@ mod tests {
         }
     }
 
+    // Stage 18 slice 3: a replication slot holds WAL-ring truncation at a
+    // standby's received LSN, survives a restart, and is invalidated once it
+    // lags past `max_slot_retain_bytes`.
+    #[test]
+    fn replication_slots_hold_truncation_persist_and_reap() {
+        let path = unique_temp_path("repl-slots");
+        let engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE t (id INT NOT NULL PRIMARY KEY, v INT)")
+            .expect("create");
+        for i in 1..=10 {
+            engine
+                .execute(&format!("INSERT INTO t VALUES ({i}, {i})"))
+                .expect("insert");
+        }
+        let l1 = engine.storage().wal_flushed_lsn();
+        assert!(l1 > 0, "there is log to pin");
+
+        // A slot pinned at l1 holds the WAL head there even as the tail advances.
+        engine.storage().register_repl_slot(7, l1);
+        for i in 11..=30 {
+            engine
+                .execute(&format!("INSERT INTO t VALUES ({i}, {i})"))
+                .expect("insert");
+        }
+        engine.checkpoint().expect("checkpoint");
+        assert_eq!(
+            engine.storage().wal_head(),
+            l1,
+            "the slot pins the truncation floor at its LSN"
+        );
+
+        // Advancing the slot lets the floor follow.
+        let l2 = engine.storage().wal_flushed_lsn();
+        engine.storage().advance_repl_slot(7, l2);
+        engine.checkpoint().expect("checkpoint");
+        assert_eq!(
+            engine.storage().wal_head(),
+            l2,
+            "advancing the slot advances the floor"
+        );
+
+        // The slot's hold survives a restart (re-seeded from the superblock).
+        drop(engine);
+        let engine = Engine::new(Storage::open(path.clone()).expect("open")).expect("engine");
+        assert_eq!(
+            engine.storage().repl_slot_lsn(7),
+            Some(l2),
+            "the slot survives the restart"
+        );
+
+        // Lagging past max_slot_retain invalidates the slot at the next checkpoint.
+        engine.storage().set_max_slot_retain_bytes(64);
+        for i in 31..=60 {
+            engine
+                .execute(&format!("INSERT INTO t VALUES ({i}, {i})"))
+                .expect("insert");
+        }
+        engine.checkpoint().expect("checkpoint");
+        assert_eq!(
+            engine.storage().repl_slot_lsn(7),
+            None,
+            "an over-lagging slot is invalidated"
+        );
+        assert!(
+            engine.storage().wal_head() > l2,
+            "the reclaimed floor advances past the dropped slot"
+        );
+
+        drop(engine);
+        let _ = std::fs::remove_file(path);
+    }
+
     #[test]
     fn point_in_time_restore_stops_at_a_commit_timestamp() {
         use crate::storage_layout::WAL_ENTRY_TYPE_REL;

--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -2355,6 +2355,15 @@ mod tests {
             "the slot survives the restart"
         );
 
+        // An explicit drop removes a slot (a standby that deregisters).
+        engine.storage().register_repl_slot(8, l2);
+        engine.storage().drop_repl_slot(8);
+        assert_eq!(
+            engine.storage().repl_slot_lsn(8),
+            None,
+            "an explicitly dropped slot is gone"
+        );
+
         // Lagging past max_slot_retain invalidates the slot at the next checkpoint.
         engine.storage().set_max_slot_retain_bytes(64);
         for i in 31..=60 {

--- a/crates/truthdb-core/src/storage.rs
+++ b/crates/truthdb-core/src/storage.rs
@@ -1528,6 +1528,34 @@ impl Storage {
         active.applied_lsn()
     }
 
+    /// Replication-slot test scaffolding (the transport receiver slice promotes
+    /// these to the ack path). A slot holds WAL-ring truncation at its LSN.
+    #[cfg(test)]
+    pub(crate) fn register_repl_slot(&self, id: u32, lsn: u64) {
+        self.lock().register_repl_slot(id, lsn);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn advance_repl_slot(&self, id: u32, lsn: u64) {
+        self.lock().advance_repl_slot(id, lsn);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn drop_repl_slot(&self, id: u32) {
+        self.lock().drop_repl_slot(id);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn repl_slot_lsn(&self, id: u32) -> Option<u64> {
+        self.lock().repl_slot_lsn(id)
+    }
+
+    /// Sets the slot-retention cap that the checkpoint reap enforces.
+    #[cfg(test)]
+    pub(crate) fn set_max_slot_retain_bytes(&self, bytes: u64) {
+        self.lock().max_slot_retain_bytes = bytes;
+    }
+
     /// Atomic snapshot scan: the whole table under one storage-lock hold
     /// (a versioned reader holds no table lock, so a sliced cursor could be
     /// restructured under it mid-walk), merged against the version store.
@@ -2009,13 +2037,20 @@ struct LogTruncationGate {
     /// checkpoint cannot truncate log a future `BACKUP LOG` still owes. `None`
     /// in the SIMPLE model (log is reclaimable as soon as it is checkpointed).
     log_backup: Option<u64>,
-    // Later: `repl_slots` (Stage 18) joins the same `min`.
+    /// Replication slots (id → held LSN): each pins the ring at the LSN a standby
+    /// has received, so the primary keeps log the standby still needs. Re-seeded
+    /// from the superblock on open; persisted at each checkpoint.
+    repl_slots: std::collections::BTreeMap<u32, u64>,
 }
 
 impl LogTruncationGate {
     /// The lowest LSN any hold pins, or `None` if no hold is registered.
     fn min_hold(&self) -> Option<u64> {
-        [self.backup, self.log_backup].into_iter().flatten().min()
+        [self.backup, self.log_backup]
+            .into_iter()
+            .flatten()
+            .chain(self.repl_slots.values().copied())
+            .min()
     }
 }
 
@@ -2028,6 +2063,12 @@ struct StorageFile {
     /// Holds that keep the WAL ring from truncating log a backup (or, later, a
     /// replication slot) still needs.
     truncation_gate: LogTruncationGate,
+    /// A replication slot lagging the WAL tail by more than this is invalidated
+    /// (dropped) at the next checkpoint so the ring can advance — the standby
+    /// must then reseed. `u64::MAX` (the default) = unlimited retention: a slot
+    /// holds truncation until explicitly dropped, matching the backup/log-backup
+    /// holds (a deployment configures a finite cap to protect the primary).
+    max_slot_retain_bytes: u64,
     /// FULL-model log-backup floor (mirrors the active superblock's
     /// `last_log_backup_lsn`): the LSN up to which the log has been shipped to
     /// a log archive. `0` in the SIMPLE model / before the first log backup.
@@ -4646,12 +4687,14 @@ impl StorageFile {
         let mut version = crate::relstore::version::VersionState::default();
         version.set_options_byte(active_sb.db_options());
         let last_log_backup_lsn = active_sb.last_log_backup_lsn();
+        let repl_slots = active_sb.repl_slots();
         let recovery_full = version.recovery_full;
         let mut storage = StorageFile {
             default_collation: header.default_collation(),
             file,
             wal,
             truncation_gate: LogTruncationGate::default(),
+            max_slot_retain_bytes: u64::MAX,
             last_log_backup_lsn,
             log_backup_in_progress: false,
             layout,
@@ -4669,6 +4712,12 @@ impl StorageFile {
         // backward.
         if recovery_full {
             storage.register_log_backup_hold(last_log_backup_lsn);
+        }
+        // Re-seed the replication slots so their truncation hold survives the
+        // restart (the persisted LSN is <= the live one — conservative, holds
+        // more log, safe: redo is idempotent).
+        for (id, lsn) in repl_slots {
+            storage.truncation_gate.repl_slots.insert(id, lsn);
         }
         storage.recover_allocator()?;
 
@@ -4767,6 +4816,7 @@ impl StorageFile {
             file,
             wal,
             truncation_gate: LogTruncationGate::default(),
+            max_slot_retain_bytes: u64::MAX,
             last_log_backup_lsn: 0,
             log_backup_in_progress: false,
             layout,
@@ -5234,6 +5284,46 @@ impl StorageFile {
     /// reclaimable as soon as it is checkpointed.
     fn release_log_backup_hold(&mut self) {
         self.truncation_gate.log_backup = None;
+    }
+
+    /// Drops any replication slot lagging the WAL tail by more than
+    /// `max_slot_retain_bytes` — it no longer pins the truncation floor, so the
+    /// ring can advance past it (the standby must reseed). Run at the start of a
+    /// checkpoint, before the floor is computed. A no-op under the default
+    /// unlimited retention.
+    fn reap_stale_slots(&mut self) {
+        if self.max_slot_retain_bytes == u64::MAX {
+            return;
+        }
+        let tail = self.wal.tail();
+        let max = self.max_slot_retain_bytes;
+        self.truncation_gate
+            .repl_slots
+            .retain(|_, lsn| tail.saturating_sub(*lsn) <= max);
+    }
+
+    /// Registers (or resets) a replication slot at `lsn`.
+    #[cfg(test)]
+    fn register_repl_slot(&mut self, id: u32, lsn: u64) {
+        self.truncation_gate.repl_slots.insert(id, lsn);
+    }
+
+    /// Advances a slot forward to `lsn` — a slot never moves backward (a
+    /// standby's received watermark only grows).
+    #[cfg(test)]
+    fn advance_repl_slot(&mut self, id: u32, lsn: u64) {
+        let held = self.truncation_gate.repl_slots.entry(id).or_insert(lsn);
+        *held = (*held).max(lsn);
+    }
+
+    #[cfg(test)]
+    fn drop_repl_slot(&mut self, id: u32) {
+        self.truncation_gate.repl_slots.remove(&id);
+    }
+
+    #[cfg(test)]
+    fn repl_slot_lsn(&self, id: u32) -> Option<u64> {
+        self.truncation_gate.repl_slots.get(&id).copied()
     }
 
     fn ensure_rel_usable(&self) -> Result<(), StorageError> {
@@ -6081,7 +6171,10 @@ impl StorageFile {
 
         // 4. Advance the WAL head — to the tail, or clamped to the oldest open
         //    transaction's begin LSN so its undo survives (fuzzy checkpoint) —
-        //    and publish both superblocks (new active first).
+        //    and publish both superblocks (new active first). Reap over-lagging
+        //    replication slots first, so an invalidated one no longer pins the
+        //    floor and its log becomes reclaimable this checkpoint.
+        self.reap_stale_slots();
         self.wal.set_head(self.checkpoint_wal_head());
         let new_active = match self.active_superblock {
             ActiveSuperblock::A => ActiveSuperblock::B,
@@ -6101,6 +6194,15 @@ impl StorageFile {
         // the log-backup floor must be stamped back in or a checkpoint would
         // silently reset it to 0 and drop the FULL-model hold across a restart.
         let last_log_backup_lsn = self.last_log_backup_lsn;
+        // Persist the (post-reap) replication slots, so their truncation hold is
+        // re-established on the next open. Snapshotted after the reap above, so an
+        // invalidated slot is not written back.
+        let repl_slots: Vec<(u32, u64)> = self
+            .truncation_gate
+            .repl_slots
+            .iter()
+            .map(|(&id, &lsn)| (id, lsn))
+            .collect();
         let new_sb = |active_flag: u8| -> Superblock {
             let mut sb = Superblock {
                 generation,
@@ -6119,6 +6221,8 @@ impl StorageFile {
             // superblock (else a checkpoint would silently reset it to 0). On a
             // primary this is exactly the checkpoint tail.
             sb.set_applied_lsn(tail);
+            // Re-stamp the replication slot table (same checkpoint-wipe carry).
+            sb.set_repl_slots(&repl_slots);
             sb.checksum = sb.compute_checksum();
             sb
         };

--- a/crates/truthdb-core/src/storage.rs
+++ b/crates/truthdb-core/src/storage.rs
@@ -2068,6 +2068,13 @@ struct StorageFile {
     /// must then reseed. `u64::MAX` (the default) = unlimited retention: a slot
     /// holds truncation until explicitly dropped, matching the backup/log-backup
     /// holds (a deployment configures a finite cap to protect the primary).
+    ///
+    /// A meaningful finite cap must be strictly BELOW the ring's usable capacity
+    /// (`wal_size - wal.reserve()`): a pinned slot keeps the tail within that
+    /// capacity of its LSN (appends stall with `WalFull` first), so the reap
+    /// window `tail - lsn > cap` can never open at or above it — the primary
+    /// would wedge rather than shed the slot. The setter (test-only here; the
+    /// transport slice wires the real one) must reject/clamp to that bound.
     max_slot_retain_bytes: u64,
     /// FULL-model log-backup floor (mirrors the active superblock's
     /// `last_log_backup_lsn`): the LSN up to which the log has been shipped to
@@ -5302,7 +5309,11 @@ impl StorageFile {
             .retain(|_, lsn| tail.saturating_sub(*lsn) <= max);
     }
 
-    /// Registers (or resets) a replication slot at `lsn`.
+    /// Registers (or resets) a replication slot at `lsn`. `lsn` must be `>=` the
+    /// current WAL head (a standby's received LSN is always within the retained
+    /// window — the primary cannot have already truncated it); a below-head slot
+    /// would drive `set_head` below the current head, which it forbids. The
+    /// transport slice enforces this at registration.
     #[cfg(test)]
     fn register_repl_slot(&mut self, id: u32, lsn: u64) {
         self.truncation_gate.repl_slots.insert(id, lsn);

--- a/crates/truthdb-core/src/storage_layout.rs
+++ b/crates/truthdb-core/src/storage_layout.rs
@@ -353,7 +353,46 @@ impl Superblock {
     pub fn set_applied_lsn(&mut self, lsn: u64) {
         self.reserved[24..32].copy_from_slice(&lsn.to_le_bytes());
     }
+
+    /// Persisted replication slots (reserved[32..]): a `u32` count then up to
+    /// [`MAX_REPL_SLOTS`] `(id: u32, held LSN: u64)` records. Each slot holds
+    /// WAL-ring truncation at its LSN so the primary keeps the log a standby
+    /// still needs; the table is re-seeded into the truncation gate on open.
+    /// Covered by the superblock checksum. A corrupt/oversized count is clamped,
+    /// never read out of bounds.
+    pub fn repl_slots(&self) -> Vec<(u32, u64)> {
+        let count = (u32::from_le_bytes(self.reserved[32..36].try_into().unwrap()) as usize)
+            .min(MAX_REPL_SLOTS);
+        let mut out = Vec::with_capacity(count);
+        for i in 0..count {
+            let base = 36 + i * 12;
+            let id = u32::from_le_bytes(self.reserved[base..base + 4].try_into().unwrap());
+            let lsn = u64::from_le_bytes(self.reserved[base + 4..base + 12].try_into().unwrap());
+            out.push((id, lsn));
+        }
+        out
+    }
+
+    pub fn set_repl_slots(&mut self, slots: &[(u32, u64)]) {
+        let count = slots.len().min(MAX_REPL_SLOTS);
+        self.reserved[32..36].copy_from_slice(&(count as u32).to_le_bytes());
+        for (i, (id, lsn)) in slots.iter().take(MAX_REPL_SLOTS).enumerate() {
+            let base = 36 + i * 12;
+            self.reserved[base..base + 4].copy_from_slice(&id.to_le_bytes());
+            self.reserved[base + 4..base + 12].copy_from_slice(&lsn.to_le_bytes());
+        }
+        // Zero the trailing records so a shrink never leaves stale bytes.
+        for i in count..MAX_REPL_SLOTS {
+            let base = 36 + i * 12;
+            self.reserved[base..base + 12].copy_from_slice(&[0u8; 12]);
+        }
+    }
 }
+
+/// The maximum number of replication slots a superblock persists (bounds the
+/// reserved slot table). Eight standbys is ample for the availability-group-lite
+/// topology; a slot table of `4 + 8*12 = 100` bytes fits the reserved area.
+pub const MAX_REPL_SLOTS: usize = 8;
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default)]


### PR DESCRIPTION
A replication **slot** holds WAL-ring truncation at the LSN a standby has received, so the primary keeps the log the standby still needs — and the hold survives a restart. Builds on the `LogTruncationGate` (the comment there always reserved a spot for this).

## What

- `LogTruncationGate` gains `repl_slots: BTreeMap<u32, u64>` (slot id → held LSN), folded into `min_hold` alongside the backup / log-backup holds, so a slot clamps `checkpoint_wal_head` — a checkpoint never truncates past the oldest slot.
- **Persistence**: a superblock reserved slot table at `reserved[32..]` — a `u32` count then up to `MAX_REPL_SLOTS = 8` `(id: u32, lsn: u64)` records (a corrupt/oversized count is clamped, never read OOB). Re-seeded into the gate in `open_existing`, re-stamped in `finish_checkpoint`'s default-built `new_sb` (the checkpoint-wipe carry — 3rd persisted reserved field after `last_log_backup_lsn` and `applied_lsn`). Slot advances are **in-memory between checkpoints**; a crash re-seeds the last-checkpointed LSN, which holds *more* log — safe (redo is idempotent), never less.
- **`max_slot_retain_bytes` reap**: default `u64::MAX` = unlimited retention (faithful — a slot holds until dropped, like the backup/log-backup holds and Postgres's default `max_slot_wal_keep_size = -1`). A slot lagging the tail by more than the cap is dropped at the next checkpoint, **before** the floor is computed, so the ring can advance (the standby must reseed).

The slot API (`register`/`advance`/`drop`) + the retain-cap setter are `#[cfg(test)]` until the transport receiver slice drives them from a standby's acks (same staging as slice 2's ship accessors).

## Test

`replication_slots_hold_truncation_persist_and_reap`: a slot pins the WAL head at its LSN as the tail advances 20 rows past it; advancing the slot advances the floor; the slot survives a restart (re-seeded from the superblock); setting a small `max_slot_retain_bytes` and lagging past it invalidates the slot at the next checkpoint and the reclaimed head advances past it.

`cargo test --workspace`, `cargo fmt -- --check`, `cargo clippy --all-targets --all-features -- -D warnings` all pass (incl. the backup/restore/recovery/superblock/checkpoint suites).

## Scope / deferred

- No transport yet — a slot is created/advanced/dropped by the receiver when a standby acks (slice 4). This slice lands the hold + persistence + reap mechanism, exercised directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)