### PR TITLE
Stage 18 slice 4b-i: replication handshake (constant-time auth + epoch fence)

### DIFF
--- a/crates/truthdb-core/src/repl/handshake.rs
+++ b/crates/truthdb-core/src/repl/handshake.rs
@@ -9,6 +9,11 @@
 //! fields, which binds the proof to that Hello so a captured proof cannot be
 //! replayed with different fields. TLS already prevents on-wire capture/replay,
 //! so no challenge-nonce round-trip is needed before the Hello.
+//!
+//! The whole scheme's secrecy rests on that mandatory TLS: the listener slice
+//! MUST complete the TLS accept before calling [`evaluate_hello`], never on a
+//! plaintext socket. A pre-auth rejection reveals nothing (no real epoch), and
+//! an empty shared secret is refused outright (it would otherwise fail open).
 
 use ring::hmac;
 
@@ -73,6 +78,12 @@ fn reject(primary_epoch: u64, message: &str) -> HelloAck {
 /// unauthenticated peer learns nothing about the version / cluster / epoch state
 /// (every pre-auth failure is one generic rejection).
 pub fn evaluate_hello(hello: &Hello, params: &HandshakeParams) -> HelloAck {
+    // An empty shared secret is a misconfiguration that fails OPEN — anyone could
+    // compute `compute_auth(b"", …)`. Fail closed. (Config load should also
+    // refuse to start a replication node with an empty secret.)
+    if params.shared_secret.is_empty() {
+        return reject(0, "replication handshake rejected");
+    }
     // 1. Shared-secret proof — constant-time HMAC verify, before anything else.
     let key = hmac::Key::new(hmac::HMAC_SHA256, params.shared_secret);
     let msg = auth_message(
@@ -82,7 +93,9 @@ pub fn evaluate_hello(hello: &Hello, params: &HandshakeParams) -> HelloAck {
         hello.last_received_lsn,
     );
     if hmac::verify(&key, &msg, &hello.auth).is_err() {
-        return reject(params.primary_epoch, "replication handshake rejected");
+        // Pre-auth: reveal nothing about the primary's epoch to an
+        // unauthenticated peer (0, not the real epoch).
+        return reject(0, "replication handshake rejected");
     }
     // The peer holds the shared secret; specific diagnostics are safe now.
     // 2. Protocol version.
@@ -161,6 +174,26 @@ mod tests {
         let ack = evaluate_hello(&hello, &params());
         assert!(!ack.accepted);
         assert_eq!(ack.message, "replication handshake rejected");
+        // A pre-auth rejection leaks nothing about the primary's epoch.
+        assert_eq!(ack.primary_epoch, 0);
+    }
+
+    /// An empty shared secret must fail CLOSED — otherwise anyone could compute
+    /// the proof under the empty key.
+    #[test]
+    fn an_empty_shared_secret_fails_closed() {
+        let p = HandshakeParams {
+            shared_secret: b"",
+            cluster_uuid: UUID,
+            primary_epoch: 4,
+            primary_flushed_lsn: 100_000,
+        };
+        // Even a proof computed under the empty secret is refused.
+        let auth = compute_auth(b"", 9, &UUID, 2, 50_000);
+        let hello = hello_with(9, 2, 50_000, auth);
+        let ack = evaluate_hello(&hello, &p);
+        assert!(!ack.accepted);
+        assert_eq!(ack.primary_epoch, 0);
     }
 
     /// A proof signed for one identity cannot be replayed with different fields:

--- a/crates/truthdb-core/src/repl/handshake.rs
+++ b/crates/truthdb-core/src/repl/handshake.rs
@@ -1,0 +1,218 @@
+//! The replication handshake. A standby proves membership by sending, in its
+//! [`Hello`], an HMAC-SHA256 of its identity under the cluster's shared secret;
+//! the primary verifies it in constant time, epoch-fences the standby, and
+//! answers with a [`HelloAck`]. Pure logic — the listener slice runs it after
+//! the TLS accept (TLS authenticates the primary to the standby and secures the
+//! channel; the shared-secret proof authenticates the standby to the primary).
+//!
+//! The secret is never sent on the wire — only an HMAC over the Hello's identity
+//! fields, which binds the proof to that Hello so a captured proof cannot be
+//! replayed with different fields. TLS already prevents on-wire capture/replay,
+//! so no challenge-nonce round-trip is needed before the Hello.
+
+use ring::hmac;
+
+use super::{Hello, HelloAck, REPL_PROTOCOL_VERSION};
+
+/// What the primary checks a standby's [`Hello`] against.
+pub struct HandshakeParams<'a> {
+    /// The cluster's shared secret (identical on every node). Never sent on the
+    /// wire.
+    pub shared_secret: &'a [u8],
+    /// This cluster's uuid.
+    pub cluster_uuid: [u8; 16],
+    /// The primary's current replication epoch (bumped on promotion).
+    pub primary_epoch: u64,
+    /// The primary's current durable WAL tail — the standby cannot request log
+    /// beyond it.
+    pub primary_flushed_lsn: u64,
+}
+
+/// The identity bytes the HMAC binds: `node_id ‖ cluster_uuid ‖ epoch ‖
+/// last_received_lsn`.
+fn auth_message(
+    node_id: u64,
+    cluster_uuid: &[u8; 16],
+    epoch: u64,
+    last_received_lsn: u64,
+) -> Vec<u8> {
+    let mut msg = Vec::with_capacity(8 + 16 + 8 + 8);
+    msg.extend_from_slice(&node_id.to_le_bytes());
+    msg.extend_from_slice(cluster_uuid);
+    msg.extend_from_slice(&epoch.to_le_bytes());
+    msg.extend_from_slice(&last_received_lsn.to_le_bytes());
+    msg
+}
+
+/// Computes the proof a standby sends in `Hello.auth`: the HMAC-SHA256 of its
+/// identity under the shared secret.
+pub fn compute_auth(
+    shared_secret: &[u8],
+    node_id: u64,
+    cluster_uuid: &[u8; 16],
+    epoch: u64,
+    last_received_lsn: u64,
+) -> Vec<u8> {
+    let key = hmac::Key::new(hmac::HMAC_SHA256, shared_secret);
+    let msg = auth_message(node_id, cluster_uuid, epoch, last_received_lsn);
+    hmac::sign(&key, &msg).as_ref().to_vec()
+}
+
+fn reject(primary_epoch: u64, message: &str) -> HelloAck {
+    HelloAck {
+        protocol_version: REPL_PROTOCOL_VERSION,
+        accepted: false,
+        primary_epoch,
+        primary_flushed_lsn: 0,
+        message: message.to_string(),
+    }
+}
+
+/// Authenticates and fences a standby's [`Hello`], returning the [`HelloAck`] to
+/// send back. The shared-secret proof is verified FIRST (constant-time), so an
+/// unauthenticated peer learns nothing about the version / cluster / epoch state
+/// (every pre-auth failure is one generic rejection).
+pub fn evaluate_hello(hello: &Hello, params: &HandshakeParams) -> HelloAck {
+    // 1. Shared-secret proof — constant-time HMAC verify, before anything else.
+    let key = hmac::Key::new(hmac::HMAC_SHA256, params.shared_secret);
+    let msg = auth_message(
+        hello.node_id,
+        &hello.cluster_uuid,
+        hello.epoch,
+        hello.last_received_lsn,
+    );
+    if hmac::verify(&key, &msg, &hello.auth).is_err() {
+        return reject(params.primary_epoch, "replication handshake rejected");
+    }
+    // The peer holds the shared secret; specific diagnostics are safe now.
+    // 2. Protocol version.
+    if hello.protocol_version != REPL_PROTOCOL_VERSION {
+        return reject(
+            params.primary_epoch,
+            "replication protocol version mismatch",
+        );
+    }
+    // 3. Cluster identity (defense in depth — the HMAC already bound the uuid, so
+    //    this only differs on a shared-secret misconfiguration across clusters).
+    if hello.cluster_uuid != params.cluster_uuid {
+        return reject(params.primary_epoch, "cluster uuid mismatch");
+    }
+    // 4. Epoch fence: a standby claiming a HIGHER epoch than ours means we are a
+    //    stale (demoted) primary — refuse to feed it; the operator resolves the
+    //    split and this node reseeds.
+    if hello.epoch > params.primary_epoch {
+        return reject(
+            params.primary_epoch,
+            "this primary's epoch is behind the standby",
+        );
+    }
+    HelloAck {
+        protocol_version: REPL_PROTOCOL_VERSION,
+        accepted: true,
+        primary_epoch: params.primary_epoch,
+        primary_flushed_lsn: params.primary_flushed_lsn,
+        message: "ok".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SECRET: &[u8] = b"a-shared-cluster-secret";
+    const UUID: [u8; 16] = [3u8; 16];
+
+    fn params() -> HandshakeParams<'static> {
+        HandshakeParams {
+            shared_secret: SECRET,
+            cluster_uuid: UUID,
+            primary_epoch: 4,
+            primary_flushed_lsn: 100_000,
+        }
+    }
+
+    fn hello_with(node_id: u64, epoch: u64, last_received_lsn: u64, auth: Vec<u8>) -> Hello {
+        Hello {
+            protocol_version: REPL_PROTOCOL_VERSION,
+            node_id,
+            cluster_uuid: UUID,
+            epoch,
+            last_received_lsn,
+            auth,
+        }
+    }
+
+    /// A correctly-signed, in-epoch Hello is accepted, and the ack carries the
+    /// primary's epoch + durable tail.
+    #[test]
+    fn a_valid_hello_is_accepted() {
+        let auth = compute_auth(SECRET, 9, &UUID, 2, 50_000);
+        let hello = hello_with(9, 2, 50_000, auth);
+        let ack = evaluate_hello(&hello, &params());
+        assert!(ack.accepted, "{}", ack.message);
+        assert_eq!(ack.primary_epoch, 4);
+        assert_eq!(ack.primary_flushed_lsn, 100_000);
+    }
+
+    #[test]
+    fn a_wrong_secret_is_rejected_generically() {
+        let auth = compute_auth(b"the-wrong-secret", 9, &UUID, 2, 50_000);
+        let hello = hello_with(9, 2, 50_000, auth);
+        let ack = evaluate_hello(&hello, &params());
+        assert!(!ack.accepted);
+        assert_eq!(ack.message, "replication handshake rejected");
+    }
+
+    /// A proof signed for one identity cannot be replayed with different fields:
+    /// the HMAC is over the identity, so tampering breaks it.
+    #[test]
+    fn a_tampered_identity_breaks_the_proof() {
+        let auth = compute_auth(SECRET, 9, &UUID, 2, 50_000);
+        // Same auth, but the Hello now claims a different node_id.
+        let hello = hello_with(10, 2, 50_000, auth);
+        let ack = evaluate_hello(&hello, &params());
+        assert!(!ack.accepted);
+        assert_eq!(ack.message, "replication handshake rejected");
+    }
+
+    #[test]
+    fn a_version_mismatch_is_rejected_only_after_auth() {
+        let auth = compute_auth(SECRET, 9, &UUID, 2, 50_000);
+        let mut hello = hello_with(9, 2, 50_000, auth);
+        hello.protocol_version = REPL_PROTOCOL_VERSION + 1;
+        let ack = evaluate_hello(&hello, &params());
+        assert!(!ack.accepted);
+        assert_eq!(ack.message, "replication protocol version mismatch");
+    }
+
+    #[test]
+    fn a_cluster_uuid_mismatch_is_rejected() {
+        // A peer that knows the secret but signs a different cluster uuid.
+        let other = [9u8; 16];
+        let auth = compute_auth(SECRET, 9, &other, 2, 50_000);
+        let mut hello = hello_with(9, 2, 50_000, auth);
+        hello.cluster_uuid = other;
+        let ack = evaluate_hello(&hello, &params());
+        assert!(!ack.accepted);
+        assert_eq!(ack.message, "cluster uuid mismatch");
+    }
+
+    /// A standby at a higher epoch means this primary was demoted (fencing).
+    #[test]
+    fn a_standby_ahead_in_epoch_fences_a_stale_primary() {
+        let auth = compute_auth(SECRET, 9, &UUID, 7, 50_000);
+        let hello = hello_with(9, 7, 50_000, auth); // epoch 7 > primary 4
+        let ack = evaluate_hello(&hello, &params());
+        assert!(!ack.accepted);
+        assert_eq!(ack.message, "this primary's epoch is behind the standby");
+    }
+
+    #[test]
+    fn a_standby_at_or_below_the_primary_epoch_is_accepted() {
+        for epoch in [0u64, 4] {
+            let auth = compute_auth(SECRET, 9, &UUID, epoch, 50_000);
+            let hello = hello_with(9, epoch, 50_000, auth);
+            assert!(evaluate_hello(&hello, &params()).accepted, "epoch {epoch}");
+        }
+    }
+}

--- a/crates/truthdb-core/src/repl/mod.rs
+++ b/crates/truthdb-core/src/repl/mod.rs
@@ -7,6 +7,8 @@
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
+pub mod handshake;
+
 /// Replication protocol version. Bumped on any incompatible wire change.
 pub const REPL_PROTOCOL_VERSION: u32 = 1;
 


### PR DESCRIPTION
The security core of the replication transport handshake — **pure logic, no I/O**, so it unit-tests without a listener (which follows in 4b-ii).

## What

- `compute_auth(secret, node_id, cluster_uuid, epoch, last_received_lsn)` = HMAC-SHA256 of the identity under the cluster's shared secret (`ring::hmac`). The **secret never travels on the wire** — only the HMAC, bound to the Hello's identity so a captured proof cannot be replayed with different fields.
- `evaluate_hello(hello, &HandshakeParams) -> HelloAck`:
  1. **Verify the proof first**, constant-time (`ring::hmac::verify`) — an unauthenticated peer gets one generic `"replication handshake rejected"` and learns nothing about the version/cluster/epoch state (only a secret-holder sees specific diagnostics).
  2. protocol version, 3. cluster uuid, 4. **epoch fence** — a standby claiming a higher epoch than this primary means this node was demoted; refuse to feed it and let it reseed.

TLS (mandatory, added in 4b-ii) authenticates the primary to the standby and secures the channel, so no challenge-nonce round-trip is needed before the first message.

## Tests (7, all passing)

Accept a valid in-epoch Hello (ack carries the primary's epoch + durable tail); reject a wrong secret generically; a tampered identity breaks the proof; version and cluster-uuid mismatches are rejected (only after auth); a standby ahead in epoch fences a stale primary; a standby at/below the epoch is accepted.

`cargo test -p truthdb-core --lib repl::handshake` green; fmt + clippy clean.

## Scope

Handshake decision logic only. The tokio listener on :9624, the TLS accept (`TlsConfig::from_pem` reuse, raw `tokio_rustls::accept`), and the `ReplicationConfig` wiring land in 4b-ii.

🤖 Generated with [Claude Code](https://claude.com/claude-code)