### PR TITLE
Stage 18: replication TLS + real-socket integration harness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,6 +68,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -149,6 +155,12 @@ name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 
 [[package]]
 name = "directories"
@@ -522,6 +534,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -563,6 +581,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -584,6 +612,12 @@ dependencies = [
  "writeable",
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "proc-macro-crate"
@@ -610,6 +644,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "yasna",
 ]
 
 [[package]]
@@ -964,6 +1011,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
 name = "tinystr"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1195,12 +1261,16 @@ dependencies = [
  "icu_locale_core",
  "io-uring",
  "libc",
+ "rcgen",
  "ring",
  "rstest",
+ "rustls",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-rustls",
  "truthdb-net",
  "truthdb-proto",
  "truthdb-sql",
@@ -1541,6 +1611,15 @@ name = "xxhash-rust"
 version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
+]
 
 [[package]]
 name = "yoke"

--- a/crates/truthdb-core/Cargo.toml
+++ b/crates/truthdb-core/Cargo.toml
@@ -20,6 +20,14 @@ icu_locale_core = "2.0"
 # PBKDF2-HMAC-SHA256 for login password hashing. Already in the tree via rustls
 # (truthdb-tds), so this is a manifest entry only — zero new compiled crates.
 ring = "0.17"
+# Mandatory TLS for the Stage 18 replication transport. Same versions/features as
+# truthdb-tds (which cannot be depended on here — it depends on truthdb-core), so
+# the small rustls ServerConfig/ClientConfig build is duplicated in `repl::tls`.
+rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12", "logging"] }
+tokio-rustls = { version = "0.26", default-features = false, features = ["ring", "tls12"] }
+rustls-pemfile = "2"
 
 [dev-dependencies]
 rstest = { workspace = true }
+# Generates a self-signed cert for the replication TLS integration tests.
+rcgen = "0.13"

--- a/crates/truthdb-core/src/repl/mod.rs
+++ b/crates/truthdb-core/src/repl/mod.rs
@@ -10,6 +10,7 @@ use thiserror::Error;
 pub mod framing;
 pub mod handshake;
 pub mod server;
+pub mod tls;
 
 /// Replication protocol version. Bumped on any incompatible wire change.
 pub const REPL_PROTOCOL_VERSION: u32 = 1;

--- a/crates/truthdb-core/src/repl/tls.rs
+++ b/crates/truthdb-core/src/repl/tls.rs
@@ -1,0 +1,166 @@
+//! TLS for the replication transport. TLS is mandatory: it authenticates the
+//! primary to the standby (the standby verifies the primary's certificate) and
+//! encrypts the channel the shared-secret handshake and the WAL stream travel
+//! over. This duplicates the small rustls `ServerConfig`/`ClientConfig` build
+//! from `truthdb-tds` (which cannot be depended on here — it depends on this
+//! crate); unlike the TDS path there is no PRELOGIN tunnelling, so the listener
+//! uses a raw `tokio_rustls` accept.
+
+use std::io;
+use std::sync::Arc;
+
+use rustls::pki_types::CertificateDer;
+use rustls::{ClientConfig, RootCertStore, ServerConfig};
+
+/// Builds the primary's TLS `ServerConfig` from a certificate + private key PEM.
+pub fn server_config_from_pem(cert_pem: &[u8], key_pem: &[u8]) -> io::Result<Arc<ServerConfig>> {
+    let certs = load_certs(cert_pem)?;
+    let key = rustls_pemfile::private_key(&mut &key_pem[..])
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, format!("bad private key: {e}")))?
+        .ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "no private key in the TLS key PEM",
+            )
+        })?;
+    let config =
+        ServerConfig::builder_with_provider(Arc::new(rustls::crypto::ring::default_provider()))
+            .with_safe_default_protocol_versions()
+            .map_err(|e| io::Error::other(format!("tls server config: {e}")))?
+            .with_no_client_auth()
+            .with_single_cert(certs, key)
+            .map_err(|e| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("tls server config: {e}"),
+                )
+            })?;
+    Ok(Arc::new(config))
+}
+
+/// Builds a standby's TLS `ClientConfig` that trusts exactly the given
+/// certificate(s) as roots — the primary's self-signed (or CA) cert. The standby
+/// verifies the primary against this, so a wrong endpoint fails the handshake.
+pub fn client_config_trusting(ca_pem: &[u8]) -> io::Result<Arc<ClientConfig>> {
+    let mut roots = RootCertStore::empty();
+    for cert in load_certs(ca_pem)? {
+        roots
+            .add(cert)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, format!("add root: {e}")))?;
+    }
+    let config =
+        ClientConfig::builder_with_provider(Arc::new(rustls::crypto::ring::default_provider()))
+            .with_safe_default_protocol_versions()
+            .map_err(|e| io::Error::other(format!("tls client config: {e}")))?
+            .with_root_certificates(roots)
+            .with_no_client_auth();
+    Ok(Arc::new(config))
+}
+
+fn load_certs(pem: &[u8]) -> io::Result<Vec<CertificateDer<'static>>> {
+    let certs = rustls_pemfile::certs(&mut &pem[..])
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, format!("bad certificate: {e}")))?;
+    if certs.is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "no certificate in the TLS PEM",
+        ));
+    }
+    Ok(certs)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::repl::framing::{read_repl_frame, write_repl_frame};
+    use crate::repl::{Hello, REPL_PROTOCOL_VERSION, ReplFrame, ReplMsgType};
+
+    /// Generates a self-signed `localhost` cert/key PEM for the integration test.
+    fn self_signed() -> (String, String) {
+        let cert = rcgen::generate_simple_self_signed(vec!["localhost".to_string()])
+            .expect("generate cert");
+        (cert.cert.pem(), cert.key_pair.serialize_pem())
+    }
+
+    /// A replication frame round-trips over a REAL localhost TCP + TLS connection:
+    /// the standby trusts the primary's self-signed cert, completes the TLS
+    /// handshake, and the frame survives the encrypted channel. This is the
+    /// harness foundation the listener/sender/receiver slices reuse.
+    #[tokio::test]
+    async fn a_repl_frame_round_trips_over_real_tls() {
+        let (cert_pem, key_pem) = self_signed();
+        let server_config =
+            server_config_from_pem(cert_pem.as_bytes(), key_pem.as_bytes()).expect("server config");
+        let client_config = client_config_trusting(cert_pem.as_bytes()).expect("client config");
+        let acceptor = tokio_rustls::TlsAcceptor::from(server_config);
+        let connector = tokio_rustls::TlsConnector::from(client_config);
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        // Primary side: accept one connection, TLS-wrap it, echo one frame.
+        let server = tokio::spawn(async move {
+            let (tcp, _) = listener.accept().await.unwrap();
+            let mut tls = acceptor.accept(tcp).await.expect("server tls handshake");
+            let frame = read_repl_frame(&mut tls).await.unwrap();
+            write_repl_frame(&mut tls, &frame).await.unwrap();
+        });
+
+        // Standby side: connect, verify the cert, TLS handshake, send + read back.
+        let tcp = tokio::net::TcpStream::connect(addr).await.unwrap();
+        let domain = rustls::pki_types::ServerName::try_from("localhost").unwrap();
+        let mut tls = connector
+            .connect(domain, tcp)
+            .await
+            .expect("client tls handshake");
+
+        let hello = Hello {
+            protocol_version: REPL_PROTOCOL_VERSION,
+            node_id: 1,
+            cluster_uuid: [2u8; 16],
+            epoch: 0,
+            last_received_lsn: 4096,
+            auth: vec![9, 9],
+        };
+        let sent = ReplFrame::encode(ReplMsgType::Hello, &hello).unwrap();
+        write_repl_frame(&mut tls, &sent).await.unwrap();
+        let got = read_repl_frame(&mut tls).await.unwrap();
+        assert_eq!(got.msg_type, ReplMsgType::Hello);
+        let decoded: Hello = got.decode().unwrap();
+        assert_eq!(decoded.node_id, 1);
+        assert_eq!(decoded.last_received_lsn, 4096);
+
+        server.await.unwrap();
+    }
+
+    /// A standby that does NOT trust the primary's cert fails the TLS handshake —
+    /// TLS is authenticating the primary, not just encrypting.
+    #[tokio::test]
+    async fn an_untrusted_cert_is_rejected() {
+        let (cert_pem, key_pem) = self_signed();
+        let (other_cert_pem, _) = self_signed(); // a different, untrusted cert
+        let acceptor = tokio_rustls::TlsAcceptor::from(
+            server_config_from_pem(cert_pem.as_bytes(), key_pem.as_bytes()).unwrap(),
+        );
+        // The client trusts `other_cert`, not the server's actual cert.
+        let connector = tokio_rustls::TlsConnector::from(
+            client_config_trusting(other_cert_pem.as_bytes()).unwrap(),
+        );
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            if let Ok((tcp, _)) = listener.accept().await {
+                let _ = acceptor.accept(tcp).await; // handshake will fail
+            }
+        });
+
+        let tcp = tokio::net::TcpStream::connect(addr).await.unwrap();
+        let domain = rustls::pki_types::ServerName::try_from("localhost").unwrap();
+        assert!(
+            connector.connect(domain, tcp).await.is_err(),
+            "an untrusted primary cert must fail the standby's TLS verification"
+        );
+    }
+}


### PR DESCRIPTION
The foundation the two-process replication test needs (chosen direction): **mandatory TLS** for the transport plus a **cert-generating integration test over a real localhost TCP+TLS socket**.

## What

- `repl::tls::server_config_from_pem(cert, key)` builds the primary's rustls `ServerConfig`; `client_config_trusting(ca)` builds a standby's `ClientConfig` that trusts exactly the given cert. This **duplicates** the small rustls build from `truthdb-tds` — which cannot be a dependency here (it depends on `truthdb-core`), the dependency cycle I flagged. No PRELOGIN tunnelling (unlike TDS), so the listener uses a raw `tokio_rustls` accept.
- Adds `rustls`/`tokio-rustls`/`rustls-pemfile` (same versions/features as truthdb-tds) to core, and `rcgen` as a **dev-dependency** for generating the test cert.

## Tests (real localhost TCP + TLS)

- A repl frame round-trips over the encrypted channel **after the standby verifies the primary's self-signed cert** (real TLS handshake, real socket).
- A standby that trusts a **different** cert fails the handshake — TLS authenticates the primary, not merely encrypts.

These establish the reusable cert-gen + TLS-over-real-socket harness that the listener, senders, and receiver slices build their end-to-end tests on. This directly resolves the "no cert infrastructure" gap that made the network glue untestable.

`cargo test -p truthdb-core --lib repl::tls` green; fmt + clippy clean.

## Scope

TLS plumbing + the real-socket harness. The `ReplListener` accept loop (calling `serve_handshake` over the TLS stream), `ReplicationConfig`, and main.rs wiring come next, now with a real integration test available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)