### PR TITLE
Stage 18 slice 4d: live standby WAL-stream apply

### DIFF
--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -2380,8 +2380,135 @@ mod tests {
             "the live-applied state persists across a standby restart"
         );
 
+        // A backup taken ON the standby captures the FULL applied state (the
+        // in-memory WAL tail is resynced, so the backup is not truncated to the
+        // pre-apply point).
+        let standby_bak = unique_temp_path("live-standby-bak");
+        let restored = unique_temp_path("live-standby-restored");
+        standby2
+            .storage()
+            .backup_full(&standby_bak)
+            .expect("backup on the standby");
+        Storage::restore_full(&restored, &standby_bak).expect("restore the standby backup");
+        let r = Engine::new(Storage::open(restored.clone()).expect("open")).expect("eng");
+        assert_eq!(
+            sql_rows(&r, "SELECT id, v FROM t ORDER BY id").1,
+            expected,
+            "a backup of the standby restores the full applied state"
+        );
+
+        // A checkpoint on a standby is refused (it reclaims ring space only at
+        // promotion, to keep the in-flight undo log).
+        assert!(
+            standby2.checkpoint().is_err(),
+            "checkpoint is refused on a standby"
+        );
+
         drop(primary);
         drop(standby2);
+        drop(r);
+        for p in [primary_path, bak, standby_path, standby_bak, restored] {
+            let _ = std::fs::remove_file(p);
+        }
+    }
+
+    // Stage 18 slice 4d (review fix): a shipped stream can end MID-transaction
+    // (the primary's durable watermark can land between an in-flight txn's page
+    // ops and its commit). A standby's reopen must REPEAT history (redo-only) —
+    // a full ARIES undo would roll back the in-flight rows, and since the primary
+    // commits them and resumes shipping ABOVE the standby's applied point, they
+    // would be lost forever (silent replica divergence).
+    #[test]
+    fn a_standby_reopen_is_redo_only_and_keeps_in_flight_stream_data() {
+        let primary_path = unique_temp_path("redo-primary");
+        let bak = unique_temp_path("redo-bak");
+        let standby_path = unique_temp_path("redo-standby");
+
+        let primary = new_engine(&primary_path);
+        let mut ctx = TxnContext::default();
+        batch(
+            &primary,
+            &mut ctx,
+            "CREATE TABLE t (id INT NOT NULL PRIMARY KEY, v INT)",
+        );
+        for i in 1..=10 {
+            batch(
+                &primary,
+                &mut ctx,
+                &format!("INSERT INTO t VALUES ({i}, {i})"),
+            );
+        }
+        let summary = primary.storage().backup_full(&bak).expect("backup");
+        let backup_end = summary.backup_end_lsn;
+
+        // An explicit transaction whose inserts are made durable (fsynced) but NOT
+        // committed — the durable watermark now lands mid-transaction.
+        batch(&primary, &mut ctx, "BEGIN TRANSACTION");
+        for i in 11..=20 {
+            batch(
+                &primary,
+                &mut ctx,
+                &format!("INSERT INTO t VALUES ({i}, {i})"),
+            );
+        }
+        let mid = primary.storage().wal_flushed_lsn();
+        let delta = primary
+            .storage()
+            .read_wal_range(backup_end, mid)
+            .expect("ship the mid-transaction range");
+
+        let count = |eng: &Engine| -> String {
+            sql_rows(eng, "SELECT COUNT(*) FROM t").1[0][0]
+                .clone()
+                .unwrap_or_default()
+        };
+
+        // Standby applies the mid-transaction stream live (the in-flight rows are
+        // present via redo), then RESTARTS.
+        Storage::restore_full(&standby_path, &bak).expect("restore");
+        {
+            let standby =
+                Engine::new(Storage::open(standby_path.clone()).expect("open")).expect("eng");
+            standby
+                .storage()
+                .apply_wal_stream(backup_end, &delta)
+                .expect("apply mid-txn stream");
+            assert_eq!(
+                count(&standby),
+                "20",
+                "the in-flight rows are applied via redo"
+            );
+        }
+        // THE FIX: a standby reopen is redo-only, so the applied rows survive. A
+        // full ARIES undo here would drop the 10 in-flight rows permanently.
+        let standby =
+            Engine::new(Storage::open(standby_path.clone()).expect("reopen")).expect("eng");
+        assert_eq!(
+            count(&standby),
+            "20",
+            "redo-only reopen keeps the streamed in-flight rows"
+        );
+
+        // The primary commits and ships the continuation; the standby stays
+        // consistent with the primary.
+        batch(&primary, &mut ctx, "COMMIT TRANSACTION");
+        let after = primary.storage().wal_flushed_lsn();
+        let delta2 = primary
+            .storage()
+            .read_wal_range(mid, after)
+            .expect("ship the commit");
+        standby
+            .storage()
+            .apply_wal_stream(mid, &delta2)
+            .expect("apply the commit");
+        assert_eq!(
+            sql_rows(&standby, "SELECT id, v FROM t ORDER BY id").1,
+            sql_rows(&primary, "SELECT id, v FROM t ORDER BY id").1,
+            "the standby matches the primary once the commit is shipped"
+        );
+
+        drop(primary);
+        drop(standby);
         for p in [primary_path, bak, standby_path] {
             let _ = std::fs::remove_file(p);
         }

--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -2304,6 +2304,89 @@ mod tests {
         }
     }
 
+    // Stage 18 slice 4d: an OPEN standby applies a shipped WAL range LIVE (no
+    // reopen) and its state matches the primary; the apply is idempotent and
+    // survives a standby restart.
+    #[test]
+    fn a_standby_applies_a_live_wal_stream_and_matches_the_primary() {
+        let primary_path = unique_temp_path("live-primary");
+        let bak = unique_temp_path("live-bak");
+        let standby_path = unique_temp_path("live-standby");
+
+        // Primary: rows 1..=10, a backup, then post-backup changes to ship.
+        let primary = new_engine(&primary_path);
+        primary
+            .execute("CREATE TABLE t (id INT NOT NULL PRIMARY KEY, v INT)")
+            .expect("create");
+        for i in 1..=10 {
+            primary
+                .execute(&format!("INSERT INTO t VALUES ({i}, {i})"))
+                .expect("insert");
+        }
+        let summary = primary.storage().backup_full(&bak).expect("backup");
+        let backup_end = summary.backup_end_lsn;
+        for i in 11..=25 {
+            primary
+                .execute(&format!("INSERT INTO t VALUES ({i}, {i})"))
+                .expect("insert");
+        }
+        primary
+            .execute("UPDATE t SET v = v + 100 WHERE id <= 5")
+            .expect("update");
+        let flushed = primary.storage().wal_flushed_lsn();
+        let delta = primary
+            .storage()
+            .read_wal_range(backup_end, flushed)
+            .expect("ship the delta");
+        let expected = sql_rows(&primary, "SELECT id, v FROM t ORDER BY id").1;
+
+        // Standby: restore the backup as an OPEN engine (only the 10 backed-up
+        // rows), then apply the shipped delta LIVE — no reopen.
+        Storage::restore_full(&standby_path, &bak).expect("restore");
+        let standby = Engine::new(Storage::open(standby_path.clone()).expect("open")).expect("eng");
+        assert_eq!(
+            sql_rows(&standby, "SELECT COUNT(*) FROM t").1,
+            vec![vec![Some("10".into())]],
+            "the standby starts at the backup point"
+        );
+        standby
+            .storage()
+            .apply_wal_stream(backup_end, &delta)
+            .expect("live apply");
+        assert_eq!(
+            sql_rows(&standby, "SELECT id, v FROM t ORDER BY id").1,
+            expected,
+            "the standby matches the primary after applying the live stream (no reopen)"
+        );
+
+        // Idempotent: re-applying the same range changes nothing.
+        standby
+            .storage()
+            .apply_wal_stream(backup_end, &delta)
+            .expect("re-apply");
+        assert_eq!(
+            sql_rows(&standby, "SELECT id, v FROM t ORDER BY id").1,
+            expected,
+            "re-applying the same range is idempotent"
+        );
+
+        // Durable: the applied state survives a standby restart.
+        drop(standby);
+        let standby2 =
+            Engine::new(Storage::open(standby_path.clone()).expect("reopen")).expect("eng");
+        assert_eq!(
+            sql_rows(&standby2, "SELECT id, v FROM t ORDER BY id").1,
+            expected,
+            "the live-applied state persists across a standby restart"
+        );
+
+        drop(primary);
+        drop(standby2);
+        for p in [primary_path, bak, standby_path] {
+            let _ = std::fs::remove_file(p);
+        }
+    }
+
     // Stage 18 slice 3: a replication slot holds WAL-ring truncation at a
     // standby's received LSN, survives a restart, and is invalidated once it
     // lags past `max_slot_retain_bytes`.

--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -2404,6 +2404,19 @@ mod tests {
             "checkpoint is refused on a standby"
         );
 
+        // A standby is read-only: a local client write is rejected (it would
+        // append to the replica's own WAL and diverge it from the primary).
+        let write = sql(&standby2, "INSERT INTO t VALUES (999, 999)");
+        assert!(
+            !write["error"].is_null(),
+            "a local write on a standby is rejected: {write}"
+        );
+        assert_eq!(
+            sql_rows(&standby2, "SELECT COUNT(*) FROM t").1,
+            vec![vec![Some("25".into())]],
+            "the rejected write left the standby unchanged"
+        );
+
         drop(primary);
         drop(standby2);
         drop(r);

--- a/crates/truthdb-core/src/storage.rs
+++ b/crates/truthdb-core/src/storage.rs
@@ -962,6 +962,13 @@ impl Storage {
         threshold: f64,
     ) -> Result<bool, StorageError> {
         let mut file = self.lock();
+        // A standby cannot checkpoint (it must keep the in-flight undo log until
+        // promotion), so the AUTOMATIC path skips gracefully — a read batch that
+        // triggers it must not fail with a checkpoint-refused error. An explicit
+        // `write_checkpoint` still errors, telling an operator it is unsupported.
+        if file.active_sb().is_standby() {
+            return Ok(false);
+        }
         // A wedged store's in-memory state is ahead of the durable log after a
         // failed fsync; checkpointing would flush and re-fsync exactly the data
         // whose durability failed (and was reported to the client as failed).

--- a/crates/truthdb-core/src/storage.rs
+++ b/crates/truthdb-core/src/storage.rs
@@ -1509,9 +1509,12 @@ impl Storage {
     /// primary ships `read_wal_range` output at a flushed watermark).
     ///
     /// Redo only — no analysis or undo (those need the whole log and mutate the
-    /// WAL); in-flight transactions are resolved at promotion, not here. The
-    /// standby never appends its own log, so the in-memory WAL tail is left where
-    /// it is; only the persisted superblock tail advances (re-derived on reopen).
+    /// WAL); in-flight transactions are resolved at promotion, not here. So a
+    /// shipped range ending mid-transaction leaves that transaction's rows
+    /// applied but uncommitted: a plain standby `SELECT` can read them (a
+    /// read-uncommitted anomaly). Serving consistent snapshot reads at the last
+    /// applied commit is the readable-standby slice; until then a standby is a
+    /// failover target, not a query replica.
     pub fn apply_wal_stream(&self, from_lsn: u64, bytes: &[u8]) -> Result<(), StorageError> {
         self.lock().apply_wal_stream_locked(from_lsn, bytes)
     }
@@ -4766,8 +4769,12 @@ impl StorageFile {
         }
 
         // ARIES restart for the relational store: analysis + redo, catalog
-        // reload, undo of losers with compensation logging.
-        storage.recover_rel(stop_at)?;
+        // reload, undo of losers with compensation logging. A standby (one that
+        // has applied a live WAL stream) recovers REDO-ONLY — repeat history but
+        // do not undo in-flight transactions, which the primary will commit and
+        // whose continuation resumes above this standby's applied point.
+        let redo_only = storage.active_sb().is_standby();
+        storage.recover_rel(stop_at, redo_only)?;
         Ok(storage)
     }
 
@@ -4887,7 +4894,7 @@ impl StorageFile {
     /// loser transactions with CLRs. The catalog is loaded between redo and
     /// undo (undo needs tree roots) and reloaded after (undo may have
     /// removed catalog rows).
-    fn recover_rel(&mut self, stop_at: Option<u64>) -> Result<(), StorageError> {
+    fn recover_rel(&mut self, stop_at: Option<u64>, redo_only: bool) -> Result<(), StorageError> {
         let records = self.rel_records()?;
         if records.is_empty() && self.rel.catalog_root.is_none() {
             return Ok(());
@@ -4903,7 +4910,11 @@ impl StorageFile {
         self.rel.next_txn_id = outcome.max_txn_id + 1;
 
         self.reload_catalog()?;
-        if !outcome.losers.is_empty() {
+        // A standby repeats history but never undoes: an in-flight transaction at
+        // the applied tail is the primary's, to be committed (and shipped onward)
+        // or resolved at promotion — undoing it here would drop committed data
+        // that the streaming protocol never re-ships.
+        if !redo_only && !outcome.losers.is_empty() {
             let roots = self.rel.tree_roots();
             let mut ctx = self.rel_ctx();
             rel_recovery::undo_losers(&mut ctx, &records, &outcome.losers, &roots)?;
@@ -5867,6 +5878,10 @@ impl StorageFile {
         //    recording an un-fsynced tail would trust torn bytes on reopen.
         self.seed_ring(from_lsn, bytes)?;
         self.file.sync_data()?;
+        // Advance the in-memory WAL tail to match the seeded ring, so `tail()` /
+        // `flushed_lsn()` (read by a backup, and by continuity above) reflect
+        // reality — a standby never appends, so nothing else would move them.
+        self.wal.resync_tail(advanced)?;
 
         // 2. Decode only the newly seeded range: a scan starting at `from_lsn`
         //    self-terminates where the stale bytes past `new_end` begin (their
@@ -5912,6 +5927,10 @@ impl StorageFile {
         self.commit_superblock(|sb| {
             sb.wal_tail = advanced;
             sb.set_applied_lsn(advanced);
+            // Mark this file a standby: its reopen must be redo-only, since the
+            // shipped range can end mid-transaction and undoing it would diverge
+            // the replica.
+            sb.set_standby(true);
         })?;
         Ok(())
     }
@@ -6126,6 +6145,19 @@ impl StorageFile {
         next_doc_id: u64,
     ) -> Result<(), StorageError> {
         self.ensure_rel_usable()?;
+        // A checkpoint on a standby is refused: it would advance the WAL head
+        // past the in-flight transactions the standby has applied but not
+        // resolved, discarding the undo log they need at promotion. A
+        // standby-safe checkpoint (preserving undo-ability) is designed with the
+        // standby runtime; until then a standby reclaims ring space only by
+        // promotion. The ring-fit guard in `apply_wal_stream_locked` bounds how
+        // far a standby can stream without one.
+        if self.active_sb().is_standby() {
+            return Err(StorageError::InvalidConfig(
+                "checkpoint is not supported on a replication standby (apply-only until promotion)"
+                    .to_string(),
+            ));
+        }
         if data.is_empty() {
             // An empty snapshot would produce a descriptor that
             // SnapshotDescriptor::is_valid rejects while the WAL head still
@@ -6313,6 +6345,9 @@ impl StorageFile {
         // the log-backup floor must be stamped back in or a checkpoint would
         // silently reset it to 0 and drop the FULL-model hold across a restart.
         let last_log_backup_lsn = self.last_log_backup_lsn;
+        // Carry the standby (redo-only) mode across the checkpoint (the closure
+        // builds from a default superblock that would otherwise clear it).
+        let standby = self.active_sb().is_standby();
         // Persist the (post-reap) replication slots, so their truncation hold is
         // re-established on the next open. Snapshotted after the reap above, so an
         // invalidated slot is not written back.
@@ -6342,6 +6377,7 @@ impl StorageFile {
             sb.set_applied_lsn(tail);
             // Re-stamp the replication slot table (same checkpoint-wipe carry).
             sb.set_repl_slots(&repl_slots);
+            sb.set_standby(standby);
             sb.checksum = sb.compute_checksum();
             sb
         };

--- a/crates/truthdb-core/src/storage.rs
+++ b/crates/truthdb-core/src/storage.rs
@@ -4774,6 +4774,11 @@ impl StorageFile {
         // do not undo in-flight transactions, which the primary will commit and
         // whose continuation resumes above this standby's applied point.
         let redo_only = storage.active_sb().is_standby();
+        // A standby is read-only until promotion: it appends nothing to its own
+        // WAL (only the primary's log, via apply_wal_stream). Set before
+        // recover_rel — which for a standby is redo-only and never appends, so
+        // this blocks only later local writes.
+        storage.wal.set_read_only(redo_only);
         storage.recover_rel(stop_at, redo_only)?;
         Ok(storage)
     }
@@ -5871,6 +5876,16 @@ impl StorageFile {
                  must checkpoint to reclaim ring space (not yet automatic)"
                     .to_string(),
             ));
+        }
+
+        // 0. Persist the standby flag BEFORE seeding any bytes (on the first
+        //    apply). Otherwise a crash between the seed's fsync and the tail
+        //    commit would reopen as a normal database and ARIES-undo the shipped
+        //    in-flight records — the very divergence this mode prevents. Once the
+        //    flag is durable, a crash anywhere reopens redo-only.
+        if !self.active_sb().is_standby() {
+            self.commit_superblock(|sb| sb.set_standby(true))?;
+            self.wal.set_read_only(true);
         }
 
         // 1. Place the bytes in the ring and fsync BEFORE recording the advanced

--- a/crates/truthdb-core/src/storage.rs
+++ b/crates/truthdb-core/src/storage.rs
@@ -28,7 +28,9 @@ use crate::storage_layout::{
     SnapshotDescriptor, Superblock, WAL_ENTRY_TYPE_REL, WAL_MAX_BYTES, WAL_MIN_BYTES, align_down,
     assert_layout_invariants,
 };
-use crate::wal::records::{REL_KIND_ALLOC_EXTENT, REL_KIND_FREE_EXTENT, RelRecord};
+use crate::wal::records::{
+    REL_KIND_ALLOC_EXTENT, REL_KIND_FREE_EXTENT, REL_KIND_SET_CATALOG_ROOT, RelRecord,
+};
 use crate::wal::{WalWriter, scan_ring};
 
 pub use crate::wal::WalRecord;
@@ -1494,6 +1496,24 @@ impl Storage {
 
     pub(crate) fn release_read_snapshot(&self, seq: u64) {
         self.lock().version.release_snapshot(seq);
+    }
+
+    /// Applies a shipped raw WAL ring range to this OPEN standby, live — without
+    /// a reopen. Under one storage-lock hold it places the bytes durably in the
+    /// ring, redoes their effects into the live buffer pool, refreshes the
+    /// catalog cache, and records the advanced tail, so the standby stays
+    /// queryable and its state matches the primary's up to `from_lsn +
+    /// bytes.len()`. Idempotent: a re-shipped overlapping range is a no-op (redo
+    /// is page-LSN-gated). The range must be contiguous with what the standby has
+    /// already applied (a gap is 4305) and start/end on entry boundaries (the
+    /// primary ships `read_wal_range` output at a flushed watermark).
+    ///
+    /// Redo only — no analysis or undo (those need the whole log and mutate the
+    /// WAL); in-flight transactions are resolved at promotion, not here. The
+    /// standby never appends its own log, so the in-memory WAL tail is left where
+    /// it is; only the persisted superblock tail advances (re-derived on reopen).
+    pub fn apply_wal_stream(&self, from_lsn: u64, bytes: &[u8]) -> Result<(), StorageError> {
+        self.lock().apply_wal_stream_locked(from_lsn, bytes)
     }
 
     /// The durable WAL watermark: the greatest LSN fsynced to disk (group-commit
@@ -5806,6 +5826,94 @@ impl StorageFile {
             }
         }
         Ok(start_lsn + bytes.len() as u64)
+    }
+
+    /// The active superblock (the authoritative in-memory copy).
+    fn active_sb(&self) -> &Superblock {
+        match self.active_superblock {
+            ActiveSuperblock::A => &self.superblock_a,
+            ActiveSuperblock::B => &self.superblock_b,
+        }
+    }
+
+    /// The live standby apply (see [`Storage::apply_wal_stream`]). Runs under the
+    /// storage lock held by the caller.
+    fn apply_wal_stream_locked(&mut self, from_lsn: u64, bytes: &[u8]) -> Result<(), StorageError> {
+        if bytes.is_empty() {
+            return Ok(());
+        }
+        // The standby's applied tail lives in the persisted superblock — the live
+        // WalWriter tail does not advance (the standby never appends).
+        let current_tail = self.active_sb().wal_tail;
+        if from_lsn > current_tail {
+            return Err(StorageError::InvalidFile(format!(
+                "WAL stream gap (4305): range begins at LSN {from_lsn} but the standby has applied to {current_tail}"
+            )));
+        }
+        let new_end = from_lsn + bytes.len() as u64;
+        let advanced = current_tail.max(new_end);
+        let head = self.wal.head();
+        let max_range = self.layout.wal_size.saturating_sub(self.wal.reserve());
+        if advanced.saturating_sub(head) > max_range {
+            return Err(StorageError::WalFull(
+                "the applied WAL stream exceeds the standby ring's usable size; the standby \
+                 must checkpoint to reclaim ring space (not yet automatic)"
+                    .to_string(),
+            ));
+        }
+
+        // 1. Place the bytes in the ring and fsync BEFORE recording the advanced
+        //    tail. A crash after this re-scans and re-redoes them (idempotent);
+        //    recording an un-fsynced tail would trust torn bytes on reopen.
+        self.seed_ring(from_lsn, bytes)?;
+        self.file.sync_data()?;
+
+        // 2. Decode only the newly seeded range: a scan starting at `from_lsn`
+        //    self-terminates where the stale bytes past `new_end` begin (their
+        //    logical_ts no longer equals the cursor).
+        let scan = scan_ring(
+            self.wal.file_mut(),
+            self.layout.wal_offset,
+            self.layout.wal_size,
+            from_lsn,
+            from_lsn,
+        )?;
+        let records: Vec<(u64, RelRecord)> = scan
+            .records
+            .iter()
+            .filter(|record| record.entry_type == WAL_ENTRY_TYPE_REL)
+            .map(|record| Ok((record.logical_ts, RelRecord::decode(&record.payload)?)))
+            .collect::<Result<_, StorageError>>()?;
+
+        // A catalog-root change in the range moves the standby's catalog root
+        // (the last one wins).
+        let new_catalog_root = records
+            .iter()
+            .rev()
+            .find(|(_, record)| record.kind == REL_KIND_SET_CATALOG_ROOT)
+            .map(|(_, record)| record.decode_catalog_root())
+            .transpose()?;
+
+        // 3. Redo into the LIVE pool (page-LSN-gated, idempotent, appends
+        //    nothing), then refresh the catalog cache so standby reads see any
+        //    new tables/columns.
+        {
+            let mut ctx = self.rel_ctx();
+            rel_recovery::redo_records(&mut ctx, &records)?;
+        }
+        if let Some(root) = new_catalog_root {
+            self.rel.catalog_root = Some(root);
+        }
+        self.reload_catalog()?;
+
+        // 4. Record the advanced tail durably (light dual-write, no page flush —
+        //    the pages are recoverable from the now-durable ring). `applied_lsn`
+        //    tracks the tail for the replication restartpoint.
+        self.commit_superblock(|sb| {
+            sb.wal_tail = advanced;
+            sb.set_applied_lsn(advanced);
+        })?;
+        Ok(())
     }
 
     /// Writes the restored superblock: the source's catalog root and options as

--- a/crates/truthdb-core/src/storage_layout.rs
+++ b/crates/truthdb-core/src/storage_layout.rs
@@ -323,6 +323,22 @@ impl Superblock {
         self.reserved[0] = byte;
     }
 
+    /// Standby (redo-only) recovery mode, in reserved byte 1 (was padding). Set
+    /// once this file has applied a LIVE replication WAL stream. A standby's
+    /// shipped log legitimately ends mid-transaction, so its reopen must REPEAT
+    /// history (redo) WITHOUT ARIES undo: undoing an in-flight transaction the
+    /// primary later commits — and whose continuation resumes above the standby's
+    /// applied point — would permanently and silently diverge the replica.
+    /// In-flight transactions are resolved only at promotion (which clears this
+    /// and runs a full recovery).
+    pub fn is_standby(&self) -> bool {
+        self.reserved[1] != 0
+    }
+
+    pub fn set_standby(&mut self, standby: bool) {
+        self.reserved[1] = standby as u8;
+    }
+
     /// FULL-recovery-model log-backup floor: the LSN up to which the log has
     /// been shipped to a log archive (`0` = none). Stored in the reserved area
     /// (bytes 8..16; byte 0 is `db_options`, 1..8 are padding) and covered by

--- a/crates/truthdb-core/src/wal/mod.rs
+++ b/crates/truthdb-core/src/wal/mod.rs
@@ -91,6 +91,28 @@ impl WalWriter {
         })
     }
 
+    /// Re-seats the writer at `new_tail` after a standby applied shipped log
+    /// into the ring behind the writer's back (a standby never appends, so its
+    /// in-memory tail otherwise lags the seeded ring — breaking anything that
+    /// reads `tail()`/`flushed_lsn()`, e.g. a backup or checkpoint). The ring
+    /// bytes up to `new_tail` are already durable, so this mirrors `open`: seat a
+    /// fresh buffer at `new_tail` and seed its current page from disk. `new_tail`
+    /// must not move the tail backward.
+    pub(crate) fn resync_tail(&mut self, new_tail: u64) -> Result<(), StorageError> {
+        debug_assert!(new_tail >= self.tail());
+        let mut buffer = LogBuffer::new_at(new_tail);
+        if !buffer.current_page_is_empty() {
+            let (page_start, _) = buffer.current_page();
+            let file_offset = self.ring_offset + page_start % self.ring_size;
+            let mut disk_page = AlignedPageBuf::new();
+            self.file.read_page_into(file_offset, &mut disk_page)?;
+            buffer.seed_prefix(&disk_page);
+        }
+        self.buffer = buffer;
+        self.flushed = new_tail;
+        Ok(())
+    }
+
     /// Test hook: shrink the lazy-superblock cadence so it can be exercised
     /// without appending tens of MiB.
     #[cfg(test)]

--- a/crates/truthdb-core/src/wal/mod.rs
+++ b/crates/truthdb-core/src/wal/mod.rs
@@ -54,6 +54,11 @@ pub(crate) struct WalWriter {
     /// Set when a page write failed mid-append: the in-memory tail no longer
     /// matches the disk and no further appends can be trusted.
     poisoned: bool,
+    /// A replication standby is read-only: it appends nothing to its own WAL
+    /// (it only receives the primary's log via `apply_wal_stream`). A local
+    /// write would diverge the replica and corrupt the next apply, so every
+    /// append is rejected until promotion clears this.
+    read_only: bool,
     bytes_since_superblock: u64,
     superblock_interval: u64,
 }
@@ -86,6 +91,7 @@ impl WalWriter {
             flushed: tail,
             reserve: ring_size / 4,
             poisoned: false,
+            read_only: false,
             bytes_since_superblock: 0,
             superblock_interval: SUPERBLOCK_REWRITE_INTERVAL,
         })
@@ -118,6 +124,12 @@ impl WalWriter {
     #[cfg(test)]
     pub fn set_superblock_interval(&mut self, bytes: u64) {
         self.superblock_interval = bytes;
+    }
+
+    /// Marks the writer read-only (a replication standby) or writable again (at
+    /// promotion). While read-only every append is rejected.
+    pub(crate) fn set_read_only(&mut self, read_only: bool) {
+        self.read_only = read_only;
     }
 
     pub fn head(&self) -> u64 {
@@ -236,6 +248,12 @@ impl WalWriter {
         sync: bool,
         allow_reserve: bool,
     ) -> Result<u64, StorageError> {
+        if self.read_only {
+            return Err(StorageError::InvalidConfig(
+                "write rejected: this database is a replication standby (read-only until promotion)"
+                    .to_string(),
+            ));
+        }
         if self.poisoned {
             return Err(StorageError::InvalidFile(
                 "wal writer disabled after a failed page write; restart to recover".to_string(),


### PR DESCRIPTION
`Storage::apply_wal_stream(from_lsn, bytes)` applies a shipped raw WAL range to an **OPEN standby, live — no reopen**. This is the recovery-critical heart of streaming replication, and the live path deferred back in slice 2 (whose offline `restore_full_with_wal_ranges` seeds + reopens).

## What it does (one storage-lock hold)

1. **Validate** contiguity with what the standby has already applied (a gap is 4305) and ring fit.
2. **Seed** the bytes into the ring and **fsync them BEFORE** recording the advanced tail — a crash after this re-scans and re-redoes them (idempotent); recording an un-fsynced tail would trust torn bytes on reopen.
3. **Decode** only the new range — a `scan_ring` starting at `from_lsn` self-terminates where the stale bytes past `new_end` begin (their `logical_ts` no longer equals the cursor) — and pick up any catalog-root change.
4. **`redo_records`** into the LIVE buffer pool (page-LSN-gated, idempotent, appends nothing), then `reload_catalog` so standby reads see new tables/columns.
5. **`commit_superblock(wal_tail, applied_lsn)`** — a light dual-write, no page flush (the pages are recoverable from the now-durable ring).

## Key design points (confirmed by an internals map)

- **No `set_tail` surgery.** A read-only standby never appends its own log, so the in-memory `WalWriter` tail is left as is; only the *persisted* superblock tail advances (re-derived by the scan on reopen/promotion). This is why the earlier "WalWriter-tail surgery" concern dissolved.
- **Redo only** — no analysis or undo (those need the whole log and mutate the WAL; they belong to promotion). `redo_records` is exactly the append-free, LSN-gated primitive for this, extracted in an earlier slice.
- Runs under the single storage mutex as one unit, so a concurrent reader never sees advanced pages with a stale catalog cache.

## Test (end-to-end, in-process)

A standby restored from a backup (10 rows) applies a shipped delta **live** and matches the primary (25 rows + an `UPDATE`) with **no reopen**; re-applying the same range is idempotent; the applied state survives a standby restart.

`cargo test --workspace`, fmt, clippy all pass (incl. the backup/restore/recovery/superblock suites).

## Review

Recovery-critical — running a mandatory multi-lens adversarial review (crash-ordering, torn/partial range, page-LSN gate, catalog-root tracking, concurrent reads, non-contiguous ranges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)