### PR TITLE
Stage 18 slice 4c: replication sender, standby receiver, config/main wiring

### DIFF
--- a/config/default.toml
+++ b/config/default.toml
@@ -46,3 +46,29 @@ snapshot_wal_threshold = 0.7
 # here, an sa login is still created but DISABLED. Send passwords over TLS: see
 # encryption above.
 # sa = "change-me"
+
+# Physical replication. Disabled by default. Every member of a cluster shares
+# the same cluster_uuid and shared_secret. A primary listens on port (TLS
+# mandatory: tls_cert/tls_key) and streams WAL to standbys; a standby dials
+# primary_addr, verifies the primary against tls_ca, and applies the stream.
+# Seed a standby's database file with:  truthdb-cli restore --standby
+# [replication]
+# enabled = true
+# role = "primary"            # or "standby"
+# node_id = 1                 # unique per member (a standby's slot id)
+# cluster_uuid = "8f0e7a34-2d51-4c11-9c9e-3f6d2a7b1c05"
+# shared_secret = "change-me"
+#
+# Primary:
+# addr = "0.0.0.0"
+# port = 9624
+# tls_cert = "/etc/truthdb/repl.crt"
+# tls_key = "/etc/truthdb/repl.key"
+# heartbeat_ms = 1000
+# max_slot_retain_bytes = 0   # 0 = unlimited: a lagging standby is never dropped
+#
+# Standby:
+# primary_addr = "primary.example:9624"
+# tls_ca = "/etc/truthdb/repl.crt"   # the primary's cert (or its CA)
+# server_name = "primary.example"    # defaults to the host part of primary_addr
+# reconnect_delay_ms = 1000

--- a/crates/truthdb-cli/src/main.rs
+++ b/crates/truthdb-cli/src/main.rs
@@ -71,6 +71,11 @@ enum Command {
         /// after it are undone.
         #[arg(long = "stopat")]
         stopat: Option<u64>,
+        /// Restore as a replication STANDBY seed: recovery repeats history
+        /// only (no undo of in-flight transactions) and the file opens
+        /// read-only, ready to follow a primary. Incompatible with --stopat.
+        #[arg(long, conflicts_with = "stopat")]
+        standby: bool,
     },
 }
 
@@ -102,11 +107,17 @@ async fn main() -> Result<()> {
             to,
             log,
             stopat,
+            standby,
         } => {
-            match truthdb_core::storage::Storage::restore_full_with_logs(&full, &to, &log, stopat) {
+            let result = if standby {
+                truthdb_core::storage::Storage::restore_full_standby(&to, &full, &log)
+            } else {
+                truthdb_core::storage::Storage::restore_full_with_logs(&to, &full, &log, stopat)
+            };
+            match result {
                 Ok(()) => {
                     println!(
-                        "restored {} from {}{}{}",
+                        "restored {} from {}{}{}{}",
                         to.display(),
                         full.display(),
                         if log.is_empty() {
@@ -117,7 +128,8 @@ async fn main() -> Result<()> {
                         match stopat {
                             Some(ts) => format!(" (stopped at {ts})"),
                             None => String::new(),
-                        }
+                        },
+                        if standby { " (standby seed)" } else { "" }
                     );
                     Ok(())
                 }

--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -2443,7 +2443,7 @@ mod tests {
     async fn the_replication_transport_streams_live_writes_to_a_standby() {
         use crate::repl::listener::{PrimaryReplContext, run_repl_listener};
         use crate::repl::receiver::{ReceiverConfig, run_standby_receiver};
-        use crate::repl::tls::{client_config_trusting, server_config_from_pem};
+        use crate::repl::tls::server_config_from_pem;
         use std::sync::Arc;
         use std::time::Duration;
         use tokio::sync::watch;
@@ -2468,7 +2468,10 @@ mod tests {
                 .expect("insert");
         }
         primary.storage().backup_full(&bak).expect("backup");
-        for i in 11..=20 {
+        // A catch-up backlog spanning MANY sender chunks (the context below
+        // sets 512-byte chunks), so entry-boundary chunking is exercised end
+        // to end — a mid-entry cut would fail the apply's coverage check.
+        for i in 11..=120 {
             primary
                 .execute(&format!("INSERT INTO t VALUES ({i}, {i})"))
                 .expect("insert");
@@ -2490,6 +2493,9 @@ mod tests {
             cluster_uuid: UUID,
             storage: primary.storage_arc(),
             heartbeat: Duration::from_millis(200),
+            stall_timeout: Duration::from_secs(30),
+            chunk_bytes: 512,
+            active_nodes: Arc::default(),
         };
         let listener_task = tokio::spawn(run_repl_listener(
             listener,
@@ -2515,6 +2521,7 @@ mod tests {
             cluster_uuid: UUID,
             node_id: 7,
             reconnect_delay: Duration::from_millis(100),
+            stall_timeout: Duration::from_secs(30),
         };
         let (rx_shutdown_tx, rx_shutdown_rx) = watch::channel(false);
         let receiver_task = tokio::spawn(run_standby_receiver(

--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -2878,6 +2878,25 @@ mod tests {
             .storage()
             .try_register_repl_slot(8, lsn)
             .expect("re-register");
+        // A mid-entry LSN off the wire is refused: it would become the
+        // checkpoint truncation floor and, at the next restart, a WAL head the
+        // scan cannot decode (entries are >= 48 bytes and 8-aligned, so
+        // `fresh - 1` is never a boundary). Fresh writes keep it above the
+        // head so the boundary check — not the head fence — is what fires.
+        for i in 11..=13 {
+            engine
+                .execute(&format!("INSERT INTO t VALUES ({i})"))
+                .expect("insert");
+        }
+        let fresh = engine.storage().wal_flushed_lsn();
+        let err = engine
+            .storage()
+            .try_register_repl_slot(8, fresh - 1)
+            .expect_err("a mid-entry slot LSN is refused");
+        assert!(
+            err.to_string().contains("boundary"),
+            "the error names the misalignment: {err}"
+        );
         // An ack for a never-registered (or reaped) slot must not create one.
         engine.storage().advance_repl_slot(42, lsn);
         assert_eq!(engine.storage().repl_slot_lsn(42), None);

--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -1,5 +1,5 @@
 use std::collections::{BTreeMap, BTreeSet};
-use std::sync::RwLock;
+use std::sync::{Arc, RwLock};
 
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value, json};
@@ -36,7 +36,7 @@ struct EngineMeta {
 /// concurrent native batch could read a relational batch's half-applied
 /// writes — which the old single-threaded actor prevented for free.
 pub struct Engine {
-    storage: Storage,
+    storage: Arc<Storage>,
     meta: RwLock<EngineMeta>,
 }
 
@@ -78,9 +78,17 @@ impl Engine {
         }
 
         Ok(Engine {
-            storage,
+            storage: Arc::new(storage),
             meta: RwLock::new(meta),
         })
+    }
+
+    /// A shared handle to the underlying storage, for subsystems that run
+    /// beside the engine's worker pool — the replication listener/sender on a
+    /// primary and the replication receiver on a standby. `Storage` is
+    /// internally synchronized, so the tasks and the workers share it safely.
+    pub fn storage_arc(&self) -> Arc<Storage> {
+        Arc::clone(&self.storage)
     }
 
     /// The underlying storage handle, so a test can drive an online backup
@@ -2425,6 +2433,181 @@ mod tests {
         }
     }
 
+    // Stage 18 slice 4c: the full transport, end to end over a real TCP+TLS
+    // socket — listener + handshake + per-standby sender on the primary,
+    // reconnecting receiver on the standby. A backup-seeded standby catches up,
+    // follows live commits (woken by the flushed watch, no polling), its
+    // FlushAcks advance the primary's slot, and a receiver restart resumes from
+    // the standby's persisted watermark.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn the_replication_transport_streams_live_writes_to_a_standby() {
+        use crate::repl::listener::{PrimaryReplContext, run_repl_listener};
+        use crate::repl::receiver::{ReceiverConfig, run_standby_receiver};
+        use crate::repl::tls::{client_config_trusting, server_config_from_pem};
+        use std::sync::Arc;
+        use std::time::Duration;
+        use tokio::sync::watch;
+        use tokio_rustls::TlsAcceptor;
+
+        const SECRET: &[u8] = b"transport-secret";
+        const UUID: [u8; 16] = [7u8; 16];
+
+        let primary_path = unique_temp_path("xport-primary");
+        let bak = unique_temp_path("xport-bak");
+        let standby_path = unique_temp_path("xport-standby");
+
+        // Primary: rows 1..=10, a backup to seed the standby, then post-backup
+        // rows the transport must catch the standby up on.
+        let primary = new_engine(&primary_path);
+        primary
+            .execute("CREATE TABLE t (id INT NOT NULL PRIMARY KEY, v INT)")
+            .expect("create");
+        for i in 1..=10 {
+            primary
+                .execute(&format!("INSERT INTO t VALUES ({i}, {i})"))
+                .expect("insert");
+        }
+        primary.storage().backup_full(&bak).expect("backup");
+        for i in 11..=20 {
+            primary
+                .execute(&format!("INSERT INTO t VALUES ({i}, {i})"))
+                .expect("insert");
+        }
+
+        // The primary's replication listener on an ephemeral port.
+        let (cert_pem, key_pem) = {
+            let c = rcgen::generate_simple_self_signed(vec!["localhost".to_string()]).unwrap();
+            (c.cert.pem(), c.key_pair.serialize_pem())
+        };
+        let acceptor = TlsAcceptor::from(
+            server_config_from_pem(cert_pem.as_bytes(), key_pem.as_bytes()).unwrap(),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+        let ctx = PrimaryReplContext {
+            shared_secret: Arc::new(SECRET.to_vec()),
+            cluster_uuid: UUID,
+            storage: primary.storage_arc(),
+            heartbeat: Duration::from_millis(200),
+        };
+        let listener_task = tokio::spawn(run_repl_listener(
+            listener,
+            acceptor,
+            ctx,
+            shutdown_rx.clone(),
+        ));
+
+        // Standby: seeded with a --standby restore (stamped redo-only +
+        // read-only before its first open), opened live, then its receiver
+        // dials the primary.
+        Storage::restore_full_standby(&standby_path, &bak, &[]).expect("restore");
+        let standby = Engine::new(Storage::open(standby_path.clone()).expect("open")).expect("eng");
+        assert!(
+            standby.storage().is_standby(),
+            "a --standby restore stamps the standby mode before the first open"
+        );
+        let receiver_cfg = ReceiverConfig {
+            primary_addr: addr.to_string(),
+            server_name: "localhost".to_string(),
+            tls_ca_pem: cert_pem.as_bytes().to_vec(),
+            shared_secret: SECRET.to_vec(),
+            cluster_uuid: UUID,
+            node_id: 7,
+            reconnect_delay: Duration::from_millis(100),
+        };
+        let (rx_shutdown_tx, rx_shutdown_rx) = watch::channel(false);
+        let receiver_task = tokio::spawn(run_standby_receiver(
+            receiver_cfg.clone(),
+            standby.storage_arc(),
+            rx_shutdown_rx,
+        ));
+
+        async fn wait_until(what: &str, mut cond: impl FnMut() -> bool) {
+            let deadline = std::time::Instant::now() + Duration::from_secs(20);
+            while !cond() {
+                assert!(
+                    std::time::Instant::now() < deadline,
+                    "timed out waiting for {what}"
+                );
+                tokio::time::sleep(Duration::from_millis(25)).await;
+            }
+        }
+
+        // Catch-up: the standby reaches the primary's durable watermark.
+        let target = primary.storage().wal_flushed_lsn();
+        wait_until("catch-up", || standby.storage().wal_tail() >= target).await;
+        let expected = sql_rows(&primary, "SELECT id, v FROM t ORDER BY id").1;
+        assert_eq!(
+            sql_rows(&standby, "SELECT id, v FROM t ORDER BY id").1,
+            expected,
+            "the standby matches the primary after catch-up"
+        );
+
+        // Live follow: new commits arrive without any reconnect.
+        for i in 21..=30 {
+            primary
+                .execute(&format!("INSERT INTO t VALUES ({i}, {i})"))
+                .expect("insert");
+        }
+        primary
+            .execute("UPDATE t SET v = v + 100 WHERE id <= 5")
+            .expect("update");
+        let target = primary.storage().wal_flushed_lsn();
+        wait_until("live follow", || standby.storage().wal_tail() >= target).await;
+        let expected = sql_rows(&primary, "SELECT id, v FROM t ORDER BY id").1;
+        assert_eq!(
+            sql_rows(&standby, "SELECT id, v FROM t ORDER BY id").1,
+            expected,
+            "the standby follows live commits"
+        );
+
+        // The standby's FlushAcks advance the primary's slot to its watermark,
+        // so the primary can reclaim the shipped log.
+        wait_until("slot advance", || {
+            primary.storage().repl_slot_lsn(7) == Some(target)
+        })
+        .await;
+
+        // Reconnect: stop the receiver, commit more, restart it — the stream
+        // resumes from the standby's persisted watermark (the slot held the
+        // log in between).
+        rx_shutdown_tx.send(true).unwrap();
+        let _ = receiver_task.await;
+        for i in 31..=40 {
+            primary
+                .execute(&format!("INSERT INTO t VALUES ({i}, {i})"))
+                .expect("insert");
+        }
+        let (rx_shutdown_tx2, rx_shutdown_rx2) = watch::channel(false);
+        let receiver_task2 = tokio::spawn(run_standby_receiver(
+            receiver_cfg,
+            standby.storage_arc(),
+            rx_shutdown_rx2,
+        ));
+        let target = primary.storage().wal_flushed_lsn();
+        wait_until("resume after reconnect", || {
+            standby.storage().wal_tail() >= target
+        })
+        .await;
+        let expected = sql_rows(&primary, "SELECT id, v FROM t ORDER BY id").1;
+        assert_eq!(
+            sql_rows(&standby, "SELECT id, v FROM t ORDER BY id").1,
+            expected,
+            "the standby resumes and matches after a receiver restart"
+        );
+
+        rx_shutdown_tx2.send(true).unwrap();
+        let _ = receiver_task2.await;
+        shutdown_tx.send(true).unwrap();
+        let _ = listener_task.await;
+        drop(standby);
+        drop(primary);
+        for p in [primary_path, bak, standby_path] {
+            let _ = std::fs::remove_file(p);
+        }
+    }
+
     // Stage 18 slice 4d (review fix): a shipped stream can end MID-transaction
     // (the primary's durable watermark can land between an in-flight txn's page
     // ops and its commit). A standby's reopen must REPEAT history (redo-only) —
@@ -2546,7 +2729,10 @@ mod tests {
         assert!(l1 > 0, "there is log to pin");
 
         // A slot pinned at l1 holds the WAL head there even as the tail advances.
-        engine.storage().register_repl_slot(7, l1);
+        engine
+            .storage()
+            .try_register_repl_slot(7, l1)
+            .expect("register");
         for i in 11..=30 {
             engine
                 .execute(&format!("INSERT INTO t VALUES ({i}, {i})"))
@@ -2579,7 +2765,10 @@ mod tests {
         );
 
         // An explicit drop removes a slot (a standby that deregisters).
-        engine.storage().register_repl_slot(8, l2);
+        engine
+            .storage()
+            .try_register_repl_slot(8, l2)
+            .expect("register");
         engine.storage().drop_repl_slot(8);
         assert_eq!(
             engine.storage().repl_slot_lsn(8),
@@ -2588,7 +2777,10 @@ mod tests {
         );
 
         // Lagging past max_slot_retain invalidates the slot at the next checkpoint.
-        engine.storage().set_max_slot_retain_bytes(64);
+        engine
+            .storage()
+            .set_max_slot_retain_bytes(64)
+            .expect("set cap");
         for i in 31..=60 {
             engine
                 .execute(&format!("INSERT INTO t VALUES ({i}, {i})"))
@@ -2605,6 +2797,112 @@ mod tests {
             "the reclaimed floor advances past the dropped slot"
         );
 
+        drop(engine);
+        let _ = std::fs::remove_file(path);
+    }
+
+    // A replication sender wakes on the group-commit flushed watch instead of
+    // polling: a committed write advances the watch past the subscriber's last
+    // seen value, and the durable watermark it re-reads covers the commit.
+    #[test]
+    fn the_flushed_watch_wakes_on_a_committed_write() {
+        let path = unique_temp_path("repl-watch");
+        let engine = new_engine(&path);
+        let mut rx = engine.storage().subscribe_wal_flushed();
+        let before = *rx.borrow_and_update();
+        engine
+            .execute("CREATE TABLE t (id INT NOT NULL PRIMARY KEY)")
+            .expect("create");
+        engine.execute("INSERT INTO t VALUES (1)").expect("insert");
+        assert!(
+            rx.has_changed().expect("sender alive"),
+            "a durable commit signals the watch"
+        );
+        let hint = *rx.borrow_and_update();
+        assert!(hint > before, "the watch value advances");
+        assert!(
+            engine.storage().wal_flushed_lsn() >= hint,
+            "the re-read watermark covers the hint"
+        );
+        drop(engine);
+        let _ = std::fs::remove_file(path);
+    }
+
+    // Slot registration is atomically fenced against truncation: a slot below
+    // the WAL head is refused (the log it needs is gone — reseed), and the
+    // table is bounded so a slot never silently fails to persist.
+    #[test]
+    fn slot_registration_rejects_below_head_and_a_full_table() {
+        let path = unique_temp_path("repl-slot-guards");
+        let engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE t (id INT NOT NULL PRIMARY KEY)")
+            .expect("create");
+        for i in 1..=10 {
+            engine
+                .execute(&format!("INSERT INTO t VALUES ({i})"))
+                .expect("insert");
+        }
+        engine.checkpoint().expect("checkpoint");
+        let head = engine.storage().wal_head();
+        assert!(head > 0, "the checkpoint truncated some log");
+        let err = engine
+            .storage()
+            .try_register_repl_slot(1, head - 1)
+            .expect_err("a below-head slot is refused");
+        assert!(
+            err.to_string().contains("reseed"),
+            "the error tells the operator to reseed: {err}"
+        );
+
+        let lsn = engine.storage().wal_flushed_lsn();
+        for id in 1..=8 {
+            engine
+                .storage()
+                .try_register_repl_slot(id, lsn)
+                .expect("register");
+        }
+        engine
+            .storage()
+            .try_register_repl_slot(9, lsn)
+            .expect_err("a ninth slot exceeds the persisted table");
+        // Re-registering an existing id is a reset, not a new slot.
+        engine
+            .storage()
+            .try_register_repl_slot(8, lsn)
+            .expect("re-register");
+        // An ack for a never-registered (or reaped) slot must not create one.
+        engine.storage().advance_repl_slot(42, lsn);
+        assert_eq!(engine.storage().repl_slot_lsn(42), None);
+        drop(engine);
+        let _ = std::fs::remove_file(path);
+    }
+
+    // The replication epoch persists across a checkpoint (whose superblock
+    // rebuild zeroes the reserved area — the checkpoint-wipe carry) and a
+    // restart, and the retention-cap setter refuses a cap the ring cannot
+    // honor.
+    #[test]
+    fn the_replication_epoch_persists_and_the_retain_cap_is_bounded() {
+        let path = unique_temp_path("repl-epoch");
+        let engine = new_engine(&path);
+        assert_eq!(engine.storage().epoch(), 0, "a fresh file is epoch 0");
+        engine.storage().set_epoch(5).expect("set epoch");
+        engine
+            .execute("CREATE TABLE t (id INT NOT NULL PRIMARY KEY)")
+            .expect("create");
+        engine.checkpoint().expect("checkpoint");
+        drop(engine);
+        let engine = Engine::new(Storage::open(path.clone()).expect("open")).expect("engine");
+        assert_eq!(
+            engine.storage().epoch(),
+            5,
+            "the epoch survives the checkpoint and the restart"
+        );
+        engine
+            .storage()
+            .set_max_slot_retain_bytes(u64::MAX - 1)
+            .expect_err("a cap at or above the usable ring is refused");
         drop(engine);
         let _ = std::fs::remove_file(path);
     }

--- a/crates/truthdb-core/src/group_commit.rs
+++ b/crates/truthdb-core/src/group_commit.rs
@@ -40,6 +40,14 @@ pub(crate) struct GroupCommit {
     flushed_cv: Condvar,
     /// The log-writer waits here for a higher `requested`.
     wake_cv: Condvar,
+    /// Async mirror of `flushed` advances, so a tokio task (the replication
+    /// sender) can await new durable WAL without polling. `send_replace` from
+    /// the log-writer thread needs no runtime. The carried value is a wake-up
+    /// hint only: WAL made durable by a direct sync (rollback, checkpoint)
+    /// advances the durable watermark without passing through here, so a
+    /// subscriber must re-read `Storage::wal_flushed_lsn` after each wake and
+    /// pair the watch with a periodic tick.
+    flushed_tx: tokio::sync::watch::Sender<u64>,
 }
 
 impl GroupCommit {
@@ -56,6 +64,7 @@ impl GroupCommit {
             }),
             flushed_cv: Condvar::new(),
             wake_cv: Condvar::new(),
+            flushed_tx: tokio::sync::watch::channel(0).0,
         });
         let writer_gc = Arc::clone(&gc);
         let writer = std::thread::Builder::new()
@@ -116,6 +125,12 @@ impl GroupCommit {
             .flushed
     }
 
+    /// Subscribes to `flushed`-watermark advances (see the `flushed_tx` field
+    /// note: the value is a hint, re-read the real watermark after each wake).
+    pub(crate) fn subscribe_flushed(&self) -> tokio::sync::watch::Receiver<u64> {
+        self.flushed_tx.subscribe()
+    }
+
     /// The number of fsyncs the log-writer has issued so far.
     #[cfg(test)]
     pub(crate) fn fsync_count(&self) -> u64 {
@@ -148,6 +163,7 @@ impl GroupCommit {
                 Ok(()) => {
                     if target > state.flushed {
                         state.flushed = target;
+                        self.flushed_tx.send_replace(target);
                     }
                     self.flushed_cv.notify_all();
                 }

--- a/crates/truthdb-core/src/repl/listener.rs
+++ b/crates/truthdb-core/src/repl/listener.rs
@@ -1,34 +1,39 @@
 //! The primary's replication listener: a tokio accept loop (mirroring
-//! `client_listener`) that TLS-wraps each standby connection and runs the
-//! [`serve_handshake`] exchange. TLS is completed BEFORE the handshake — the
-//! shared-secret proof is never evaluated on a plaintext socket. On acceptance
-//! the connection is ready for the sender to stream log over (slice 4c); until
-//! that lands, an accepted connection simply completes its handshake.
+//! `client_listener`) that TLS-wraps each standby connection, runs the
+//! [`serve_handshake`] exchange, and on acceptance hands the connection to the
+//! per-standby [`run_sender`] task, which registers the standby's slot and
+//! streams log until the connection drops. TLS is completed BEFORE the
+//! handshake — the shared-secret proof is never evaluated on a plaintext
+//! socket.
 
 use std::io;
 use std::sync::Arc;
+use std::time::Duration;
 
 use tokio::net::TcpListener;
 use tokio::sync::watch;
 use tokio_rustls::TlsAcceptor;
 
 use super::handshake::HandshakeParams;
-use super::server::{AcceptedStandby, serve_handshake};
+use super::sender::run_sender;
+use super::server::serve_handshake;
+use crate::storage::Storage;
 
 /// The primary's replication identity + secret, shared across all standby
-/// connections. Cheap to clone (the secret and the LSN source are `Arc`s).
+/// connections. Cheap to clone (`Arc`s). The epoch and durable watermark are
+/// read from `storage` fresh per connection, so they track live progress.
 #[derive(Clone)]
 pub struct PrimaryReplContext {
     /// The cluster's shared secret — verified against each standby's HMAC proof.
     pub shared_secret: Arc<Vec<u8>>,
     /// This cluster's uuid.
     pub cluster_uuid: [u8; 16],
-    /// The primary's replication epoch (bumped on promotion).
-    pub epoch: u64,
-    /// Reads the primary's current durable WAL tail — the ship ceiling the
-    /// HelloAck advertises. Called fresh per connection so it reflects live
-    /// progress.
-    pub flushed_lsn: Arc<dyn Fn() -> u64 + Send + Sync>,
+    /// The primary's live storage: the handshake reads its epoch and durable
+    /// watermark, and the sender ships its WAL and drives its slots.
+    pub storage: Arc<Storage>,
+    /// The sender's idle heartbeat interval (also bounds how stale a
+    /// direct-sync watermark advance can go unshipped).
+    pub heartbeat: Duration,
 }
 
 impl PrimaryReplContext {
@@ -36,15 +41,15 @@ impl PrimaryReplContext {
         HandshakeParams {
             shared_secret: &self.shared_secret,
             cluster_uuid: self.cluster_uuid,
-            primary_epoch: self.epoch,
+            primary_epoch: self.storage.epoch(),
             primary_flushed_lsn,
         }
     }
 }
 
-/// Accepts standby connections until `shutdown` flips, TLS-wrapping and
-/// handshaking each in its own task. Per-connection failures are isolated (a bad
-/// standby never stops the loop).
+/// Accepts standby connections until `shutdown` flips, TLS-wrapping,
+/// handshaking and then serving each in its own task. Per-connection failures
+/// are isolated (a bad standby never stops the loop).
 pub async fn run_repl_listener(
     listener: TcpListener,
     acceptor: TlsAcceptor,
@@ -61,29 +66,34 @@ pub async fn run_repl_listener(
                 };
                 let acceptor = acceptor.clone();
                 let ctx = ctx.clone();
+                let shutdown = shutdown.clone();
                 tokio::spawn(async move {
-                    let _ = handle_standby(tcp, acceptor, ctx).await;
+                    if let Err(err) = handle_standby(tcp, acceptor, ctx, shutdown).await {
+                        eprintln!("replication sender: {err}");
+                    }
                 });
             }
         }
     }
 }
 
-/// Completes the TLS handshake, then the replication handshake, over one
-/// connection. Returns the accepted standby (for the caller/sender to stream to)
-/// or `None` if the handshake was rejected.
+/// Completes the TLS handshake, then the replication handshake, then streams
+/// log to the accepted standby until the connection ends. A rejected handshake
+/// returns `Ok` (the refusal was the response).
 async fn handle_standby(
     tcp: tokio::net::TcpStream,
     acceptor: TlsAcceptor,
     ctx: PrimaryReplContext,
-) -> io::Result<Option<AcceptedStandby>> {
+    shutdown: watch::Receiver<bool>,
+) -> io::Result<()> {
     // TLS FIRST — the shared-secret handshake never runs on a plaintext socket.
     let mut tls = acceptor.accept(tcp).await?;
-    let flushed = (ctx.flushed_lsn)();
+    let flushed = ctx.storage.wal_flushed_lsn();
     let params = ctx.params(flushed);
-    serve_handshake(&mut tls, &params).await
-    // On accept the stream is ready for the sender (4c); dropping it here (until
-    // the sender lands) closes the connection after the handshake.
+    match serve_handshake(&mut tls, &params).await? {
+        Some(standby) => run_sender(tls, ctx.storage, standby, ctx.heartbeat, shutdown).await,
+        None => Ok(()),
+    }
 }
 
 #[cfg(test)]
@@ -93,6 +103,7 @@ mod tests {
     use crate::repl::handshake::compute_auth;
     use crate::repl::tls::{client_config_trusting, server_config_from_pem};
     use crate::repl::{Hello, HelloAck, REPL_PROTOCOL_VERSION, ReplFrame, ReplMsgType};
+    use crate::storage::{Storage, StorageOptions};
 
     fn self_signed() -> (String, String) {
         let c = rcgen::generate_simple_self_signed(vec!["localhost".to_string()]).unwrap();
@@ -102,10 +113,36 @@ mod tests {
     const SECRET: &[u8] = b"listener-secret";
     const UUID: [u8; 16] = [6u8; 16];
 
-    /// Spins up the listener on an ephemeral port with a self-signed cert, then
-    /// connects a real TLS standby that sends `hello` and returns the ack it
-    /// gets. `flushed` is what the primary reports as its durable tail.
-    async fn connect_and_handshake(hello: Hello, flushed: u64) -> HelloAck {
+    fn temp_storage(label: &str) -> (Arc<Storage>, std::path::PathBuf) {
+        let mut path = std::env::temp_dir();
+        path.push(format!(
+            "truthdb-repl-listener-{label}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let storage = Storage::create(
+            path.clone(),
+            StorageOptions {
+                size_gib: 1,
+                wal_ratio: 0.05,
+                metadata_ratio: 0.08,
+                snapshot_ratio: 0.02,
+                allocator_ratio: 0.02,
+                reserved_ratio: 0.17,
+                default_collation: None,
+            },
+        )
+        .unwrap();
+        (Arc::new(storage), path)
+    }
+
+    /// Spins up the listener on an ephemeral port with a self-signed cert and a
+    /// real (empty) storage, then connects a real TLS standby that sends
+    /// `hello` and returns the ack it gets.
+    async fn connect_and_handshake(hello: Hello) -> HelloAck {
         let (cert_pem, key_pem) = self_signed();
         let acceptor = TlsAcceptor::from(
             server_config_from_pem(cert_pem.as_bytes(), key_pem.as_bytes()).unwrap(),
@@ -116,11 +153,12 @@ mod tests {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
         let (shutdown_tx, shutdown_rx) = watch::channel(false);
+        let (storage, path) = temp_storage("handshake");
         let ctx = PrimaryReplContext {
             shared_secret: Arc::new(SECRET.to_vec()),
             cluster_uuid: UUID,
-            epoch: 2,
-            flushed_lsn: Arc::new(move || flushed),
+            storage,
+            heartbeat: Duration::from_secs(30),
         };
         let server = tokio::spawn(run_repl_listener(listener, acceptor, ctx, shutdown_rx));
 
@@ -137,40 +175,39 @@ mod tests {
 
         shutdown_tx.send(true).unwrap();
         let _ = server.await;
+        let _ = std::fs::remove_file(path);
         ack
     }
 
     #[tokio::test]
     async fn the_listener_accepts_a_valid_standby_over_tls() {
-        let auth = compute_auth(SECRET, 9, &UUID, 1, 40_000);
+        // A fresh (empty) primary storage: epoch 0, and the standby resumes at
+        // the primary's current tail (nothing to catch up).
+        let auth = compute_auth(SECRET, 9, &UUID, 0, 0);
         let hello = Hello {
             protocol_version: REPL_PROTOCOL_VERSION,
             node_id: 9,
             cluster_uuid: UUID,
-            epoch: 1,
-            last_received_lsn: 40_000,
+            epoch: 0,
+            last_received_lsn: 0,
             auth,
         };
-        let ack = connect_and_handshake(hello, 55_000).await;
+        let ack = connect_and_handshake(hello).await;
         assert!(ack.accepted, "{}", ack.message);
-        assert_eq!(
-            ack.primary_flushed_lsn, 55_000,
-            "the ack advertises the live durable tail"
-        );
     }
 
     #[tokio::test]
     async fn the_listener_rejects_a_bad_secret_over_tls() {
-        let auth = compute_auth(b"wrong-secret", 9, &UUID, 1, 40_000);
+        let auth = compute_auth(b"wrong-secret", 9, &UUID, 0, 0);
         let hello = Hello {
             protocol_version: REPL_PROTOCOL_VERSION,
             node_id: 9,
             cluster_uuid: UUID,
-            epoch: 1,
-            last_received_lsn: 40_000,
+            epoch: 0,
+            last_received_lsn: 0,
             auth,
         };
-        let ack = connect_and_handshake(hello, 55_000).await;
+        let ack = connect_and_handshake(hello).await;
         assert!(!ack.accepted);
         assert_eq!(ack.message, "replication handshake rejected");
     }

--- a/crates/truthdb-core/src/repl/listener.rs
+++ b/crates/truthdb-core/src/repl/listener.rs
@@ -34,6 +34,15 @@ pub struct PrimaryReplContext {
     /// The sender's idle heartbeat interval (also bounds how stale a
     /// direct-sync watermark advance can go unshipped).
     pub heartbeat: Duration,
+    /// How long a connected standby may stay completely silent (a healthy one
+    /// acks every heartbeat) before its connection is torn down.
+    pub stall_timeout: Duration,
+    /// Target bytes per `LogData` frame during catch-up (cut on entry
+    /// boundaries; see `sender::DEFAULT_CHUNK_BYTES`).
+    pub chunk_bytes: u64,
+    /// Node ids with a live sender, so a second connection under the same id
+    /// is refused instead of corrupting the first's slot.
+    pub active_nodes: Arc<std::sync::Mutex<std::collections::HashSet<u32>>>,
 }
 
 impl PrimaryReplContext {
@@ -91,7 +100,7 @@ async fn handle_standby(
     let flushed = ctx.storage.wal_flushed_lsn();
     let params = ctx.params(flushed);
     match serve_handshake(&mut tls, &params).await? {
-        Some(standby) => run_sender(tls, ctx.storage, standby, ctx.heartbeat, shutdown).await,
+        Some(standby) => run_sender(tls, ctx, standby, shutdown).await,
         None => Ok(()),
     }
 }
@@ -159,6 +168,9 @@ mod tests {
             cluster_uuid: UUID,
             storage,
             heartbeat: Duration::from_secs(30),
+            stall_timeout: Duration::from_secs(30),
+            chunk_bytes: crate::repl::sender::DEFAULT_CHUNK_BYTES,
+            active_nodes: Arc::default(),
         };
         let server = tokio::spawn(run_repl_listener(listener, acceptor, ctx, shutdown_rx));
 

--- a/crates/truthdb-core/src/repl/mod.rs
+++ b/crates/truthdb-core/src/repl/mod.rs
@@ -1,8 +1,15 @@
 //! Stage 18 replication wire protocol: the message types and their bincode +
-//! framed codec. Pure data — no I/O; the async listener and per-standby senders
-//! (later slices) frame these over a TLS socket. Mirrors the native
-//! `truthdb-proto` codec: an 8-byte big-endian header (payload length `u32`,
-//! message type `u16`, flags `u16`) followed by the bincode payload.
+//! framed codec. Pure data — no I/O; the async listener, the per-standby
+//! senders and the standby receiver frame these over a TLS socket. Mirrors the
+//! native `truthdb-proto` codec: an 8-byte big-endian header (payload length
+//! `u32`, message type `u16`, flags `u16`) followed by the bincode payload.
+//!
+//! Message flow: the standby dials in and sends `Hello`; the primary answers
+//! `HelloAck` and, on acceptance, streams `LogData` (with `Heartbeat` when
+//! idle) while the standby acknowledges progress with `FlushAck`. A `HelloAck
+//! { accepted: false }` arriving *after* the handshake is the primary's
+//! post-handshake rejection notice (diverged timeline, slot table full, ...)
+//! — connection-fatal, with the operator fix in `message`.
 
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -10,6 +17,8 @@ use thiserror::Error;
 pub mod framing;
 pub mod handshake;
 pub mod listener;
+pub mod receiver;
+pub mod sender;
 pub mod server;
 pub mod tls;
 

--- a/crates/truthdb-core/src/repl/receiver.rs
+++ b/crates/truthdb-core/src/repl/receiver.rs
@@ -38,6 +38,10 @@ pub struct ReceiverConfig {
     pub node_id: u32,
     /// Delay between reconnect attempts after a connection fails.
     pub reconnect_delay: Duration,
+    /// How long the primary may stay completely silent (a healthy one
+    /// heartbeats when idle) before the connection is presumed dead and
+    /// re-dialed — a silent partition must not stall replication forever.
+    pub stall_timeout: Duration,
 }
 
 /// Runs the standby's receive loop until `shutdown` flips: connect, stream,
@@ -86,10 +90,13 @@ async fn connect_and_stream(cfg: &ReceiverConfig, storage: &Arc<Storage>) -> io:
         .map_err(|err| io::Error::new(io::ErrorKind::InvalidInput, err))?;
     let mut tls = connector.connect(domain, tcp).await?;
 
-    // Resume from the persisted tail: everything below it is applied and
-    // durable here (a standby's live tail never runs ahead of its superblock —
-    // it only advances through `apply_wal_stream`, which persists it).
-    let last_received = storage.wal_tail();
+    // Resume from the PERSISTED tail (see `standby_resume_lsn`): after a crash
+    // between an apply's ring fsync and its superblock commit, or a redo-only
+    // reopen that recovered extra durable ring bytes, the live tail runs ahead
+    // of the persisted one — and the apply continuity check compares against
+    // the persisted value, so resuming from the live tail would wedge every
+    // reconnect on a 4305 gap. The overlap re-ship is idempotent.
+    let last_received = storage.standby_resume_lsn();
     let epoch = storage.epoch();
     let hello = Hello {
         protocol_version: REPL_PROTOCOL_VERSION,
@@ -126,7 +133,7 @@ async fn connect_and_stream(cfg: &ReceiverConfig, storage: &Arc<Storage>) -> io:
         ));
     }
 
-    stream_frames(&mut tls, storage).await
+    stream_frames(&mut tls, storage, cfg.stall_timeout).await
 }
 
 async fn read_ack<S>(stream: &mut S) -> io::Result<HelloAck>
@@ -143,12 +150,22 @@ where
     frame.decode().map_err(io::Error::other)
 }
 
-async fn stream_frames<S>(stream: &mut S, storage: &Arc<Storage>) -> io::Result<()>
+async fn stream_frames<S>(stream: &mut S, storage: &Arc<Storage>, stall: Duration) -> io::Result<()>
 where
     S: AsyncRead + AsyncWrite + Unpin,
 {
     loop {
-        let frame = read_repl_frame(stream).await?;
+        // The primary heartbeats when idle; total silence past the deadline is
+        // a dead peer or a silent partition — reconnect rather than stall
+        // replication forever on a connection that will never speak again.
+        let frame = tokio::time::timeout(stall, read_repl_frame(stream))
+            .await
+            .map_err(|_| {
+                io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    format!("primary sent nothing for {stall:?}"),
+                )
+            })??;
         match frame.msg_type {
             ReplMsgType::LogData => {
                 let ld: LogData = frame.decode().map_err(io::Error::other)?;
@@ -181,13 +198,15 @@ where
     }
 }
 
-/// Acknowledges the standby's current watermark. `apply_wal_stream` is durable
-/// before it returns, so received, flushed and applied coincide.
+/// Acknowledges the standby's current PERSISTED watermark (`apply_wal_stream`
+/// is durable before it returns, so received, flushed and applied coincide —
+/// and the persisted value is what a restart resumes from, which is what the
+/// primary's slot must hold log for).
 async fn ack_current<S>(stream: &mut S, storage: &Arc<Storage>) -> io::Result<()>
 where
     S: AsyncWrite + Unpin,
 {
-    let tail = storage.wal_tail();
+    let tail = storage.standby_resume_lsn();
     let ack = FlushAck {
         received_lsn: tail,
         flushed_lsn: tail,

--- a/crates/truthdb-core/src/repl/receiver.rs
+++ b/crates/truthdb-core/src/repl/receiver.rs
@@ -1,0 +1,198 @@
+//! The standby's replication receiver: a reconnecting client loop that dials
+//! the primary's replication listener, completes TLS and the shared-secret
+//! handshake, then applies every `LogData` frame via
+//! [`Storage::apply_wal_stream`] and acknowledges each with a `FlushAck` (the
+//! apply is durable before it returns, so received = flushed = applied). The
+//! resume point is the standby's own persisted WAL tail — nothing is negotiated
+//! or cached, so a crash or disconnect at any point resumes correctly (an
+//! overlapping re-ship is idempotent).
+
+use std::io;
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::sync::watch;
+use tokio_rustls::TlsConnector;
+
+use super::framing::{read_repl_frame, write_repl_frame};
+use super::handshake::compute_auth;
+use super::tls::client_config_trusting;
+use super::{FlushAck, Hello, HelloAck, LogData, REPL_PROTOCOL_VERSION, ReplFrame, ReplMsgType};
+use crate::storage::Storage;
+
+/// How a standby reaches and authenticates to its primary.
+#[derive(Clone)]
+pub struct ReceiverConfig {
+    /// The primary's replication endpoint, `host:port`.
+    pub primary_addr: String,
+    /// The TLS server name the primary's certificate must match.
+    pub server_name: String,
+    /// PEM of the certificate (or CA) to trust for the primary.
+    pub tls_ca_pem: Vec<u8>,
+    /// The cluster's shared secret (the HMAC key for the handshake proof).
+    pub shared_secret: Vec<u8>,
+    /// This cluster's uuid — must match the primary's.
+    pub cluster_uuid: [u8; 16],
+    /// This standby's node id (also its replication-slot id on the primary).
+    pub node_id: u32,
+    /// Delay between reconnect attempts after a connection fails.
+    pub reconnect_delay: Duration,
+}
+
+/// Runs the standby's receive loop until `shutdown` flips: connect, stream,
+/// and on any failure log it and reconnect after `reconnect_delay`. A
+/// rejection notice from the primary (wrong secret, diverged timeline, slot
+/// table full) is surfaced verbatim — most name the fix (e.g. reseed).
+pub async fn run_standby_receiver(
+    cfg: ReceiverConfig,
+    storage: Arc<Storage>,
+    mut shutdown: watch::Receiver<bool>,
+) {
+    // The seed must be `restore --standby`: a plain restore ran ARIES undo,
+    // whose CLRs can mask shipped redo and silently diverge the replica. The
+    // flag also keeps the file read-only from birth, so no local write can
+    // slip in between opening and the first shipped frame.
+    if !storage.is_standby() {
+        eprintln!(
+            "replication receiver refusing to start: this database is not a standby seed \
+             (restore it with `truthdb-cli restore --standby`)"
+        );
+        return;
+    }
+    loop {
+        tokio::select! {
+            _ = shutdown.changed() => return,
+            res = connect_and_stream(&cfg, &storage) => {
+                if let Err(err) = res {
+                    eprintln!("replication receiver: {err}; reconnecting to {} in {:?}",
+                        cfg.primary_addr, cfg.reconnect_delay);
+                }
+            }
+        }
+        tokio::select! {
+            _ = shutdown.changed() => return,
+            _ = tokio::time::sleep(cfg.reconnect_delay) => {}
+        }
+    }
+}
+
+/// One connection's lifetime: dial, handshake, then apply frames until the
+/// stream ends or fails.
+async fn connect_and_stream(cfg: &ReceiverConfig, storage: &Arc<Storage>) -> io::Result<()> {
+    let tcp = tokio::net::TcpStream::connect(&cfg.primary_addr).await?;
+    let connector = TlsConnector::from(client_config_trusting(&cfg.tls_ca_pem)?);
+    let domain = rustls::pki_types::ServerName::try_from(cfg.server_name.clone())
+        .map_err(|err| io::Error::new(io::ErrorKind::InvalidInput, err))?;
+    let mut tls = connector.connect(domain, tcp).await?;
+
+    // Resume from the persisted tail: everything below it is applied and
+    // durable here (a standby's live tail never runs ahead of its superblock —
+    // it only advances through `apply_wal_stream`, which persists it).
+    let last_received = storage.wal_tail();
+    let epoch = storage.epoch();
+    let hello = Hello {
+        protocol_version: REPL_PROTOCOL_VERSION,
+        node_id: u64::from(cfg.node_id),
+        cluster_uuid: cfg.cluster_uuid,
+        epoch,
+        last_received_lsn: last_received,
+        auth: compute_auth(
+            &cfg.shared_secret,
+            u64::from(cfg.node_id),
+            &cfg.cluster_uuid,
+            epoch,
+            last_received,
+        ),
+    };
+    let frame = ReplFrame::encode(ReplMsgType::Hello, &hello).map_err(io::Error::other)?;
+    write_repl_frame(&mut tls, &frame).await?;
+    let ack = read_ack(&mut tls).await?;
+    if !ack.accepted {
+        return Err(io::Error::new(
+            io::ErrorKind::ConnectionRefused,
+            format!("primary rejected the handshake: {}", ack.message),
+        ));
+    }
+    if ack.primary_epoch < epoch {
+        // A primary behind this standby's epoch is a stale timeline (e.g. an
+        // old primary that missed a failover). Following it would diverge.
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "primary epoch {} is behind this standby's epoch {epoch}: stale primary",
+                ack.primary_epoch
+            ),
+        ));
+    }
+
+    stream_frames(&mut tls, storage).await
+}
+
+async fn read_ack<S>(stream: &mut S) -> io::Result<HelloAck>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    let frame = read_repl_frame(stream).await?;
+    if frame.msg_type != ReplMsgType::HelloAck {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "expected a HelloAck as the first frame",
+        ));
+    }
+    frame.decode().map_err(io::Error::other)
+}
+
+async fn stream_frames<S>(stream: &mut S, storage: &Arc<Storage>) -> io::Result<()>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    loop {
+        let frame = read_repl_frame(stream).await?;
+        match frame.msg_type {
+            ReplMsgType::LogData => {
+                let ld: LogData = frame.decode().map_err(io::Error::other)?;
+                storage
+                    .apply_wal_stream(ld.from_lsn, &ld.bytes)
+                    .map_err(|err| io::Error::other(format!("apply failed: {err}")))?;
+                ack_current(stream, storage).await?;
+            }
+            // A heartbeat keeps the connection verified while idle; ack it so
+            // the primary's slot (and, later, lag metrics) track a quiet
+            // standby too.
+            ReplMsgType::Heartbeat => ack_current(stream, storage).await?,
+            // A HelloAck after the handshake is the primary's rejection
+            // notice (diverged timeline, slot table full, ...): fatal for
+            // this connection, and the message names the operator fix.
+            ReplMsgType::HelloAck => {
+                let notice: HelloAck = frame.decode().map_err(io::Error::other)?;
+                return Err(io::Error::new(
+                    io::ErrorKind::ConnectionAborted,
+                    format!("primary refused the stream: {}", notice.message),
+                ));
+            }
+            other => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("unexpected replication frame: {other:?}"),
+                ));
+            }
+        }
+    }
+}
+
+/// Acknowledges the standby's current watermark. `apply_wal_stream` is durable
+/// before it returns, so received, flushed and applied coincide.
+async fn ack_current<S>(stream: &mut S, storage: &Arc<Storage>) -> io::Result<()>
+where
+    S: AsyncWrite + Unpin,
+{
+    let tail = storage.wal_tail();
+    let ack = FlushAck {
+        received_lsn: tail,
+        flushed_lsn: tail,
+        applied_lsn: tail,
+    };
+    let frame = ReplFrame::encode(ReplMsgType::FlushAck, &ack).map_err(io::Error::other)?;
+    write_repl_frame(stream, &frame).await
+}

--- a/crates/truthdb-core/src/repl/sender.rs
+++ b/crates/truthdb-core/src/repl/sender.rs
@@ -1,0 +1,288 @@
+//! The primary's per-standby log sender: after [`serve_handshake`] accepts a
+//! standby, this task registers the standby's replication slot (holding WAL
+//! truncation at its resume point) and streams `Storage::read_wal_range` output
+//! to it as `LogData` frames — first the catch-up backlog, then live, waking on
+//! the group-commit flushed watch as new WAL becomes durable. A concurrent
+//! reader half consumes the standby's `FlushAck`s and advances the slot, so the
+//! primary reclaims log the standby has made durable. The slot survives a
+//! disconnect by design: it keeps holding log for the standby's reconnect, and
+//! is reclaimed only by the checkpoint retention reap.
+//!
+//! [`serve_handshake`]: super::server::serve_handshake
+
+use std::io;
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
+use tokio::sync::watch;
+use tokio::task::JoinHandle;
+
+use super::framing::{read_repl_frame, write_repl_frame};
+use super::server::AcceptedStandby;
+use super::{
+    FlushAck, Heartbeat, HelloAck, LogData, REPL_PROTOCOL_VERSION, ReplFrame, ReplMsgType,
+};
+use crate::storage::Storage;
+
+/// Bytes of WAL per `LogData` frame while catching a standby up (well under
+/// `REPL_MAX_PAYLOAD`, and each chunk is read under one storage-lock hold).
+const SENDER_CHUNK: u64 = 4 * 1024 * 1024;
+
+/// Streams durable WAL to one accepted standby until the connection drops, the
+/// storage shuts down, or `shutdown` flips. Errors are connection-fatal only —
+/// the standby reconnects and resumes from its persisted watermark.
+pub(crate) async fn run_sender<S>(
+    stream: S,
+    storage: Arc<Storage>,
+    standby: AcceptedStandby,
+    heartbeat: Duration,
+    shutdown: watch::Receiver<bool>,
+) -> io::Result<()>
+where
+    S: AsyncRead + AsyncWrite + Send + Unpin + 'static,
+{
+    // Slot ids are u32 (the persisted slot table); the wire's node_id is u64.
+    // Configured node ids are u32, so an overflow is a foreign client.
+    let mut stream = stream;
+    let slot_id = match u32::try_from(standby.node_id) {
+        Ok(id) => id,
+        Err(_) => {
+            let msg = format!(
+                "node_id {} exceeds the slot-id range (u32); configure a smaller node id",
+                standby.node_id
+            );
+            return refuse(&mut stream, &storage, &msg).await;
+        }
+    };
+    let sent = standby.last_received_lsn;
+    let flushed = storage.wal_flushed_lsn();
+    if sent > flushed {
+        // The standby has log this primary never wrote (or lost): a diverged
+        // timeline. Shipping from `sent` would fabricate continuity.
+        let msg = format!(
+            "standby received LSN {sent} is ahead of the primary's durable WAL ({flushed}): \
+             diverged timelines — reseed the standby from a fresh backup"
+        );
+        return refuse(&mut stream, &storage, &msg).await;
+    }
+    // Register the slot before the first read: the registration is fenced
+    // against the WAL head under the storage lock, so from here the log at
+    // `sent` cannot be truncated out from under the stream.
+    if let Err(err) = storage.try_register_repl_slot(slot_id, sent) {
+        return refuse(&mut stream, &storage, &err.to_string()).await;
+    }
+
+    let (rd, mut wr) = tokio::io::split(stream);
+    let mut acks = spawn_ack_reader(rd, Arc::clone(&storage), slot_id);
+    let result = ship_loop(&mut wr, &storage, sent, heartbeat, shutdown, &mut acks).await;
+    acks.abort();
+    result
+}
+
+/// Reads the standby's frames (`FlushAck` advances the slot; anything else is
+/// ignored) until the connection drops.
+fn spawn_ack_reader<R>(mut rd: R, storage: Arc<Storage>, slot_id: u32) -> JoinHandle<io::Result<()>>
+where
+    R: AsyncRead + Send + Unpin + 'static,
+{
+    tokio::spawn(async move {
+        loop {
+            let frame = read_repl_frame(&mut rd).await?;
+            if frame.msg_type == ReplMsgType::FlushAck {
+                let ack: FlushAck = frame.decode().map_err(io::Error::other)?;
+                // Advance at the standby's *durable* watermark: log below it is
+                // safe to reclaim even if the standby crashes right now.
+                storage.advance_repl_slot(slot_id, ack.flushed_lsn);
+            }
+        }
+    })
+}
+
+async fn ship_loop<W>(
+    wr: &mut W,
+    storage: &Arc<Storage>,
+    mut sent: u64,
+    heartbeat: Duration,
+    mut shutdown: watch::Receiver<bool>,
+    acks: &mut JoinHandle<io::Result<()>>,
+) -> io::Result<()>
+where
+    W: AsyncWrite + Unpin,
+{
+    let mut flushed_watch = storage.subscribe_wal_flushed();
+    let mut tick = tokio::time::interval(heartbeat);
+    tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    loop {
+        // Ship everything durable, then wait for more. The watch value is a
+        // hint only — the watermark is re-read every pass (a direct WAL sync
+        // advances it without signalling the watch; the tick covers that).
+        let flushed = storage.wal_flushed_lsn();
+        while sent < flushed {
+            let end = flushed.min(sent + SENDER_CHUNK);
+            let bytes = storage
+                .read_wal_range(sent, end)
+                .map_err(io::Error::other)?;
+            let frame = ReplFrame::encode(
+                ReplMsgType::LogData,
+                &LogData {
+                    from_lsn: sent,
+                    bytes,
+                },
+            )
+            .map_err(io::Error::other)?;
+            // A stalled standby (full TCP send buffer) must not be able to
+            // hang server shutdown: abandon the write when shutdown flips (the
+            // connection is being torn down anyway).
+            tokio::select! {
+                written = write_repl_frame(wr, &frame) => written?,
+                _ = shutdown.changed() => return Ok(()),
+            }
+            sent = end;
+        }
+        tokio::select! {
+            res = &mut *acks => {
+                // The standby hung up (or its stream failed): connection over.
+                return match res {
+                    Ok(inner) => inner,
+                    Err(join) => Err(io::Error::other(join)),
+                };
+            }
+            changed = flushed_watch.changed() => {
+                if changed.is_err() {
+                    // Storage (and its log-writer) shut down.
+                    return Ok(());
+                }
+            }
+            _ = tick.tick() => {
+                if storage.wal_flushed_lsn() <= sent {
+                    let hb = Heartbeat { time_ms: now_ms() };
+                    let frame = ReplFrame::encode(ReplMsgType::Heartbeat, &hb)
+                        .map_err(io::Error::other)?;
+                    tokio::select! {
+                        written = write_repl_frame(wr, &frame) => written?,
+                        _ = shutdown.changed() => return Ok(()),
+                    }
+                }
+            }
+            _ = shutdown.changed() => return Ok(()),
+        }
+    }
+}
+
+/// Sends a post-handshake rejection notice — a `HelloAck { accepted: false }`
+/// status frame naming the reason (the standby surfaces it to its operator,
+/// e.g. "reseed from a fresh backup") — then fails the connection.
+async fn refuse<S>(stream: &mut S, storage: &Storage, msg: &str) -> io::Result<()>
+where
+    S: AsyncWrite + Unpin,
+{
+    let notice = HelloAck {
+        protocol_version: REPL_PROTOCOL_VERSION,
+        accepted: false,
+        primary_epoch: storage.epoch(),
+        primary_flushed_lsn: storage.wal_flushed_lsn(),
+        message: msg.to_string(),
+    };
+    let frame = ReplFrame::encode(ReplMsgType::HelloAck, &notice).map_err(io::Error::other)?;
+    write_repl_frame(stream, &frame).await?;
+    stream.flush().await?;
+    Err(io::Error::new(io::ErrorKind::InvalidData, msg.to_string()))
+}
+
+fn now_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::StorageOptions;
+
+    fn temp_storage(label: &str) -> (Arc<Storage>, std::path::PathBuf) {
+        let mut path = std::env::temp_dir();
+        path.push(format!(
+            "truthdb-repl-sender-{label}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let storage = Storage::create(
+            path.clone(),
+            StorageOptions {
+                size_gib: 1,
+                wal_ratio: 0.05,
+                metadata_ratio: 0.08,
+                snapshot_ratio: 0.02,
+                allocator_ratio: 0.02,
+                reserved_ratio: 0.17,
+                default_collation: None,
+            },
+        )
+        .unwrap();
+        (Arc::new(storage), path)
+    }
+
+    async fn refusal_message(standby: AcceptedStandby) -> (io::Result<()>, HelloAck) {
+        let (server_end, mut client_end) = tokio::io::duplex(64 * 1024);
+        let (storage, path) = temp_storage("refuse");
+        let (_shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+        let sender = tokio::spawn(run_sender(
+            server_end,
+            storage,
+            standby,
+            Duration::from_secs(30),
+            shutdown_rx,
+        ));
+        let notice: HelloAck = read_repl_frame(&mut client_end)
+            .await
+            .unwrap()
+            .decode()
+            .unwrap();
+        let result = sender.await.unwrap();
+        let _ = std::fs::remove_file(path);
+        (result, notice)
+    }
+
+    // A standby claiming log the primary never durably wrote is a diverged
+    // timeline: the sender refuses with a notice instead of fabricating
+    // continuity.
+    #[tokio::test]
+    async fn an_ahead_standby_is_refused_as_diverged() {
+        let (result, notice) = refusal_message(AcceptedStandby {
+            node_id: 3,
+            last_received_lsn: u64::MAX / 2,
+        })
+        .await;
+        assert!(result.is_err());
+        assert!(!notice.accepted);
+        assert!(
+            notice.message.contains("reseed"),
+            "the notice names the fix: {}",
+            notice.message
+        );
+    }
+
+    // Slot ids are the persisted u32 table's; a node id that cannot be one is
+    // refused up front rather than truncated into a colliding slot.
+    #[tokio::test]
+    async fn an_oversized_node_id_is_refused() {
+        let (result, notice) = refusal_message(AcceptedStandby {
+            node_id: u64::from(u32::MAX) + 1,
+            last_received_lsn: 0,
+        })
+        .await;
+        assert!(result.is_err());
+        assert!(!notice.accepted);
+        assert!(
+            notice.message.contains("node id"),
+            "the notice names the cause: {}",
+            notice.message
+        );
+    }
+}

--- a/crates/truthdb-core/src/repl/sender.rs
+++ b/crates/truthdb-core/src/repl/sender.rs
@@ -242,10 +242,18 @@ where
             )
             .map_err(io::Error::other)?;
             // A stalled standby (full TCP send buffer) must not be able to
-            // hang server shutdown: abandon the write when shutdown flips (the
-            // connection is being torn down anyway).
+            // hang server shutdown or hold this node id forever: abandon the
+            // write on shutdown, and fail the connection when the write itself
+            // stalls past the deadline (the ack reader cannot time it out —
+            // it is only polled between writes).
             tokio::select! {
                 written = write_repl_frame(wr, &frame) => written?,
+                _ = tokio::time::sleep(ctx.stall_timeout) => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::TimedOut,
+                        format!("standby did not accept a frame within {:?}", ctx.stall_timeout),
+                    ));
+                }
                 _ = shutdown.changed() => return Ok(()),
             }
             shipped
@@ -276,6 +284,15 @@ where
                         .map_err(io::Error::other)?;
                     tokio::select! {
                         written = write_repl_frame(wr, &frame) => written?,
+                        _ = tokio::time::sleep(ctx.stall_timeout) => {
+                            return Err(io::Error::new(
+                                io::ErrorKind::TimedOut,
+                                format!(
+                                    "standby did not accept a heartbeat within {:?}",
+                                    ctx.stall_timeout
+                                ),
+                            ));
+                        }
                         _ = shutdown.changed() => return Ok(()),
                     }
                 }

--- a/crates/truthdb-core/src/repl/sender.rs
+++ b/crates/truthdb-core/src/repl/sender.rs
@@ -1,17 +1,28 @@
 //! The primary's per-standby log sender: after [`serve_handshake`] accepts a
 //! standby, this task registers the standby's replication slot (holding WAL
-//! truncation at its resume point) and streams `Storage::read_wal_range` output
-//! to it as `LogData` frames — first the catch-up backlog, then live, waking on
-//! the group-commit flushed watch as new WAL becomes durable. A concurrent
-//! reader half consumes the standby's `FlushAck`s and advances the slot, so the
-//! primary reclaims log the standby has made durable. The slot survives a
-//! disconnect by design: it keeps holding log for the standby's reconnect, and
-//! is reclaimed only by the checkpoint retention reap.
+//! truncation at its resume point) and streams the log to it as `LogData`
+//! frames — first the catch-up backlog, then live, waking on the group-commit
+//! flushed watch as new WAL becomes durable. Chunks are cut on WAL-ENTRY
+//! BOUNDARIES ([`Storage::read_wal_chunk`]): the standby persists each range's
+//! end as its applied tail, and a mid-entry end would make every later decode
+//! silently no-op — permanent silent divergence. The same primitive fences the
+//! read against the WAL head under one lock hold, so a slot reaped by the
+//! retention cap turns the NEXT read into a loud reseed error instead of
+//! shipping recycled ring bytes from a newer lap.
+//!
+//! A concurrent reader half consumes the standby's `FlushAck`s and advances
+//! the slot — but only ever to a boundary this sender actually shipped, so a
+//! malicious or corrupt ack cannot park the slot (and therefore the checkpoint
+//! truncation floor, which becomes the WAL head the next restart scans from)
+//! in the middle of an entry. The slot survives a disconnect by design: it
+//! keeps holding log for the standby's reconnect, and is reclaimed only by the
+//! checkpoint retention reap.
 //!
 //! [`serve_handshake`]: super::server::serve_handshake
 
+use std::collections::BTreeSet;
 use std::io;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
@@ -19,24 +30,26 @@ use tokio::sync::watch;
 use tokio::task::JoinHandle;
 
 use super::framing::{read_repl_frame, write_repl_frame};
+use super::listener::PrimaryReplContext;
 use super::server::AcceptedStandby;
 use super::{
-    FlushAck, Heartbeat, HelloAck, LogData, REPL_PROTOCOL_VERSION, ReplFrame, ReplMsgType,
+    FlushAck, Heartbeat, HelloAck, LogData, REPL_MAX_PAYLOAD, REPL_PROTOCOL_VERSION, ReplFrame,
+    ReplMsgType,
 };
 use crate::storage::Storage;
 
-/// Bytes of WAL per `LogData` frame while catching a standby up (well under
-/// `REPL_MAX_PAYLOAD`, and each chunk is read under one storage-lock hold).
-const SENDER_CHUNK: u64 = 4 * 1024 * 1024;
+/// Default bytes of WAL per `LogData` frame while catching a standby up (well
+/// under `REPL_MAX_PAYLOAD`; a single oversized WAL entry may exceed it, the
+/// wire cap below is the hard limit).
+pub const DEFAULT_CHUNK_BYTES: u64 = 4 * 1024 * 1024;
 
 /// Streams durable WAL to one accepted standby until the connection drops, the
 /// storage shuts down, or `shutdown` flips. Errors are connection-fatal only —
 /// the standby reconnects and resumes from its persisted watermark.
 pub(crate) async fn run_sender<S>(
     stream: S,
-    storage: Arc<Storage>,
+    ctx: PrimaryReplContext,
     standby: AcceptedStandby,
-    heartbeat: Duration,
     shutdown: watch::Receiver<bool>,
 ) -> io::Result<()>
 where
@@ -45,12 +58,26 @@ where
     // Slot ids are u32 (the persisted slot table); the wire's node_id is u64.
     // Configured node ids are u32, so an overflow is a foreign client.
     let mut stream = stream;
+    let storage = Arc::clone(&ctx.storage);
     let slot_id = match u32::try_from(standby.node_id) {
         Ok(id) => id,
         Err(_) => {
             let msg = format!(
                 "node_id {} exceeds the slot-id range (u32); configure a smaller node id",
                 standby.node_id
+            );
+            return refuse(&mut stream, &storage, &msg).await;
+        }
+    };
+    // One connection per node id: a second stream under the same id would
+    // reset the first's slot and its acks would advance it out from under the
+    // other stream's shipping position (the shipped default node_id is the
+    // same on every node, so this is an easy misconfiguration to hit).
+    let _membership = match NodeMembership::acquire(&ctx.active_nodes, slot_id) {
+        Some(m) => m,
+        None => {
+            let msg = format!(
+                "node id {slot_id} is already connected; every standby needs a distinct node_id"
             );
             return refuse(&mut stream, &storage, &msg).await;
         }
@@ -68,32 +95,101 @@ where
     }
     // Register the slot before the first read: the registration is fenced
     // against the WAL head under the storage lock, so from here the log at
-    // `sent` cannot be truncated out from under the stream.
+    // `sent` cannot be truncated out from under the stream (unless the
+    // retention-cap reap drops the slot — which the per-chunk head fence in
+    // `read_wal_chunk` then reports as a reseed error).
     if let Err(err) = storage.try_register_repl_slot(slot_id, sent) {
         return refuse(&mut stream, &storage, &err.to_string()).await;
     }
 
+    // Boundaries this sender has shipped (or started from): the only LSNs an
+    // ack may advance the slot to.
+    let shipped = Arc::new(Mutex::new(BTreeSet::from([sent])));
     let (rd, mut wr) = tokio::io::split(stream);
-    let mut acks = spawn_ack_reader(rd, Arc::clone(&storage), slot_id);
-    let result = ship_loop(&mut wr, &storage, sent, heartbeat, shutdown, &mut acks).await;
+    let mut acks = spawn_ack_reader(
+        rd,
+        Arc::clone(&storage),
+        slot_id,
+        Arc::clone(&shipped),
+        ctx.stall_timeout,
+    );
+    let result = ship_loop(&mut wr, &ctx, sent, shutdown, &mut acks, &shipped).await;
     acks.abort();
     result
 }
 
-/// Reads the standby's frames (`FlushAck` advances the slot; anything else is
-/// ignored) until the connection drops.
-fn spawn_ack_reader<R>(mut rd: R, storage: Arc<Storage>, slot_id: u32) -> JoinHandle<io::Result<()>>
+/// RAII membership in the primary's connected-node set.
+struct NodeMembership {
+    nodes: Arc<Mutex<std::collections::HashSet<u32>>>,
+    id: u32,
+}
+
+impl NodeMembership {
+    fn acquire(nodes: &Arc<Mutex<std::collections::HashSet<u32>>>, id: u32) -> Option<Self> {
+        let mut set = nodes.lock().expect("active-node set poisoned");
+        if !set.insert(id) {
+            return None;
+        }
+        Some(NodeMembership {
+            nodes: Arc::clone(nodes),
+            id,
+        })
+    }
+}
+
+impl Drop for NodeMembership {
+    fn drop(&mut self) {
+        self.nodes
+            .lock()
+            .expect("active-node set poisoned")
+            .remove(&self.id);
+    }
+}
+
+/// Reads the standby's frames until the connection drops or stays silent past
+/// `stall` (a healthy standby acks every heartbeat, so silence means a dead or
+/// half-open peer — the connection is torn down; the slot remains). A
+/// `FlushAck` advances the slot, clamped to the greatest boundary this sender
+/// shipped at or below the acked LSN.
+fn spawn_ack_reader<R>(
+    mut rd: R,
+    storage: Arc<Storage>,
+    slot_id: u32,
+    shipped: Arc<Mutex<BTreeSet<u64>>>,
+    stall: Duration,
+) -> JoinHandle<io::Result<()>>
 where
     R: AsyncRead + Send + Unpin + 'static,
 {
     tokio::spawn(async move {
         loop {
-            let frame = read_repl_frame(&mut rd).await?;
+            let frame = tokio::time::timeout(stall, read_repl_frame(&mut rd))
+                .await
+                .map_err(|_| {
+                    io::Error::new(
+                        io::ErrorKind::TimedOut,
+                        format!("standby sent nothing for {stall:?}; dropping the connection"),
+                    )
+                })??;
             if frame.msg_type == ReplMsgType::FlushAck {
                 let ack: FlushAck = frame.decode().map_err(io::Error::other)?;
-                // Advance at the standby's *durable* watermark: log below it is
-                // safe to reclaim even if the standby crashes right now.
-                storage.advance_repl_slot(slot_id, ack.flushed_lsn);
+                // Advance at the standby's *durable* watermark — but only to a
+                // boundary we shipped: the slot LSN feeds the checkpoint
+                // truncation floor (= the restart scan's start), which must
+                // never sit mid-entry.
+                let bounded = {
+                    let mut set = shipped.lock().expect("shipped-boundary set poisoned");
+                    let target = set.range(..=ack.flushed_lsn).next_back().copied();
+                    if let Some(lsn) = target {
+                        // Boundaries at or below the ack are consumed.
+                        let keep = set.split_off(&lsn);
+                        *set = keep;
+                    }
+                    target
+                };
+                if let Some(lsn) = bounded {
+                    storage.advance_repl_slot(slot_id, lsn);
+                }
             }
         }
     })
@@ -101,17 +197,18 @@ where
 
 async fn ship_loop<W>(
     wr: &mut W,
-    storage: &Arc<Storage>,
+    ctx: &PrimaryReplContext,
     mut sent: u64,
-    heartbeat: Duration,
     mut shutdown: watch::Receiver<bool>,
     acks: &mut JoinHandle<io::Result<()>>,
+    shipped: &Arc<Mutex<BTreeSet<u64>>>,
 ) -> io::Result<()>
 where
     W: AsyncWrite + Unpin,
 {
+    let storage = &ctx.storage;
     let mut flushed_watch = storage.subscribe_wal_flushed();
-    let mut tick = tokio::time::interval(heartbeat);
+    let mut tick = tokio::time::interval(ctx.heartbeat);
     tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     loop {
         // Ship everything durable, then wait for more. The watch value is a
@@ -119,10 +216,23 @@ where
         // advances it without signalling the watch; the tick covers that).
         let flushed = storage.wal_flushed_lsn();
         while sent < flushed {
-            let end = flushed.min(sent + SENDER_CHUNK);
-            let bytes = storage
-                .read_wal_range(sent, end)
+            let (bytes, end) = storage
+                .read_wal_chunk(sent, flushed, ctx.chunk_bytes)
                 .map_err(io::Error::other)?;
+            if end == sent {
+                // No complete entry fits below the cap (transient boundary
+                // state); wait for the watermark to move past it.
+                break;
+            }
+            if bytes.len() + 64 > REPL_MAX_PAYLOAD {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "WAL entry at LSN {sent} is larger than the replication frame cap \
+                         ({REPL_MAX_PAYLOAD} bytes); cannot ship it"
+                    ),
+                ));
+            }
             let frame = ReplFrame::encode(
                 ReplMsgType::LogData,
                 &LogData {
@@ -138,11 +248,16 @@ where
                 written = write_repl_frame(wr, &frame) => written?,
                 _ = shutdown.changed() => return Ok(()),
             }
+            shipped
+                .lock()
+                .expect("shipped-boundary set poisoned")
+                .insert(end);
             sent = end;
         }
         tokio::select! {
             res = &mut *acks => {
-                // The standby hung up (or its stream failed): connection over.
+                // The standby hung up, went silent past the stall deadline, or
+                // its stream failed: connection over.
                 return match res {
                     Ok(inner) => inner,
                     Err(join) => Err(io::Error::other(join)),
@@ -228,15 +343,26 @@ mod tests {
         (Arc::new(storage), path)
     }
 
+    fn test_ctx(storage: Arc<Storage>) -> PrimaryReplContext {
+        PrimaryReplContext {
+            shared_secret: Arc::new(b"unused".to_vec()),
+            cluster_uuid: [0u8; 16],
+            storage,
+            heartbeat: Duration::from_secs(30),
+            stall_timeout: Duration::from_secs(30),
+            chunk_bytes: DEFAULT_CHUNK_BYTES,
+            active_nodes: Arc::default(),
+        }
+    }
+
     async fn refusal_message(standby: AcceptedStandby) -> (io::Result<()>, HelloAck) {
         let (server_end, mut client_end) = tokio::io::duplex(64 * 1024);
         let (storage, path) = temp_storage("refuse");
         let (_shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
         let sender = tokio::spawn(run_sender(
             server_end,
-            storage,
+            test_ctx(storage),
             standby,
-            Duration::from_secs(30),
             shutdown_rx,
         ));
         let notice: HelloAck = read_repl_frame(&mut client_end)
@@ -284,5 +410,58 @@ mod tests {
             "the notice names the cause: {}",
             notice.message
         );
+    }
+
+    // A second connection under an in-use node id is refused: it would reset
+    // the live stream's slot and cross-release its truncation pin.
+    #[tokio::test]
+    async fn a_duplicate_node_id_is_refused() {
+        let (storage, path) = temp_storage("dup-node");
+        let ctx = test_ctx(storage);
+        let (_shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+
+        // First connection holds node 5.
+        let (server1, _client1) = tokio::io::duplex(64 * 1024);
+        let ctx1 = ctx.clone();
+        let first = tokio::spawn(run_sender(
+            server1,
+            ctx1,
+            AcceptedStandby {
+                node_id: 5,
+                last_received_lsn: 0,
+            },
+            shutdown_rx.clone(),
+        ));
+        // Give the first sender time to register.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        let (server2, mut client2) = tokio::io::duplex(64 * 1024);
+        let second = tokio::spawn(run_sender(
+            server2,
+            ctx.clone(),
+            AcceptedStandby {
+                node_id: 5,
+                last_received_lsn: 0,
+            },
+            shutdown_rx,
+        ));
+        let notice: HelloAck = read_repl_frame(&mut client2)
+            .await
+            .unwrap()
+            .decode()
+            .unwrap();
+        assert!(!notice.accepted);
+        assert!(
+            notice.message.contains("already connected"),
+            "{}",
+            notice.message
+        );
+        assert!(second.await.unwrap().is_err());
+
+        first.abort();
+        let _ = first.await;
+        // The membership guard released the id on abort, so it is reusable.
+        assert!(!ctx.active_nodes.lock().unwrap().contains(&5));
+        let _ = std::fs::remove_file(path);
     }
 }

--- a/crates/truthdb-core/src/repl/tls.rs
+++ b/crates/truthdb-core/src/repl/tls.rs
@@ -38,6 +38,14 @@ pub fn server_config_from_pem(cert_pem: &[u8], key_pem: &[u8]) -> io::Result<Arc
     Ok(Arc::new(config))
 }
 
+/// Builds the primary listener's `TlsAcceptor` from a certificate + private
+/// key PEM — the one-call form the server binary wires from its config.
+pub fn acceptor_from_pem(cert_pem: &[u8], key_pem: &[u8]) -> io::Result<tokio_rustls::TlsAcceptor> {
+    Ok(tokio_rustls::TlsAcceptor::from(server_config_from_pem(
+        cert_pem, key_pem,
+    )?))
+}
+
 /// Builds a standby's TLS `ClientConfig` that trusts exactly the given
 /// certificate(s) as roots — the primary's self-signed (or CA) cert. The standby
 /// verifies the primary against this, so a wrong endpoint fails the handshake.

--- a/crates/truthdb-core/src/storage.rs
+++ b/crates/truthdb-core/src/storage.rs
@@ -746,7 +746,24 @@ impl Storage {
         log_paths: &[std::path::PathBuf],
         stop_at: Option<u64>,
     ) -> Result<(), StorageError> {
-        Self::restore_full_inner(dst_path, bak_path, log_paths, &[], stop_at)
+        Self::restore_full_inner(dst_path, bak_path, log_paths, &[], stop_at, false)
+    }
+
+    /// Offline restore of a full backup (plus an optional `BACKUP LOG` chain)
+    /// as a replication STANDBY seed: the file is stamped `is_standby` before
+    /// its validating open, so recovery REPEATS history only (redo, no ARIES
+    /// undo) and the file opens read-only. A plain restore's undo would roll
+    /// back a transaction that was in flight at backup time with CLRs; if the
+    /// primary later committed it, the CLRs' page LSNs would mask the shipped
+    /// redo and the replica would silently diverge. Point-in-time restore is
+    /// meaningless for a seed (the standby must match the primary, not a past
+    /// point), so there is no `stop_at` here.
+    pub fn restore_full_standby(
+        dst_path: &Path,
+        bak_path: &Path,
+        log_paths: &[std::path::PathBuf],
+    ) -> Result<(), StorageError> {
+        Self::restore_full_inner(dst_path, bak_path, log_paths, &[], None, true)
     }
 
     /// Offline restore of a full backup followed by raw shipped WAL ring ranges —
@@ -759,7 +776,7 @@ impl Storage {
         bak_path: &Path,
         wal_ranges: &[(u64, Vec<u8>)],
     ) -> Result<(), StorageError> {
-        Self::restore_full_inner(dst_path, bak_path, &[], wal_ranges, None)
+        Self::restore_full_inner(dst_path, bak_path, &[], wal_ranges, None, false)
     }
 
     fn restore_full_inner(
@@ -768,6 +785,7 @@ impl Storage {
         log_paths: &[std::path::PathBuf],
         wal_ranges: &[(u64, Vec<u8>)],
         stop_at: Option<u64>,
+        standby: bool,
     ) -> Result<(), StorageError> {
         assert_layout_invariants();
         let reader = std::io::BufReader::new(std::fs::File::open(bak_path)?);
@@ -799,7 +817,7 @@ impl Storage {
         // later step fails, so a retry (which requires a fresh destination) can
         // proceed. Everything ABOVE this point errors without having created it.
         let outcome = Self::restore_body(
-            file, backup, &header, log_paths, wal_ranges, dst_path, stop_at,
+            file, backup, &header, log_paths, wal_ranges, dst_path, stop_at, standby,
         );
         if outcome.is_err() {
             let _ = std::fs::remove_file(dst_path);
@@ -820,6 +838,7 @@ impl Storage {
         wal_ranges: &[(u64, Vec<u8>)],
         dst_path: &Path,
         stop_at: Option<u64>,
+        standby: bool,
     ) -> Result<(), StorageError> {
         use crate::backup::{BlockType, decode_alloc_map, decode_log_chunk, decode_page_run};
         let data_pages = header.data_size / PAGE_SIZE as u64;
@@ -890,8 +909,10 @@ impl Storage {
             )?;
         }
         // The restored superblock brackets the ring at `[redo_start, tail)`; the
-        // log-backup floor is the end of the applied chain (a fresh chain).
-        file.restore_superblock(header, tail)?;
+        // log-backup floor is the end of the applied chain (a fresh chain). A
+        // standby seed is stamped BEFORE the validating open, so that open is
+        // redo-only + read-only from the file's first moment.
+        file.restore_superblock(header, tail, standby)?;
         file.sync_file()?;
         drop(file);
 
@@ -1529,25 +1550,31 @@ impl Storage {
     /// The durable WAL watermark: the greatest LSN fsynced to disk (group-commit
     /// or a direct WAL sync). A replication sender may ship the ring up to here;
     /// bytes past it are not yet durable on the primary and must not be applied
-    /// to a standby. (Test scaffolding for the offline standby-apply slice; the
-    /// replication transport slice promotes it to the sender.)
-    #[cfg(test)]
+    /// to a standby.
     pub(crate) fn wal_flushed_lsn(&self) -> u64 {
         let durable = self.gc.flushed();
         self.lock().wal.flushed_lsn().max(durable)
     }
 
+    /// Subscribes to group-commit durable-watermark advances so a tokio task
+    /// (the replication sender) can await new shippable WAL. The carried value
+    /// is a wake-up hint: WAL made durable by a direct sync bypasses the
+    /// channel, so re-read [`Self::wal_flushed_lsn`] after each wake and pair
+    /// the watch with a periodic tick.
+    pub(crate) fn subscribe_wal_flushed(&self) -> tokio::sync::watch::Receiver<u64> {
+        self.gc.subscribe_flushed()
+    }
+
     /// Reads raw WAL ring bytes `[from, to)` — the physical-replication ship
-    /// primitive. A standby applies the bytes via
-    /// [`Storage::restore_full_with_wal_ranges`].
-    #[cfg(test)]
+    /// primitive. A standby applies the bytes via [`Storage::apply_wal_stream`]
+    /// (live) or [`Storage::restore_full_with_wal_ranges`] (offline seed).
     pub(crate) fn read_wal_range(&self, from: u64, to: u64) -> Result<Vec<u8>, StorageError> {
         self.lock().read_ring_range(from, to)
     }
 
     /// The persisted replication restartpoint (the active superblock's
     /// `applied_lsn`): the LSN up to which this file's WAL is present and
-    /// recovered.
+    /// recovered. (Test-only until the monitoring slice reads it.)
     #[cfg(test)]
     pub(crate) fn applied_lsn(&self) -> u64 {
         let guard = self.lock();
@@ -1558,14 +1585,47 @@ impl Storage {
         active.applied_lsn()
     }
 
-    /// Replication-slot test scaffolding (the transport receiver slice promotes
-    /// these to the ack path). A slot holds WAL-ring truncation at its LSN.
-    #[cfg(test)]
-    pub(crate) fn register_repl_slot(&self, id: u32, lsn: u64) {
-        self.lock().register_repl_slot(id, lsn);
+    /// Whether this file is a replication standby (redo-only, read-only until
+    /// promotion).
+    pub fn is_standby(&self) -> bool {
+        let guard = self.lock();
+        let active = match guard.active_superblock {
+            ActiveSuperblock::A => &guard.superblock_a,
+            ActiveSuperblock::B => &guard.superblock_b,
+        };
+        active.is_standby()
     }
 
+    /// The persisted replication epoch (bumped once at each promotion; zero
+    /// until the first failover). Both sides of the replication handshake
+    /// exchange it so a diverged old primary's stream can be fenced off.
+    pub(crate) fn epoch(&self) -> u64 {
+        let guard = self.lock();
+        let active = match guard.active_superblock {
+            ActiveSuperblock::A => &guard.superblock_a,
+            ActiveSuperblock::B => &guard.superblock_b,
+        };
+        active.epoch()
+    }
+
+    /// Durably sets the replication epoch (a promotion bumps it by one;
+    /// test-only until the failover slice performs promotions).
     #[cfg(test)]
+    pub(crate) fn set_epoch(&self, epoch: u64) -> Result<(), StorageError> {
+        self.lock().commit_superblock(|sb| sb.set_epoch(epoch))
+    }
+
+    /// Registers (or resets) a replication slot at `lsn`, holding WAL-ring
+    /// truncation there. Fails if `lsn` is behind the WAL head (the log the
+    /// standby needs is already truncated — it must reseed) or if the slot
+    /// table is full; the check and the insert happen under one lock hold, so
+    /// a concurrent checkpoint cannot truncate between them.
+    pub(crate) fn try_register_repl_slot(&self, id: u32, lsn: u64) -> Result<(), StorageError> {
+        self.lock().try_register_repl_slot(id, lsn)
+    }
+
+    /// Advances a slot's held LSN (never backward). A no-op if the slot does
+    /// not exist — an ack racing a reap must not resurrect a reaped slot.
     pub(crate) fn advance_repl_slot(&self, id: u32, lsn: u64) {
         self.lock().advance_repl_slot(id, lsn);
     }
@@ -1575,15 +1635,27 @@ impl Storage {
         self.lock().drop_repl_slot(id);
     }
 
+    /// A slot's held LSN. (Test-only until the monitoring slice reads it.)
     #[cfg(test)]
     pub(crate) fn repl_slot_lsn(&self, id: u32) -> Option<u64> {
         self.lock().repl_slot_lsn(id)
     }
 
-    /// Sets the slot-retention cap that the checkpoint reap enforces.
-    #[cfg(test)]
-    pub(crate) fn set_max_slot_retain_bytes(&self, bytes: u64) {
-        self.lock().max_slot_retain_bytes = bytes;
+    /// Sets the slot-retention cap that the checkpoint reap enforces. The cap
+    /// must be strictly below the ring's usable capacity (`wal_size -
+    /// reserve`): at or above it, appends hit `WalFull` before any slot lags
+    /// far enough to reap, wedging the primary behind a dead standby.
+    pub fn set_max_slot_retain_bytes(&self, bytes: u64) -> Result<(), StorageError> {
+        let mut guard = self.lock();
+        let usable = guard.layout.wal_size.saturating_sub(guard.wal.reserve());
+        if bytes >= usable {
+            return Err(StorageError::InvalidConfig(format!(
+                "max_slot_retain_bytes ({bytes}) must be below the WAL ring's usable capacity ({usable}); \
+                 a cap at or above it wedges the primary with WalFull before the slot reap can run"
+            )));
+        }
+        guard.max_slot_retain_bytes = bytes;
+        Ok(())
     }
 
     /// Atomic snapshot scan: the whole table under one storage-lock hold
@@ -5355,19 +5427,41 @@ impl StorageFile {
     /// Registers (or resets) a replication slot at `lsn`. `lsn` must be `>=` the
     /// current WAL head (a standby's received LSN is always within the retained
     /// window — the primary cannot have already truncated it); a below-head slot
-    /// would drive `set_head` below the current head, which it forbids. The
-    /// transport slice enforces this at registration.
-    #[cfg(test)]
-    fn register_repl_slot(&mut self, id: u32, lsn: u64) {
+    /// would drive `set_head` below the current head, which it forbids. Checked
+    /// here, under the storage lock, so a checkpoint cannot truncate between
+    /// the check and the insert. The table is bounded by [`MAX_REPL_SLOTS`]
+    /// (the superblock persists at most that many; a silent in-memory overflow
+    /// would lose a slot's hold across a restart).
+    fn try_register_repl_slot(&mut self, id: u32, lsn: u64) -> Result<(), StorageError> {
+        let head = self.wal.head();
+        if lsn < head {
+            return Err(StorageError::InvalidConfig(format!(
+                "replication slot {id} at LSN {lsn} is behind the WAL head ({head}): \
+                 the log the standby needs is already truncated; reseed the standby \
+                 from a fresh backup"
+            )));
+        }
+        if self.truncation_gate.repl_slots.len() >= crate::storage_layout::MAX_REPL_SLOTS
+            && !self.truncation_gate.repl_slots.contains_key(&id)
+        {
+            return Err(StorageError::InvalidConfig(format!(
+                "replication slot table is full ({} slots): drop a stale slot before \
+                 registering slot {id}",
+                crate::storage_layout::MAX_REPL_SLOTS
+            )));
+        }
         self.truncation_gate.repl_slots.insert(id, lsn);
+        Ok(())
     }
 
     /// Advances a slot forward to `lsn` — a slot never moves backward (a
-    /// standby's received watermark only grows).
-    #[cfg(test)]
+    /// standby's received watermark only grows), and a missing slot is not
+    /// created (an ack arriving after a reap must not resurrect the slot
+    /// without the registration checks).
     fn advance_repl_slot(&mut self, id: u32, lsn: u64) {
-        let held = self.truncation_gate.repl_slots.entry(id).or_insert(lsn);
-        *held = (*held).max(lsn);
+        if let Some(held) = self.truncation_gate.repl_slots.get_mut(&id) {
+            *held = (*held).max(lsn);
+        }
     }
 
     #[cfg(test)]
@@ -5965,6 +6059,7 @@ impl StorageFile {
         &mut self,
         header: &crate::backup::BackupHeader,
         backup_end: u64,
+        standby: bool,
     ) -> Result<(), StorageError> {
         let mut base = Superblock {
             wal_head: header.redo_start_lsn,
@@ -5982,6 +6077,7 @@ impl StorageFile {
         // The restartpoint = the end of everything laid down (full backup + any
         // applied log chain / shipped WAL ranges), which is the restored tail.
         base.set_applied_lsn(backup_end);
+        base.set_standby(standby);
 
         let mut a = base;
         a.generation = 1;
@@ -6367,9 +6463,11 @@ impl StorageFile {
         // the log-backup floor must be stamped back in or a checkpoint would
         // silently reset it to 0 and drop the FULL-model hold across a restart.
         let last_log_backup_lsn = self.last_log_backup_lsn;
-        // Carry the standby (redo-only) mode across the checkpoint (the closure
-        // builds from a default superblock that would otherwise clear it).
+        // Carry the standby (redo-only) mode and the replication epoch across
+        // the checkpoint (the closure builds from a default superblock that
+        // would otherwise clear them).
         let standby = self.active_sb().is_standby();
+        let epoch = self.active_sb().epoch();
         // Persist the (post-reap) replication slots, so their truncation hold is
         // re-established on the next open. Snapshotted after the reap above, so an
         // invalidated slot is not written back.
@@ -6400,6 +6498,7 @@ impl StorageFile {
             // Re-stamp the replication slot table (same checkpoint-wipe carry).
             sb.set_repl_slots(&repl_slots);
             sb.set_standby(standby);
+            sb.set_epoch(epoch);
             sb.checksum = sb.compute_checksum();
             sb
         };

--- a/crates/truthdb-core/src/storage.rs
+++ b/crates/truthdb-core/src/storage.rs
@@ -25,8 +25,8 @@ use crate::relstore::version::{
 };
 use crate::storage_layout::{
     FileHeader, PAGE_SIZE, SNAPSHOT_DESCRIPTOR_SIZE, SUPERBLOCK_ACTIVE_A, SUPERBLOCK_ACTIVE_B,
-    SnapshotDescriptor, Superblock, WAL_ENTRY_TYPE_REL, WAL_MAX_BYTES, WAL_MIN_BYTES, align_down,
-    assert_layout_invariants,
+    SnapshotDescriptor, Superblock, WAL_ENTRY_HEADER_SIZE, WAL_ENTRY_TYPE_REL, WAL_MAX_BYTES,
+    WAL_MIN_BYTES, WalEntryHeader, align_down, assert_layout_invariants, wal_entry_padded_len,
 };
 use crate::wal::records::{
     REL_KIND_ALLOC_EXTENT, REL_KIND_FREE_EXTENT, REL_KIND_SET_CATALOG_ROOT, RelRecord,
@@ -1565,11 +1565,43 @@ impl Storage {
         self.gc.subscribe_flushed()
     }
 
-    /// Reads raw WAL ring bytes `[from, to)` — the physical-replication ship
-    /// primitive. A standby applies the bytes via [`Storage::apply_wal_stream`]
-    /// (live) or [`Storage::restore_full_with_wal_ranges`] (offline seed).
+    /// Reads raw WAL ring bytes `[from, to)`. Test scaffolding: the production
+    /// ship primitive is [`Self::read_wal_chunk`], which cuts on entry
+    /// boundaries and fences against the WAL head.
+    #[cfg(test)]
     pub(crate) fn read_wal_range(&self, from: u64, to: u64) -> Result<Vec<u8>, StorageError> {
         self.lock().read_ring_range(from, to)
+    }
+
+    /// The physical-replication ship primitive: reads one chunk of raw WAL
+    /// ring bytes starting at `from`, ending on a WAL-ENTRY BOUNDARY at most
+    /// `max_bytes` past `from` (a single oversized entry is returned whole),
+    /// and never past `to_cap`. Returns the bytes and the chunk's end LSN —
+    /// the only LSNs a sender may hand a standby, since
+    /// [`Storage::apply_wal_stream`] persists its range end as the standby's
+    /// applied tail and a mid-entry tail would make every later decode
+    /// silently fail. The head fence and the read happen under one lock hold:
+    /// if `from` is below the WAL head the log is already truncated (the
+    /// standby's slot was reaped) and shipping would return recycled
+    /// ring bytes from a newer lap — the error tells the standby to reseed.
+    pub(crate) fn read_wal_chunk(
+        &self,
+        from: u64,
+        to_cap: u64,
+        max_bytes: u64,
+    ) -> Result<(Vec<u8>, u64), StorageError> {
+        let mut guard = self.lock();
+        let head = guard.wal.head();
+        if from < head {
+            return Err(StorageError::InvalidConfig(format!(
+                "replication position {from} is behind the WAL head ({head}): the log the \
+                 standby needs was truncated (its slot lapsed); reseed the standby from a \
+                 fresh backup"
+            )));
+        }
+        let end = guard.wal_chunk_end(from, to_cap, max_bytes)?;
+        let bytes = guard.read_ring_range(from, end)?;
+        Ok((bytes, end))
     }
 
     /// The persisted replication restartpoint (the active superblock's
@@ -1583,6 +1615,22 @@ impl Storage {
             ActiveSuperblock::B => &guard.superblock_b,
         };
         active.applied_lsn()
+    }
+
+    /// The LSN a standby resumes shipping from: the PERSISTED tail (the active
+    /// superblock's), not the live one. A crash between an apply's ring fsync
+    /// and its superblock commit — or a redo-only reopen that recovered extra
+    /// durable ring bytes — leaves the live tail ahead of the persisted tail,
+    /// and the apply continuity check compares against the persisted value; a
+    /// resume from the live tail would then be a permanent 4305 gap. Resuming
+    /// from the persisted tail re-ships the overlap, which is idempotent.
+    pub(crate) fn standby_resume_lsn(&self) -> u64 {
+        let guard = self.lock();
+        let active = match guard.active_superblock {
+            ActiveSuperblock::A => &guard.superblock_a,
+            ActiveSuperblock::B => &guard.superblock_b,
+        };
+        active.wal_tail
     }
 
     /// Whether this file is a replication standby (redo-only, read-only until
@@ -5455,10 +5503,12 @@ impl StorageFile {
     }
 
     /// Advances a slot forward to `lsn` — a slot never moves backward (a
-    /// standby's received watermark only grows), and a missing slot is not
-    /// created (an ack arriving after a reap must not resurrect the slot
+    /// standby's received watermark only grows), never past the WAL tail (an
+    /// absurd acked LSN must not unpin log that exists), and a missing slot is
+    /// not created (an ack arriving after a reap must not resurrect the slot
     /// without the registration checks).
     fn advance_repl_slot(&mut self, id: u32, lsn: u64) {
+        let lsn = lsn.min(self.wal.tail());
         if let Some(held) = self.truncation_gate.repl_slots.get_mut(&id) {
             *held = (*held).max(lsn);
         }
@@ -5806,6 +5856,82 @@ impl StorageFile {
         Ok(out)
     }
 
+    /// Walks WAL-entry headers from `from` (which must itself be an entry
+    /// boundary within the valid log) and returns the furthest ENTRY BOUNDARY
+    /// reachable within `max_bytes`, never past `to_cap`. A ring-wrap gap
+    /// (zero-fill to the lap end) is crossed together with the first entry of
+    /// the next lap, so a returned boundary is never inside or at the start of
+    /// a gap a chunk does not also bridge. If the very first step (one entry,
+    /// or gap + one entry) exceeds `max_bytes`, it is returned anyway — the
+    /// chunk must make progress, and the caller bounds the frame size.
+    fn wal_chunk_end(
+        &mut self,
+        from: u64,
+        to_cap: u64,
+        max_bytes: u64,
+    ) -> Result<u64, StorageError> {
+        let wal_offset = self.layout.wal_offset;
+        let wal_size = self.layout.wal_size;
+        let mut cursor = from;
+        let mut last_boundary = from;
+        while cursor < to_cap {
+            let ring_pos = cursor % wal_size;
+            let bytes_to_lap_end = wal_size - ring_pos;
+            // A wrap gap (too small for a header, or zero-filled): cross it as
+            // part of the next entry's step.
+            let gap_jump = if bytes_to_lap_end < WAL_ENTRY_HEADER_SIZE as u64 {
+                true
+            } else {
+                let mut header_bytes = [0u8; WAL_ENTRY_HEADER_SIZE];
+                self.wal
+                    .file_mut()
+                    .read_exact_at(wal_offset + ring_pos, &mut header_bytes)?;
+                if header_bytes.iter().all(|b| *b == 0) {
+                    true
+                } else {
+                    let header = WalEntryHeader::from_le_bytes(&header_bytes);
+                    if !header.verify_header_crc() {
+                        return Err(StorageError::InvalidFile(format!(
+                            "WAL entry header at LSN {cursor} fails its CRC inside the \
+                             durable range [{from}, {to_cap}): cannot ship the log"
+                        )));
+                    }
+                    let entry_len = wal_entry_padded_len(header.payload_len as usize) as u64;
+                    let next = cursor + entry_len;
+                    if next > to_cap {
+                        // The durable cap always sits on an entry boundary; an
+                        // entry crossing it means `from` was not a boundary.
+                        return Err(StorageError::InvalidFile(format!(
+                            "WAL entry at LSN {cursor} extends past the durable watermark \
+                             {to_cap}: misaligned ship position"
+                        )));
+                    }
+                    if next - from > max_bytes && last_boundary > from {
+                        return Ok(last_boundary);
+                    }
+                    cursor = next;
+                    last_boundary = next;
+                    continue;
+                }
+            };
+            if gap_jump {
+                // Jump to the lap end; the loop then takes the next lap's first
+                // entry before this jump can become a boundary.
+                let next = cursor + bytes_to_lap_end;
+                if next >= to_cap {
+                    // Nothing but gap remains below the cap.
+                    return Ok(last_boundary);
+                }
+                if next - from > max_bytes && last_boundary > from {
+                    return Ok(last_boundary);
+                }
+                cursor = next;
+                // NOT a boundary: fall through to read the next lap's entry.
+            }
+        }
+        Ok(last_boundary)
+    }
+
     /// Phase 1 of `BACKUP LOG`: under the storage lock, capture the log range
     /// `[last_log_backup_lsn, tail)` and its bytes plus the archive header. Does
     /// NOT advance the marker or hold, so the old marker keeps pinning the range
@@ -6009,12 +6135,44 @@ impl StorageFile {
             from_lsn,
             from_lsn,
         )?;
+        // The shipped range must decode END TO END. A short scan means the
+        // range was cut mid-entry (a misaligned sender) or carries recycled
+        // bytes from another ring lap (a lapsed slot): advancing the tail over
+        // undecoded bytes would silently skip their redo forever — the page-LSN
+        // gate then masks the loss on every future record. Fail the apply
+        // instead; the connection drops and the operator sees it.
+        if scan.tail < advanced {
+            return Err(StorageError::InvalidFile(format!(
+                "shipped WAL range [{from_lsn}, {new_end}) only decodes to {}: the range is \
+                 cut mid-entry or holds recycled bytes; refusing to apply it",
+                scan.tail
+            )));
+        }
         let records: Vec<(u64, RelRecord)> = scan
             .records
             .iter()
             .filter(|record| record.entry_type == WAL_ENTRY_TYPE_REL)
             .map(|record| Ok((record.logical_ts, RelRecord::decode(&record.payload)?)))
             .collect::<Result<_, StorageError>>()?;
+
+        // Replay allocation state: the live pool redo below writes page images,
+        // but the ALLOCATOR is only rebuilt at open — without this, an extent
+        // the primary allocated after the standby opened stays free in the
+        // standby's in-memory bitmap, and a spilling read on the standby could
+        // allocate scratch space over replicated pages.
+        for (_, record) in &records {
+            match record.kind {
+                REL_KIND_ALLOC_EXTENT => {
+                    let (start, pages) = record.decode_extent_redo()?;
+                    self.allocator.mark_used(start, pages);
+                }
+                REL_KIND_FREE_EXTENT => {
+                    let (start, pages) = record.decode_extent_redo()?;
+                    self.allocator.free(start, pages);
+                }
+                _ => {}
+            }
+        }
 
         // A catalog-root change in the range moves the standby's catalog root
         // (the last one wins).

--- a/crates/truthdb-core/src/storage.rs
+++ b/crates/truthdb-core/src/storage.rs
@@ -5498,8 +5498,76 @@ impl StorageFile {
                 crate::storage_layout::MAX_REPL_SLOTS
             )));
         }
+        // The LSN comes off the wire (Hello.last_received_lsn) and becomes the
+        // truncation floor — which a checkpoint persists as the WAL head, the
+        // very position the next restart scans from. A mid-entry floor would
+        // make that scan read garbage and silently truncate every commit since
+        // the checkpoint. Only a verifiable ENTRY BOUNDARY may be registered;
+        // an honest standby's persisted tail always is one.
+        if !self.is_wal_entry_boundary(lsn)? {
+            return Err(StorageError::InvalidConfig(format!(
+                "replication slot {id} at LSN {lsn} is not on a WAL entry boundary: \
+                 the standby's resume state is corrupt or forged; reseed the standby \
+                 from a fresh backup"
+            )));
+        }
         self.truncation_gate.repl_slots.insert(id, lsn);
         Ok(())
+    }
+
+    /// Whether `lsn` sits on a WAL entry boundary of THIS log: the tail
+    /// itself, a position carrying a CRC-valid entry header that self-identifies
+    /// (`logical_ts == lsn`), or a ring-wrap gap start whose next lap opens
+    /// with a self-identifying valid entry. A forger cannot fabricate any of
+    /// these without controlling the actual log contents.
+    fn is_wal_entry_boundary(&mut self, lsn: u64) -> Result<bool, StorageError> {
+        let tail = self.wal.tail();
+        if lsn == tail {
+            return Ok(true);
+        }
+        if lsn > tail {
+            return Ok(false);
+        }
+        let wal_offset = self.layout.wal_offset;
+        let wal_size = self.layout.wal_size;
+        let check_entry_at =
+            |file: &mut crate::direct_io::DirectFile, pos: u64| -> Result<bool, StorageError> {
+                let ring_pos = pos % wal_size;
+                if wal_size - ring_pos < WAL_ENTRY_HEADER_SIZE as u64 {
+                    return Ok(false);
+                }
+                let mut header_bytes = [0u8; WAL_ENTRY_HEADER_SIZE];
+                file.read_exact_at(wal_offset + ring_pos, &mut header_bytes)?;
+                if header_bytes.iter().all(|b| *b == 0) {
+                    return Ok(false);
+                }
+                let header = WalEntryHeader::from_le_bytes(&header_bytes);
+                Ok(header.verify_header_crc() && header.logical_ts == pos)
+            };
+        let ring_pos = lsn % wal_size;
+        let bytes_to_lap_end = wal_size - ring_pos;
+        if bytes_to_lap_end >= WAL_ENTRY_HEADER_SIZE as u64 {
+            let mut header_bytes = [0u8; WAL_ENTRY_HEADER_SIZE];
+            self.wal
+                .file_mut()
+                .read_exact_at(wal_offset + ring_pos, &mut header_bytes)?;
+            if !header_bytes.iter().all(|b| *b == 0) {
+                let header = WalEntryHeader::from_le_bytes(&header_bytes);
+                return Ok(header.verify_header_crc() && header.logical_ts == lsn);
+            }
+        }
+        // Zeros (or no room for a header): a genuine boundary here is a wrap-gap
+        // start, provable by the next lap opening with a real entry below the
+        // tail. Mid-entry zeros cannot fake that — the jump target's entry must
+        // self-identify at exactly that position.
+        let jump = lsn + bytes_to_lap_end;
+        if jump == tail {
+            return Ok(true);
+        }
+        if jump > tail {
+            return Ok(false);
+        }
+        check_entry_at(self.wal.file_mut(), jump)
     }
 
     /// Advances a slot forward to `lsn` — a slot never moves backward (a
@@ -5637,6 +5705,22 @@ impl StorageFile {
 
     fn allocate_extent(&mut self, temp: bool) -> Result<u64, StorageError> {
         if temp {
+            // Spill scratch shares the data region and the allocator bitmap
+            // with REPLICATED extents. On a standby, an extent that is free at
+            // the applied LSN may already be allocated on the primary (its
+            // ALLOC record still in flight) — a spool there would be clobbered
+            // by the arriving redo, and the spool's raw writes would clobber
+            // replicated pages. Refuse until the readable-standby slice gives
+            // scratch its own storage.
+            if self.active_sb().is_standby() {
+                return Err(StorageError::InvalidConfig(
+                    "a query on this replication standby needed spill scratch, which shares \
+                     the data region the primary's stream writes into; re-run with more \
+                     memory or run it on the primary (readable-standby spill arrives with \
+                     snapshot standby reads)"
+                        .to_string(),
+                ));
+            }
             return self.allocator.allocate_temp_extent().ok_or_else(|| {
                 StorageError::InvalidConfig("data region full: cannot allocate extent".to_string())
             });

--- a/crates/truthdb-core/src/storage_layout.rs
+++ b/crates/truthdb-core/src/storage_layout.rs
@@ -352,15 +352,25 @@ impl Superblock {
         self.reserved[8..16].copy_from_slice(&lsn.to_le_bytes());
     }
 
+    /// Replication epoch: bumped once at each promotion, so a diverged old
+    /// primary's stream (a lower epoch) can be fenced off. Zero on every file
+    /// until the first failover. Stored in the reserved area (bytes 16..24)
+    /// and covered by the superblock checksum.
+    pub fn epoch(&self) -> u64 {
+        u64::from_le_bytes(self.reserved[16..24].try_into().unwrap())
+    }
+
+    pub fn set_epoch(&mut self, epoch: u64) {
+        self.reserved[16..24].copy_from_slice(&epoch.to_le_bytes());
+    }
+
     /// Replication restartpoint: the LSN up to which this file's WAL is present
     /// and recovered — a standby reads it to know where to resume shipping. It is
     /// stamped at each durable restartpoint (a checkpoint or a restore), where it
     /// equals `wal_tail`; between restartpoints the persisted value lags the live
     /// tail, exactly as the superblock's own `wal_tail` does. Stored in the
-    /// reserved area (bytes 24..32; 16..24 is left for the future replication
-    /// epoch) and covered by the superblock checksum. (The reader is test-only
-    /// until the replication receiver slice consumes the restartpoint in
-    /// production.)
+    /// reserved area (bytes 24..32) and covered by the superblock checksum.
+    /// (The reader is test-only until the monitoring slice consumes it.)
     #[cfg(test)]
     pub fn applied_lsn(&self) -> u64 {
         u64::from_le_bytes(self.reserved[24..32].try_into().unwrap())

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,6 +14,148 @@ pub struct Config {
 
     #[serde(default)]
     pub tds: TdsConfig,
+
+    #[serde(default)]
+    pub replication: ReplicationConfig,
+}
+
+/// Physical replication (Stage 18). Disabled by default. A `primary` runs the
+/// replication listener on `port` (default 9624, TLS mandatory) and streams WAL
+/// to authenticated standbys; a `standby` dials `primary_addr` and applies the
+/// stream (its database file must be seeded with `truthdb-cli restore
+/// --standby`). Both roles need the same `cluster_uuid` and `shared_secret`.
+#[derive(Debug, Deserialize)]
+pub struct ReplicationConfig {
+    #[serde(default)]
+    pub enabled: bool,
+
+    #[serde(default)]
+    pub role: ReplicationRole,
+
+    /// Primary: listener bind address.
+    #[serde(default = "default_addr")]
+    pub addr: String,
+
+    /// Primary: listener port.
+    #[serde(default = "default_replication_port")]
+    pub port: u16,
+
+    /// This node's id (also its replication-slot id on the primary; standbys
+    /// must use distinct ids).
+    #[serde(default = "default_replication_node_id")]
+    pub node_id: u32,
+
+    /// The cluster's identity, shared by every member: a UUID (hyphens
+    /// optional). Required when enabled.
+    #[serde(default)]
+    pub cluster_uuid: Option<String>,
+
+    /// The cluster's shared secret (the handshake's HMAC key). Required when
+    /// enabled; must not be empty.
+    #[serde(default)]
+    pub shared_secret: Option<String>,
+
+    /// Primary: PEM certificate chain path for the replication listener's TLS.
+    #[serde(default)]
+    pub tls_cert: Option<String>,
+
+    /// Primary: PEM private key path (paired with `tls_cert`).
+    #[serde(default)]
+    pub tls_key: Option<String>,
+
+    /// Standby: PEM path of the certificate (or CA) to trust for the primary.
+    #[serde(default)]
+    pub tls_ca: Option<String>,
+
+    /// Standby: the primary's replication endpoint, `host:port`.
+    #[serde(default)]
+    pub primary_addr: Option<String>,
+
+    /// Standby: the TLS server name the primary's certificate must match
+    /// (defaults to the host part of `primary_addr`).
+    #[serde(default)]
+    pub server_name: Option<String>,
+
+    /// Primary: the sender's idle heartbeat interval.
+    #[serde(default = "default_replication_heartbeat_ms")]
+    pub heartbeat_ms: u64,
+
+    /// Standby: delay between reconnect attempts.
+    #[serde(default = "default_replication_reconnect_ms")]
+    pub reconnect_delay_ms: u64,
+
+    /// Primary: drop a replication slot once it lags the WAL tail by more than
+    /// this many bytes (the standby must reseed). 0 = unlimited retention.
+    #[serde(default)]
+    pub max_slot_retain_bytes: u64,
+}
+
+/// `[replication] role = "primary" | "standby"`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ReplicationRole {
+    #[default]
+    Primary,
+    Standby,
+}
+
+impl Default for ReplicationConfig {
+    fn default() -> Self {
+        ReplicationConfig {
+            enabled: false,
+            role: ReplicationRole::default(),
+            addr: default_addr(),
+            port: default_replication_port(),
+            node_id: default_replication_node_id(),
+            cluster_uuid: None,
+            shared_secret: None,
+            tls_cert: None,
+            tls_key: None,
+            tls_ca: None,
+            primary_addr: None,
+            server_name: None,
+            heartbeat_ms: default_replication_heartbeat_ms(),
+            reconnect_delay_ms: default_replication_reconnect_ms(),
+            max_slot_retain_bytes: 0,
+        }
+    }
+}
+
+fn default_replication_port() -> u16 {
+    9624
+}
+
+fn default_replication_node_id() -> u32 {
+    1
+}
+
+fn default_replication_heartbeat_ms() -> u64 {
+    1000
+}
+
+fn default_replication_reconnect_ms() -> u64 {
+    1000
+}
+
+impl ReplicationConfig {
+    /// Parses `cluster_uuid` into its 16 raw bytes (hyphens optional).
+    pub fn cluster_uuid_bytes(&self) -> Result<[u8; 16], String> {
+        let raw = self
+            .cluster_uuid
+            .as_deref()
+            .ok_or("replication.cluster_uuid is required when replication is enabled")?;
+        let hex: String = raw.chars().filter(|c| *c != '-').collect();
+        if hex.len() != 32 || !hex.chars().all(|c| c.is_ascii_hexdigit()) {
+            return Err(format!(
+                "replication.cluster_uuid must be a UUID (32 hex digits, hyphens optional): {raw}"
+            ));
+        }
+        let mut out = [0u8; 16];
+        for (i, byte) in out.iter_mut().enumerate() {
+            *byte = u8::from_str_radix(&hex[i * 2..i * 2 + 2], 16).expect("checked hex");
+        }
+        Ok(out)
+    }
 }
 
 /// TDS (SQL Server protocol) gateway settings. Disabled by default; when
@@ -325,6 +467,9 @@ fn apply_override(override_cfg: ConfigOverride, config: &mut Config) {
     if let Some(tds) = override_cfg.tds {
         apply_tds_override(&mut config.tds, tds);
     }
+    if let Some(replication) = override_cfg.replication {
+        apply_replication_override(&mut config.replication, replication);
+    }
 }
 
 #[derive(Debug, Deserialize, Default)]
@@ -334,6 +479,74 @@ struct ConfigOverride {
     network: Option<NetworkConfigOverride>,
     storage: Option<StorageConfigOverride>,
     tds: Option<TdsConfigOverride>,
+    replication: Option<ReplicationConfigOverride>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct ReplicationConfigOverride {
+    enabled: Option<bool>,
+    role: Option<ReplicationRole>,
+    addr: Option<String>,
+    port: Option<u16>,
+    node_id: Option<u32>,
+    cluster_uuid: Option<String>,
+    shared_secret: Option<String>,
+    tls_cert: Option<String>,
+    tls_key: Option<String>,
+    tls_ca: Option<String>,
+    primary_addr: Option<String>,
+    server_name: Option<String>,
+    heartbeat_ms: Option<u64>,
+    reconnect_delay_ms: Option<u64>,
+    max_slot_retain_bytes: Option<u64>,
+}
+
+fn apply_replication_override(target: &mut ReplicationConfig, source: ReplicationConfigOverride) {
+    if let Some(enabled) = source.enabled {
+        target.enabled = enabled;
+    }
+    if let Some(role) = source.role {
+        target.role = role;
+    }
+    if let Some(addr) = source.addr {
+        target.addr = addr;
+    }
+    if let Some(port) = source.port {
+        target.port = port;
+    }
+    if let Some(node_id) = source.node_id {
+        target.node_id = node_id;
+    }
+    if source.cluster_uuid.is_some() {
+        target.cluster_uuid = source.cluster_uuid;
+    }
+    if source.shared_secret.is_some() {
+        target.shared_secret = source.shared_secret;
+    }
+    if source.tls_cert.is_some() {
+        target.tls_cert = source.tls_cert;
+    }
+    if source.tls_key.is_some() {
+        target.tls_key = source.tls_key;
+    }
+    if source.tls_ca.is_some() {
+        target.tls_ca = source.tls_ca;
+    }
+    if source.primary_addr.is_some() {
+        target.primary_addr = source.primary_addr;
+    }
+    if source.server_name.is_some() {
+        target.server_name = source.server_name;
+    }
+    if let Some(heartbeat_ms) = source.heartbeat_ms {
+        target.heartbeat_ms = heartbeat_ms;
+    }
+    if let Some(reconnect_delay_ms) = source.reconnect_delay_ms {
+        target.reconnect_delay_ms = reconnect_delay_ms;
+    }
+    if let Some(max_slot_retain_bytes) = source.max_slot_retain_bytes {
+        target.max_slot_retain_bytes = max_slot_retain_bytes;
+    }
 }
 
 #[derive(Debug, Deserialize, Default)]
@@ -468,6 +681,37 @@ mod tests {
         // Unset fields keep defaults.
         assert_eq!(config.network.addr, "0.0.0.0");
         assert_eq!(config.storage.path, "truth.db");
+    }
+
+    #[test]
+    fn replication_override_applies_and_uuid_parses() {
+        let toml = r#"
+            [replication]
+            enabled = true
+            role = "standby"
+            node_id = 3
+            cluster_uuid = "8f0e7a34-2d51-4c11-9c9e-3f6d2a7b1c05"
+            shared_secret = "s3cret"
+            primary_addr = "primary.example:9624"
+            tls_ca = "/tmp/ca.pem"
+        "#;
+        let mut config = default_config();
+        assert!(!config.replication.enabled, "disabled by default");
+        let override_cfg: ConfigOverride = toml::from_str(toml).unwrap();
+        apply_override(override_cfg, &mut config);
+
+        assert!(config.replication.enabled);
+        assert_eq!(config.replication.role, ReplicationRole::Standby);
+        assert_eq!(config.replication.node_id, 3);
+        assert_eq!(config.replication.port, 9624, "default port kept");
+        let uuid = config.replication.cluster_uuid_bytes().unwrap();
+        assert_eq!(uuid[0], 0x8f);
+        assert_eq!(uuid[15], 0x05);
+
+        config.replication.cluster_uuid = Some("not-a-uuid".to_string());
+        assert!(config.replication.cluster_uuid_bytes().is_err());
+        config.replication.cluster_uuid = None;
+        assert!(config.replication.cluster_uuid_bytes().is_err());
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -24,7 +24,7 @@ pub struct Config {
 /// to authenticated standbys; a `standby` dials `primary_addr` and applies the
 /// stream (its database file must be seeded with `truthdb-cli restore
 /// --standby`). Both roles need the same `cluster_uuid` and `shared_secret`.
-#[derive(Debug, Deserialize)]
+#[derive(Deserialize)]
 pub struct ReplicationConfig {
     #[serde(default)]
     pub enabled: bool,
@@ -84,10 +84,40 @@ pub struct ReplicationConfig {
     #[serde(default = "default_replication_reconnect_ms")]
     pub reconnect_delay_ms: u64,
 
+    /// Both roles: how long the peer may stay completely silent before the
+    /// connection is presumed dead (a healthy pair exchanges heartbeats/acks).
+    #[serde(default = "default_replication_stall_ms")]
+    pub stall_timeout_ms: u64,
+
     /// Primary: drop a replication slot once it lags the WAL tail by more than
     /// this many bytes (the standby must reseed). 0 = unlimited retention.
     #[serde(default)]
     pub max_slot_retain_bytes: u64,
+}
+
+/// The shared secret must not appear in logs (`debug!(?config)` logs the whole
+/// config at startup), so Debug redacts it.
+impl std::fmt::Debug for ReplicationConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ReplicationConfig")
+            .field("enabled", &self.enabled)
+            .field("role", &self.role)
+            .field("addr", &self.addr)
+            .field("port", &self.port)
+            .field("node_id", &self.node_id)
+            .field("cluster_uuid", &self.cluster_uuid)
+            .field("shared_secret", &self.shared_secret.as_ref().map(|_| "***"))
+            .field("tls_cert", &self.tls_cert)
+            .field("tls_key", &self.tls_key)
+            .field("tls_ca", &self.tls_ca)
+            .field("primary_addr", &self.primary_addr)
+            .field("server_name", &self.server_name)
+            .field("heartbeat_ms", &self.heartbeat_ms)
+            .field("reconnect_delay_ms", &self.reconnect_delay_ms)
+            .field("stall_timeout_ms", &self.stall_timeout_ms)
+            .field("max_slot_retain_bytes", &self.max_slot_retain_bytes)
+            .finish()
+    }
 }
 
 /// `[replication] role = "primary" | "standby"`.
@@ -116,6 +146,7 @@ impl Default for ReplicationConfig {
             server_name: None,
             heartbeat_ms: default_replication_heartbeat_ms(),
             reconnect_delay_ms: default_replication_reconnect_ms(),
+            stall_timeout_ms: default_replication_stall_ms(),
             max_slot_retain_bytes: 0,
         }
     }
@@ -135,6 +166,10 @@ fn default_replication_heartbeat_ms() -> u64 {
 
 fn default_replication_reconnect_ms() -> u64 {
     1000
+}
+
+fn default_replication_stall_ms() -> u64 {
+    30_000
 }
 
 impl ReplicationConfig {
@@ -498,6 +533,7 @@ struct ReplicationConfigOverride {
     server_name: Option<String>,
     heartbeat_ms: Option<u64>,
     reconnect_delay_ms: Option<u64>,
+    stall_timeout_ms: Option<u64>,
     max_slot_retain_bytes: Option<u64>,
 }
 
@@ -543,6 +579,9 @@ fn apply_replication_override(target: &mut ReplicationConfig, source: Replicatio
     }
     if let Some(reconnect_delay_ms) = source.reconnect_delay_ms {
         target.reconnect_delay_ms = reconnect_delay_ms;
+    }
+    if let Some(stall_timeout_ms) = source.stall_timeout_ms {
+        target.stall_timeout_ms = stall_timeout_ms;
     }
     if let Some(max_slot_retain_bytes) = source.max_slot_retain_bytes {
         target.max_slot_retain_bytes = max_slot_retain_bytes;

--- a/src/main.rs
+++ b/src/main.rs
@@ -266,6 +266,17 @@ async fn start_replication(
     if cfg.stall_timeout_ms == 0 {
         return Err("replication.stall_timeout_ms must be greater than 0".to_string());
     }
+    // Both stall deadlines assume the peer speaks at least once per window (a
+    // caught-up pair only exchanges heartbeats + their acks): a stall window
+    // that a healthy idle link cannot meet makes every connection flap.
+    if cfg.stall_timeout_ms < cfg.heartbeat_ms.saturating_mul(2) {
+        return Err(format!(
+            "replication.stall_timeout_ms ({}) must be at least twice heartbeat_ms ({}): \
+             a caught-up standby only speaks when the primary heartbeats, so a tighter \
+             stall window tears down healthy idle connections",
+            cfg.stall_timeout_ms, cfg.heartbeat_ms
+        ));
+    }
     let secret =
         cfg.shared_secret.clone().filter(|s| !s.is_empty()).ok_or(
             "replication.shared_secret is required (non-empty) when replication is enabled",

--- a/src/main.rs
+++ b/src/main.rs
@@ -113,6 +113,10 @@ async fn main() {
             return;
         }
     }
+    // The replication tasks share the storage directly (it is internally
+    // synchronized); the handle must be taken before the engine moves into its
+    // worker pool.
+    let storage_arc = engine.storage_arc();
     // The engine runs on its own thread behind a message channel; the async
     // listeners talk to it through a cloneable handle.
     let (engine, engine_join) = truthdb_core::session::spawn_engine(engine);
@@ -200,6 +204,20 @@ async fn main() {
         None
     };
 
+    // Optional physical replication (Stage 18): a primary's listener + senders,
+    // or a standby's receiver.
+    let repl_task = if config.replication.enabled {
+        match start_replication(&config.replication, storage_arc, &shutdown_tx).await {
+            Ok(task) => Some(task),
+            Err(err) => {
+                eprintln!("Failed to start replication: {err}");
+                return;
+            }
+        }
+    } else {
+        None
+    };
+
     info!("Starting TruthDB...");
 
     info!("TruthDB running (waiting for stop signal)");
@@ -210,6 +228,9 @@ async fn main() {
     let _ = listener_task.await;
     if let Some(tds_task) = tds_task {
         let _ = tds_task.await;
+    }
+    if let Some(repl_task) = repl_task {
+        let _ = repl_task.await;
     }
     // Stop the engine thread and wait for it to drain/exit.
     engine.shutdown();
@@ -222,4 +243,104 @@ fn load_tds_tls(cert_path: &str, key_path: &str) -> std::io::Result<truthdb_tds:
     let cert = std::fs::read(cert_path)?;
     let key = std::fs::read(key_path)?;
     truthdb_tds::tls::TlsConfig::from_pem(&cert, &key)
+}
+
+/// Validates the replication config and spawns the role's task: a primary's
+/// TLS listener (+ per-standby senders), or a standby's reconnecting receiver.
+/// A misconfiguration is a startup error, not a degraded run.
+async fn start_replication(
+    cfg: &config::ReplicationConfig,
+    storage: std::sync::Arc<Storage>,
+    shutdown_tx: &watch::Sender<bool>,
+) -> Result<tokio::task::JoinHandle<()>, String> {
+    use truthdb_core::repl::listener::{PrimaryReplContext, run_repl_listener};
+    use truthdb_core::repl::receiver::{ReceiverConfig, run_standby_receiver};
+
+    let cluster_uuid = cfg.cluster_uuid_bytes()?;
+    let secret =
+        cfg.shared_secret.clone().filter(|s| !s.is_empty()).ok_or(
+            "replication.shared_secret is required (non-empty) when replication is enabled",
+        )?;
+
+    match cfg.role {
+        config::ReplicationRole::Primary => {
+            let (cert_path, key_path) = match (&cfg.tls_cert, &cfg.tls_key) {
+                (Some(cert), Some(key)) => (cert, key),
+                _ => return Err("a replication primary needs tls_cert and tls_key".to_string()),
+            };
+            let cert = std::fs::read(cert_path)
+                .map_err(|err| format!("replication tls_cert {cert_path}: {err}"))?;
+            let key = std::fs::read(key_path)
+                .map_err(|err| format!("replication tls_key {key_path}: {err}"))?;
+            let acceptor = truthdb_core::repl::tls::acceptor_from_pem(&cert, &key)
+                .map_err(|err| format!("replication TLS: {err}"))?;
+            if cfg.max_slot_retain_bytes > 0 {
+                storage
+                    .set_max_slot_retain_bytes(cfg.max_slot_retain_bytes)
+                    .map_err(|err| err.to_string())?;
+            }
+            let listener = tokio::net::TcpListener::bind((cfg.addr.as_str(), cfg.port))
+                .await
+                .map_err(|err| format!("replication listener {}:{}: {err}", cfg.addr, cfg.port))?;
+            info!(
+                "Replication primary listening on {}:{} (node {})",
+                cfg.addr, cfg.port, cfg.node_id
+            );
+            let ctx = PrimaryReplContext {
+                shared_secret: std::sync::Arc::new(secret.into_bytes()),
+                cluster_uuid,
+                storage,
+                heartbeat: std::time::Duration::from_millis(cfg.heartbeat_ms),
+            };
+            let shutdown_rx = shutdown_tx.subscribe();
+            Ok(tokio::spawn(run_repl_listener(
+                listener,
+                acceptor,
+                ctx,
+                shutdown_rx,
+            )))
+        }
+        config::ReplicationRole::Standby => {
+            let primary_addr = cfg
+                .primary_addr
+                .clone()
+                .ok_or("a replication standby needs primary_addr")?;
+            let ca_path = cfg
+                .tls_ca
+                .as_ref()
+                .ok_or("a replication standby needs tls_ca (the certificate to trust)")?;
+            let tls_ca_pem = std::fs::read(ca_path)
+                .map_err(|err| format!("replication tls_ca {ca_path}: {err}"))?;
+            if !storage.is_standby() {
+                return Err("this database is not a standby seed; restore it with \
+                     `truthdb-cli restore --standby`"
+                    .to_string());
+            }
+            let server_name = cfg.server_name.clone().unwrap_or_else(|| {
+                primary_addr
+                    .rsplit_once(':')
+                    .map(|(host, _)| host.to_string())
+                    .unwrap_or_else(|| primary_addr.clone())
+            });
+            let receiver_cfg = ReceiverConfig {
+                primary_addr: primary_addr.clone(),
+                server_name,
+                tls_ca_pem,
+                shared_secret: secret.into_bytes(),
+                cluster_uuid,
+                node_id: cfg.node_id,
+                reconnect_delay: std::time::Duration::from_millis(cfg.reconnect_delay_ms),
+            };
+            info!(
+                "Replication standby (node {}) following {}",
+                cfg.node_id, primary_addr
+            );
+            let shutdown_rx = shutdown_tx.subscribe();
+            Ok(tokio::spawn(run_standby_receiver(
+                receiver_cfg,
+                storage,
+                shutdown_rx,
+            )))
+        }
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -257,6 +257,15 @@ async fn start_replication(
     use truthdb_core::repl::receiver::{ReceiverConfig, run_standby_receiver};
 
     let cluster_uuid = cfg.cluster_uuid_bytes()?;
+    if cfg.heartbeat_ms == 0 {
+        return Err("replication.heartbeat_ms must be greater than 0".to_string());
+    }
+    if cfg.reconnect_delay_ms == 0 {
+        return Err("replication.reconnect_delay_ms must be greater than 0".to_string());
+    }
+    if cfg.stall_timeout_ms == 0 {
+        return Err("replication.stall_timeout_ms must be greater than 0".to_string());
+    }
     let secret =
         cfg.shared_secret.clone().filter(|s| !s.is_empty()).ok_or(
             "replication.shared_secret is required (non-empty) when replication is enabled",
@@ -291,6 +300,9 @@ async fn start_replication(
                 cluster_uuid,
                 storage,
                 heartbeat: std::time::Duration::from_millis(cfg.heartbeat_ms),
+                stall_timeout: std::time::Duration::from_millis(cfg.stall_timeout_ms),
+                chunk_bytes: truthdb_core::repl::sender::DEFAULT_CHUNK_BYTES,
+                active_nodes: std::sync::Arc::default(),
             };
             let shutdown_rx = shutdown_tx.subscribe();
             Ok(tokio::spawn(run_repl_listener(
@@ -317,10 +329,16 @@ async fn start_replication(
                     .to_string());
             }
             let server_name = cfg.server_name.clone().unwrap_or_else(|| {
-                primary_addr
+                let host = primary_addr
                     .rsplit_once(':')
-                    .map(|(host, _)| host.to_string())
-                    .unwrap_or_else(|| primary_addr.clone())
+                    .map(|(host, _)| host)
+                    .unwrap_or(primary_addr.as_str());
+                // A bracketed IPv6 host ("[2001:db8::1]:9624") is not a valid
+                // TLS server name with the brackets on.
+                host.strip_prefix('[')
+                    .and_then(|h| h.strip_suffix(']'))
+                    .unwrap_or(host)
+                    .to_string()
             });
             let receiver_cfg = ReceiverConfig {
                 primary_addr: primary_addr.clone(),
@@ -330,6 +348,7 @@ async fn start_replication(
                 cluster_uuid,
                 node_id: cfg.node_id,
                 reconnect_delay: std::time::Duration::from_millis(cfg.reconnect_delay_ms),
+                stall_timeout: std::time::Duration::from_millis(cfg.stall_timeout_ms),
             };
             info!(
                 "Replication standby (node {}) following {}",


### PR DESCRIPTION
The transport runtime for physical replication — the primary now actually ships WAL, and a standby actually follows.

## Primary side
- `repl::sender`: after the (pre-existing) TLS + HMAC handshake accepts a standby, a per-connection task registers the standby's replication slot and streams `read_wal_range` output as chunked `LogData` frames — catch-up first, then live, woken by a new `tokio::watch` the group-commit log-writer signals as the durable watermark advances (no polling; a periodic heartbeat tick covers direct-sync advances and keeps the connection verified when idle). A split reader half consumes `FlushAck`s and advances the slot at the standby's durable watermark.
- Slot API promoted to production and hardened: `try_register_repl_slot` checks `lsn >= WAL head` and the `MAX_REPL_SLOTS` bound atomically under the storage lock (closes the register-vs-truncate race documented in #157); `advance_repl_slot` no longer resurrects a reaped slot; the retain-cap setter enforces the usable-ring upper bound the #157 review documented.
- Post-handshake rejection notices: a diverged standby (received LSN ahead of the primary's durable WAL), an oversized node id, or a failed slot registration gets a `HelloAck { accepted: false }` naming the operator fix (e.g. reseed) before the connection closes.

## Standby side
- `repl::receiver`: a reconnecting client loop — TLS (verifying the primary's cert), HMAC `Hello`, then `apply_wal_stream` per `LogData` with a `FlushAck` after each durable apply. The resume point is the standby's persisted WAL tail; nothing is negotiated, so any crash/disconnect resumes correctly (overlap re-ship is idempotent). Refuses a stale primary (lower epoch) and refuses to run on a database that is not a standby seed.
- **`restore --standby`** (CLI + `Storage::restore_full_standby`): stamps `is_standby` before the restore's validating open, so the seed recovery is redo-only. A plain restore runs ARIES undo; over a backup that bracketed an in-flight transaction the undo CLRs advance page LSNs past the shipped redo and the replica silently diverges — the same divergence class the #164 review caught at reopen, at seed time.

## Plumbing
- `Engine` holds `Arc<Storage>` + `storage_arc()`, so the replication tasks share the live storage beside the worker pool.
- Replication epoch persisted at superblock `reserved[16..24]` (with the `finish_checkpoint` carry), read by both handshake sides; bumped at promotion in the next slice.
- `[replication]` config section (role, cluster uuid, shared secret, TLS paths, ports, retention cap) + main.rs spawns the role's task; misconfiguration is a startup error.

## Fixes
- Pre-existing CLI bug: `truthdb-cli restore` passed `(backup, destination)` into `(dst, bak)` parameters, so every offline CLI restore failed on a missing-file open. Arguments now match the signature.
- Sender writes are shutdown-safe: a stalled standby TCP connection can no longer hang server shutdown.

## Tests
End-to-end over a real TCP+TLS socket: a backup-seeded standby catches up, follows live commits, its acks advance the primary's slot to the flushed watermark, and a receiver restart resumes from the persisted watermark. Plus sender refusal notices over duplex, slot registration guards, epoch persistence across checkpoint + restart, flushed-watch wake on commit, and config override/uuid parsing. `cargo test --workspace` green; fmt + clippy (`-D warnings`) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)