### PR TITLE
Stage 18.4 (D1): standby promotion — truthdb-cli promote, epoch fencing, epoch-carrying seeds

### DIFF
--- a/crates/truthdb-cli/src/main.rs
+++ b/crates/truthdb-cli/src/main.rs
@@ -77,6 +77,17 @@ enum Command {
         #[arg(long, conflicts_with = "stopat")]
         standby: bool,
     },
+    /// OFFLINE: promote a replication standby to a read-write primary (manual
+    /// failover). The server must be stopped. Finishes recovery (redo + undo
+    /// of in-flight shipped transactions), clears the standby mode, and bumps
+    /// the replication epoch — fencing the old timeline: the old primary (and
+    /// any standby seeded before the failover) must reseed from a fresh
+    /// backup of this node before it can follow it.
+    Promote {
+        /// Path to the standby's storage file (e.g. /var/lib/truthdb/truth.db).
+        #[arg(long)]
+        path: std::path::PathBuf,
+    },
 }
 
 #[tokio::main]
@@ -136,6 +147,17 @@ async fn main() -> Result<()> {
                 Err(err) => Err(anyhow::anyhow!("restore failed: {err}")),
             }
         }
+        Command::Promote { path } => match truthdb_core::storage::Storage::promote(&path) {
+            Ok(epoch) => {
+                println!(
+                    "promoted {} to primary (replication epoch {epoch}); reconfigure it as \
+                     role = \"primary\" and reseed any other standby from a fresh backup",
+                    path.display()
+                );
+                Ok(())
+            }
+            Err(err) => Err(anyhow::anyhow!("promote failed: {err}")),
+        },
     }
 }
 

--- a/crates/truthdb-core/src/backup.rs
+++ b/crates/truthdb-core/src/backup.rs
@@ -27,7 +27,7 @@ use crate::storage_layout::PAGE_SIZE;
 /// The magic bytes at the start of every `TDBBAK1` file.
 pub const MAGIC: &[u8; 8] = b"TDBBAK1\0";
 /// Format version — bumped on any incompatible framing/header change.
-pub const FORMAT_VERSION: u32 = 1;
+pub const FORMAT_VERSION: u32 = 2;
 
 /// The kind of a framed block.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -103,6 +103,10 @@ pub struct BackupHeader {
     pub last_committed_seq: u64,
     /// The source's database-options byte (RCSI / ALLOW_SNAPSHOT bits).
     pub db_options: u8,
+    /// The source's replication epoch: a restored `--standby` seed carries its
+    /// timeline, so the handshake's equal-epoch fence can tell a same-timeline
+    /// standby (a guaranteed log prefix) from a diverged one that must reseed.
+    pub epoch: u64,
     /// Wall-clock time the backup finished, milliseconds since the Unix epoch.
     pub finished_at_millis: u64,
     pub flags: BackupFlags,
@@ -124,6 +128,7 @@ impl BackupHeader {
         out.extend_from_slice(&self.metadata_root.to_le_bytes());
         out.extend_from_slice(&self.last_committed_seq.to_le_bytes());
         out.extend_from_slice(&self.finished_at_millis.to_le_bytes());
+        out.extend_from_slice(&self.epoch.to_le_bytes());
         out.push(self.db_options);
         let flag_bits = (self.flags.checksum as u8)
             | ((self.flags.copy_only as u8) << 1)
@@ -156,6 +161,7 @@ impl BackupHeader {
         let metadata_root = cursor.u64()?;
         let last_committed_seq = cursor.u64()?;
         let finished_at_millis = cursor.u64()?;
+        let epoch = cursor.u64()?;
         let db_options = cursor.u8()?;
         let flag_bits = cursor.u8()?;
         let collation_len = cursor.u32()?;
@@ -183,6 +189,7 @@ impl BackupHeader {
             metadata_root,
             last_committed_seq,
             db_options,
+            epoch,
             finished_at_millis,
             flags: BackupFlags {
                 checksum: flag_bits & 1 != 0,
@@ -473,6 +480,7 @@ mod tests {
             metadata_root: 4096 * 40,
             last_committed_seq: 7,
             db_options: 0b01,
+            epoch: 3,
             finished_at_millis: 1_700_000_000_000,
             flags: BackupFlags {
                 checksum: true,

--- a/crates/truthdb-core/src/backup.rs
+++ b/crates/truthdb-core/src/backup.rs
@@ -149,6 +149,15 @@ impl BackupHeader {
     fn decode(bytes: &[u8]) -> io::Result<Self> {
         let mut cursor = Cursor { bytes, pos: 0 };
         let format_version = cursor.u32()?;
+        // Checked FIRST, before any version-dependent field is read — an old
+        // file must fail with a version message, not a bogus "corrupt" one.
+        // v1 (pre-epoch) files stay readable: the epoch field is additive and
+        // a pre-epoch backup is timeline 0 by definition.
+        if format_version == 0 || format_version > FORMAT_VERSION {
+            return Err(corrupt(&format!(
+                "unsupported backup format version {format_version} (this build reads 1..={FORMAT_VERSION})"
+            )));
+        }
         let page_size = cursor.u32()?;
         let total_size = cursor.u64()?;
         let wal_size = cursor.u64()?;
@@ -161,7 +170,11 @@ impl BackupHeader {
         let metadata_root = cursor.u64()?;
         let last_committed_seq = cursor.u64()?;
         let finished_at_millis = cursor.u64()?;
-        let epoch = cursor.u64()?;
+        let epoch = if format_version >= 2 {
+            cursor.u64()?
+        } else {
+            0
+        };
         let db_options = cursor.u8()?;
         let flag_bits = cursor.u8()?;
         let collation_len = cursor.u32()?;
@@ -338,13 +351,9 @@ impl<R: Read> BackupReader<R> {
         if block_type != BlockType::Header {
             return Err(corrupt("first block is not the header"));
         }
+        // The version range is enforced inside `decode` (before any
+        // version-dependent field is read).
         let header = BackupHeader::decode(&payload)?;
-        if header.format_version != FORMAT_VERSION {
-            return Err(corrupt(&format!(
-                "unsupported backup format version {}",
-                header.format_version
-            )));
-        }
         Ok((this, header))
     }
 
@@ -463,6 +472,36 @@ impl Cursor<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // A v1 (pre-epoch) header decodes with epoch 0 — the fleet's existing
+    // backups stay restorable across the format bump, and a pre-epoch backup
+    // is timeline 0 by definition. An unknown future version fails with a
+    // version message, not a bogus "corrupt" one.
+    #[test]
+    fn a_v1_header_decodes_with_epoch_zero() {
+        let header = sample_header();
+        // Re-encode by hand in the v1 layout: no epoch field, version 1.
+        let v2 = header.encode();
+        let mut v1 = Vec::new();
+        v1.extend_from_slice(&1u32.to_le_bytes());
+        v1.extend_from_slice(&v2[4..96]); // page_size ..= finished_at_millis
+        v1.extend_from_slice(&v2[104..]); // db_options onward (epoch skipped)
+        let decoded = BackupHeader::decode(&v1).expect("v1 decodes");
+        assert_eq!(decoded.format_version, 1);
+        assert_eq!(decoded.epoch, 0, "a pre-epoch backup is timeline 0");
+        assert_eq!(decoded.redo_start_lsn, header.redo_start_lsn);
+        assert_eq!(decoded.default_collation, header.default_collation);
+        assert_eq!(decoded.flags, header.flags);
+
+        let mut v3 = v2.clone();
+        v3[0..4].copy_from_slice(&99u32.to_le_bytes());
+        let err = BackupHeader::decode(&v3).expect_err("future version refused");
+        assert!(
+            err.to_string()
+                .contains("unsupported backup format version 99"),
+            "{err}"
+        );
+    }
 
     fn sample_header() -> BackupHeader {
         BackupHeader {

--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -2751,6 +2751,179 @@ mod tests {
         }
     }
 
+    // `ALTER DATABASE <name> FAILOVER` online mirrors RESTORE DATABASE: the
+    // answer is the pointer at the offline CLI.
+    #[test]
+    fn alter_database_failover_points_at_the_offline_cli() {
+        let path = unique_temp_path("failover-online");
+        let engine = new_engine(&path);
+        assert_eq!(
+            sql_error_number(&engine, "ALTER DATABASE CURRENT FAILOVER"),
+            3101
+        );
+        let response = sql(&engine, "ALTER DATABASE CURRENT FAILOVER");
+        assert!(
+            response["error"]["message"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("truthdb-cli promote"),
+            "{response}"
+        );
+        drop(engine);
+        let _ = std::fs::remove_file(path);
+    }
+
+    // Stage 18.4 (D1 manual failover): offline promotion turns a standby into
+    // a read-write primary — finish recovery (undo the shipped in-flight
+    // transactions), clear the standby mode, bump the epoch. The epoch fences
+    // the old timeline: only an EQUAL epoch may follow the new primary, so
+    // the old primary and pre-failover seeds must reseed.
+    #[test]
+    fn promotion_finishes_recovery_bumps_the_epoch_and_fences_the_old_timeline() {
+        use crate::repl::handshake::{HandshakeParams, compute_auth, evaluate_hello};
+
+        let primary_path = unique_temp_path("promo-primary");
+        let bak = unique_temp_path("promo-bak");
+        let standby_path = unique_temp_path("promo-standby");
+        let reseed_bak = unique_temp_path("promo-reseed-bak");
+        let reseed_path = unique_temp_path("promo-reseed");
+
+        let primary = new_engine(&primary_path);
+        let mut ctx = TxnContext::default();
+        batch(
+            &primary,
+            &mut ctx,
+            "CREATE TABLE t (id INT NOT NULL PRIMARY KEY, v INT)",
+        );
+        for i in 1..=10 {
+            batch(
+                &primary,
+                &mut ctx,
+                &format!("INSERT INTO t VALUES ({i}, {i})"),
+            );
+        }
+        let summary = primary.storage().backup_full(&bak).expect("backup");
+        let backup_end = summary.backup_end_lsn;
+        for i in 11..=20 {
+            batch(
+                &primary,
+                &mut ctx,
+                &format!("INSERT INTO t VALUES ({i}, {i})"),
+            );
+        }
+        // An in-flight transaction, durable but uncommitted: the primary dies
+        // here; promotion must roll it back.
+        batch(&primary, &mut ctx, "BEGIN TRANSACTION");
+        for i in 21..=25 {
+            batch(
+                &primary,
+                &mut ctx,
+                &format!("INSERT INTO t VALUES ({i}, {i})"),
+            );
+        }
+        let mid = primary.storage().wal_flushed_lsn();
+        let delta = primary
+            .storage()
+            .read_wal_range(backup_end, mid)
+            .expect("delta");
+
+        Storage::restore_full_standby(&standby_path, &bak, &[]).expect("restore");
+        let standby = Engine::new(Storage::open(standby_path.clone()).expect("open")).expect("eng");
+        standby
+            .storage()
+            .apply_wal_stream(backup_end, &delta)
+            .expect("apply");
+
+        // A running server holds the advisory lock: promote refuses.
+        assert!(
+            Storage::promote(&standby_path).is_err(),
+            "promote refuses a file a live server holds"
+        );
+        drop(standby);
+
+        // A non-standby cannot be promoted.
+        drop(primary);
+        let err = Storage::promote(&primary_path).expect_err("primary is not a standby");
+        assert!(
+            err.to_string().contains("not a replication standby"),
+            "{err}"
+        );
+
+        let epoch = Storage::promote(&standby_path).expect("promote");
+        assert_eq!(epoch, 1, "the first failover bumps epoch 0 -> 1");
+
+        let promoted =
+            Engine::new(Storage::open(standby_path.clone()).expect("open")).expect("eng");
+        assert!(
+            !promoted.storage().is_standby(),
+            "the promoted node is a normal primary"
+        );
+        assert_eq!(promoted.storage().epoch(), 1);
+        assert_eq!(
+            sql_rows(&promoted, "SELECT COUNT(*) FROM t").1,
+            vec![vec![Some("20".into())]],
+            "the shipped in-flight transaction was undone at promotion"
+        );
+        promoted
+            .execute("INSERT INTO t VALUES (999, 999)")
+            .expect("the promoted node accepts writes");
+
+        // Epoch fencing: the OLD timeline (epoch 0 — the dead primary, or any
+        // pre-failover seed) cannot follow the new primary.
+        const SECRET: &[u8] = b"promo-secret";
+        const UUID: [u8; 16] = [9u8; 16];
+        let params = HandshakeParams {
+            shared_secret: SECRET,
+            cluster_uuid: UUID,
+            primary_epoch: promoted.storage().epoch(),
+            primary_flushed_lsn: promoted.storage().wal_flushed_lsn(),
+        };
+        let old_auth = compute_auth(SECRET, 3, &UUID, 0, mid);
+        let old_hello = crate::repl::Hello {
+            protocol_version: crate::repl::REPL_PROTOCOL_VERSION,
+            node_id: 3,
+            cluster_uuid: UUID,
+            epoch: 0,
+            last_received_lsn: mid,
+            auth: old_auth,
+        };
+        let ack = evaluate_hello(&old_hello, &params);
+        assert!(!ack.accepted, "the old timeline is fenced off");
+        assert!(ack.message.contains("reseed"), "{}", ack.message);
+
+        // A FRESH seed from the new primary carries epoch 1 and is accepted.
+        promoted
+            .storage()
+            .backup_full(&reseed_bak)
+            .expect("backup of the promoted node");
+        Storage::restore_full_standby(&reseed_path, &reseed_bak, &[]).expect("reseed");
+        let reseeded = Engine::new(Storage::open(reseed_path.clone()).expect("open")).expect("eng");
+        assert_eq!(
+            reseeded.storage().epoch(),
+            1,
+            "the seed carries the new timeline's epoch"
+        );
+        let new_auth = compute_auth(SECRET, 3, &UUID, 1, reseeded.storage().wal_tail());
+        let new_hello = crate::repl::Hello {
+            protocol_version: crate::repl::REPL_PROTOCOL_VERSION,
+            node_id: 3,
+            cluster_uuid: UUID,
+            epoch: 1,
+            last_received_lsn: reseeded.storage().wal_tail(),
+            auth: new_auth,
+        };
+        assert!(
+            evaluate_hello(&new_hello, &params).accepted,
+            "an equal-epoch seed follows the new primary"
+        );
+
+        drop(promoted);
+        drop(reseeded);
+        for p in [primary_path, bak, standby_path, reseed_bak, reseed_path] {
+            let _ = std::fs::remove_file(p);
+        }
+    }
+
     // A FAILED apply (a cut or corrupt chunk) advances the live ring tail but
     // not the persisted one, and folds nothing into the restartpoint floors.
     // The restartpoint must reclaim only up to the persisted tail — the last
@@ -3528,7 +3701,7 @@ mod tests {
         assert!(cols.contains(&"Checksum".to_string()));
         let col = |name: &str| rows[0][cols.iter().position(|c| c == name).unwrap()].clone();
         assert_eq!(col("BackupType"), Some("1".to_string()), "full backup");
-        assert_eq!(col("FormatVersion"), Some("1".to_string()));
+        assert_eq!(col("FormatVersion"), Some("2".to_string()));
         assert_eq!(col("PageSize"), Some("4096".to_string()));
 
         // FILELISTONLY: a data row ('D') and a log row ('L').

--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -2751,6 +2751,47 @@ mod tests {
         }
     }
 
+    // A WRITABLE restore is a NEW timeline (its history rewinds and its future
+    // writes diverge), so it must not present the source's epoch to standbys
+    // that followed the source — the epoch bumps. A --standby seed stays on
+    // the source's timeline verbatim.
+    #[test]
+    fn a_writable_restore_is_a_new_timeline_a_standby_seed_is_not() {
+        let src = unique_temp_path("tl-src");
+        let bak = unique_temp_path("tl-bak");
+        let writable = unique_temp_path("tl-writable");
+        let seed = unique_temp_path("tl-seed");
+
+        let engine = new_engine(&src);
+        engine
+            .execute("CREATE TABLE t (id INT NOT NULL PRIMARY KEY)")
+            .expect("create");
+        engine.execute("INSERT INTO t VALUES (1)").expect("insert");
+        engine.storage().backup_full(&bak).expect("backup");
+        drop(engine);
+
+        Storage::restore_full(&writable, &bak).expect("plain restore");
+        let restored = Engine::new(Storage::open(writable.clone()).expect("open")).expect("eng");
+        assert_eq!(
+            restored.storage().epoch(),
+            1,
+            "a writable restore bumps the epoch (new timeline)"
+        );
+        drop(restored);
+
+        Storage::restore_full_standby(&seed, &bak, &[]).expect("standby seed");
+        let standby = Engine::new(Storage::open(seed.clone()).expect("open")).expect("eng");
+        assert_eq!(
+            standby.storage().epoch(),
+            0,
+            "a standby seed carries the source's timeline"
+        );
+        drop(standby);
+        for p in [src, bak, writable, seed] {
+            let _ = std::fs::remove_file(p);
+        }
+    }
+
     // `ALTER DATABASE <name> FAILOVER` online mirrors RESTORE DATABASE: the
     // answer is the pointer at the offline CLI.
     #[test]

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -7320,6 +7320,24 @@ fn exec_alter_database(
         )
         .at(name.span));
     }
+    // FAILOVER (standby promotion) is offline-only, like RESTORE DATABASE: the
+    // in-flight-transaction undo and the epoch bump run against a stopped
+    // server. Checked before anything else — the pointer to the CLI is the
+    // whole answer.
+    if alter
+        .options
+        .iter()
+        .any(|(option, _)| *option == DatabaseOption::Failover)
+    {
+        return Err(SqlError::new(
+            3101,
+            16,
+            1,
+            "Exclusive access could not be obtained because the database is in use. TruthDB \
+             promotes a standby offline: stop the server and run `truthdb-cli promote`."
+                .to_string(),
+        ));
+    }
     // A SNAPSHOT transaction idle between batches holds no locks, so the
     // batch's Database X does not prove no snapshot is live. Flipping the
     // options under one would reset (or stop publishing to) the store its
@@ -7346,6 +7364,8 @@ fn exec_alter_database(
             DatabaseOption::AllowSnapshotIsolation => allow_snapshot = Some(*on),
             // For Recovery the bool is the mode: true = FULL, false = SIMPLE.
             DatabaseOption::Recovery => recovery_full = Some(*on),
+            // Returned as 3101 above, before this loop runs.
+            DatabaseOption::Failover => unreachable!("failover is rejected before options apply"),
         }
     }
     storage

--- a/crates/truthdb-core/src/repl/handshake.rs
+++ b/crates/truthdb-core/src/repl/handshake.rs
@@ -110,13 +110,25 @@ pub fn evaluate_hello(hello: &Hello, params: &HandshakeParams) -> HelloAck {
     if hello.cluster_uuid != params.cluster_uuid {
         return reject(params.primary_epoch, "cluster uuid mismatch");
     }
-    // 4. Epoch fence: a standby claiming a HIGHER epoch than ours means we are a
-    //    stale (demoted) primary — refuse to feed it; the operator resolves the
-    //    split and this node reseeds.
+    // 4. Epoch fence, BOTH directions. A standby AHEAD of us means we are a
+    //    stale (demoted) primary — refuse to feed it. A standby BEHIND us is
+    //    from an older timeline (it was seeded before a failover, or it IS the
+    //    old primary rejoining): its log may contain records the new timeline
+    //    never had, and LSNs alone cannot detect that divergence — only an
+    //    EQUAL epoch guarantees the standby's log is a prefix of ours (its
+    //    seed came from this timeline's backup and it only ever applied this
+    //    timeline's stream). Anything else must reseed.
     if hello.epoch > params.primary_epoch {
         return reject(
             params.primary_epoch,
             "this primary's epoch is behind the standby",
+        );
+    }
+    if hello.epoch < params.primary_epoch {
+        return reject(
+            params.primary_epoch,
+            "standby epoch is behind this primary (an older timeline): reseed the \
+             standby from a fresh backup",
         );
     }
     HelloAck {
@@ -159,8 +171,8 @@ mod tests {
     /// primary's epoch + durable tail.
     #[test]
     fn a_valid_hello_is_accepted() {
-        let auth = compute_auth(SECRET, 9, &UUID, 2, 50_000);
-        let hello = hello_with(9, 2, 50_000, auth);
+        let auth = compute_auth(SECRET, 9, &UUID, 4, 50_000);
+        let hello = hello_with(9, 4, 50_000, auth);
         let ack = evaluate_hello(&hello, &params());
         assert!(ack.accepted, "{}", ack.message);
         assert_eq!(ack.primary_epoch, 4);
@@ -241,11 +253,22 @@ mod tests {
     }
 
     #[test]
-    fn a_standby_at_or_below_the_primary_epoch_is_accepted() {
-        for epoch in [0u64, 4] {
+    fn only_a_standby_at_the_primary_epoch_is_accepted() {
+        // Equal epoch = same timeline = a guaranteed log prefix.
+        let auth = compute_auth(SECRET, 9, &UUID, 4, 50_000);
+        let hello = hello_with(9, 4, 50_000, auth);
+        assert!(evaluate_hello(&hello, &params()).accepted);
+        // A LOWER epoch is an older timeline — possibly diverged; reseed.
+        for epoch in [0u64, 3] {
             let auth = compute_auth(SECRET, 9, &UUID, epoch, 50_000);
             let hello = hello_with(9, epoch, 50_000, auth);
-            assert!(evaluate_hello(&hello, &params()).accepted, "epoch {epoch}");
+            let ack = evaluate_hello(&hello, &params());
+            assert!(!ack.accepted, "epoch {epoch}");
+            assert!(
+                ack.message.contains("reseed"),
+                "epoch {epoch}: {}",
+                ack.message
+            );
         }
     }
 }

--- a/crates/truthdb-core/src/repl/receiver.rs
+++ b/crates/truthdb-core/src/repl/receiver.rs
@@ -121,13 +121,16 @@ async fn connect_and_stream(cfg: &ReceiverConfig, storage: &Arc<Storage>) -> io:
             format!("primary rejected the handshake: {}", ack.message),
         ));
     }
-    if ack.primary_epoch < epoch {
-        // A primary behind this standby's epoch is a stale timeline (e.g. an
-        // old primary that missed a failover). Following it would diverge.
+    if ack.primary_epoch != epoch {
+        // Enforce the equal-epoch fence on THIS side too: a primary behind us
+        // is a stale timeline, and one ahead of us means we are — a primary
+        // running an older build could accept a behind-epoch standby, and the
+        // standby must not stream across that divergence.
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
             format!(
-                "primary epoch {} is behind this standby's epoch {epoch}: stale primary",
+                "primary epoch {} does not match this standby's epoch {epoch}: \
+                 different timelines — reseed this standby from the primary",
                 ack.primary_epoch
             ),
         ));

--- a/crates/truthdb-core/src/repl/server.rs
+++ b/crates/truthdb-core/src/repl/server.rs
@@ -118,8 +118,8 @@ mod tests {
 
     #[tokio::test]
     async fn a_valid_standby_is_accepted_over_the_wire() {
-        let auth = compute_auth(SECRET, 5, &UUID, 1, 40_000);
-        let (outcome, ack) = exchange(hello(5, 1, 40_000, auth)).await;
+        let auth = compute_auth(SECRET, 5, &UUID, 3, 40_000);
+        let (outcome, ack) = exchange(hello(5, 3, 40_000, auth)).await;
         assert!(ack.accepted, "{}", ack.message);
         assert_eq!(ack.primary_flushed_lsn, 77_000);
         assert_eq!(

--- a/crates/truthdb-core/src/storage.rs
+++ b/crates/truthdb-core/src/storage.rs
@@ -810,6 +810,13 @@ impl Storage {
                     "header checksum mismatch".to_string(),
                 ));
             }
+            if header.version != crate::storage_layout::FILE_VERSION {
+                return Err(StorageError::InvalidFile(format!(
+                    "file version {} is not promotable (open it with the server once to \
+                     upgrade, then retry)",
+                    header.version
+                )));
+            }
             let mut sb_a_bytes = [0u8; crate::storage_layout::SUPERBLOCK_SIZE];
             file.read_exact_at(header.superblock_a_offset, &mut sb_a_bytes)?;
             let superblock_a = Superblock::from_le_bytes(&sb_a_bytes);
@@ -844,9 +851,51 @@ impl Storage {
                 ),
             };
             if !active.is_standby() {
-                return Err(StorageError::InvalidConfig(
-                    "this database is not a replication standby; nothing to promote".to_string(),
-                ));
+                // A crash between promote's two superblock writes leaves the
+                // ACTIVE slot promoted and the backup slot still standby: the
+                // promotion durably won (the active slot's higher generation
+                // decides), so FINISH it — rewrite the backup slot to match —
+                // rather than telling the operator their failover failed. (An
+                // in-place active-slot rewrite tearing later could otherwise
+                // fall back to the stale standby state.)
+                let backup_slot = match active_slot {
+                    ActiveSuperblock::A => superblock_b,
+                    ActiveSuperblock::B => superblock_a,
+                };
+                if backup_slot.is_standby() {
+                    let mut backup = active;
+                    backup.active = backup_flag;
+                    backup.checksum = backup.compute_checksum();
+                    file.write_all_at(backup_offset, &backup.to_le_bytes_with_checksum())?;
+                    file.sync_data()?;
+                    drop(file);
+                    drop(Storage::open(path.to_path_buf())?);
+                    return Ok(active.epoch());
+                }
+                return Err(StorageError::InvalidConfig(format!(
+                    "this database is not a replication standby; nothing to promote (if a \
+                     previous promote was interrupted, it already took effect — the current \
+                     replication epoch is {}; start the server normally)",
+                    active.epoch()
+                )));
+            }
+            // Promotion's undo appends CLRs for every shipped in-flight
+            // transaction, and undo volume is roughly the loser records'
+            // forward volume. Refuse while the retained ring exceeds half its
+            // size: below that, headroom (>= half the ring) covers the worst
+            // case (every retained byte a loser). The remedy is real — the
+            // standby restartpoints at 50% usage, so this fires only right
+            // after a large catch-up; start the standby server briefly (its
+            // maintenance thread restartpoints) and retry.
+            let occupancy = active.wal_tail.saturating_sub(active.wal_head);
+            if occupancy > header.wal_size / 2 {
+                return Err(StorageError::InvalidConfig(format!(
+                    "the standby's retained WAL ({occupancy} bytes) exceeds half its ring \
+                     ({} bytes): promotion's undo could run the ring full and leave the \
+                     file unopenable. Start the standby server briefly (it will take a \
+                     restartpoint) and retry the promote",
+                    header.wal_size
+                )));
             }
             let generation = superblock_a
                 .generation
@@ -991,7 +1040,13 @@ impl Storage {
         // backup's end. Each archive continues from the current coverage (no
         // gap) and the whole range must fit the ring.
         for log_path in log_paths {
-            apply_log_archive(&mut file, log_path, header.redo_start_lsn, &mut tail)?;
+            apply_log_archive(
+                &mut file,
+                log_path,
+                header.redo_start_lsn,
+                &mut tail,
+                header.epoch,
+            )?;
         }
         // Apply raw shipped WAL ranges (physical replication) after the log
         // chain, on the same seeded ring, extending the tail further.
@@ -6624,10 +6679,17 @@ impl StorageFile {
         // applied log chain / shipped WAL ranges), which is the restored tail.
         base.set_applied_lsn(backup_end);
         base.set_standby(standby);
-        // The seed carries the source's timeline: the handshake's equal-epoch
-        // fence relies on it to tell a same-timeline standby from a diverged
-        // one.
-        base.set_epoch(header.epoch);
+        // A STANDBY seed carries the source's timeline verbatim (the equal-epoch
+        // fence relies on it: same epoch = a guaranteed log prefix). A WRITABLE
+        // restore is a NEW timeline — its history is rewound to the restore
+        // point (with PITR, deliberately) and its future writes diverge from
+        // the original's, so it must NOT present the original's epoch to
+        // standbys that followed the original.
+        base.set_epoch(if standby {
+            header.epoch
+        } else {
+            header.epoch.saturating_add(1)
+        });
 
         let mut a = base;
         a.generation = 1;
@@ -7511,6 +7573,7 @@ fn apply_log_archive(
     path: &Path,
     head: u64,
     tail: &mut u64,
+    expected_epoch: u64,
 ) -> Result<(), StorageError> {
     use crate::backup::{BlockType, decode_log_chunk};
     let reader = std::io::BufReader::new(std::fs::File::open(path)?);
@@ -7519,6 +7582,18 @@ fn apply_log_archive(
         return Err(StorageError::InvalidFile(format!(
             "{}: --log expects a BACKUP LOG archive, but this is a full backup",
             path.display()
+        )));
+    }
+    // Timeline guard: after a failover, the old and new timelines' archives
+    // share geometry AND continuous-looking LSNs — a mixed chain would restore
+    // into a silent chimera. Only same-epoch archives may extend this chain.
+    if header.epoch != expected_epoch {
+        return Err(StorageError::InvalidFile(format!(
+            "{}: log archive is from replication epoch {} but the restore chain is \
+             epoch {expected_epoch} — a different timeline's archive cannot extend \
+             this chain",
+            path.display(),
+            header.epoch
         )));
     }
     // Partial identity guard: a log archive whose page or ring geometry differs

--- a/crates/truthdb-core/src/storage.rs
+++ b/crates/truthdb-core/src/storage.rs
@@ -779,6 +779,102 @@ impl Storage {
         Self::restore_full_inner(dst_path, bak_path, &[], wal_ranges, None, false)
     }
 
+    /// Offline PROMOTION of a replication standby to a read-write primary
+    /// (manual failover). The server must be stopped — the advisory file lock
+    /// fails this fast if it is not. Two phases, each crash-safe:
+    ///
+    /// 1. Flip the superblocks: clear `is_standby` and bump the epoch by one,
+    ///    in a single dual-write (active slot first, fsync between — a torn
+    ///    write falls back to the still-standby backup slot and the promote is
+    ///    simply retried). The epoch bump fences the old timeline: the
+    ///    handshake accepts only EQUAL epochs, so the old primary — whose log
+    ///    may hold records this timeline never had — cannot rejoin without a
+    ///    reseed, and neither can standbys seeded before the failover.
+    /// 2. A validating [`Storage::open`]: with the standby flag gone, recovery
+    ///    runs IN FULL — redo, then undo of the shipped in-flight transactions
+    ///    (with CLRs, on the now-writable WAL). This is where "drain, finish
+    ///    redo+undo" happens; a crash mid-recovery re-runs it on the next open.
+    ///
+    /// Returns the new epoch.
+    pub fn promote(path: &Path) -> Result<u64, StorageError> {
+        let new_epoch = {
+            let mut file = DirectFile::open_existing(path.to_path_buf())?;
+            let mut header_bytes = [0u8; crate::storage_layout::FILE_HEADER_SIZE];
+            file.read_exact_at(0, &mut header_bytes)?;
+            let header = FileHeader::from_le_bytes(&header_bytes);
+            if header.magic != crate::storage_layout::FILE_MAGIC {
+                return Err(StorageError::InvalidFile("bad magic".to_string()));
+            }
+            if header.header_checksum != header.compute_checksum() {
+                return Err(StorageError::InvalidFile(
+                    "header checksum mismatch".to_string(),
+                ));
+            }
+            let mut sb_a_bytes = [0u8; crate::storage_layout::SUPERBLOCK_SIZE];
+            file.read_exact_at(header.superblock_a_offset, &mut sb_a_bytes)?;
+            let superblock_a = Superblock::from_le_bytes(&sb_a_bytes);
+            let sb_a_valid = superblock_a.checksum == superblock_a.compute_checksum();
+            let mut sb_b_bytes = [0u8; crate::storage_layout::SUPERBLOCK_SIZE];
+            file.read_exact_at(header.superblock_b_offset, &mut sb_b_bytes)?;
+            let superblock_b = Superblock::from_le_bytes(&sb_b_bytes);
+            let sb_b_valid = superblock_b.checksum == superblock_b.compute_checksum();
+            if !sb_a_valid && !sb_b_valid {
+                return Err(StorageError::InvalidFile(
+                    "both superblocks have checksum mismatch".to_string(),
+                ));
+            }
+            let active_slot = ActiveSuperblock::from_superblocks(
+                &superblock_a,
+                &superblock_b,
+                sb_a_valid,
+                sb_b_valid,
+            );
+            let (active, primary_offset, backup_flag, backup_offset) = match active_slot {
+                ActiveSuperblock::A => (
+                    superblock_a,
+                    header.superblock_a_offset,
+                    SUPERBLOCK_ACTIVE_B,
+                    header.superblock_b_offset,
+                ),
+                ActiveSuperblock::B => (
+                    superblock_b,
+                    header.superblock_b_offset,
+                    SUPERBLOCK_ACTIVE_A,
+                    header.superblock_a_offset,
+                ),
+            };
+            if !active.is_standby() {
+                return Err(StorageError::InvalidConfig(
+                    "this database is not a replication standby; nothing to promote".to_string(),
+                ));
+            }
+            let generation = superblock_a
+                .generation
+                .max(superblock_b.generation)
+                .saturating_add(1);
+            let new_epoch = active.epoch().saturating_add(1);
+            let mut primary = active;
+            let mut backup = active;
+            backup.active = backup_flag;
+            for sb in [&mut primary, &mut backup] {
+                sb.set_standby(false);
+                sb.set_epoch(new_epoch);
+                sb.generation = generation;
+                sb.checksum = sb.compute_checksum();
+            }
+            file.write_all_at(primary_offset, &primary.to_le_bytes_with_checksum())?;
+            file.sync_data()?;
+            file.write_all_at(backup_offset, &backup.to_le_bytes_with_checksum())?;
+            file.sync_data()?;
+            new_epoch
+            // The file handle (and its advisory lock) drops here.
+        };
+        // Validate + finalize: a full open runs redo AND undo (the standby flag
+        // is gone), sealing the shipped in-flight transactions with CLRs.
+        drop(Storage::open(path.to_path_buf())?);
+        Ok(new_epoch)
+    }
+
     fn restore_full_inner(
         dst_path: &Path,
         bak_path: &Path,
@@ -6009,6 +6105,7 @@ impl StorageFile {
             metadata_root,
             last_committed_seq,
             db_options,
+            epoch: self.active_sb().epoch(),
             runs,
             checksum,
             copy_only,
@@ -6242,6 +6339,7 @@ impl StorageFile {
             metadata_root: 0,
             last_committed_seq: 0,
             db_options: self.version.options_byte(),
+            epoch: self.active_sb().epoch(),
             finished_at_millis: now_millis(),
             flags: crate::backup::BackupFlags {
                 checksum,
@@ -6526,6 +6624,10 @@ impl StorageFile {
         // applied log chain / shipped WAL ranges), which is the restored tail.
         base.set_applied_lsn(backup_end);
         base.set_standby(standby);
+        // The seed carries the source's timeline: the handshake's equal-epoch
+        // fence relies on it to tell a same-timeline standby from a diverged
+        // one.
+        base.set_epoch(header.epoch);
 
         let mut a = base;
         a.generation = 1;
@@ -7285,6 +7387,7 @@ struct BackupPlan {
     metadata_root: u64,
     last_committed_seq: u64,
     db_options: u8,
+    epoch: u64,
     runs: Vec<(u64, u64)>,
     checksum: bool,
     copy_only: bool,
@@ -7308,6 +7411,7 @@ impl BackupPlan {
             metadata_root: self.metadata_root,
             last_committed_seq: self.last_committed_seq,
             db_options: self.db_options,
+            epoch: self.epoch,
             finished_at_millis: self.finished_at_millis,
             flags: crate::backup::BackupFlags {
                 checksum: self.checksum,

--- a/crates/truthdb-sql/src/ast.rs
+++ b/crates/truthdb-sql/src/ast.rs
@@ -522,6 +522,10 @@ pub enum DatabaseOption {
     /// `SET RECOVERY {FULL | SIMPLE}`. Unlike the ON/OFF options, the paired
     /// bool carries the mode: `true` = FULL, `false` = SIMPLE.
     Recovery,
+    /// `ALTER DATABASE <name> FAILOVER` — promotion of a replication standby.
+    /// Online it always errors pointing at the offline `truthdb-cli promote`
+    /// (the paired bool is unused).
+    Failover,
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/crates/truthdb-sql/src/parser.rs
+++ b/crates/truthdb-sql/src/parser.rs
@@ -1696,6 +1696,15 @@ impl Parser {
         } else {
             Some(self.parse_name()?)
         };
+        // `ALTER DATABASE <name> FAILOVER` (no SET): standby promotion.
+        if self.peek_keyword().as_deref() == Some("FAILOVER") {
+            let end = self.bump().span;
+            return Ok(Statement::AlterDatabase(AlterDatabase {
+                name,
+                options: vec![(DatabaseOption::Failover, true)],
+                span: start.to(end),
+            }));
+        }
         self.expect_keyword("SET")?;
         let mut options = Vec::new();
         let mut end;


### PR DESCRIPTION
Manual failover (D1). Offline `truthdb-cli promote` clears the standby mode and bumps the epoch in one crash-safe dual-superblock write, then a validating open finishes recovery — redo plus undo of the shipped in-flight transactions (the log a standby retains below its restartpoint floor exists exactly for this moment). The epoch fence becomes equal-only in both directions, so the dead primary and every pre-failover seed are refused with a reseed message, while backups now carry the source epoch (TDBBAK1 v2) so a fresh seed of the new primary follows it immediately. `ALTER DATABASE <name> FAILOVER` online returns the 3101-style pointer at the CLI, mirroring RESTORE DATABASE.

`cargo test --workspace` green (620 core tests), clippy `-D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)