### PR TITLE
Stage 18.5 (D2): synchronous commit + readable-standby snapshot reads

### DIFF
--- a/config/default.toml
+++ b/config/default.toml
@@ -65,7 +65,11 @@ snapshot_wal_threshold = 0.7
 # tls_cert = "/etc/truthdb/repl.crt"
 # tls_key = "/etc/truthdb/repl.key"
 # heartbeat_ms = 1000
+# stall_timeout_ms = 30000    # tear down a totally silent connection (>= 2x heartbeat)
 # max_slot_retain_bytes = 0   # 0 = unlimited: a lagging standby is never dropped
+# synchronous_commit = false  # commits wait for a standby ack (availability-first)
+# sync_timeout_ms = 10000     # the sync-commit wait bound; on timeout the link
+#                             # degrades to NOT_SYNCHRONIZED and commits proceed
 #
 # Standby:
 # primary_addr = "primary.example:9624"

--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -2814,6 +2814,203 @@ mod tests {
         let _ = std::fs::remove_file(path);
     }
 
+    // Stage 18.5 (D2) readable standby: reads resolve through the version
+    // store at the last-applied-commit snapshot — shipped in-flight changes
+    // (inserts AND updates of pre-existing rows) are invisible until their
+    // commit ships; an aborted shipped transaction unwinds; the store is
+    // rebuilt at reopen from the retained ring.
+    #[test]
+    fn a_readable_standby_serves_only_committed_state() {
+        let primary_path = unique_temp_path("read-primary");
+        let bak = unique_temp_path("read-bak");
+        let standby_path = unique_temp_path("read-standby");
+
+        let primary = new_engine(&primary_path);
+        let mut ctx = TxnContext::default();
+        batch(
+            &primary,
+            &mut ctx,
+            "CREATE TABLE t (id INT NOT NULL PRIMARY KEY, v INT)",
+        );
+        for i in 1..=10 {
+            batch(
+                &primary,
+                &mut ctx,
+                &format!("INSERT INTO t VALUES ({i}, {i})"),
+            );
+        }
+        let summary = primary.storage().backup_full(&bak).expect("backup");
+        let backup_end = summary.backup_end_lsn;
+        // Committed post-backup work...
+        for i in 11..=15 {
+            batch(
+                &primary,
+                &mut ctx,
+                &format!("INSERT INTO t VALUES ({i}, {i})"),
+            );
+        }
+        // ...then an in-flight transaction: new rows AND an update of row 1.
+        batch(&primary, &mut ctx, "BEGIN TRANSACTION");
+        for i in 16..=20 {
+            batch(
+                &primary,
+                &mut ctx,
+                &format!("INSERT INTO t VALUES ({i}, {i})"),
+            );
+        }
+        batch(&primary, &mut ctx, "UPDATE t SET v = 999 WHERE id = 1");
+        let mid = primary.storage().wal_flushed_lsn();
+        let delta = primary
+            .storage()
+            .read_wal_range(backup_end, mid)
+            .expect("delta");
+
+        Storage::restore_full_standby(&standby_path, &bak, &[]).expect("seed");
+        let standby = Engine::new(Storage::open(standby_path.clone()).expect("open")).expect("eng");
+        standby
+            .storage()
+            .apply_wal_stream(backup_end, &delta)
+            .expect("apply");
+        assert_eq!(
+            sql_rows(&standby, "SELECT COUNT(*) FROM t").1,
+            vec![vec![Some("15".into())]],
+            "in-flight inserts are invisible; committed ones are visible"
+        );
+        assert_eq!(
+            sql_rows(&standby, "SELECT v FROM t WHERE id = 1").1,
+            vec![vec![Some("1".into())]],
+            "an in-flight update serves the committed pre-image"
+        );
+
+        // The store rebuilds at reopen from the retained ring.
+        drop(standby);
+        let standby = Engine::new(Storage::open(standby_path.clone()).expect("open")).expect("eng");
+        assert_eq!(
+            sql_rows(&standby, "SELECT v FROM t WHERE id = 1").1,
+            vec![vec![Some("1".into())]],
+            "committed-state reads survive a reopen"
+        );
+        assert_eq!(
+            sql_rows(&standby, "SELECT COUNT(*) FROM t").1,
+            vec![vec![Some("15".into())]]
+        );
+
+        // The commit ships: everything becomes visible.
+        batch(&primary, &mut ctx, "COMMIT TRANSACTION");
+        let committed = primary.storage().wal_flushed_lsn();
+        let delta2 = primary
+            .storage()
+            .read_wal_range(mid, committed)
+            .expect("commit range");
+        standby
+            .storage()
+            .apply_wal_stream(mid, &delta2)
+            .expect("apply commit");
+        assert_eq!(
+            sql_rows(&standby, "SELECT COUNT(*) FROM t").1,
+            vec![vec![Some("20".into())]],
+            "the committed transaction is visible"
+        );
+        assert_eq!(
+            sql_rows(&standby, "SELECT v FROM t WHERE id = 1").1,
+            vec![vec![Some("999".into())]],
+            "the committed update is visible"
+        );
+
+        // An aborted shipped transaction: its effects never surface, and its
+        // version chains unwind.
+        batch(&primary, &mut ctx, "BEGIN TRANSACTION");
+        batch(&primary, &mut ctx, "UPDATE t SET v = -1 WHERE id = 2");
+        batch(&primary, &mut ctx, "ROLLBACK TRANSACTION");
+        let aborted = primary.storage().wal_flushed_lsn();
+        let delta3 = primary
+            .storage()
+            .read_wal_range(committed, aborted)
+            .expect("abort range");
+        standby
+            .storage()
+            .apply_wal_stream(committed, &delta3)
+            .expect("apply abort");
+        assert_eq!(
+            sql_rows(&standby, "SELECT v FROM t WHERE id = 2").1,
+            vec![vec![Some("2".into())]],
+            "an aborted shipped transaction never surfaces"
+        );
+
+        drop(primary);
+        drop(standby);
+        for p in [primary_path, bak, standby_path] {
+            let _ = std::fs::remove_file(p);
+        }
+    }
+
+    // Stage 18.5 (D2) synchronous commit: a commit waits — after local
+    // durability — for a standby acknowledgement; a timeout degrades the link
+    // (NOT_SYNCHRONIZED) availability-first, and a caught-up acknowledgement
+    // re-synchronizes it.
+    #[test]
+    fn synchronous_commit_waits_for_acks_and_degrades_on_timeout() {
+        let path = unique_temp_path("sync-commit");
+        let engine = new_engine(&path);
+        engine
+            .execute("CREATE TABLE t (id INT NOT NULL PRIMARY KEY)")
+            .expect("create");
+        engine
+            .storage()
+            .arm_sync_commit(std::time::Duration::from_millis(250));
+
+        // A healthy standby: an acker thread mirrors the durable watermark.
+        let storage = engine.storage_arc();
+        let stop = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let stop2 = std::sync::Arc::clone(&stop);
+        let acker = std::thread::spawn(move || {
+            while !stop2.load(std::sync::atomic::Ordering::Relaxed) {
+                storage.publish_sync_ack(storage.wal_flushed_lsn());
+                std::thread::sleep(std::time::Duration::from_millis(5));
+            }
+        });
+        engine.execute("INSERT INTO t VALUES (1)").expect("insert");
+        assert!(
+            !engine.storage().sync_commit_degraded(),
+            "an acked commit keeps the link synchronized"
+        );
+        stop.store(true, std::sync::atomic::Ordering::Relaxed);
+        acker.join().expect("acker");
+
+        // The standby goes silent: the next commit stalls out the timeout,
+        // degrades the link, and still succeeds.
+        let t0 = std::time::Instant::now();
+        engine.execute("INSERT INTO t VALUES (2)").expect("insert");
+        assert!(
+            t0.elapsed() >= std::time::Duration::from_millis(250),
+            "the degrading commit waited out the timeout"
+        );
+        assert!(
+            engine.storage().sync_commit_degraded(),
+            "the timed-out link is NOT_SYNCHRONIZED"
+        );
+
+        // Degraded: commits pass straight through (bounded by well under the
+        // timeout — generous margin against CI jitter).
+        let t1 = std::time::Instant::now();
+        engine.execute("INSERT INTO t VALUES (3)").expect("insert");
+        assert!(
+            t1.elapsed() < std::time::Duration::from_millis(200),
+            "a degraded link does not delay commits"
+        );
+
+        // A caught-up acknowledgement re-synchronizes.
+        engine
+            .storage()
+            .publish_sync_ack(engine.storage().wal_flushed_lsn());
+        assert!(
+            !engine.storage().sync_commit_degraded(),
+            "a caught-up standby re-synchronizes the link"
+        );
+        drop(engine);
+        let _ = std::fs::remove_file(path);
+    }
+
     // Stage 18.4 (D1 manual failover): offline promotion turns a standby into
     // a read-write primary — finish recovery (undo the shipped in-flight
     // transactions), clear the standby mode, bump the epoch. The epoch fences
@@ -3365,8 +3562,10 @@ mod tests {
                 .unwrap_or_default()
         };
 
-        // Standby applies the mid-transaction stream live (the in-flight rows are
-        // present via redo), then RESTARTS.
+        // Standby applies the mid-transaction stream live: the in-flight rows
+        // are applied PHYSICALLY via redo (proven by the post-commit equality
+        // below) but hidden from reads — a readable standby serves only
+        // committed state.
         Storage::restore_full(&standby_path, &bak).expect("restore");
         {
             let standby =
@@ -3377,8 +3576,8 @@ mod tests {
                 .expect("apply mid-txn stream");
             assert_eq!(
                 count(&standby),
-                "20",
-                "the in-flight rows are applied via redo"
+                "10",
+                "in-flight rows are applied but not visible"
             );
         }
         // THE FIX: a standby reopen is redo-only, so the applied rows survive. A
@@ -3387,8 +3586,8 @@ mod tests {
             Engine::new(Storage::open(standby_path.clone()).expect("reopen")).expect("eng");
         assert_eq!(
             count(&standby),
-            "20",
-            "redo-only reopen keeps the streamed in-flight rows"
+            "10",
+            "redo-only reopen keeps the streamed in-flight rows physically, still hidden"
         );
 
         // The primary commits and ships the continuation; the standby stays

--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -2944,6 +2944,118 @@ mod tests {
         }
     }
 
+    // The two review-caught wrong-results bugs, pinned: heap undo payloads
+    // are CELL bytes (a tag byte before the row — served raw they decode as
+    // garbage), and a statement rollback inside a transaction that LATER
+    // COMMITS ships CLRs with no TXN_END — un-captured, the rolled-back
+    // delete's chain head would hide a committed, physically present row.
+    #[test]
+    fn readable_standby_handles_heap_cells_and_statement_rollbacks() {
+        let primary_path = unique_temp_path("edge-primary");
+        let bak = unique_temp_path("edge-bak");
+        let standby_path = unique_temp_path("edge-standby");
+
+        let primary = new_engine(&primary_path);
+        let mut ctx = TxnContext::default();
+        // A HEAP table (no primary key) — its undo payloads are tagged cells.
+        batch(&primary, &mut ctx, "CREATE TABLE h (id INT, v INT)");
+        for i in 1..=3 {
+            batch(
+                &primary,
+                &mut ctx,
+                &format!("INSERT INTO h VALUES ({i}, {i})"),
+            );
+        }
+        // A keyed table for the savepoint flow.
+        batch(
+            &primary,
+            &mut ctx,
+            "CREATE TABLE t (id INT NOT NULL PRIMARY KEY, v INT)",
+        );
+        for i in 1..=3 {
+            batch(
+                &primary,
+                &mut ctx,
+                &format!("INSERT INTO t VALUES ({i}, {i})"),
+            );
+        }
+        let summary = primary.storage().backup_full(&bak).expect("backup");
+        let backup_end = summary.backup_end_lsn;
+
+        // In-flight heap update: the standby must serve the OLD row, decoded
+        // correctly (the tag byte stripped).
+        batch(&primary, &mut ctx, "BEGIN TRANSACTION");
+        batch(&primary, &mut ctx, "UPDATE h SET v = 999 WHERE id = 1");
+        let mid = primary.storage().wal_flushed_lsn();
+        let delta = primary
+            .storage()
+            .read_wal_range(backup_end, mid)
+            .expect("delta");
+
+        Storage::restore_full_standby(&standby_path, &bak, &[]).expect("seed");
+        let standby = Engine::new(Storage::open(standby_path.clone()).expect("open")).expect("eng");
+        standby
+            .storage()
+            .apply_wal_stream(backup_end, &delta)
+            .expect("apply");
+        assert_eq!(
+            sql_rows(&standby, "SELECT id, v FROM h ORDER BY id").1,
+            vec![
+                vec![Some("1".into()), Some("1".into())],
+                vec![Some("2".into()), Some("2".into())],
+                vec![Some("3".into()), Some("3".into())],
+            ],
+            "an in-flight heap update serves the committed pre-image, decoded as a row"
+        );
+
+        // Commit the heap txn, then a mid-transaction STATEMENT rollback: a
+        // multi-row re-key that collides part-way is undone with CLRs (no
+        // TXN_END — the transaction continues and commits). Un-captured, the
+        // undone delete's chain head would hide committed row 1 forever.
+        batch(&primary, &mut ctx, "COMMIT TRANSACTION");
+        batch(&primary, &mut ctx, "INSERT INTO t VALUES (10, 10)");
+        batch(&primary, &mut ctx, "BEGIN TRANSACTION");
+        let failed = batch(&primary, &mut ctx, "UPDATE t SET id = id + 9 WHERE id <= 2");
+        assert!(
+            failed.error.is_some(),
+            "the re-key collides with row 10 and the statement rolls back"
+        );
+        batch(&primary, &mut ctx, "INSERT INTO t VALUES (4, 4)");
+        batch(&primary, &mut ctx, "COMMIT TRANSACTION");
+        assert_eq!(
+            sql_rows(&primary, "SELECT COUNT(*) FROM t").1,
+            vec![vec![Some("5".into())]],
+            "primary: rows 1,2,3,10,4 (the failed statement fully undone)"
+        );
+        let done = primary.storage().wal_flushed_lsn();
+        let delta2 = primary.storage().read_wal_range(mid, done).expect("delta2");
+        standby
+            .storage()
+            .apply_wal_stream(mid, &delta2)
+            .expect("apply2");
+        assert_eq!(
+            sql_rows(&standby, "SELECT id FROM t ORDER BY id").1,
+            sql_rows(&primary, "SELECT id FROM t ORDER BY id").1,
+            "the CLR-undone statement's rows stay visible on the standby"
+        );
+        assert_eq!(
+            sql_rows(&standby, "SELECT v FROM t WHERE id = 1").1,
+            vec![vec![Some("1".into())]],
+            "row 1 — deleted, CLR-restored, then committed — is served"
+        );
+        assert_eq!(
+            sql_rows(&standby, "SELECT v FROM h WHERE id = 1").1,
+            vec![vec![Some("999".into())]],
+            "the committed heap update is visible"
+        );
+
+        drop(primary);
+        drop(standby);
+        for p in [primary_path, bak, standby_path] {
+            let _ = std::fs::remove_file(p);
+        }
+    }
+
     // Stage 18.5 (D2) synchronous commit: a commit waits — after local
     // durability — for a standby acknowledgement; a timeout degrades the link
     // (NOT_SYNCHRONIZED) availability-first, and a caught-up acknowledgement
@@ -2957,7 +3069,7 @@ mod tests {
             .expect("create");
         engine
             .storage()
-            .arm_sync_commit(std::time::Duration::from_millis(250));
+            .arm_sync_commit(std::time::Duration::from_millis(500));
 
         // A healthy standby: an acker thread mirrors the durable watermark.
         let storage = engine.storage_arc();
@@ -2982,7 +3094,7 @@ mod tests {
         let t0 = std::time::Instant::now();
         engine.execute("INSERT INTO t VALUES (2)").expect("insert");
         assert!(
-            t0.elapsed() >= std::time::Duration::from_millis(250),
+            t0.elapsed() >= std::time::Duration::from_millis(500),
             "the degrading commit waited out the timeout"
         );
         assert!(
@@ -2995,7 +3107,7 @@ mod tests {
         let t1 = std::time::Instant::now();
         engine.execute("INSERT INTO t VALUES (3)").expect("insert");
         assert!(
-            t1.elapsed() < std::time::Duration::from_millis(200),
+            t1.elapsed() < std::time::Duration::from_millis(400),
             "a degraded link does not delay commits"
         );
 

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -1552,6 +1552,13 @@ fn enter_condition_scopes<'a>(
         return Ok((None, None));
     }
     match txn_ctx.isolation() {
+        // A readable STANDBY snapshots condition reads too (see the statement
+        // arming above): only the last-applied-commit snapshot yields
+        // committed-state reads there.
+        _ if storage.is_standby() => {
+            run.flush(storage)?;
+            Ok((Some(SnapshotScope::enter(storage, None)), None))
+        }
         Isolation::ReadCommitted if storage.rcsi_enabled() => {
             // The snapshot is the durable commit prefix: the session's own
             // just-committed statements must be durable before capture.
@@ -2613,6 +2620,15 @@ fn exec_statement_streamed(
     // so the body cannot read the caller's @t — see arm_table_var_view.
     let _table_var_scope = arm_table_var_view(&txn_ctx.table_variables);
     match txn_ctx.isolation() {
+        // A readable STANDBY snapshots every SELECT regardless of the
+        // session's isolation: redo leaves the primary's in-flight rows on its
+        // pages, and shipped transactions hold no local locks — only the
+        // version-store snapshot (pinned at the last applied commit) yields
+        // committed-state reads.
+        _ if matches!(statement, Statement::Select(_)) && storage.is_standby() => {
+            run.flush(storage)?;
+            _stmt_scope = Some(SnapshotScope::enter(storage, None));
+        }
         Isolation::ReadCommitted
             if matches!(statement, Statement::Select(_)) && storage.rcsi_enabled() =>
         {

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -1552,13 +1552,6 @@ fn enter_condition_scopes<'a>(
         return Ok((None, None));
     }
     match txn_ctx.isolation() {
-        // A readable STANDBY snapshots condition reads too (see the statement
-        // arming above): only the last-applied-commit snapshot yields
-        // committed-state reads there.
-        _ if storage.is_standby() => {
-            run.flush(storage)?;
-            Ok((Some(SnapshotScope::enter(storage, None)), None))
-        }
         Isolation::ReadCommitted if storage.rcsi_enabled() => {
             // The snapshot is the durable commit prefix: the session's own
             // just-committed statements must be durable before capture.
@@ -1591,6 +1584,13 @@ fn enter_condition_scopes<'a>(
                 run.flush(storage)?;
                 Ok((Some(SnapshotScope::enter(storage, None)), None))
             }
+        }
+        // A readable STANDBY snapshots condition reads too (below the
+        // RCSI/SNAPSHOT arms — see the statement arming): only the
+        // last-applied-commit snapshot yields committed-state reads there.
+        _ if storage.is_standby() => {
+            run.flush(storage)?;
+            Ok((Some(SnapshotScope::enter(storage, None)), None))
         }
         _ => Ok((None, None)),
     }
@@ -2620,15 +2620,6 @@ fn exec_statement_streamed(
     // so the body cannot read the caller's @t — see arm_table_var_view.
     let _table_var_scope = arm_table_var_view(&txn_ctx.table_variables);
     match txn_ctx.isolation() {
-        // A readable STANDBY snapshots every SELECT regardless of the
-        // session's isolation: redo leaves the primary's in-flight rows on its
-        // pages, and shipped transactions hold no local locks — only the
-        // version-store snapshot (pinned at the last applied commit) yields
-        // committed-state reads.
-        _ if matches!(statement, Statement::Select(_)) && storage.is_standby() => {
-            run.flush(storage)?;
-            _stmt_scope = Some(SnapshotScope::enter(storage, None));
-        }
         Isolation::ReadCommitted
             if matches!(statement, Statement::Select(_)) && storage.rcsi_enabled() =>
         {
@@ -2665,6 +2656,18 @@ fn exec_statement_streamed(
                 run.flush(storage)?;
                 _stmt_scope = Some(SnapshotScope::enter(storage, None));
             }
+        }
+        // A readable STANDBY snapshots every table-reading statement — not
+        // just SELECTs: cursors, table-variable INSERT ... SELECT sources, and
+        // function bodies read too — regardless of the session's isolation
+        // (redo leaves the primary's in-flight rows on its pages, and shipped
+        // transactions hold no local locks; only the version-store snapshot at
+        // the last applied commit yields committed-state reads). Ordered
+        // BELOW the RCSI/SNAPSHOT arms so a SNAPSHOT session on a standby
+        // keeps its transaction-lifetime view.
+        _ if statement_reads_tables(storage, statement) && storage.is_standby() => {
+            run.flush(storage)?;
+            _stmt_scope = Some(SnapshotScope::enter(storage, None));
         }
         _ => {}
     }

--- a/crates/truthdb-core/src/relstore/heap.rs
+++ b/crates/truthdb-core/src/relstore/heap.rs
@@ -60,6 +60,17 @@ fn moved_cell(home: Rid, row: &[u8]) -> Vec<u8> {
     cell
 }
 
+/// Splits a raw heap CELL into row bytes, for consumers holding WAL undo
+/// payloads (which carry cells verbatim): `(home-rid override for a MOVED
+/// cell, row bytes)`; `None` for stubs (pointers, not rows) and unknown tags.
+pub(crate) fn cell_row(cell: &[u8]) -> Option<(Option<Rid>, &[u8])> {
+    match *cell.first()? {
+        TAG_ROW => Some((None, &cell[1..])),
+        TAG_MOVED if cell.len() >= 11 => Some((Some(parse_rid(&cell[1..11])), &cell[11..])),
+        _ => None,
+    }
+}
+
 fn parse_rid(bytes: &[u8]) -> Rid {
     Rid {
         page: u64::from_le_bytes(bytes[0..8].try_into().unwrap()),

--- a/crates/truthdb-core/src/relstore/version.rs
+++ b/crates/truthdb-core/src/relstore/version.rs
@@ -116,6 +116,10 @@ pub(crate) struct VersionState {
     /// FULL recovery model (vs SIMPLE, the default). Independent of the
     /// version store — it does not affect `publishing()`.
     pub recovery_full: bool,
+    /// Readable-standby mode: the replication apply mirrors shipped changes
+    /// into this store (pre-images from the WAL's undo payloads), and every
+    /// standby read resolves through it at the last-applied-commit snapshot.
+    pub standby_reads: bool,
     /// Committed transactions -> commit sequence. Entries live until no chain
     /// references them and the watermark has passed (pruned together with the
     /// chains). A transaction absent here is running or rolled back — either
@@ -144,7 +148,7 @@ impl VersionState {
     /// Whether writes must publish versions (any versioned isolation can be
     /// in use).
     pub fn publishing(&self) -> bool {
-        self.rcsi || self.allow_snapshot
+        self.rcsi || self.allow_snapshot || self.standby_reads
     }
 
     /// Applies `ALTER DATABASE` option changes. Turning the last option off

--- a/crates/truthdb-core/src/repl/sender.rs
+++ b/crates/truthdb-core/src/repl/sender.rs
@@ -189,6 +189,9 @@ where
                 };
                 if let Some(lsn) = bounded {
                     storage.advance_repl_slot(slot_id, lsn);
+                    // D2 synchronous commit: a committer may be waiting on this
+                    // acknowledgement (a no-op when sync commit is not armed).
+                    storage.publish_sync_ack(lsn);
                 }
             }
         }

--- a/crates/truthdb-core/src/storage.rs
+++ b/crates/truthdb-core/src/storage.rs
@@ -35,6 +35,102 @@ use crate::wal::{WalWriter, scan_ring};
 
 pub use crate::wal::WalRecord;
 
+/// D2 synchronous-commit coordination (primary side). Committers wait on
+/// `acked` (a standby's highest acknowledged durable LSN, published by the
+/// sender's ack reader) after their local fsync. Availability-first: a wait
+/// that exceeds the armed timeout degrades the link (`degraded = true`,
+/// logged once) and every commit passes straight through until an
+/// acknowledgement catches up to the primary's durable watermark, which
+/// re-synchronizes the link (logged once).
+struct SyncCommitState {
+    armed: std::sync::atomic::AtomicBool,
+    timeout_ms: std::sync::atomic::AtomicU64,
+    degraded: std::sync::atomic::AtomicBool,
+    acked: std::sync::Mutex<u64>,
+    acked_cv: std::sync::Condvar,
+}
+
+impl Default for SyncCommitState {
+    fn default() -> Self {
+        SyncCommitState {
+            armed: std::sync::atomic::AtomicBool::new(false),
+            timeout_ms: std::sync::atomic::AtomicU64::new(0),
+            degraded: std::sync::atomic::AtomicBool::new(false),
+            acked: std::sync::Mutex::new(0),
+            acked_cv: std::sync::Condvar::new(),
+        }
+    }
+}
+
+impl SyncCommitState {
+    fn arm(&self, timeout: std::time::Duration) {
+        self.timeout_ms.store(
+            timeout.as_millis().min(u64::MAX as u128) as u64,
+            std::sync::atomic::Ordering::Relaxed,
+        );
+        self.armed.store(true, std::sync::atomic::Ordering::Release);
+    }
+
+    fn publish(&self, lsn: u64, caught_up: bool) {
+        if !self.armed.load(std::sync::atomic::Ordering::Acquire) {
+            return;
+        }
+        {
+            let mut acked = self.acked.lock().expect("sync-commit state poisoned");
+            if lsn > *acked {
+                *acked = lsn;
+            }
+        }
+        self.acked_cv.notify_all();
+        if caught_up
+            && self
+                .degraded
+                .swap(false, std::sync::atomic::Ordering::AcqRel)
+        {
+            eprintln!(
+                "synchronous commit: a standby caught up (acknowledged {lsn}); the link is \
+                 SYNCHRONIZED again"
+            );
+        }
+    }
+
+    /// Waits for an acknowledgement covering `target`, honoring the
+    /// availability-first timeout. Never returns an error: degradation is a
+    /// logged state change, not a commit failure.
+    fn wait_for_ack(&self, target: u64) {
+        use std::sync::atomic::Ordering;
+        if !self.armed.load(Ordering::Acquire) || self.degraded.load(Ordering::Acquire) {
+            return;
+        }
+        let timeout =
+            std::time::Duration::from_millis(self.timeout_ms.load(Ordering::Relaxed).max(1));
+        let deadline = std::time::Instant::now() + timeout;
+        let mut acked = self.acked.lock().expect("sync-commit state poisoned");
+        while *acked < target {
+            // A concurrent timeout already degraded the link: stop waiting.
+            if self.degraded.load(Ordering::Acquire) {
+                return;
+            }
+            let now = std::time::Instant::now();
+            if now >= deadline {
+                if !self.degraded.swap(true, Ordering::AcqRel) {
+                    eprintln!(
+                        "synchronous commit: no standby acknowledged LSN {target} within \
+                         {timeout:?} — the link is NOT_SYNCHRONIZED; commits proceed on \
+                         local durability alone until a standby catches up"
+                    );
+                }
+                return;
+            }
+            let (guard, _timed_out) = self
+                .acked_cv
+                .wait_timeout(acked, deadline - now)
+                .expect("sync-commit state poisoned");
+            acked = guard;
+        }
+    }
+}
+
 impl From<TypeError> for StorageError {
     fn from(err: TypeError) -> Self {
         StorageError::InvalidConfig(err.0)
@@ -279,6 +375,10 @@ pub struct Storage {
     /// Group-commit coordinator: commits register their WAL tail here and wait
     /// for the log-writer to fsync past it. Shared with the log-writer thread.
     gc: Arc<GroupCommit>,
+    /// D2 synchronous commit (primary side): when armed, a commit additionally
+    /// waits — after LOCAL durability — for a standby's `FlushAck` to cover its
+    /// target, with an availability-first timeout (see [`SyncCommitState`]).
+    sync_commit: SyncCommitState,
     /// The log-writer thread's join handle, taken in `Drop` after signalling it.
     log_writer: Option<JoinHandle<()>>,
     /// `READ_COMMITTED_SNAPSHOT` / `ALLOW_SNAPSHOT_ISOLATION` mirrors of the
@@ -375,6 +475,7 @@ impl Storage {
             path,
             inner: std::sync::Mutex::new(file),
             gc,
+            sync_commit: SyncCommitState::default(),
             log_writer: Some(log_writer),
             rcsi: std::sync::atomic::AtomicBool::new(rcsi),
             allow_snapshot: std::sync::atomic::AtomicBool::new(allow_snapshot),
@@ -587,9 +688,40 @@ impl Storage {
 
     /// Blocks until the WAL is fsync-durable up to `target` — the tail past a
     /// committed record. The executor calls this once per batch that committed,
-    /// so one log-writer fsync makes many concurrent commits durable.
+    /// so one log-writer fsync makes many concurrent commits durable. With
+    /// synchronous commit armed, the commit then also waits for a standby's
+    /// acknowledgement of `target` — unless the link is already degraded
+    /// (NOT_SYNCHRONIZED), in which case commits proceed on local durability
+    /// alone until a standby catches back up.
     pub(crate) fn ensure_durable(&self, target: u64) -> Result<(), StorageError> {
-        self.gc.ensure_durable(target)
+        self.gc.ensure_durable(target)?;
+        self.sync_commit.wait_for_ack(target);
+        Ok(())
+    }
+
+    /// Arms D2 synchronous commit: every commit waits (after local durability)
+    /// for a standby `FlushAck` at or past its target. `timeout` is the
+    /// availability-first knob: a commit that waits longer marks the link
+    /// NOT_SYNCHRONIZED and proceeds — as do all commits after it — until a
+    /// standby's acknowledgements catch back up to the durable watermark.
+    pub fn arm_sync_commit(&self, timeout: std::time::Duration) {
+        self.sync_commit.arm(timeout);
+    }
+
+    /// Whether the synchronous-commit link is degraded (NOT_SYNCHRONIZED).
+    #[cfg(test)]
+    pub(crate) fn sync_commit_degraded(&self) -> bool {
+        self.sync_commit
+            .degraded
+            .load(std::sync::atomic::Ordering::Acquire)
+    }
+
+    /// Publishes a standby's acknowledged durable LSN (the sender's ack path
+    /// calls this beside the slot advance). Re-synchronizes the link when the
+    /// acknowledgement has caught up to the primary's durable watermark.
+    pub(crate) fn publish_sync_ack(&self, acked: u64) {
+        let caught_up = acked >= self.wal_flushed_lsn();
+        self.sync_commit.publish(acked, caught_up);
     }
 
     /// The current WAL tail — the durability target for a batch that committed.
@@ -2481,6 +2613,14 @@ struct StorageFile {
     /// prefix, and could truncate undo of a transaction whose resolution has
     /// not shipped yet. Seeded at open from the same records recovery scans.
     standby_att: std::collections::HashMap<u64, u64>,
+    /// Readable standby: publish records per SHIPPED transaction, so an abort
+    /// (CLRs + TXN_END with no commit) can unwind its version-chain heads the
+    /// same way a local rollback would.
+    standby_published: std::collections::HashMap<u64, Vec<crate::relstore::version::PublishRecord>>,
+    /// Readable standby: the LSN up to which shipped changes have been folded
+    /// into the version store — an overlap re-ship must not publish the same
+    /// change twice (duplicate chain entries).
+    standby_version_floor: u64,
     /// The first ring LSN of a search-subsystem (`entry_type == 1`) record the
     /// seed snapshot does not cover: a restartpoint must not advance the head
     /// past it, or a reopen's search replay would lose the event (a standby
@@ -5119,6 +5259,8 @@ impl StorageFile {
             standby_att: std::collections::HashMap::new(),
             standby_search_floor: None,
             snapshot_next_seq_no: 0,
+            standby_published: std::collections::HashMap::new(),
+            standby_version_floor: 0,
             last_log_backup_lsn,
             log_backup_in_progress: false,
             layout,
@@ -5284,6 +5426,8 @@ impl StorageFile {
             standby_att: std::collections::HashMap::new(),
             standby_search_floor: None,
             snapshot_next_seq_no: 0,
+            standby_published: std::collections::HashMap::new(),
+            standby_version_floor: 0,
             last_log_backup_lsn: 0,
             log_backup_in_progress: false,
             layout,
@@ -5352,6 +5496,16 @@ impl StorageFile {
             let mut ctx = self.rel_ctx();
             rel_recovery::undo_losers(&mut ctx, &records, &outcome.losers, &roots)?;
             self.reload_catalog()?;
+        }
+        // Readable standby: rebuild the version store from the retained ring
+        // (the store is in-memory only — without this a reopen would serve the
+        // redo-applied in-flight rows raw). Runs AFTER redo, so heap pages
+        // self-identify their owner even when they were formatted within the
+        // replayed range.
+        if redo_only {
+            self.version.standby_reads = true;
+            self.standby_capture_versions(&records)?;
+            self.standby_version_floor = self.wal.tail();
         }
         // Object ids are shared by tables, their secondary indexes, and logins
         // (principals draw from the same counter), so the next id must clear all
@@ -5782,6 +5936,117 @@ impl StorageFile {
     }
 
     /// Drops any replication slot lagging the WAL tail by more than
+    /// Readable standby: mirrors a fully-redone shipped range into the version
+    /// store — the pre-image of every row change is already in the record's
+    /// UNDO payload, so `publish` + `record_commit` reproduce exactly what the
+    /// primary's own commit path builds. Uncommitted (in-flight) writers have
+    /// no commit seq, so a snapshot reader at the last-applied-commit sequence
+    /// resolves past their chain heads to the pre-image — the committed state.
+    /// An aborted shipped transaction (CLRs + TXN_END, no commit) unwinds its
+    /// heads like a local rollback. The floor makes an overlap re-ship a
+    /// no-op, and structural/system records (page splits, counters, images
+    /// with no row undo) are skipped — they do not change row visibility.
+    fn standby_capture_versions(
+        &mut self,
+        records: &[(u64, RelRecord)],
+    ) -> Result<(), StorageError> {
+        use crate::relstore::version::{PendingVersion, RowChange};
+        use crate::wal::records::{
+            PageOpUndo, REL_KIND_PAGE_IMAGE, REL_KIND_PAGE_OP, REL_KIND_TXN_COMMIT,
+            REL_KIND_TXN_END,
+        };
+        for (lsn, record) in records {
+            if *lsn < self.standby_version_floor {
+                continue;
+            }
+            match record.kind {
+                REL_KIND_PAGE_OP | REL_KIND_PAGE_IMAGE if record.txn_id != 0 => {
+                    let pending = match record.decode_page_op_undo()? {
+                        PageOpUndo::TreeDeleteKey { object_id, key } => Some(PendingVersion {
+                            object_id,
+                            identity: key,
+                            change: RowChange::Insert,
+                        }),
+                        PageOpUndo::TreeInsertRow {
+                            object_id,
+                            key,
+                            row,
+                        } => Some(PendingVersion {
+                            object_id,
+                            identity: key,
+                            change: RowChange::Delete { prior: row },
+                        }),
+                        PageOpUndo::TreeUpdateRow {
+                            object_id,
+                            key,
+                            row,
+                        } => Some(PendingVersion {
+                            object_id,
+                            identity: key,
+                            change: RowChange::Update { prior: row },
+                        }),
+                        PageOpUndo::HeapDeleteSlot { page, slot } => self
+                            .heap_page_object_id(page)?
+                            .map(|object_id| PendingVersion {
+                                object_id,
+                                identity: rid_identity(crate::relstore::heap::Rid { page, slot }),
+                                change: RowChange::Insert,
+                            }),
+                        PageOpUndo::HeapInsertRow { page, slot, bytes } => self
+                            .heap_page_object_id(page)?
+                            .map(|object_id| PendingVersion {
+                                object_id,
+                                identity: rid_identity(crate::relstore::heap::Rid { page, slot }),
+                                change: RowChange::Delete { prior: bytes },
+                            }),
+                        PageOpUndo::HeapUpdateRow { page, slot, bytes } => self
+                            .heap_page_object_id(page)?
+                            .map(|object_id| PendingVersion {
+                                object_id,
+                                identity: rid_identity(crate::relstore::heap::Rid { page, slot }),
+                                change: RowChange::Update { prior: bytes },
+                            }),
+                        _ => None,
+                    };
+                    if let Some(pending) = pending {
+                        let published = self.version.publish(pending, record.txn_id);
+                        self.standby_published
+                            .entry(record.txn_id)
+                            .or_default()
+                            .push(published);
+                    }
+                }
+                REL_KIND_TXN_COMMIT => {
+                    self.version.record_commit(record.txn_id, *lsn);
+                    self.standby_published.remove(&record.txn_id);
+                }
+                REL_KIND_TXN_END => {
+                    // A TXN_END without a preceding commit seals an abort: the
+                    // CLRs restored the pages, and the chain heads come off in
+                    // reverse publish order, like a local rollback.
+                    if let Some(published) = self.standby_published.remove(&record.txn_id) {
+                        for rec in published.into_iter().rev() {
+                            self.version.unpublish(rec, record.txn_id);
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+        Ok(())
+    }
+
+    /// The owning object of a heap page, from its self-identifying header
+    /// (`None` for a page that is not heap-formatted — a stale undo against a
+    /// since-freed page).
+    fn heap_page_object_id(&mut self, page: u64) -> Result<Option<u32>, StorageError> {
+        let mut ctx = self.rel_ctx();
+        let frame = ctx.fetch(page)?;
+        let header = crate::relstore::page::read_header(ctx.pool.page(frame));
+        ctx.pool.unpin(frame);
+        Ok((header.page_type == crate::relstore::page::PAGE_TYPE_HEAP).then_some(header.object_id))
+    }
+
     /// `max_slot_retain_bytes` — it no longer pins the truncation floor, so the
     /// ring can advance past it (the standby must reseed). Run at the start of a
     /// checkpoint, before the floor is computed. A no-op under the default
@@ -6623,6 +6888,13 @@ impl StorageFile {
         for (lsn, record) in &records {
             self.standby_track_rel_record(*lsn, record);
         }
+        // Readable standby: mirror the range into the version store (pre-images
+        // from the undo payloads), so snapshot reads at the last-applied-commit
+        // sequence see only committed state. Same post-redo discipline: a
+        // failed apply must feed the store nothing.
+        self.version.standby_reads = true;
+        self.standby_capture_versions(&records)?;
+        self.standby_version_floor = advanced;
         // Track the first UNCOVERED search record (the restartpoint's search
         // floor): the seed snapshot covers seq numbers below
         // `snapshot_next_seq_no`; anything at or above must stay in the ring

--- a/crates/truthdb-core/src/storage.rs
+++ b/crates/truthdb-core/src/storage.rs
@@ -46,6 +46,11 @@ struct SyncCommitState {
     armed: std::sync::atomic::AtomicBool,
     timeout_ms: std::sync::atomic::AtomicU64,
     degraded: std::sync::atomic::AtomicBool,
+    /// The LSN whose acknowledgement re-synchronizes a degraded link: the
+    /// target of the wait that timed out. Comparing against the LIVE durable
+    /// watermark instead would latch the degradation forever under sustained
+    /// writes — an ack always trails the live watermark by one round trip.
+    resync_target: std::sync::atomic::AtomicU64,
     acked: std::sync::Mutex<u64>,
     acked_cv: std::sync::Condvar,
 }
@@ -56,6 +61,7 @@ impl Default for SyncCommitState {
             armed: std::sync::atomic::AtomicBool::new(false),
             timeout_ms: std::sync::atomic::AtomicU64::new(0),
             degraded: std::sync::atomic::AtomicBool::new(false),
+            resync_target: std::sync::atomic::AtomicU64::new(0),
             acked: std::sync::Mutex::new(0),
             acked_cv: std::sync::Condvar::new(),
         }
@@ -71,8 +77,9 @@ impl SyncCommitState {
         self.armed.store(true, std::sync::atomic::Ordering::Release);
     }
 
-    fn publish(&self, lsn: u64, caught_up: bool) {
-        if !self.armed.load(std::sync::atomic::Ordering::Acquire) {
+    fn publish(&self, lsn: u64) {
+        use std::sync::atomic::Ordering;
+        if !self.armed.load(Ordering::Acquire) {
             return;
         }
         {
@@ -82,10 +89,12 @@ impl SyncCommitState {
             }
         }
         self.acked_cv.notify_all();
-        if caught_up
-            && self
-                .degraded
-                .swap(false, std::sync::atomic::Ordering::AcqRel)
+        // Re-synchronize once the acknowledgement covers the wait that
+        // degraded the link — the incident point, NOT the live watermark
+        // (which a loaded primary keeps permanently ahead of any ack).
+        if self.degraded.load(Ordering::Acquire)
+            && lsn >= self.resync_target.load(Ordering::Acquire)
+            && self.degraded.swap(false, Ordering::AcqRel)
         {
             eprintln!(
                 "synchronous commit: a standby caught up (acknowledged {lsn}); the link is \
@@ -113,6 +122,7 @@ impl SyncCommitState {
             }
             let now = std::time::Instant::now();
             if now >= deadline {
+                self.resync_target.store(target, Ordering::Release);
                 if !self.degraded.swap(true, Ordering::AcqRel) {
                     eprintln!(
                         "synchronous commit: no standby acknowledged LSN {target} within \
@@ -120,6 +130,10 @@ impl SyncCommitState {
                          local durability alone until a standby catches up"
                     );
                 }
+                // Wake concurrently parked committers: the link is degraded,
+                // they must stop waiting too.
+                drop(acked);
+                self.acked_cv.notify_all();
                 return;
             }
             let (guard, _timed_out) = self
@@ -720,8 +734,7 @@ impl Storage {
     /// calls this beside the slot advance). Re-synchronizes the link when the
     /// acknowledgement has caught up to the primary's durable watermark.
     pub(crate) fn publish_sync_ack(&self, acked: u64) {
-        let caught_up = acked >= self.wal_flushed_lsn();
-        self.sync_commit.publish(acked, caught_up);
+        self.sync_commit.publish(acked);
     }
 
     /// The current WAL tail — the durability target for a batch that committed.
@@ -2613,10 +2626,14 @@ struct StorageFile {
     /// prefix, and could truncate undo of a transaction whose resolution has
     /// not shipped yet. Seeded at open from the same records recovery scans.
     standby_att: std::collections::HashMap<u64, u64>,
-    /// Readable standby: publish records per SHIPPED transaction, so an abort
-    /// (CLRs + TXN_END with no commit) can unwind its version-chain heads the
-    /// same way a local rollback would.
-    standby_published: std::collections::HashMap<u64, Vec<crate::relstore::version::PublishRecord>>,
+    /// Readable standby: per SHIPPED transaction, one stack entry per logged
+    /// op `(record LSN, publish record if the op changed a row)`. A CLR pops
+    /// every entry above its `undo_next` and unpublishes the popped row
+    /// changes — mirroring savepoint/statement rollbacks exactly, since undo
+    /// compensates ops in reverse LSN order — and a commit-less TXN_END
+    /// unwinds whatever remains.
+    standby_published:
+        std::collections::HashMap<u64, Vec<(u64, Option<crate::relstore::version::PublishRecord>)>>,
     /// Readable standby: the LSN up to which shipped changes have been folded
     /// into the version store — an overlap re-ship must not publish the same
     /// change twice (duplicate chain entries).
@@ -5504,7 +5521,7 @@ impl StorageFile {
         // replayed range.
         if redo_only {
             self.version.standby_reads = true;
-            self.standby_capture_versions(&records)?;
+            self.standby_capture_versions(&records);
             self.standby_version_floor = self.wal.tail();
         }
         // Object ids are shared by tables, their secondary indexes, and logins
@@ -5942,78 +5959,68 @@ impl StorageFile {
     /// primary's own commit path builds. Uncommitted (in-flight) writers have
     /// no commit seq, so a snapshot reader at the last-applied-commit sequence
     /// resolves past their chain heads to the pre-image — the committed state.
-    /// An aborted shipped transaction (CLRs + TXN_END, no commit) unwinds its
-    /// heads like a local rollback. The floor makes an overlap re-ship a
-    /// no-op, and structural/system records (page splits, counters, images
-    /// with no row undo) are skipped — they do not change row visibility.
-    fn standby_capture_versions(
-        &mut self,
-        records: &[(u64, RelRecord)],
-    ) -> Result<(), StorageError> {
-        use crate::relstore::version::{PendingVersion, RowChange};
+    /// CLRs pop and unpublish the compensated suffix (savepoint/statement
+    /// rollbacks inside a transaction that later commits); a commit-less
+    /// TXN_END unwinds the rest (a full abort). Heap undo payloads are CELL
+    /// bytes — decoded (tag stripped, moved rows re-homed) before publishing.
+    /// Only live TABLE objects get chains (index-maintenance undos carry the
+    /// index's object id; nothing resolves index chains, and pruning clears
+    /// them), a page freed anywhere in the range is skipped (its historical
+    /// owner is not derivable from the post-range header), and a DDL in the
+    /// range stamps every live table so an older pinned snapshot fails 3961
+    /// instead of decoding rows under the wrong schema. Per-record failures
+    /// are logged and skipped — a capture problem must not wedge the stream
+    /// (the cost is one row's pre-image, not divergence).
+    fn standby_capture_versions(&mut self, records: &[(u64, RelRecord)]) {
         use crate::wal::records::{
-            PageOpUndo, REL_KIND_PAGE_IMAGE, REL_KIND_PAGE_OP, REL_KIND_TXN_COMMIT,
-            REL_KIND_TXN_END,
+            REL_KIND_CLR, REL_KIND_FREE_EXTENT, REL_KIND_PAGE_IMAGE, REL_KIND_PAGE_OP,
+            REL_KIND_SET_CATALOG_ROOT, REL_KIND_TXN_COMMIT, REL_KIND_TXN_END,
         };
+        let alive: std::collections::HashSet<u32> =
+            self.rel.tables.values().map(|def| def.object_id).collect();
+        let mut freed_pages: std::collections::HashSet<u64> = std::collections::HashSet::new();
+        for (_, record) in records {
+            if record.kind == REL_KIND_FREE_EXTENT
+                && let Ok((start, pages)) = record.decode_extent_redo()
+            {
+                for page in start..start.saturating_add(pages) {
+                    freed_pages.insert(page);
+                }
+            }
+        }
+        let mut catalog_changed = false;
         for (lsn, record) in records {
             if *lsn < self.standby_version_floor {
                 continue;
             }
             match record.kind {
                 REL_KIND_PAGE_OP | REL_KIND_PAGE_IMAGE if record.txn_id != 0 => {
-                    let pending = match record.decode_page_op_undo()? {
-                        PageOpUndo::TreeDeleteKey { object_id, key } => Some(PendingVersion {
-                            object_id,
-                            identity: key,
-                            change: RowChange::Insert,
-                        }),
-                        PageOpUndo::TreeInsertRow {
-                            object_id,
-                            key,
-                            row,
-                        } => Some(PendingVersion {
-                            object_id,
-                            identity: key,
-                            change: RowChange::Delete { prior: row },
-                        }),
-                        PageOpUndo::TreeUpdateRow {
-                            object_id,
-                            key,
-                            row,
-                        } => Some(PendingVersion {
-                            object_id,
-                            identity: key,
-                            change: RowChange::Update { prior: row },
-                        }),
-                        PageOpUndo::HeapDeleteSlot { page, slot } => self
-                            .heap_page_object_id(page)?
-                            .map(|object_id| PendingVersion {
-                                object_id,
-                                identity: rid_identity(crate::relstore::heap::Rid { page, slot }),
-                                change: RowChange::Insert,
-                            }),
-                        PageOpUndo::HeapInsertRow { page, slot, bytes } => self
-                            .heap_page_object_id(page)?
-                            .map(|object_id| PendingVersion {
-                                object_id,
-                                identity: rid_identity(crate::relstore::heap::Rid { page, slot }),
-                                change: RowChange::Delete { prior: bytes },
-                            }),
-                        PageOpUndo::HeapUpdateRow { page, slot, bytes } => self
-                            .heap_page_object_id(page)?
-                            .map(|object_id| PendingVersion {
-                                object_id,
-                                identity: rid_identity(crate::relstore::heap::Rid { page, slot }),
-                                change: RowChange::Update { prior: bytes },
-                            }),
-                        _ => None,
-                    };
-                    if let Some(pending) = pending {
-                        let published = self.version.publish(pending, record.txn_id);
-                        self.standby_published
-                            .entry(record.txn_id)
-                            .or_default()
-                            .push(published);
+                    let pending = self
+                        .standby_pending_version(record, &alive, &freed_pages)
+                        .unwrap_or_else(|err| {
+                            eprintln!(
+                                "standby version capture: skipping record at LSN {lsn}: {err}"
+                            );
+                            None
+                        });
+                    let published = pending.map(|p| self.version.publish(p, record.txn_id));
+                    self.standby_published
+                        .entry(record.txn_id)
+                        .or_default()
+                        .push((*lsn, published));
+                }
+                REL_KIND_CLR if record.txn_id != 0 => {
+                    // The CLR's redo opens with the `undo_next` LSN: everything
+                    // the transaction logged ABOVE it is now compensated.
+                    if record.redo.len() >= 8 {
+                        let undo_next = u64::from_le_bytes(record.redo[0..8].try_into().unwrap());
+                        if let Some(stack) = self.standby_published.get_mut(&record.txn_id) {
+                            while stack.last().is_some_and(|(l, _)| *l > undo_next) {
+                                if let Some((_, Some(rec))) = stack.pop() {
+                                    self.version.unpublish(rec, record.txn_id);
+                                }
+                            }
+                        }
                     }
                 }
                 REL_KIND_TXN_COMMIT => {
@@ -6021,19 +6028,129 @@ impl StorageFile {
                     self.standby_published.remove(&record.txn_id);
                 }
                 REL_KIND_TXN_END => {
-                    // A TXN_END without a preceding commit seals an abort: the
-                    // CLRs restored the pages, and the chain heads come off in
-                    // reverse publish order, like a local rollback.
-                    if let Some(published) = self.standby_published.remove(&record.txn_id) {
-                        for rec in published.into_iter().rev() {
-                            self.version.unpublish(rec, record.txn_id);
+                    if let Some(stack) = self.standby_published.remove(&record.txn_id) {
+                        for (_, published) in stack.into_iter().rev() {
+                            if let Some(rec) = published {
+                                self.version.unpublish(rec, record.txn_id);
+                            }
                         }
                     }
                 }
+                REL_KIND_SET_CATALOG_ROOT => catalog_changed = true,
                 _ => {}
             }
         }
-        Ok(())
+        if catalog_changed {
+            // A shipped DDL cannot wait out pinned snapshots the way the
+            // primary's Database X does; fence them instead (3961 on the next
+            // access), for every live table — conservative and correct.
+            for object_id in alive {
+                self.version.stamp_schema(object_id);
+            }
+        }
+    }
+
+    /// Builds the version-store change for one shipped row op, or `None` for
+    /// structural/system/foreign records.
+    fn standby_pending_version(
+        &mut self,
+        record: &RelRecord,
+        alive: &std::collections::HashSet<u32>,
+        freed_pages: &std::collections::HashSet<u64>,
+    ) -> Result<Option<crate::relstore::version::PendingVersion>, StorageError> {
+        use crate::relstore::version::{PendingVersion, RowChange};
+        use crate::wal::records::PageOpUndo;
+        type HeapChange = Option<(u32, Vec<u8>, Option<Vec<u8>>)>;
+        let heap_change = |this: &mut Self,
+                           page: u64,
+                           slot: u16,
+                           cell: Option<Vec<u8>>|
+         -> Result<HeapChange, StorageError> {
+            if freed_pages.contains(&page) {
+                return Ok(None);
+            }
+            let Some(object_id) = this.heap_page_object_id(page)? else {
+                return Ok(None);
+            };
+            if !alive.contains(&object_id) {
+                return Ok(None);
+            }
+            match cell {
+                None => Ok(Some((
+                    object_id,
+                    rid_identity(crate::relstore::heap::Rid { page, slot }),
+                    None,
+                ))),
+                Some(cell) => {
+                    // The undo payload is a heap CELL: strip the tag, and home
+                    // a MOVED copy's identity to the RID readers scan under.
+                    let Some((home, row)) = crate::relstore::heap::cell_row(&cell) else {
+                        return Ok(None); // a stub — a pointer, not a row
+                    };
+                    let identity =
+                        rid_identity(home.unwrap_or(crate::relstore::heap::Rid { page, slot }));
+                    Ok(Some((object_id, identity, Some(row.to_vec()))))
+                }
+            }
+        };
+        let pending =
+            match record.decode_page_op_undo()? {
+                PageOpUndo::TreeDeleteKey { object_id, key } if alive.contains(&object_id) => {
+                    Some(PendingVersion {
+                        object_id,
+                        identity: key,
+                        change: RowChange::Insert,
+                    })
+                }
+                PageOpUndo::TreeInsertRow {
+                    object_id,
+                    key,
+                    row,
+                } if alive.contains(&object_id) => Some(PendingVersion {
+                    object_id,
+                    identity: key,
+                    change: RowChange::Delete { prior: row },
+                }),
+                PageOpUndo::TreeUpdateRow {
+                    object_id,
+                    key,
+                    row,
+                } if alive.contains(&object_id) => Some(PendingVersion {
+                    object_id,
+                    identity: key,
+                    change: RowChange::Update { prior: row },
+                }),
+                PageOpUndo::HeapDeleteSlot { page, slot } => heap_change(self, page, slot, None)?
+                    .map(|(object_id, identity, _)| PendingVersion {
+                        object_id,
+                        identity,
+                        change: RowChange::Insert,
+                    }),
+                PageOpUndo::HeapInsertRow { page, slot, bytes } => {
+                    heap_change(self, page, slot, Some(bytes))?.map(|(object_id, identity, row)| {
+                        PendingVersion {
+                            object_id,
+                            identity,
+                            change: RowChange::Delete {
+                                prior: row.expect("cell decoded"),
+                            },
+                        }
+                    })
+                }
+                PageOpUndo::HeapUpdateRow { page, slot, bytes } => {
+                    heap_change(self, page, slot, Some(bytes))?.map(|(object_id, identity, row)| {
+                        PendingVersion {
+                            object_id,
+                            identity,
+                            change: RowChange::Update {
+                                prior: row.expect("cell decoded"),
+                            },
+                        }
+                    })
+                }
+                _ => None,
+            };
+        Ok(pending)
     }
 
     /// The owning object of a heap page, from its self-identifying header
@@ -6305,9 +6422,9 @@ impl StorageFile {
             if self.active_sb().is_standby() {
                 return Err(StorageError::InvalidConfig(
                     "a query on this replication standby needed spill scratch, which shares \
-                     the data region the primary's stream writes into; re-run with more \
-                     memory or run it on the primary (readable-standby spill arrives with \
-                     snapshot standby reads)"
+                     the data region the primary's stream writes into; run it on the primary \
+                     or raise the memory budget (dedicated standby scratch storage is \
+                     planned)"
                         .to_string(),
                 ));
             }
@@ -6893,7 +7010,7 @@ impl StorageFile {
         // sequence see only committed state. Same post-redo discipline: a
         // failed apply must feed the store nothing.
         self.version.standby_reads = true;
-        self.standby_capture_versions(&records)?;
+        self.standby_capture_versions(&records);
         self.standby_version_floor = advanced;
         // Track the first UNCOVERED search record (the restartpoint's search
         // floor): the seed snapshot covers seq numbers below

--- a/src/config.rs
+++ b/src/config.rs
@@ -93,6 +93,18 @@ pub struct ReplicationConfig {
     /// this many bytes (the standby must reseed). 0 = unlimited retention.
     #[serde(default)]
     pub max_slot_retain_bytes: u64,
+
+    /// Primary: D2 synchronous commit — every commit waits (after local
+    /// durability) for a standby's acknowledgement. Availability-first: a
+    /// commit that waits past `sync_timeout_ms` marks the link
+    /// NOT_SYNCHRONIZED and proceeds, as do later commits, until a standby
+    /// catches back up.
+    #[serde(default)]
+    pub synchronous_commit: bool,
+
+    /// Primary: the synchronous-commit wait bound (the strictness knob).
+    #[serde(default = "default_replication_sync_timeout_ms")]
+    pub sync_timeout_ms: u64,
 }
 
 /// The shared secret must not appear in logs (`debug!(?config)` logs the whole
@@ -116,6 +128,8 @@ impl std::fmt::Debug for ReplicationConfig {
             .field("reconnect_delay_ms", &self.reconnect_delay_ms)
             .field("stall_timeout_ms", &self.stall_timeout_ms)
             .field("max_slot_retain_bytes", &self.max_slot_retain_bytes)
+            .field("synchronous_commit", &self.synchronous_commit)
+            .field("sync_timeout_ms", &self.sync_timeout_ms)
             .finish()
     }
 }
@@ -148,6 +162,8 @@ impl Default for ReplicationConfig {
             reconnect_delay_ms: default_replication_reconnect_ms(),
             stall_timeout_ms: default_replication_stall_ms(),
             max_slot_retain_bytes: 0,
+            synchronous_commit: false,
+            sync_timeout_ms: default_replication_sync_timeout_ms(),
         }
     }
 }
@@ -170,6 +186,10 @@ fn default_replication_reconnect_ms() -> u64 {
 
 fn default_replication_stall_ms() -> u64 {
     30_000
+}
+
+fn default_replication_sync_timeout_ms() -> u64 {
+    10_000
 }
 
 impl ReplicationConfig {
@@ -535,6 +555,8 @@ struct ReplicationConfigOverride {
     reconnect_delay_ms: Option<u64>,
     stall_timeout_ms: Option<u64>,
     max_slot_retain_bytes: Option<u64>,
+    synchronous_commit: Option<bool>,
+    sync_timeout_ms: Option<u64>,
 }
 
 fn apply_replication_override(target: &mut ReplicationConfig, source: ReplicationConfigOverride) {
@@ -585,6 +607,12 @@ fn apply_replication_override(target: &mut ReplicationConfig, source: Replicatio
     }
     if let Some(max_slot_retain_bytes) = source.max_slot_retain_bytes {
         target.max_slot_retain_bytes = max_slot_retain_bytes;
+    }
+    if let Some(synchronous_commit) = source.synchronous_commit {
+        target.synchronous_commit = synchronous_commit;
+    }
+    if let Some(sync_timeout_ms) = source.sync_timeout_ms {
+        target.sync_timeout_ms = sync_timeout_ms;
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -299,6 +299,16 @@ async fn start_replication(
                     .set_max_slot_retain_bytes(cfg.max_slot_retain_bytes)
                     .map_err(|err| err.to_string())?;
             }
+            if cfg.synchronous_commit {
+                if cfg.sync_timeout_ms == 0 {
+                    return Err("replication.sync_timeout_ms must be greater than 0".to_string());
+                }
+                storage.arm_sync_commit(std::time::Duration::from_millis(cfg.sync_timeout_ms));
+                info!(
+                    "Synchronous commit armed (timeout {} ms, availability-first)",
+                    cfg.sync_timeout_ms
+                );
+            }
             let listener = tokio::net::TcpListener::bind((cfg.addr.as_str(), cfg.port))
                 .await
                 .map_err(|err| format!("replication listener {}:{}: {err}", cfg.addr, cfg.port))?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -349,6 +349,13 @@ async fn start_replication(
                      `truthdb-cli restore --standby`"
                     .to_string());
             }
+            if cfg.synchronous_commit {
+                return Err(
+                    "replication.synchronous_commit applies to the primary role; \
+                     remove it from this standby's config"
+                        .to_string(),
+                );
+            }
             let server_name = cfg.server_name.clone().unwrap_or_else(|| {
                 let host = primary_addr
                     .rsplit_once(':')


### PR DESCRIPTION
Both halves of D2.

**Synchronous commit**: `[replication] synchronous_commit = true` makes every commit wait (after local fsync) for a standby acknowledgement, with the documented availability-first timeout — a stalled link degrades to NOT_SYNCHRONIZED and commits proceed until an ack catches back up.

**Readable standby**: standby reads now resolve through the Stage-13 version store at the last-applied-commit snapshot. The apply mirrors shipped changes into the store using the pre-images already present in every WAL record's undo payload — no WAL format change, no version-store schema change, and the existing scan/seek merge paths enforce visibility unmodified. Aborted shipped transactions unwind via the existing rollback machinery; the store rebuilds at reopen from the retained ring; a failed apply feeds it nothing.

`cargo test --workspace` green, clippy `-D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)