### PR TITLE
Stage 18.6: replication monitoring — sys.dm_repl_* DMVs + truthdb-cli repl-status

### DIFF
--- a/crates/truthdb-cli/src/main.rs
+++ b/crates/truthdb-cli/src/main.rs
@@ -88,6 +88,10 @@ enum Command {
         #[arg(long)]
         path: std::path::PathBuf,
     },
+    /// ONLINE: show this server's replication state (role, slots, connected
+    /// standbys, lag, sync-commit status) by querying the `sys.dm_repl_*`
+    /// views over the native protocol.
+    ReplStatus,
 }
 
 #[tokio::main]
@@ -147,6 +151,7 @@ async fn main() -> Result<()> {
                 Err(err) => Err(anyhow::anyhow!("restore failed: {err}")),
             }
         }
+        Command::ReplStatus => repl_status(&addr).await,
         Command::Promote { path } => match truthdb_core::storage::Storage::promote(&path) {
             Ok(epoch) => {
                 println!(
@@ -159,6 +164,31 @@ async fn main() -> Result<()> {
             Err(err) => Err(anyhow::anyhow!("promote failed: {err}")),
         },
     }
+}
+
+/// Queries the replication DMVs and prints them.
+async fn repl_status(addr: &str) -> Result<()> {
+    let mut stream = TcpStream::connect(addr).await?;
+    send_hello(&mut stream).await?;
+    let mut id = 1u64;
+    for (title, query) in [
+        (
+            "replica states",
+            "SELECT * FROM sys.dm_repl_replica_states;",
+        ),
+        ("slots", "SELECT * FROM sys.dm_repl_slots;"),
+    ] {
+        let resp = send_command(&mut stream, id, query).await?;
+        id = id.wrapping_add(1);
+        println!("-- {title} --");
+        let rendered = render::render(resp.ok, &resp.message);
+        if rendered.is_empty() {
+            println!("(none)");
+        } else {
+            println!("{rendered}");
+        }
+    }
+    Ok(())
 }
 
 async fn repl(addr: &str) -> Result<()> {

--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -2518,7 +2518,6 @@ mod tests {
             heartbeat: Duration::from_millis(200),
             stall_timeout: Duration::from_secs(30),
             chunk_bytes: 512,
-            active_nodes: Arc::default(),
         };
         let listener_task = tokio::spawn(run_repl_listener(
             listener,
@@ -3048,6 +3047,91 @@ mod tests {
             vec![vec![Some("999".into())]],
             "the committed heap update is visible"
         );
+
+        drop(primary);
+        drop(standby);
+        for p in [primary_path, bak, standby_path] {
+            let _ = std::fs::remove_file(p);
+        }
+    }
+
+    // Stage 18.6 monitoring: the replication DMVs report role, slots,
+    // connectedness, and lag on both sides of a link.
+    #[test]
+    fn replication_dmvs_report_slots_lag_and_role() {
+        let primary_path = unique_temp_path("dmv-primary");
+        let bak = unique_temp_path("dmv-bak");
+        let standby_path = unique_temp_path("dmv-standby");
+
+        let primary = new_engine(&primary_path);
+        primary
+            .execute("CREATE TABLE t (id INT NOT NULL PRIMARY KEY)")
+            .expect("create");
+        for i in 1..=5 {
+            primary
+                .execute(&format!("INSERT INTO t VALUES ({i})"))
+                .expect("insert");
+        }
+        // No slots yet: the primary reports zero replica rows.
+        assert_eq!(
+            sql_rows(&primary, "SELECT COUNT(*) FROM sys.dm_repl_replica_states").1,
+            vec![vec![Some("0".into())]],
+        );
+        assert_eq!(
+            sql_rows(&primary, "SELECT COUNT(*) FROM sys.dm_repl_slots").1[0][0],
+            Some("0".into())
+        );
+
+        // Register a slot (as the sender would) and check the reporting.
+        let held = primary.storage().wal_flushed_lsn();
+        primary
+            .storage()
+            .try_register_repl_slot(3, held)
+            .expect("slot");
+        for i in 6..=10 {
+            primary
+                .execute(&format!("INSERT INTO t VALUES ({i})"))
+                .expect("insert");
+        }
+        let (cols, rows) = sql_rows(
+            &primary,
+            "SELECT role, node_id, is_connected, lag_bytes, sync_state \
+             FROM sys.dm_repl_replica_states",
+        );
+        assert_eq!(
+            cols,
+            vec!["role", "node_id", "is_connected", "lag_bytes", "sync_state"]
+        );
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0][0], Some("PRIMARY".into()));
+        assert_eq!(rows[0][1], Some("3".into()));
+        assert_eq!(
+            rows[0][2],
+            Some("0".into()),
+            "no live sender (bit renders 0)"
+        );
+        let lag: i64 = rows[0][3].as_deref().unwrap().parse().expect("lag");
+        assert!(lag > 0, "the slot lags the new commits");
+        assert_eq!(rows[0][4], Some("ASYNC".into()));
+        let (_, slot_rows) = sql_rows(
+            &primary,
+            "SELECT slot_id, retained_bytes FROM sys.dm_repl_slots",
+        );
+        assert_eq!(slot_rows[0][0], Some("3".into()));
+        assert!(slot_rows[0][1].as_deref().unwrap().parse::<i64>().unwrap() > 0);
+
+        // A standby reports its own role and applied position.
+        let summary = primary.storage().backup_full(&bak).expect("backup");
+        Storage::restore_full_standby(&standby_path, &bak, &[]).expect("seed");
+        let standby = Engine::new(Storage::open(standby_path.clone()).expect("open")).expect("eng");
+        let _ = summary;
+        let (_, srows) = sql_rows(
+            &standby,
+            "SELECT role, sync_state FROM sys.dm_repl_replica_states",
+        );
+        assert_eq!(srows.len(), 1);
+        assert_eq!(srows[0][0], Some("STANDBY".into()));
+        assert_eq!(srows[0][1], Some("NOT_APPLICABLE".into()));
 
         drop(primary);
         drop(standby);

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -10587,6 +10587,8 @@ fn is_sys_view(name: &str) -> bool {
             | "sys.foreign_keys"
             | "sys.default_constraints"
             | "sys.databases"
+            | "sys.dm_repl_replica_states"
+            | "sys.dm_repl_slots"
             | "sys.configurations"
             | "sys.database_principals"
             | "sys.database_role_members"
@@ -12129,6 +12131,8 @@ fn build_table_source(
     let base = match name.value.to_ascii_lowercase().as_str() {
         "sys.tables" => sys_tables(storage),
         "sys.databases" => sys_databases(storage, eval_ctx),
+        "sys.dm_repl_replica_states" => sys_dm_repl_replica_states(storage),
+        "sys.dm_repl_slots" => sys_dm_repl_slots(storage),
         "sys.configurations" => sys_configurations(),
         "sys.views" => sys_views(storage),
         "sys.procedures" => sys_procedures(storage),
@@ -13432,6 +13436,106 @@ fn sys_tables(storage: &Storage) -> Source {
 }
 
 /// `sys.views` — one row per view, with its stored definition text.
+/// `sys.dm_repl_slots` (Stage 18): the primary's replication slots and the
+/// WAL-ring positions they pin. Empty on a standby (and on a primary with no
+/// standby ever connected).
+fn sys_dm_repl_slots(storage: &Storage) -> Source {
+    let columns = vec![
+        int_col("slot_id"),
+        bigint_col("held_lsn"),
+        bigint_col("wal_head"),
+        bigint_col("wal_tail"),
+        bigint_col("retained_bytes"),
+    ];
+    let head = storage.wal_head();
+    let tail = storage.wal_tail();
+    let rows: Vec<Vec<Datum>> = storage
+        .repl_slots_snapshot()
+        .into_iter()
+        .map(|(id, lsn)| {
+            vec![
+                Datum::Int(id as i32),
+                Datum::BigInt(lsn as i64),
+                Datum::BigInt(head as i64),
+                Datum::BigInt(tail as i64),
+                Datum::BigInt(tail.saturating_sub(lsn) as i64),
+            ]
+        })
+        .collect();
+    let collations = vec![None; columns.len()];
+    let qualifiers = vec![None; columns.len()];
+    Source {
+        columns,
+        qualifiers,
+        collations,
+        rows: SourceRows::Materialized(rows),
+    }
+}
+
+/// `sys.dm_repl_replica_states` (Stage 18): this node's replication role and,
+/// on a primary, one row per replication slot with its connection and lag
+/// state; on a standby, one row describing its own applied position.
+fn sys_dm_repl_replica_states(storage: &Storage) -> Source {
+    let columns = vec![
+        nvarchar("role", 20),
+        int_col("node_id"),
+        ResultColumn {
+            name: "is_connected".into(),
+            column_type: ColumnType::Bit,
+        },
+        bigint_col("acked_lsn"),
+        bigint_col("durable_lsn"),
+        bigint_col("lag_bytes"),
+        nvarchar("sync_state", 30),
+        bigint_col("epoch"),
+    ];
+    let epoch = storage.epoch() as i64;
+    let rows = if storage.is_standby() {
+        vec![vec![
+            Datum::NVarChar("STANDBY".into()),
+            Datum::Null,
+            Datum::Null,
+            Datum::BigInt(storage.applied_lsn() as i64),
+            Datum::BigInt(storage.wal_flushed_lsn() as i64),
+            Datum::BigInt(0),
+            Datum::NVarChar("NOT_APPLICABLE".into()),
+            Datum::BigInt(epoch),
+        ]]
+    } else {
+        let durable = storage.wal_flushed_lsn();
+        let connected = storage.repl_connected_nodes();
+        let sync_state = match storage.sync_commit_status() {
+            None => "ASYNC",
+            Some(false) => "SYNCHRONIZED",
+            Some(true) => "NOT_SYNCHRONIZED",
+        };
+        storage
+            .repl_slots_snapshot()
+            .into_iter()
+            .map(|(id, lsn)| {
+                vec![
+                    Datum::NVarChar("PRIMARY".into()),
+                    Datum::Int(id as i32),
+                    Datum::Bit(connected.contains(&id)),
+                    Datum::BigInt(lsn as i64),
+                    Datum::BigInt(durable as i64),
+                    Datum::BigInt(durable.saturating_sub(lsn) as i64),
+                    Datum::NVarChar(sync_state.into()),
+                    Datum::BigInt(epoch),
+                ]
+            })
+            .collect()
+    };
+    let collations = vec![None; columns.len()];
+    let qualifiers = vec![None; columns.len()];
+    Source {
+        columns,
+        qualifiers,
+        collations,
+        rows: SourceRows::Materialized(rows),
+    }
+}
+
 /// `sys.databases` (Stage 14, SSMS query-window probes): the one database
 /// this instance serves, with the columns tools actually read. The
 /// versioning flags report the live `ALTER DATABASE` options.

--- a/crates/truthdb-core/src/repl/listener.rs
+++ b/crates/truthdb-core/src/repl/listener.rs
@@ -40,9 +40,6 @@ pub struct PrimaryReplContext {
     /// Target bytes per `LogData` frame during catch-up (cut on entry
     /// boundaries; see `sender::DEFAULT_CHUNK_BYTES`).
     pub chunk_bytes: u64,
-    /// Node ids with a live sender, so a second connection under the same id
-    /// is refused instead of corrupting the first's slot.
-    pub active_nodes: Arc<std::sync::Mutex<std::collections::HashSet<u32>>>,
 }
 
 impl PrimaryReplContext {
@@ -170,7 +167,6 @@ mod tests {
             heartbeat: Duration::from_secs(30),
             stall_timeout: Duration::from_secs(30),
             chunk_bytes: crate::repl::sender::DEFAULT_CHUNK_BYTES,
-            active_nodes: Arc::default(),
         };
         let server = tokio::spawn(run_repl_listener(listener, acceptor, ctx, shutdown_rx));
 

--- a/crates/truthdb-core/src/repl/sender.rs
+++ b/crates/truthdb-core/src/repl/sender.rs
@@ -72,8 +72,9 @@ where
     // One connection per node id: a second stream under the same id would
     // reset the first's slot and its acks would advance it out from under the
     // other stream's shipping position (the shipped default node_id is the
-    // same on every node, so this is an easy misconfiguration to hit).
-    let _membership = match NodeMembership::acquire(&ctx.active_nodes, slot_id) {
+    // same on every node, so this is an easy misconfiguration to hit). The
+    // registry lives on Storage so the monitoring DMVs can report it.
+    let _membership = match NodeMembership::acquire(&storage, slot_id) {
         Some(m) => m,
         None => {
             let msg = format!(
@@ -118,20 +119,17 @@ where
     result
 }
 
-/// RAII membership in the primary's connected-node set.
+/// RAII membership in the primary's connected-node set (kept on Storage so
+/// the monitoring DMVs can report connectedness).
 struct NodeMembership {
-    nodes: Arc<Mutex<std::collections::HashSet<u32>>>,
+    storage: Arc<Storage>,
     id: u32,
 }
 
 impl NodeMembership {
-    fn acquire(nodes: &Arc<Mutex<std::collections::HashSet<u32>>>, id: u32) -> Option<Self> {
-        let mut set = nodes.lock().expect("active-node set poisoned");
-        if !set.insert(id) {
-            return None;
-        }
-        Some(NodeMembership {
-            nodes: Arc::clone(nodes),
+    fn acquire(storage: &Arc<Storage>, id: u32) -> Option<Self> {
+        storage.try_join_repl_node(id).then(|| NodeMembership {
+            storage: Arc::clone(storage),
             id,
         })
     }
@@ -139,10 +137,7 @@ impl NodeMembership {
 
 impl Drop for NodeMembership {
     fn drop(&mut self) {
-        self.nodes
-            .lock()
-            .expect("active-node set poisoned")
-            .remove(&self.id);
+        self.storage.leave_repl_node(self.id);
     }
 }
 
@@ -371,7 +366,6 @@ mod tests {
             heartbeat: Duration::from_secs(30),
             stall_timeout: Duration::from_secs(30),
             chunk_bytes: DEFAULT_CHUNK_BYTES,
-            active_nodes: Arc::default(),
         }
     }
 
@@ -481,7 +475,7 @@ mod tests {
         first.abort();
         let _ = first.await;
         // The membership guard released the id on abort, so it is reusable.
-        assert!(!ctx.active_nodes.lock().unwrap().contains(&5));
+        assert!(!ctx.storage.repl_connected_nodes().contains(&5));
         let _ = std::fs::remove_file(path);
     }
 }

--- a/crates/truthdb-core/src/storage.rs
+++ b/crates/truthdb-core/src/storage.rs
@@ -393,6 +393,9 @@ pub struct Storage {
     /// waits — after LOCAL durability — for a standby's `FlushAck` to cover its
     /// target, with an availability-first timeout (see [`SyncCommitState`]).
     sync_commit: SyncCommitState,
+    /// Node ids with a live replication sender (one connection per id; the
+    /// monitoring DMVs report connectedness from here).
+    repl_connected: std::sync::Mutex<std::collections::HashSet<u32>>,
     /// The log-writer thread's join handle, taken in `Drop` after signalling it.
     log_writer: Option<JoinHandle<()>>,
     /// `READ_COMMITTED_SNAPSHOT` / `ALLOW_SNAPSHOT_ISOLATION` mirrors of the
@@ -490,6 +493,7 @@ impl Storage {
             inner: std::sync::Mutex::new(file),
             gc,
             sync_commit: SyncCommitState::default(),
+            repl_connected: std::sync::Mutex::new(std::collections::HashSet::new()),
             log_writer: Some(log_writer),
             rcsi: std::sync::atomic::AtomicBool::new(rcsi),
             allow_snapshot: std::sync::atomic::AtomicBool::new(allow_snapshot),
@@ -744,7 +748,6 @@ impl Storage {
 
     /// The current WAL head (the reclaim floor) — for tests that verify the
     /// FULL-model log-backup hold pins truncation.
-    #[cfg(test)]
     pub(crate) fn wal_head(&self) -> u64 {
         self.lock().wal.head()
     }
@@ -1996,8 +1999,7 @@ impl Storage {
 
     /// The persisted replication restartpoint (the active superblock's
     /// `applied_lsn`): the LSN up to which this file's WAL is present and
-    /// recovered. (Test-only until the monitoring slice reads it.)
-    #[cfg(test)]
+    /// recovered.
     pub(crate) fn applied_lsn(&self) -> u64 {
         let guard = self.lock();
         let active = match guard.active_superblock {
@@ -2021,6 +2023,52 @@ impl Storage {
             ActiveSuperblock::B => &guard.superblock_b,
         };
         active.wal_tail
+    }
+
+    /// Joins the connected-standby registry (one live sender per node id).
+    /// Returns false if the id is already connected.
+    pub(crate) fn try_join_repl_node(&self, id: u32) -> bool {
+        self.repl_connected
+            .lock()
+            .expect("repl-connected set poisoned")
+            .insert(id)
+    }
+
+    /// Leaves the connected-standby registry.
+    pub(crate) fn leave_repl_node(&self, id: u32) {
+        self.repl_connected
+            .lock()
+            .expect("repl-connected set poisoned")
+            .remove(&id);
+    }
+
+    /// Node ids with a live sender (for the monitoring DMVs).
+    pub(crate) fn repl_connected_nodes(&self) -> std::collections::HashSet<u32> {
+        self.repl_connected
+            .lock()
+            .expect("repl-connected set poisoned")
+            .clone()
+    }
+
+    /// The registered replication slots `(id, held LSN)` (for the monitoring
+    /// DMVs).
+    pub(crate) fn repl_slots_snapshot(&self) -> Vec<(u32, u64)> {
+        self.lock()
+            .truncation_gate
+            .repl_slots
+            .iter()
+            .map(|(&id, &lsn)| (id, lsn))
+            .collect()
+    }
+
+    /// Synchronous-commit status: `None` when not armed, else whether the link
+    /// is currently degraded (NOT_SYNCHRONIZED).
+    pub(crate) fn sync_commit_status(&self) -> Option<bool> {
+        use std::sync::atomic::Ordering;
+        self.sync_commit
+            .armed
+            .load(Ordering::Acquire)
+            .then(|| self.sync_commit.degraded.load(Ordering::Acquire))
     }
 
     /// Whether this file is a replication standby (redo-only, read-only until

--- a/crates/truthdb-core/src/storage_layout.rs
+++ b/crates/truthdb-core/src/storage_layout.rs
@@ -370,8 +370,6 @@ impl Superblock {
     /// equals `wal_tail`; between restartpoints the persisted value lags the live
     /// tail, exactly as the superblock's own `wal_tail` does. Stored in the
     /// reserved area (bytes 24..32) and covered by the superblock checksum.
-    /// (The reader is test-only until the monitoring slice consumes it.)
-    #[cfg(test)]
     pub fn applied_lsn(&self) -> u64 {
         u64::from_le_bytes(self.reserved[24..32].try_into().unwrap())
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -323,7 +323,6 @@ async fn start_replication(
                 heartbeat: std::time::Duration::from_millis(cfg.heartbeat_ms),
                 stall_timeout: std::time::Duration::from_millis(cfg.stall_timeout_ms),
                 chunk_bytes: truthdb_core::repl::sender::DEFAULT_CHUNK_BYTES,
-                active_nodes: std::sync::Arc::default(),
             };
             let shutdown_rx = shutdown_tx.subscribe();
             Ok(tokio::spawn(run_repl_listener(


### PR DESCRIPTION
18.6 in one slice: the two virtual tables (following the sys.databases pattern) and the CLI verb that renders them over the native protocol. The sender's node registry moved onto Storage so connectedness is observable. `cargo test --workspace` green, clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)