### PR TITLE
Multiple databases A1: database entities in the catalog, (db, name) keying

### DIFF
--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -390,7 +390,12 @@ impl Engine {
         input: &str,
         isolation: crate::rel::Isolation,
     ) -> Vec<(crate::lock::Resource, crate::lock::LockMode)> {
-        crate::rel::analyze_locks(&self.storage, input, isolation)
+        crate::rel::analyze_locks(
+            &self.storage,
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
+            input,
+            isolation,
+        )
     }
 
     pub fn checkpoint(&self) -> Result<(), EngineError> {

--- a/crates/truthdb-core/src/engine.rs
+++ b/crates/truthdb-core/src/engine.rs
@@ -384,18 +384,24 @@ impl Engine {
 
     /// The table/database locks a SQL batch needs at the given isolation
     /// level (see [`crate::rel::analyze_locks`]). The session loop acquires
-    /// these before running the batch.
+    /// these before running the batch. `db_id` is the session's current
+    /// database — the same namespace execution will resolve names in; the two
+    /// derivations must agree or a batch under-locks.
     pub fn analyze_locks(
         &self,
+        db_id: u32,
         input: &str,
         isolation: crate::rel::Isolation,
     ) -> Vec<(crate::lock::Resource, crate::lock::LockMode)> {
-        crate::rel::analyze_locks(
-            &self.storage,
-            crate::relstore::catalog::DEFAULT_DATABASE_ID,
-            input,
-            isolation,
-        )
+        crate::rel::analyze_locks(&self.storage, db_id, input, isolation)
+    }
+
+    /// Stamps the default database's name (id 1) from the instance
+    /// configuration, refusing a name a stored `CREATE DATABASE` row already
+    /// uses. Called once at startup, before any session opens.
+    pub fn set_default_database(&self, name: &str) -> Result<(), EngineError> {
+        self.storage.set_default_database_name(name)?;
+        Ok(())
     }
 
     pub fn checkpoint(&self) -> Result<(), EngineError> {
@@ -4779,6 +4785,7 @@ mod tests {
         // write-locked (Exclusive); without the Shared lock this INSERT could
         // read another transaction's uncommitted rows.
         let locks = engine.analyze_locks(
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
             "INSERT INTO t2 (v) SELECT v FROM t1",
             Isolation::ReadCommitted,
         );
@@ -4793,6 +4800,7 @@ mod tests {
 
         // A self-insert combines the read and write into a single Exclusive lock.
         let self_locks = engine.analyze_locks(
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
             "INSERT INTO t1 (id, v) SELECT id, v FROM t1",
             Isolation::ReadCommitted,
         );
@@ -4808,6 +4816,7 @@ mod tests {
 
         // READ UNCOMMITTED takes no read lock on the source.
         let ru = engine.analyze_locks(
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
             "INSERT INTO t2 (v) SELECT v FROM t1",
             Isolation::ReadUncommitted,
         );
@@ -5167,6 +5176,7 @@ mod tests {
 
         // Plain query with a nested CTE.
         let direct = engine.analyze_locks(
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
             "WITH c AS (WITH d AS (SELECT z FROM secret) SELECT z FROM d) SELECT z FROM c",
             Isolation::ReadCommitted,
         );
@@ -5181,7 +5191,11 @@ mod tests {
                 "CREATE VIEW v AS WITH c AS (WITH d AS (SELECT z FROM secret) SELECT z FROM d) SELECT z FROM c",
             )
             .expect("view");
-        let via_view = engine.analyze_locks("SELECT z FROM v", Isolation::ReadCommitted);
+        let via_view = engine.analyze_locks(
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
+            "SELECT z FROM v",
+            Isolation::ReadCommitted,
+        );
         assert!(
             via_view.contains(&(Resource::Table(secret), LockMode::Shared)),
             "view over a nested-CTE body must lock secret: {via_view:?}"
@@ -5206,7 +5220,11 @@ mod tests {
             .expect("view");
         let base = table_object_id(&engine, "base");
 
-        let locks = engine.analyze_locks("SELECT x FROM v", Isolation::ReadCommitted);
+        let locks = engine.analyze_locks(
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
+            "SELECT x FROM v",
+            Isolation::ReadCommitted,
+        );
         assert!(
             locks.contains(&(Resource::Table(base), LockMode::Shared)),
             "a view's base table (via its CTE) must be Shared-locked: {locks:?}"
@@ -5216,7 +5234,11 @@ mod tests {
         engine
             .execute("CREATE VIEW v2 AS SELECT x FROM v")
             .expect("v2");
-        let nested = engine.analyze_locks("SELECT x FROM v2", Isolation::ReadCommitted);
+        let nested = engine.analyze_locks(
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
+            "SELECT x FROM v2",
+            Isolation::ReadCommitted,
+        );
         assert!(
             nested.contains(&(Resource::Table(base), LockMode::Shared)),
             "a nested view must Shared-lock the base table through both views: {nested:?}"
@@ -5246,7 +5268,11 @@ mod tests {
         let base = table_object_id(&engine, "base");
         let secret = table_object_id(&engine, "secret");
 
-        let locks = engine.analyze_locks("SELECT x FROM v", Isolation::ReadCommitted);
+        let locks = engine.analyze_locks(
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
+            "SELECT x FROM v",
+            Isolation::ReadCommitted,
+        );
         assert!(
             locks.contains(&(Resource::Table(base), LockMode::Shared)),
             "base must be locked: {locks:?}"
@@ -5303,6 +5329,7 @@ mod tests {
         let secret = table_object_id(&engine, "secret");
 
         let locks = engine.analyze_locks(
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
             "DECLARE @v INT; WITH c AS (SELECT x FROM secret) SELECT @v = (SELECT MAX(x) FROM c)",
             Isolation::ReadCommitted,
         );
@@ -5591,7 +5618,11 @@ mod tests {
         };
 
         // Point UPDATE: Table IX + a single Row X, no Table X.
-        let up = engine.analyze_locks("UPDATE t SET v = 9 WHERE id = 5", rc);
+        let up = engine.analyze_locks(
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
+            "UPDATE t SET v = 9 WHERE id = 5",
+            rc,
+        );
         assert!(up.contains(&(Resource::Table(t), LockMode::IntentExclusive)));
         assert!(
             !has_table_x(&up),
@@ -5600,17 +5631,33 @@ mod tests {
         let k5 = row_x(&up).expect("point UPDATE row lock");
 
         // Point DELETE: same row key as the UPDATE of id = 5.
-        let del = engine.analyze_locks("DELETE FROM t WHERE id = 5", rc);
+        let del = engine.analyze_locks(
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
+            "DELETE FROM t WHERE id = 5",
+            rc,
+        );
         assert_eq!(row_x(&del), Some(k5), "DELETE id=5 must lock the same row");
 
         // A different key → a different row resource (so the two run concurrently).
-        let up6 = engine.analyze_locks("UPDATE t SET v = 1 WHERE id = 6", rc);
+        let up6 = engine.analyze_locks(
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
+            "UPDATE t SET v = 1 WHERE id = 6",
+            rc,
+        );
         assert_ne!(row_x(&up6), Some(k5));
 
         // Point INSERT (literal key) row-locks; INSERT ... SELECT does not.
-        let ins = engine.analyze_locks("INSERT INTO t VALUES (7, 1)", rc);
+        let ins = engine.analyze_locks(
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
+            "INSERT INTO t VALUES (7, 1)",
+            rc,
+        );
         assert!(row_x(&ins).is_some() && !has_table_x(&ins));
-        let ins_sel = engine.analyze_locks("INSERT INTO t SELECT id, v FROM t", rc);
+        let ins_sel = engine.analyze_locks(
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
+            "INSERT INTO t SELECT id, v FROM t",
+            rc,
+        );
         assert!(has_table_x(&ins_sel) && row_x(&ins_sel).is_none());
 
         // Range / OR / partial predicates fall back to Table X.
@@ -5621,7 +5668,8 @@ mod tests {
             "UPDATE t SET id = 2 WHERE id = 5", // key change moves the row
             "DELETE FROM t WHERE id = (SELECT MAX(id) FROM t)",
         ] {
-            let locks = engine.analyze_locks(sql, rc);
+            let locks =
+                engine.analyze_locks(crate::relstore::catalog::DEFAULT_DATABASE_ID, sql, rc);
             assert!(
                 has_table_x(&locks) && row_x(&locks).is_none(),
                 "table lock for `{sql}`: {locks:?}"
@@ -5664,28 +5712,55 @@ mod tests {
 
         // Character PK vs a *string* literal row-locks; vs a *numeric* literal it
         // does not (the executor's string->number match is many-to-one).
-        let str_lit = engine.analyze_locks("UPDATE cs SET v = 1 WHERE id = '05'", rc);
+        let str_lit = engine.analyze_locks(
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
+            "UPDATE cs SET v = 1 WHERE id = '05'",
+            rc,
+        );
         assert!(has_row(&str_lit, cs));
-        let num_lit = engine.analyze_locks("UPDATE cs SET v = 1 WHERE id = 5", rc);
+        let num_lit = engine.analyze_locks(
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
+            "UPDATE cs SET v = 1 WHERE id = 5",
+            rc,
+        );
         assert!(table_x(&num_lit, cs) && !has_row(&num_lit, cs));
 
         // A table with a secondary UNIQUE index: INSERT/UPDATE keep Table X;
         // DELETE may still row-lock (a delete cannot create a duplicate).
-        let ins = engine.analyze_locks("INSERT INTO u VALUES (1, 'a@b.com')", rc);
+        let ins = engine.analyze_locks(
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
+            "INSERT INTO u VALUES (1, 'a@b.com')",
+            rc,
+        );
         assert!(table_x(&ins, u) && !has_row(&ins, u));
-        let upd = engine.analyze_locks("UPDATE u SET email = 'x' WHERE id = 1", rc);
+        let upd = engine.analyze_locks(
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
+            "UPDATE u SET email = 'x' WHERE id = 1",
+            rc,
+        );
         assert!(table_x(&upd, u) && !has_row(&upd, u));
-        let del = engine.analyze_locks("DELETE FROM u WHERE id = 1", rc);
+        let del = engine.analyze_locks(
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
+            "DELETE FROM u WHERE id = 1",
+            rc,
+        );
         assert!(has_row(&del, u) && !table_x(&del, u));
 
         // FLOAT PK is never row-locked (signed zero / NaN encode ambiguity).
-        let fl = engine.analyze_locks("UPDATE f SET v = 1 WHERE k = 1.0", rc);
+        let fl = engine.analyze_locks(
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
+            "UPDATE f SET v = 1 WHERE k = 1.0",
+            rc,
+        );
         assert!(table_x(&fl, f) && !has_row(&fl, f));
 
         // A batch that point-writes AND reads the same table must end up with an
         // exclusive table lock (the IX+S -> X combine fix), not a Shared lock.
-        let batch =
-            engine.analyze_locks("UPDATE cs SET v = 1 WHERE id = '05'; SELECT * FROM cs", rc);
+        let batch = engine.analyze_locks(
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
+            "UPDATE cs SET v = 1 WHERE id = '05'; SELECT * FROM cs",
+            rc,
+        );
         assert!(
             table_x(&batch, cs),
             "point-write + same-table read must hold Table X: {batch:?}"
@@ -5714,11 +5789,17 @@ mod tests {
             })
         };
         // Both key columns pinned → row lock.
-        assert!(row_x(
-            &engine.analyze_locks("UPDATE t SET v = 1 WHERE a = 1 AND b = 2", rc)
-        ));
+        assert!(row_x(&engine.analyze_locks(
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
+            "UPDATE t SET v = 1 WHERE a = 1 AND b = 2",
+            rc
+        )));
         // Only one pinned → table lock.
-        let partial = engine.analyze_locks("UPDATE t SET v = 1 WHERE a = 1", rc);
+        let partial = engine.analyze_locks(
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
+            "UPDATE t SET v = 1 WHERE a = 1",
+            rc,
+        );
         assert!(!row_x(&partial) && partial.contains(&(Resource::Table(t), LockMode::Exclusive)));
         let _ = std::fs::remove_file(path);
     }
@@ -5742,7 +5823,11 @@ mod tests {
         // on the parent (else it could read an uncommitted parent row). The
         // child is not itself an FK parent, so its point INSERT row-locks:
         // Table IntentExclusive + a Row Exclusive on the inserted key.
-        let locks = engine.analyze_locks("INSERT INTO c VALUES (1, 1)", Isolation::ReadCommitted);
+        let locks = engine.analyze_locks(
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
+            "INSERT INTO c VALUES (1, 1)",
+            Isolation::ReadCommitted,
+        );
         assert!(
             locks.contains(&(Resource::Table(c), LockMode::IntentExclusive)),
             "child IntentExclusive: {locks:?}"
@@ -5759,7 +5844,11 @@ mod tests {
             "parent Shared: {locks:?}"
         );
         // DELETE of the parent reads the child (NO ACTION check) -> child Shared.
-        let del = engine.analyze_locks("DELETE FROM p WHERE id = 1", Isolation::ReadCommitted);
+        let del = engine.analyze_locks(
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
+            "DELETE FROM p WHERE id = 1",
+            Isolation::ReadCommitted,
+        );
         assert!(
             del.contains(&(Resource::Table(p), LockMode::Exclusive)),
             "parent Exclusive: {del:?}"
@@ -6010,6 +6099,7 @@ mod tests {
         // A subquery over `b` inside `a`'s WHERE reads `b`, so it must take a
         // Shared lock on `b` (else it could read `b`'s uncommitted rows).
         let locks = engine.analyze_locks(
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
             "SELECT id FROM a WHERE id IN (SELECT id FROM b)",
             Isolation::ReadCommitted,
         );
@@ -8639,7 +8729,11 @@ mod tests {
             "SELECT id FROM t2 WHERE dbo.secret_count() > 0",
             "IF dbo.secret_count() > 0 SELECT 1 AS n",
         ] {
-            let locks = engine.analyze_locks(sql, Isolation::ReadCommitted);
+            let locks = engine.analyze_locks(
+                crate::relstore::catalog::DEFAULT_DATABASE_ID,
+                sql,
+                Isolation::ReadCommitted,
+            );
             assert!(
                 locks.contains(&(Resource::Table(secret), LockMode::Shared)),
                 "the function's inner-read table must be Shared-locked for `{sql}`: {locks:?}"
@@ -9232,7 +9326,11 @@ mod tests {
         let secret = table_object_id(&engine, "secret");
         // A UDF reached THROUGH a view must still have its body's table Shared-
         // locked — else the view-nested UDF reads secret unlocked under 2PL.
-        let locks = engine.analyze_locks("SELECT * FROM v", Isolation::ReadCommitted);
+        let locks = engine.analyze_locks(
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
+            "SELECT * FROM v",
+            Isolation::ReadCommitted,
+        );
         assert!(
             locks.contains(&(Resource::Table(secret), LockMode::Shared)),
             "a view-nested UDF's body table must be Shared-locked: {locks:?}"
@@ -9281,7 +9379,11 @@ mod tests {
             .expect("tvf");
         let secret = table_object_id(&engine, "secret");
         // A TVF in FROM must Shared-lock the table its body reads, up front.
-        let locks = engine.analyze_locks("SELECT z FROM dbo.rows_of(1)", Isolation::ReadCommitted);
+        let locks = engine.analyze_locks(
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
+            "SELECT z FROM dbo.rows_of(1)",
+            Isolation::ReadCommitted,
+        );
         assert!(
             locks.contains(&(Resource::Table(secret), LockMode::Shared)),
             "a TVF's body table must be Shared-locked: {locks:?}"
@@ -9318,7 +9420,11 @@ mod tests {
         // intent lock may still appear; only object locks are asserted absent.)
         let has_object_lock = |sql: &str| {
             engine
-                .analyze_locks(sql, Isolation::ReadCommitted)
+                .analyze_locks(
+                    crate::relstore::catalog::DEFAULT_DATABASE_ID,
+                    sql,
+                    Isolation::ReadCommitted,
+                )
                 .iter()
                 .any(|(r, _)| matches!(r, Resource::Table(_) | Resource::Row(..)))
         };
@@ -9335,6 +9441,7 @@ mod tests {
         let base = table_object_id(&engine, "base");
         // A join of base with @t locks only base; the @t side adds nothing.
         let join_locks = engine.analyze_locks(
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
             "SELECT * FROM base AS b JOIN @t AS t ON b.id = t.id",
             Isolation::ReadCommitted,
         );
@@ -9345,6 +9452,7 @@ mod tests {
             "the @t side of a join must add no table lock beyond base's: {join_locks:?}"
         );
         let locks = engine.analyze_locks(
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
             "INSERT INTO @t SELECT id FROM base",
             Isolation::ReadCommitted,
         );
@@ -9497,7 +9605,11 @@ mod tests {
             .expect("bomb");
         let (tx, rx) = std::sync::mpsc::channel();
         std::thread::spawn(move || {
-            let _ = engine.analyze_locks("SELECT id FROM dbo.bomb(1)", Isolation::ReadCommitted);
+            let _ = engine.analyze_locks(
+                crate::relstore::catalog::DEFAULT_DATABASE_ID,
+                "SELECT id FROM dbo.bomb(1)",
+                Isolation::ReadCommitted,
+            );
             let _ = tx.send(());
         });
         assert!(
@@ -9538,7 +9650,11 @@ mod tests {
         // Exclusive lock up front (the trigger body writes it) — else the body
         // writes unlocked under 2PL.
         let audit = table_object_id(&engine, "audit");
-        let locks = engine.analyze_locks("INSERT INTO t VALUES (9, 9)", Isolation::ReadCommitted);
+        let locks = engine.analyze_locks(
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
+            "INSERT INTO t VALUES (9, 9)",
+            Isolation::ReadCommitted,
+        );
         assert!(
             locks.contains(&(Resource::Table(audit), LockMode::Exclusive)),
             "the trigger body's audit write must be X-locked up front: {locks:?}"
@@ -9682,7 +9798,11 @@ mod tests {
             .expect("trg_b");
         let (tx, rx) = std::sync::mpsc::channel();
         std::thread::spawn(move || {
-            let _ = engine.analyze_locks("INSERT INTO a VALUES (1)", Isolation::ReadCommitted);
+            let _ = engine.analyze_locks(
+                crate::relstore::catalog::DEFAULT_DATABASE_ID,
+                "INSERT INTO a VALUES (1)",
+                Isolation::ReadCommitted,
+            );
             let _ = tx.send(());
         });
         assert!(
@@ -9751,7 +9871,11 @@ mod tests {
             .expect("trigger");
         let w = table_object_id(&engine, "w");
         let parent = table_object_id(&engine, "parent");
-        let locks = engine.analyze_locks("INSERT INTO t VALUES (1)", Isolation::ReadCommitted);
+        let locks = engine.analyze_locks(
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
+            "INSERT INTO t VALUES (1)",
+            Isolation::ReadCommitted,
+        );
         // The single-row proc INSERT locks w at Table-IX + Row-X; assert w is
         // locked at all (a write lock, IX or X), proving the EXEC was analyzed.
         assert!(
@@ -9917,6 +10041,7 @@ mod tests {
         // lock-based — Table S — not drop it as a versioned read. The trigger
         // body analysis now forwards the escalation-corrected isolation.
         let locks = engine.analyze_locks(
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
             "SET TRANSACTION ISOLATION LEVEL SERIALIZABLE; INSERT INTO t VALUES (1)",
             Isolation::Snapshot,
         );
@@ -11102,8 +11227,11 @@ mod tests {
         let secret = table_object_id(&engine, "secret");
         // The body's read of `secret` must be Shared-locked up front, just like
         // an inline TVF or a scalar UDF body — the lock seam.
-        let locks =
-            engine.analyze_locks("SELECT z FROM dbo.copy_secret()", Isolation::ReadCommitted);
+        let locks = engine.analyze_locks(
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
+            "SELECT z FROM dbo.copy_secret()",
+            Isolation::ReadCommitted,
+        );
         assert!(
             locks.contains(&(Resource::Table(secret), LockMode::Shared)),
             "a multi-statement TVF's body table must be Shared-locked: {locks:?}"
@@ -14648,6 +14776,103 @@ mod tests {
             first_rowset(&out).columns
         );
         assert_eq!(first_rowset(&out).rows.len(), 5, "the view's own rows");
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn fk_enforcement_and_sys_views_stay_inside_the_session_database() {
+        // The children-of-parent decision (FK NO ACTION on parent DML, the
+        // DROP TABLE 3726 guard) and the sys.* enumerations are all derived
+        // per database. A same-named parent/child pair in ANOTHER database
+        // must not leak into a default-database session.
+        let path = unique_temp_path("multidb-exec-scope");
+        let engine = new_engine(&path);
+        sql(&engine, "CREATE TABLE p (id INT PRIMARY KEY, v INT)");
+        sql(&engine, "INSERT INTO p (id, v) VALUES (1, 10)");
+
+        // Another database with its own p, plus a child c referencing it —
+        // including a row whose FK key collides with the default db's p row.
+        let storage = engine.storage_arc();
+        let hr = storage.rel_create_database("hr").expect("create hr");
+        for (name, key, fks) in [
+            ("p", vec!["id".to_string()], Vec::new()),
+            (
+                "c",
+                vec!["id".to_string()],
+                vec![crate::relstore::catalog::ForeignKeyDef {
+                    name: "fk_c_p".to_string(),
+                    columns: vec![1],
+                    parent: "p".to_string(),
+                }],
+            ),
+        ] {
+            storage
+                .rel_create_table(
+                    hr,
+                    name,
+                    vec![
+                        crate::relstore::row::Column {
+                            name: "id".to_string(),
+                            column_type: crate::relstore::types::ColumnType::Int,
+                            nullable: false,
+                            collation: None,
+                        },
+                        crate::relstore::row::Column {
+                            name: "pid".to_string(),
+                            column_type: crate::relstore::types::ColumnType::Int,
+                            nullable: false,
+                            collation: None,
+                        },
+                    ],
+                    &key,
+                    Vec::new(),
+                    None,
+                    Vec::new(),
+                    fks,
+                )
+                .expect("hr table");
+        }
+        storage
+            .rel_insert(
+                hr,
+                "p",
+                vec![
+                    crate::relstore::types::Datum::Int(1),
+                    crate::relstore::types::Datum::Int(0),
+                ],
+            )
+            .expect("hr p row");
+        storage
+            .rel_insert(
+                hr,
+                "c",
+                vec![
+                    crate::relstore::types::Datum::Int(10),
+                    crate::relstore::types::Datum::Int(1),
+                ],
+            )
+            .expect("hr c row referencing hr p id 1");
+
+        // DELETE of the default db's p row must not see hr's child (no false
+        // 547), and DROP TABLE p must not be blocked by hr's FK (no 3726).
+        let env = sql(&engine, "DELETE FROM p WHERE id = 1");
+        assert_eq!(
+            env["results"][0]["rows_affected"].as_i64(),
+            Some(1),
+            "cross-database child must not block the delete: {env}"
+        );
+        let env = sql(&engine, "DROP TABLE p");
+        assert!(
+            env["error"].is_null(),
+            "cross-database FK must not raise 3726: {env}"
+        );
+
+        // sys.* views enumerate only the session's database.
+        let (_, rows) = sql_rows(&engine, "SELECT name FROM sys.tables ORDER BY name");
+        assert!(
+            rows.iter().all(|r| r[0].as_deref() != Some("c")),
+            "hr's objects must not appear in a default-db session's sys.tables: {rows:?}"
+        );
         let _ = std::fs::remove_file(path);
     }
 }

--- a/crates/truthdb-core/src/rel/aggregate.rs
+++ b/crates/truthdb-core/src/rel/aggregate.rs
@@ -30,7 +30,7 @@ fn eval_bound(
     resolver: &JoinScope,
     eval_ctx: &EvalContext,
 ) -> Result<SqlValue, SqlError> {
-    if crate::rel::expr_needs_binding(storage, expr) {
+    if crate::rel::expr_needs_binding(storage, eval_ctx.database_id, expr) {
         let outer = |name: &str| resolver.resolve(name);
         let bound =
             crate::rel::substitute_correlated_in_expr(storage, expr, &outer, row, eval_ctx)?;
@@ -254,7 +254,7 @@ fn aggregate_partition(
             // A reference to a non-grouped column stays unresolved and errors
             // inside the subquery, as SQL Server rejects it too.
             let bound;
-            let having = if crate::rel::expr_needs_binding(storage, having) {
+            let having = if crate::rel::expr_needs_binding(storage, eval_ctx.database_id, having) {
                 // A user function's args were rewritten to the synthetic group
                 // columns ($gk/$agg), which `synth` resolves; a subquery keeps its
                 // original grouping-column names, which `group_key_resolver`
@@ -286,7 +286,7 @@ fn aggregate_partition(
             // A subquery here is correlated to a grouping column (the
             // rewrite left it): bind the group row, exactly as HAVING does.
             let bound;
-            let expr = if crate::rel::expr_needs_binding(storage, expr) {
+            let expr = if crate::rel::expr_needs_binding(storage, eval_ctx.database_id, expr) {
                 let gkr = group_key_resolver(select, resolver);
                 let outer = |name: &str| synth.resolve(name).or_else(|| gkr(name));
                 bound = crate::rel::substitute_correlated_in_expr(

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -5761,13 +5761,17 @@ fn enforce_parent_fks(
         .iter()
         .map(|k| collated_key(k, &parent_key_coll))
         .collect();
+    // Children live in the parent's database — cross-database foreign keys
+    // do not exist, and lock analysis (fk_child_object_ids) filters the same
+    // way; the two derivations must agree.
     let children: Vec<TableDef> = storage
         .rel_tables()
         .into_iter()
         .filter(|t| {
-            t.foreign_keys
-                .iter()
-                .any(|fk| fk.parent.eq_ignore_ascii_case(&parent.name))
+            t.database_id == parent.database_id
+                && t.foreign_keys
+                    .iter()
+                    .any(|fk| fk.parent.eq_ignore_ascii_case(&parent.name))
         })
         .collect();
     for child in &children {
@@ -5988,7 +5992,8 @@ fn exec_drop_table(
             // A table still referenced by another table's foreign key cannot be
             // dropped (SQL Server 3726) — it would leave a dangling reference.
             if let Some(child) = storage.rel_tables().into_iter().find(|t| {
-                !t.name.eq_ignore_ascii_case(&name)
+                t.database_id == db_id
+                    && !t.name.eq_ignore_ascii_case(&name)
                     && t.foreign_keys
                         .iter()
                         .any(|fk| fk.parent.eq_ignore_ascii_case(&name))
@@ -12272,28 +12277,28 @@ fn build_table_source(
         return Ok(source);
     }
     let base = match name.value.to_ascii_lowercase().as_str() {
-        "sys.tables" => sys_tables(storage),
+        "sys.tables" => sys_tables(storage, eval_ctx.database_id),
         "sys.databases" => sys_databases(storage, eval_ctx),
         "sys.dm_repl_replica_states" => sys_dm_repl_replica_states(storage),
         "sys.dm_repl_slots" => sys_dm_repl_slots(storage),
         "sys.configurations" => sys_configurations(),
-        "sys.views" => sys_views(storage),
-        "sys.procedures" => sys_procedures(storage),
-        "sys.triggers" => sys_triggers(storage),
-        "sys.trigger_events" => sys_trigger_events(storage),
+        "sys.views" => sys_views(storage, eval_ctx.database_id),
+        "sys.procedures" => sys_procedures(storage, eval_ctx.database_id),
+        "sys.triggers" => sys_triggers(storage, eval_ctx.database_id),
+        "sys.trigger_events" => sys_trigger_events(storage, eval_ctx.database_id),
         "sys.server_principals" => sys_server_principals(storage),
         "sys.sql_logins" => sys_sql_logins(storage),
         "sys.database_principals" => sys_database_principals(storage),
         "sys.database_role_members" => sys_database_role_members(storage),
-        "sys.database_permissions" => sys_database_permissions(storage),
-        "sys.parameters" => sys_parameters(storage),
-        "sys.objects" => sys_objects(storage),
-        "sys.sql_modules" => sys_sql_modules(storage),
-        "sys.columns" => sys_columns(storage),
-        "sys.indexes" => sys_indexes(storage),
-        "sys.check_constraints" => sys_check_constraints(storage),
-        "sys.foreign_keys" => sys_foreign_keys(storage),
-        "sys.default_constraints" => sys_default_constraints(storage),
+        "sys.database_permissions" => sys_database_permissions(storage, eval_ctx.database_id),
+        "sys.parameters" => sys_parameters(storage, eval_ctx.database_id),
+        "sys.objects" => sys_objects(storage, eval_ctx.database_id),
+        "sys.sql_modules" => sys_sql_modules(storage, eval_ctx.database_id),
+        "sys.columns" => sys_columns(storage, eval_ctx.database_id),
+        "sys.indexes" => sys_indexes(storage, eval_ctx.database_id),
+        "sys.check_constraints" => sys_check_constraints(storage, eval_ctx.database_id),
+        "sys.foreign_keys" => sys_foreign_keys(storage, eval_ctx.database_id),
+        "sys.default_constraints" => sys_default_constraints(storage, eval_ctx.database_id),
         _ => {
             let def = resolve_table(storage, eval_ctx.database_id, &name.value)
                 .ok_or_else(|| SqlError::invalid_object(&name.value).at(name.span))?;
@@ -13565,11 +13570,12 @@ fn restore_filelist_rows(header: &crate::backup::BackupHeader) -> RowSet {
     RowSet { columns, rows }
 }
 
-fn sys_tables(storage: &Storage) -> Source {
+fn sys_tables(storage: &Storage, db_id: u32) -> Source {
     let columns = vec![int_col("object_id"), nvarchar("name", 128)];
     let rows = storage
         .rel_tables()
         .into_iter()
+        .filter(|def| def.database_id == db_id)
         // Only base tables. (The `!is_view()` filter alone let procedures leak
         // in — a pre-existing gap — so exclude every non-table object kind.)
         .filter(|def| {
@@ -13797,7 +13803,7 @@ fn sys_configurations() -> Source {
     }
 }
 
-fn sys_views(storage: &Storage) -> Source {
+fn sys_views(storage: &Storage, db_id: u32) -> Source {
     let columns = vec![
         int_col("object_id"),
         nvarchar("name", 128),
@@ -13806,6 +13812,7 @@ fn sys_views(storage: &Storage) -> Source {
     let rows = storage
         .rel_tables()
         .into_iter()
+        .filter(|def| def.database_id == db_id)
         .filter_map(|def| {
             def.view_query.map(|q| {
                 vec![
@@ -13829,11 +13836,12 @@ fn sys_views(storage: &Storage) -> Source {
 /// `sys.sql_modules`: the SQL definition of each module (currently views), keyed
 /// by `object_id`. SQL Server surfaces view/procedure/trigger text here; today
 /// only views carry a definition.
-fn sys_sql_modules(storage: &Storage) -> Source {
+fn sys_sql_modules(storage: &Storage, db_id: u32) -> Source {
     let columns = vec![int_col("object_id"), nvarchar("definition", 4000)];
     let rows = storage
         .rel_tables()
         .into_iter()
+        .filter(|def| def.database_id == db_id)
         .filter_map(|def| {
             // Views store their SELECT; procedures and functions their body.
             let definition = def
@@ -13864,11 +13872,12 @@ fn sys_sql_modules(storage: &Storage) -> Source {
     }
 }
 
-fn sys_procedures(storage: &Storage) -> Source {
+fn sys_procedures(storage: &Storage, db_id: u32) -> Source {
     let columns = vec![nvarchar("name", 128), int_col("object_id")];
     let rows = storage
         .rel_tables()
         .into_iter()
+        .filter(|def| def.database_id == db_id)
         .filter(|def| def.is_procedure())
         .map(|def| {
             vec![
@@ -13887,7 +13896,7 @@ fn sys_procedures(storage: &Storage) -> Source {
     }
 }
 
-fn sys_triggers(storage: &Storage) -> Source {
+fn sys_triggers(storage: &Storage, db_id: u32) -> Source {
     let columns = vec![
         nvarchar("name", 128),
         int_col("object_id"),
@@ -13899,6 +13908,7 @@ fn sys_triggers(storage: &Storage) -> Source {
     let rows = storage
         .rel_tables()
         .into_iter()
+        .filter(|def| def.database_id == db_id)
         .filter_map(|def| {
             let trigger = def.trigger.as_ref()?;
             Some(vec![
@@ -13921,7 +13931,7 @@ fn sys_triggers(storage: &Storage) -> Source {
     }
 }
 
-fn sys_trigger_events(storage: &Storage) -> Source {
+fn sys_trigger_events(storage: &Storage, db_id: u32) -> Source {
     let columns = vec![
         int_col("object_id"),
         int_col("type"),
@@ -13929,6 +13939,9 @@ fn sys_trigger_events(storage: &Storage) -> Source {
     ];
     let mut rows = Vec::new();
     for def in storage.rel_tables() {
+        if def.database_id != db_id {
+            continue;
+        }
         let Some(trigger) = def.trigger.as_ref() else {
             continue;
         };
@@ -14113,7 +14126,7 @@ fn sys_database_role_members(storage: &Storage) -> Source {
     }
 }
 
-fn sys_database_permissions(storage: &Storage) -> Source {
+fn sys_database_permissions(storage: &Storage, db_id: u32) -> Source {
     let columns = vec![
         int_col("class"),
         nvarchar("class_desc", 60),
@@ -14126,6 +14139,9 @@ fn sys_database_permissions(storage: &Storage) -> Source {
     ];
     let mut rows: Vec<Vec<Datum>> = Vec::new();
     for def in storage.rel_tables() {
+        if def.database_id != db_id {
+            continue;
+        }
         for perm in &def.permissions {
             let (state, state_desc) = if perm.deny {
                 ("D", "DENY")
@@ -14154,7 +14170,7 @@ fn sys_database_permissions(storage: &Storage) -> Source {
     }
 }
 
-fn sys_parameters(storage: &Storage) -> Source {
+fn sys_parameters(storage: &Storage, db_id: u32) -> Source {
     let columns = vec![
         int_col("object_id"),
         nvarchar("name", 128),
@@ -14180,6 +14196,9 @@ fn sys_parameters(storage: &Storage) -> Source {
         ]);
     };
     for def in storage.rel_tables() {
+        if def.database_id != db_id {
+            continue;
+        }
         if let Some(procedure) = &def.procedure {
             for (index, param) in procedure.params.iter().enumerate() {
                 push_param(
@@ -14227,7 +14246,7 @@ fn sys_parameters(storage: &Storage) -> Source {
     }
 }
 
-fn sys_objects(storage: &Storage) -> Source {
+fn sys_objects(storage: &Storage, db_id: u32) -> Source {
     let columns = vec![
         nvarchar("name", 128),
         int_col("object_id"),
@@ -14237,6 +14256,7 @@ fn sys_objects(storage: &Storage) -> Source {
     let rows = storage
         .rel_tables()
         .into_iter()
+        .filter(|def| def.database_id == db_id)
         .map(|def| {
             // SQL Server's single-letter codes carry a trailing space; the
             // two-letter function codes fill CHAR(2) exactly.
@@ -14277,7 +14297,7 @@ fn sys_objects(storage: &Storage) -> Source {
     }
 }
 
-fn sys_columns(storage: &Storage) -> Source {
+fn sys_columns(storage: &Storage, db_id: u32) -> Source {
     let columns = vec![
         int_col("object_id"),
         nvarchar("name", 128),
@@ -14291,6 +14311,9 @@ fn sys_columns(storage: &Storage) -> Source {
     ];
     let mut rows = Vec::new();
     for def in storage.rel_tables() {
+        if def.database_id != db_id {
+            continue;
+        }
         for (index, (name, type_spec, nullable)) in def.columns.iter().enumerate() {
             let collation = def
                 .collations
@@ -14319,7 +14342,7 @@ fn sys_columns(storage: &Storage) -> Source {
     }
 }
 
-fn sys_indexes(storage: &Storage) -> Source {
+fn sys_indexes(storage: &Storage, db_id: u32) -> Source {
     let columns = vec![
         int_col("object_id"),
         int_col("index_id"),
@@ -14331,6 +14354,9 @@ fn sys_indexes(storage: &Storage) -> Source {
     ];
     let mut rows = Vec::new();
     for def in storage.rel_tables() {
+        if def.database_id != db_id {
+            continue;
+        }
         for index in &def.indexes {
             rows.push(vec![
                 Datum::Int(def.object_id as i32),
@@ -14350,7 +14376,7 @@ fn sys_indexes(storage: &Storage) -> Source {
     }
 }
 
-fn sys_check_constraints(storage: &Storage) -> Source {
+fn sys_check_constraints(storage: &Storage, db_id: u32) -> Source {
     let columns = vec![
         nvarchar("name", 128),
         int_col("parent_object_id"),
@@ -14358,6 +14384,9 @@ fn sys_check_constraints(storage: &Storage) -> Source {
     ];
     let mut rows = Vec::new();
     for def in storage.rel_tables() {
+        if def.database_id != db_id {
+            continue;
+        }
         for check in &def.check_constraints {
             rows.push(vec![
                 Datum::NVarChar(check.name.clone()),
@@ -14376,14 +14405,18 @@ fn sys_check_constraints(storage: &Storage) -> Source {
     }
 }
 
-fn sys_foreign_keys(storage: &Storage) -> Source {
+fn sys_foreign_keys(storage: &Storage, db_id: u32) -> Source {
     let columns = vec![
         nvarchar("name", 128),
         int_col("parent_object_id"),
         int_col("referenced_object_id"),
     ];
     // Resolve parent (referenced) table names to object ids.
-    let tables = storage.rel_tables();
+    let tables: Vec<TableDef> = storage
+        .rel_tables()
+        .into_iter()
+        .filter(|t| t.database_id == db_id)
+        .collect();
     let oid_of = |name: &str| {
         tables
             .iter()
@@ -14412,7 +14445,7 @@ fn sys_foreign_keys(storage: &Storage) -> Source {
     }
 }
 
-fn sys_default_constraints(storage: &Storage) -> Source {
+fn sys_default_constraints(storage: &Storage, db_id: u32) -> Source {
     let columns = vec![
         nvarchar("name", 128),
         int_col("parent_object_id"),
@@ -14423,6 +14456,9 @@ fn sys_default_constraints(storage: &Storage) -> Source {
     // `DF__<table>__<column>__...`. We synthesize a stable `DF__<table>__<col>`.
     let mut rows = Vec::new();
     for def in storage.rel_tables() {
+        if def.database_id != db_id {
+            continue;
+        }
         for (index, text) in def.defaults.iter().enumerate() {
             let Some(text) = text else { continue };
             let column = &def.columns[index].0;

--- a/crates/truthdb-core/src/rel/mod.rs
+++ b/crates/truthdb-core/src/rel/mod.rs
@@ -55,6 +55,24 @@ struct TableVar {
     rows: Vec<Vec<Datum>>,
 }
 
+/// truthdb-sql cannot depend on this crate, so it mirrors the default
+/// database id; the two constants must never drift.
+const _: () = assert!(
+    truthdb_sql::eval::DEFAULT_DATABASE_ID == crate::relstore::catalog::DEFAULT_DATABASE_ID
+);
+
+/// A session's current database id. A wrapper so `TxnContext::default()`
+/// lands in the DEFAULT database (id 1), never a nonexistent id 0 — one
+/// representation of "the default database", not two.
+#[derive(Clone, Copy, PartialEq, Eq)]
+struct CurrentDb(u32);
+
+impl Default for CurrentDb {
+    fn default() -> Self {
+        CurrentDb(crate::relstore::catalog::DEFAULT_DATABASE_ID)
+    }
+}
+
 /// Per-session transaction state carried across statements/batches. Lives in
 /// the session (engine thread); autocommit statements use `Default`.
 #[derive(Default)]
@@ -110,6 +128,10 @@ pub struct TxnContext {
     /// Connection identity for session intrinsics (`DB_NAME()`,
     /// `SUSER_SNAME()`, `@@SPID`), set once when the session opens.
     database: String,
+    /// The session's current database id — the namespace every unqualified
+    /// object name resolves in. Sessions run in the default database until
+    /// `USE` learns to switch it (the multi-database plan's A2 slice).
+    database_id: CurrentDb,
     login: String,
     spid: i32,
     /// The session's database user name (`USER_NAME()`), resolved from the login
@@ -178,6 +200,7 @@ impl TxnContext {
 
     fn eval_context(&self) -> EvalContext {
         EvalContext {
+            database_id: self.database_id.0,
             trancount: self.trancount as i32,
             variables: self
                 .variables
@@ -257,6 +280,12 @@ impl TxnContext {
         self.user = user;
         self.login_sid = login_sid;
         self.user_sid = user_sid;
+    }
+
+    /// The session's current database id — the namespace unqualified names
+    /// resolve in.
+    pub(crate) fn database_id(&self) -> u32 {
+        self.database_id.0
     }
 
     /// Refreshes the session's effective role NAMES from the membership cache.
@@ -1298,7 +1327,7 @@ fn run_exec(
 ) -> Result<(), ExecError> {
     if !strip_schema(&exec.proc.value).eq_ignore_ascii_case("sp_executesql") {
         // A user procedure, if the catalog has one; 2812 otherwise.
-        if let Some(def) = resolve_table(storage, &exec.proc.value)
+        if let Some(def) = resolve_table(storage, txn_ctx.database_id(), &exec.proc.value)
             && def.is_procedure()
         {
             enforce_object_permission(&def, &txn_ctx.security, PermAction::Execute)
@@ -1548,7 +1577,9 @@ fn enter_condition_scopes<'a>(
     // those reads must observe the same snapshot as a direct read (the lock
     // analysis already resolved them), so arm the scope when the condition
     // reaches any table directly OR through a called function.
-    if tables.is_empty() && expr_function_read_ids(storage, condition).is_empty() {
+    if tables.is_empty()
+        && expr_function_read_ids(storage, txn_ctx.database_id(), condition).is_empty()
+    {
         return Ok((None, None));
     }
     match txn_ctx.isolation() {
@@ -2550,14 +2581,14 @@ impl Drop for TxnSnapshotScope {
 /// only when its FROM/subqueries name one. `SELECT 1` under SNAPSHOT must
 /// neither raise 3952 nor establish the transaction's snapshot — SQL Server
 /// defers both to the first read of an actual object.
-fn statement_reads_tables(storage: &Storage, statement: &Statement) -> bool {
+fn statement_reads_tables(storage: &Storage, db_id: u32, statement: &Statement) -> bool {
     match statement {
-        Statement::Select(select) => select_reads_tables(storage, select),
+        Statement::Select(select) => select_reads_tables(storage, db_id, select),
         // An INSERT whose TARGET is a table variable writes only session memory,
         // so — unlike a base-table INSERT — it is not itself a data access; but a
         // `SELECT` source still reads real tables and must arm the snapshot.
         Statement::Insert(insert) if insert.table.value.starts_with('@') => match &insert.source {
-            InsertSource::Select(select) => select_reads_tables(storage, select),
+            InsertSource::Select(select) => select_reads_tables(storage, db_id, select),
             _ => false,
         },
         _ => true,
@@ -2567,11 +2598,11 @@ fn statement_reads_tables(storage: &Storage, statement: &Statement) -> bool {
 /// Whether a SELECT reads any real table — directly (FROM/subqueries) or through
 /// a scalar function it calls. A `@t` table-variable source is session-local and
 /// is not counted (it neither locks nor snapshots).
-fn select_reads_tables(storage: &Storage, select: &Select) -> bool {
+fn select_reads_tables(storage: &Storage, db_id: u32, select: &Select) -> bool {
     let expanded = expand_ctes(select);
     let mut tables = Vec::new();
     collect_locked_tables(&expanded, &mut tables);
-    !tables.is_empty() || !select_function_read_ids(storage, &expanded).is_empty()
+    !tables.is_empty() || !select_function_read_ids(storage, db_id, &expanded).is_empty()
 }
 
 /// SQL Server 3952: SNAPSHOT isolation used while the database does not
@@ -2635,7 +2666,9 @@ fn exec_statement_streamed(
                 txn_ctx.txn.as_ref().map(StorageTxn::txn_id),
             ));
         }
-        Isolation::Snapshot if data_access && statement_reads_tables(storage, statement) => {
+        Isolation::Snapshot
+            if data_access && statement_reads_tables(storage, txn_ctx.database_id(), statement) =>
+        {
             if !storage.snapshot_isolation_allowed() {
                 if txn_ctx.in_txn() {
                     txn_ctx.doomed = true;
@@ -2665,7 +2698,9 @@ fn exec_statement_streamed(
         // the last applied commit yields committed-state reads). Ordered
         // BELOW the RCSI/SNAPSHOT arms so a SNAPSHOT session on a standby
         // keeps its transaction-lifetime view.
-        _ if statement_reads_tables(storage, statement) && storage.is_standby() => {
+        _ if statement_reads_tables(storage, txn_ctx.database_id(), statement)
+            && storage.is_standby() =>
+        {
             run.flush(storage)?;
             _stmt_scope = Some(SnapshotScope::enter(storage, None));
         }
@@ -2757,19 +2792,20 @@ fn statement_may_commit(statement: &Statement) -> bool {
 fn fk_parent_object_ids(storage: &Storage, def: &TableDef) -> Vec<u32> {
     def.foreign_keys
         .iter()
-        .filter_map(|fk| resolve_table(storage, &fk.parent).map(|p| p.object_id))
+        .filter_map(|fk| resolve_table(storage, def.database_id, &fk.parent).map(|p| p.object_id))
         .collect()
 }
 
 /// Object ids of the tables whose foreign keys reference `parent_name`.
-fn fk_child_object_ids(storage: &Storage, parent_name: &str) -> Vec<u32> {
+fn fk_child_object_ids(storage: &Storage, db_id: u32, parent_name: &str) -> Vec<u32> {
     storage
         .rel_tables()
         .into_iter()
         .filter(|t| {
-            t.foreign_keys
-                .iter()
-                .any(|fk| fk.parent.eq_ignore_ascii_case(parent_name))
+            t.database_id == db_id
+                && t.foreign_keys
+                    .iter()
+                    .any(|fk| fk.parent.eq_ignore_ascii_case(parent_name))
         })
         .map(|t| t.object_id)
         .collect()
@@ -2779,8 +2815,8 @@ fn fk_child_object_ids(storage: &Storage, parent_name: &str) -> Vec<u32> {
 /// FK parent. Such a table keeps table-granular write locks so an FK
 /// existence-read (Table IS on the parent) still serializes against a
 /// concurrent change to the referenced row.
-fn is_fk_parent(storage: &Storage, name: &str) -> bool {
-    !fk_child_object_ids(storage, name).is_empty()
+fn is_fk_parent(storage: &Storage, db_id: u32, name: &str) -> bool {
+    !fk_child_object_ids(storage, db_id, name).is_empty()
 }
 
 /// Above this many row-lock keys for one statement, `analyze_locks` escalates to
@@ -3034,6 +3070,7 @@ fn update_row_key_hash(def: &TableDef, update: &Update) -> Option<u64> {
 
 pub fn analyze_locks(
     storage: &Storage,
+    db_id: u32,
     sql: &str,
     isolation: Isolation,
 ) -> Vec<(Resource, LockMode)> {
@@ -3052,6 +3089,7 @@ pub fn analyze_locks(
     let mut trigger_visited = std::collections::HashSet::new();
     analyze_statements_locks(
         storage,
+        db_id,
         &parsed,
         isolation,
         &mut visited,
@@ -3061,6 +3099,7 @@ pub fn analyze_locks(
 
 fn analyze_statements_locks(
     storage: &Storage,
+    db_id: u32,
     parsed: &[Statement],
     isolation: Isolation,
     visited: &mut std::collections::HashSet<(String, Isolation)>,
@@ -3141,7 +3180,7 @@ fn analyze_statements_locks(
                 let mut tables = Vec::new();
                 collect_locked_tables(&expanded, &mut tables);
                 for name in tables {
-                    for oid in read_lock_object_ids(storage, &name.value) {
+                    for oid in read_lock_object_ids(storage, db_id, &name.value) {
                         add(Resource::Database, LockMode::IntentShared);
                         if !versioned_reads {
                             add(Resource::Table(oid), LockMode::Shared);
@@ -3151,7 +3190,7 @@ fn analyze_statements_locks(
                 // A scalar function the query calls reads tables through its
                 // body; lock those up front too (2PL), or the body would read
                 // with no lock held. read_lock_object_ids recurses the body.
-                for oid in select_function_read_ids(storage, &expanded) {
+                for oid in select_function_read_ids(storage, db_id, &expanded) {
                     add(Resource::Database, LockMode::IntentShared);
                     if !versioned_reads {
                         add(Resource::Table(oid), LockMode::Shared);
@@ -3159,7 +3198,7 @@ fn analyze_statements_locks(
                 }
             }
             Statement::Insert(insert) => {
-                if let Some(def) = resolve_table(storage, &insert.table.value) {
+                if let Some(def) = resolve_table(storage, db_id, &insert.table.value) {
                     // Row X locks on each inserted key (two inserters of
                     // different keys then run concurrently under Table IX); a
                     // heap / IDENTITY / non-literal key falls back to Table X.
@@ -3168,7 +3207,7 @@ fn analyze_statements_locks(
                     // secondary UNIQUE index likewise needs table-granular
                     // serialization (the PK Row X does not cover its key).
                     let hashes =
-                        if is_fk_parent(storage, &def.name) || has_secondary_unique_index(&def) {
+                        if is_fk_parent(storage, def.database_id, &def.name) || has_secondary_unique_index(&def) {
                             None
                         } else {
                             insert_row_key_hashes(&def, insert)
@@ -3194,6 +3233,7 @@ fn analyze_statements_locks(
                     // A firing AFTER-INSERT trigger's body reads/writes further
                     // tables; hold those locks up front too (strict 2PL).
                     add_trigger_locks(
+                        db_id,
                         storage,
                         def.object_id,
                         catalog::TriggerEvent::Insert,
@@ -3212,24 +3252,24 @@ fn analyze_statements_locks(
                     let mut tables = Vec::new();
                     collect_locked_tables(&expanded, &mut tables);
                     for name in tables {
-                        for oid in read_lock_object_ids(storage, &name.value) {
+                        for oid in read_lock_object_ids(storage, db_id, &name.value) {
                             add(Resource::Database, LockMode::IntentShared);
                             add(Resource::Table(oid), LockMode::Shared);
                         }
                     }
-                    for oid in select_function_read_ids(storage, &expanded) {
+                    for oid in select_function_read_ids(storage, db_id, &expanded) {
                         add(Resource::Database, LockMode::IntentShared);
                         add(Resource::Table(oid), LockMode::Shared);
                     }
                 }
             }
             Statement::Update(update) => {
-                if let Some(def) = resolve_table(storage, &update.table.value) {
+                if let Some(def) = resolve_table(storage, db_id, &update.table.value) {
                     // A point UPDATE (WHERE pins the whole key, no key-column
                     // write, no subquery) takes Table IX + a single Row X. An FK
                     // parent or a secondary UNIQUE index keeps Table X (see INSERT).
                     let hash =
-                        if is_fk_parent(storage, &def.name) || has_secondary_unique_index(&def) {
+                        if is_fk_parent(storage, def.database_id, &def.name) || has_secondary_unique_index(&def) {
                             None
                         } else {
                             update_row_key_hash(&def, update)
@@ -3251,11 +3291,12 @@ fn analyze_statements_locks(
                         add(Resource::Database, LockMode::IntentShared);
                         add(Resource::Table(oid), LockMode::Shared);
                     }
-                    for oid in fk_child_object_ids(storage, &def.name) {
+                    for oid in fk_child_object_ids(storage, def.database_id, &def.name) {
                         add(Resource::Database, LockMode::IntentShared);
                         add(Resource::Table(oid), LockMode::Shared);
                     }
                     add_trigger_locks(
+                        db_id,
                         storage,
                         def.object_id,
                         catalog::TriggerEvent::Update,
@@ -3267,11 +3308,11 @@ fn analyze_statements_locks(
                 }
             }
             Statement::Delete(delete) => {
-                if let Some(def) = resolve_table(storage, &delete.table.value) {
+                if let Some(def) = resolve_table(storage, db_id, &delete.table.value) {
                     // A point DELETE (WHERE pins the whole key, no subquery)
                     // takes Table IX + a single Row X. A table referenced as an
                     // FK parent keeps Table X (see INSERT).
-                    let hash = if is_fk_parent(storage, &def.name) {
+                    let hash = if is_fk_parent(storage, def.database_id, &def.name) {
                         None
                     } else {
                         where_point_key_hash(&def, &delete.where_clause)
@@ -3288,11 +3329,12 @@ fn analyze_statements_locks(
                         }
                     }
                     // DELETE reads referencing children (NO ACTION check).
-                    for oid in fk_child_object_ids(storage, &def.name) {
+                    for oid in fk_child_object_ids(storage, def.database_id, &def.name) {
                         add(Resource::Database, LockMode::IntentShared);
                         add(Resource::Table(oid), LockMode::Shared);
                     }
                     add_trigger_locks(
+                        db_id,
                         storage,
                         def.object_id,
                         catalog::TriggerEvent::Delete,
@@ -3327,7 +3369,7 @@ fn analyze_statements_locks(
                 // inner text, parsed with the IN-PROCEDURE grammar — a plain
                 // parse would reject `RETURN <value>` (178), yield no locks,
                 // and the body would run UNLOCKED (the 2PL hole class).
-                if let Some(def) = resolve_table(storage, &exec.proc.value)
+                if let Some(def) = resolve_table(storage, db_id, &exec.proc.value)
                     && let Some(procedure) = &def.procedure
                 {
                     let inner_isolation = if reads_lock {
@@ -3346,6 +3388,7 @@ fn analyze_statements_locks(
                     {
                         for (resource, mode) in analyze_statements_locks(
                             storage,
+                            db_id,
                             &body,
                             inner_isolation,
                             visited,
@@ -3393,6 +3436,7 @@ fn analyze_statements_locks(
                     if let Ok(parsed) = truthdb_sql::parse(&inner) {
                         for (resource, mode) in analyze_statements_locks(
                             storage,
+                            db_id,
                             &parsed,
                             inner_isolation,
                             visited,
@@ -3433,14 +3477,14 @@ fn analyze_statements_locks(
                 let mut tables = Vec::new();
                 collect_expr_tables(condition, &mut tables);
                 for name in tables {
-                    for oid in read_lock_object_ids(storage, &name.value) {
+                    for oid in read_lock_object_ids(storage, db_id, &name.value) {
                         add(Resource::Database, LockMode::IntentShared);
                         if !versioned_reads {
                             add(Resource::Table(oid), LockMode::Shared);
                         }
                     }
                 }
-                for oid in expr_function_read_ids(storage, condition) {
+                for oid in expr_function_read_ids(storage, db_id, condition) {
                     add(Resource::Database, LockMode::IntentShared);
                     if !versioned_reads {
                         add(Resource::Table(oid), LockMode::Shared);
@@ -3596,7 +3640,7 @@ fn exec_statement_dispatch(
             if txn_ctx.in_txn() {
                 return Err(ddl_in_txn_err());
             }
-            exec_create_procedure(storage, create)
+            exec_create_procedure(storage, txn_ctx.database_id(), create)
         }
         Statement::DropProcedure {
             name, if_exists, ..
@@ -3604,13 +3648,13 @@ fn exec_statement_dispatch(
             if txn_ctx.in_txn() {
                 return Err(ddl_in_txn_err());
             }
-            exec_drop_procedure(storage, name, *if_exists)
+            exec_drop_procedure(storage, txn_ctx.database_id(), name, *if_exists)
         }
         Statement::CreateFunction(create) => {
             if txn_ctx.in_txn() {
                 return Err(ddl_in_txn_err());
             }
-            exec_create_function(storage, create)
+            exec_create_function(storage, txn_ctx.database_id(), create)
         }
         Statement::DropFunction {
             name, if_exists, ..
@@ -3618,13 +3662,13 @@ fn exec_statement_dispatch(
             if txn_ctx.in_txn() {
                 return Err(ddl_in_txn_err());
             }
-            exec_drop_function(storage, name, *if_exists)
+            exec_drop_function(storage, txn_ctx.database_id(), name, *if_exists)
         }
         Statement::CreateTrigger(create) => {
             if txn_ctx.in_txn() {
                 return Err(ddl_in_txn_err());
             }
-            exec_create_trigger(storage, create)
+            exec_create_trigger(storage, txn_ctx.database_id(), create)
         }
         Statement::DropTrigger {
             name, if_exists, ..
@@ -3632,7 +3676,7 @@ fn exec_statement_dispatch(
             if txn_ctx.in_txn() {
                 return Err(ddl_in_txn_err());
             }
-            exec_drop_trigger(storage, name, *if_exists)
+            exec_drop_trigger(storage, txn_ctx.database_id(), name, *if_exists)
         }
         Statement::SetTriggerState {
             trigger,
@@ -3643,7 +3687,7 @@ fn exec_statement_dispatch(
             if txn_ctx.in_txn() {
                 return Err(ddl_in_txn_err());
             }
-            exec_set_trigger_state(storage, trigger, table, *enable)
+            exec_set_trigger_state(storage, txn_ctx.database_id(), trigger, table, *enable)
         }
         Statement::CreateLogin(create) => {
             if txn_ctx.in_txn() {
@@ -3702,7 +3746,7 @@ fn exec_statement_dispatch(
             if txn_ctx.in_txn() {
                 return Err(ddl_in_txn_err());
             }
-            exec_permission(storage, stmt, &txn_ctx.security)
+            exec_permission(storage, txn_ctx.database_id(), stmt, &txn_ctx.security)
         }
         Statement::BackupDatabase {
             path,
@@ -3811,44 +3855,44 @@ fn exec_statement_dispatch(
             if txn_ctx.in_txn() {
                 return Err(ddl_in_txn_err());
             }
-            exec_create_table(storage, create)
+            exec_create_table(storage, txn_ctx.database_id(), create)
         }
         Statement::DropTable(drop) => {
             if txn_ctx.in_txn() {
                 return Err(ddl_in_txn_err());
             }
-            exec_drop_table(storage, drop)
+            exec_drop_table(storage, txn_ctx.database_id(), drop)
         }
         Statement::CreateView(create) => {
             if txn_ctx.in_txn() {
                 return Err(ddl_in_txn_err());
             }
-            exec_create_view(storage, create)
+            exec_create_view(storage, txn_ctx.database_id(), create)
         }
         Statement::DropView(drop) => {
             if txn_ctx.in_txn() {
                 return Err(ddl_in_txn_err());
             }
-            exec_drop_view(storage, drop)
+            exec_drop_view(storage, txn_ctx.database_id(), drop)
         }
         Statement::CreateIndex(create) => {
             if txn_ctx.in_txn() {
                 return Err(ddl_in_txn_err());
             }
-            exec_create_index(storage, create)
+            exec_create_index(storage, txn_ctx.database_id(), create)
         }
         Statement::DropIndex(drop) => {
             if txn_ctx.in_txn() {
                 return Err(ddl_in_txn_err());
             }
-            exec_drop_index(storage, drop)
+            exec_drop_index(storage, txn_ctx.database_id(), drop)
         }
         Statement::AlterTable(alter) => {
             if txn_ctx.in_txn() {
                 return Err(ddl_in_txn_err());
             }
             let eval_ctx = txn_ctx.eval_context();
-            exec_alter_table(storage, alter, &eval_ctx)
+            exec_alter_table(storage, txn_ctx.database_id(), alter, &eval_ctx)
         }
         Statement::AlterDatabase(alter) => {
             if txn_ctx.in_txn() {
@@ -3871,8 +3915,12 @@ fn exec_statement_dispatch(
                 let eval_ctx = txn_ctx.eval_context();
                 return exec_insert_table_var(storage, insert, txn_ctx, &eval_ctx);
             }
-            let (target, after, instead_of) =
-                triggers_for(storage, &insert.table.value, catalog::TriggerEvent::Insert);
+            let (target, after, instead_of) = triggers_for(
+                storage,
+                txn_ctx.database_id(),
+                &insert.table.value,
+                catalog::TriggerEvent::Insert,
+            );
             let run_insert = |txn_ctx: &mut TxnContext| -> Result<StatementResult, SqlError> {
                 let eval_ctx = txn_ctx.eval_context();
                 let (result, identity) = {
@@ -3902,8 +3950,12 @@ fn exec_statement_dispatch(
             }
         }
         Statement::Update(update) => {
-            let (target, after, instead_of) =
-                triggers_for(storage, &update.table.value, catalog::TriggerEvent::Update);
+            let (target, after, instead_of) = triggers_for(
+                storage,
+                txn_ctx.database_id(),
+                &update.table.value,
+                catalog::TriggerEvent::Update,
+            );
             let run_update = |txn_ctx: &mut TxnContext| -> Result<StatementResult, SqlError> {
                 let eval_ctx = txn_ctx.eval_context();
                 let mut scope = txn_ctx.scope();
@@ -3925,8 +3977,12 @@ fn exec_statement_dispatch(
             }
         }
         Statement::Delete(delete) => {
-            let (target, after, instead_of) =
-                triggers_for(storage, &delete.table.value, catalog::TriggerEvent::Delete);
+            let (target, after, instead_of) = triggers_for(
+                storage,
+                txn_ctx.database_id(),
+                &delete.table.value,
+                catalog::TriggerEvent::Delete,
+            );
             let run_delete = |txn_ctx: &mut TxnContext| -> Result<StatementResult, SqlError> {
                 let eval_ctx = txn_ctx.eval_context();
                 let mut scope = txn_ctx.scope();
@@ -4050,7 +4106,7 @@ fn showplan_rows(
         Some(TableRef::Table { name, .. })
             if !name.value.to_ascii_lowercase().starts_with("sys.") =>
         {
-            match resolve_table(storage, &name.value) {
+            match resolve_table(storage, eval_ctx.database_id, &name.value) {
                 Some(def) => {
                     // The scan shape carries the covering decision (it knows
                     // which columns the query reads); other shapes never
@@ -4064,7 +4120,7 @@ fn showplan_rows(
                         let row_count = if def.indexes.is_empty() || select.where_clause.is_none() {
                             None
                         } else {
-                            storage.rel_row_count(&def.name)
+                            storage.rel_row_count(def.database_id, &def.name)
                         };
                         let path = plan::choose(
                             &def,
@@ -4945,11 +5001,15 @@ fn coerce_variable(
 
 // ---- CREATE TABLE -------------------------------------------------------
 
-fn exec_create_table(storage: &Storage, create: &CreateTable) -> Result<StatementResult, SqlError> {
+fn exec_create_table(
+    storage: &Storage,
+    db_id: u32,
+    create: &CreateTable,
+) -> Result<StatementResult, SqlError> {
     // Strip an optional `dbo.` schema prefix so the table is stored (and
     // later resolved) under its bare name.
     let table_name = strip_schema(&create.table.value);
-    if resolve_table(storage, table_name).is_some() {
+    if resolve_table(storage, db_id, table_name).is_some() {
         return Err(SqlError::new(
             2714,
             16,
@@ -5077,7 +5137,8 @@ fn exec_create_table(storage: &Storage, create: &CreateTable) -> Result<Statemen
     // table's primary key and order each child column to the parent's PK.
     // Constraint names are unique across kinds, so seed with the check names.
     let check_names: Vec<String> = check_constraints.iter().map(|c| c.name.clone()).collect();
-    let foreign_keys = build_foreign_key_defs(storage, create, &columns, table_name, &check_names)?;
+    let foreign_keys =
+        build_foreign_key_defs(db_id, storage, create, &columns, table_name, &check_names)?;
 
     // UNIQUE constraints become unique indexes. Resolve their columns now (while
     // `columns` is in hand) so an invalid column errors before the table exists.
@@ -5101,6 +5162,7 @@ fn exec_create_table(storage: &Storage, create: &CreateTable) -> Result<Statemen
 
     storage
         .rel_create_table(
+            db_id,
             table_name,
             columns,
             &key_names,
@@ -5112,7 +5174,7 @@ fn exec_create_table(storage: &Storage, create: &CreateTable) -> Result<Statemen
         .map_err(|err| map_storage_err(err, table_name))?;
     for (name, cols) in unique_indexes {
         storage
-            .rel_create_index(table_name, name, cols, true, Vec::new())
+            .rel_create_index(db_id, table_name, name, cols, true, Vec::new())
             .map_err(|err| map_storage_err(err, table_name))?;
     }
     Ok(StatementResult::Done)
@@ -5123,6 +5185,7 @@ fn exec_create_table(storage: &Storage, create: &CreateTable) -> Result<Statemen
 /// already taken by the table's CHECK constraints so a FK cannot reuse one
 /// (constraint names are unique across kinds).
 fn build_foreign_key_defs(
+    db_id: u32,
     storage: &Storage,
     create: &CreateTable,
     columns: &[Column],
@@ -5160,7 +5223,7 @@ fn build_foreign_key_defs(
         let parent_pk: Vec<(String, ColumnType)> = if is_self {
             self_pk()?
         } else {
-            let parent = resolve_table(storage, &fk.parent.value)
+            let parent = resolve_table(storage, db_id, &fk.parent.value)
                 .ok_or_else(|| SqlError::invalid_object(&fk.parent.value).at(fk.parent.span))?;
             let schema = parent
                 .schema()
@@ -5504,7 +5567,7 @@ fn enforce_checks(
         // A user scalar function (or subquery) in the CHECK is folded against the
         // row before the pure evaluator runs, like the other clause positions.
         let bound;
-        let expr = if expr_needs_binding(storage, expr) {
+        let expr = if expr_needs_binding(storage, eval_ctx.database_id, expr) {
             let outer = |n: &str| resolver.resolve(n);
             bound = substitute_correlated_in_expr(storage, expr, &outer, row, eval_ctx)?;
             &bound
@@ -5561,7 +5624,7 @@ fn fk_parent_exists(
     batch: &[Vec<Datum>],
 ) -> Result<bool, SqlError> {
     if storage
-        .rel_get(&fk.parent, key)
+        .rel_get(child.database_id, &fk.parent, key)
         .map_err(|e| map_storage_err(e, &fk.parent))?
         .is_some()
     {
@@ -5738,6 +5801,7 @@ fn enforce_parent_fks(
                             let upper = crate::relstore::index::prefix_upper_bound(&lower);
                             let matches = storage
                                 .rel_index_scan(
+                                    child.database_id,
                                     &child.name,
                                     index.object_id,
                                     Some(lower),
@@ -5765,7 +5829,7 @@ fn enforce_parent_fks(
             }
             // Fallback: scan the child and compare each row's FK key.
             let child_rows = storage
-                .rel_scan(&child.name)
+                .rel_scan(child.database_id, &child.name)
                 .map_err(|e| map_storage_err(e, &child.name))?;
             for row in &child_rows {
                 // A self-referencing row that is itself being removed does not
@@ -5896,12 +5960,16 @@ fn length(n: u32, name: &str) -> Result<u16, SqlError> {
 
 // ---- DROP TABLE ---------------------------------------------------------
 
-fn exec_drop_table(storage: &Storage, drop: &DropTable) -> Result<StatementResult, SqlError> {
+fn exec_drop_table(
+    storage: &Storage,
+    db_id: u32,
+    drop: &DropTable,
+) -> Result<StatementResult, SqlError> {
     // DROP TABLE does not drop a view or a procedure (use the matching DROP).
     // The object exists but is the wrong type, so error even under IF EXISTS
     // rather than silently no-op — the review showed DROP TABLE silently
     // DESTROYING a procedure through the shared catalog path.
-    if resolve_table(storage, &drop.table.value)
+    if resolve_table(storage, db_id, &drop.table.value)
         .is_some_and(|d| d.is_view() || d.is_procedure() || d.is_function() || d.is_trigger())
     {
         return Err(SqlError::new(
@@ -5914,7 +5982,7 @@ fn exec_drop_table(storage: &Storage, drop: &DropTable) -> Result<StatementResul
             ),
         ));
     }
-    let name = resolve_table(storage, &drop.table.value).map(|d| d.name);
+    let name = resolve_table(storage, db_id, &drop.table.value).map(|d| d.name);
     match name {
         Some(name) => {
             // A table still referenced by another table's foreign key cannot be
@@ -5943,7 +6011,7 @@ fn exec_drop_table(storage: &Storage, drop: &DropTable) -> Result<StatementResul
             // Cascade-drop the table's triggers — a trigger outlives its parent
             // table nowhere in SQL Server, and an orphan would permanently block
             // its own name (and dangle in sys.triggers).
-            if let Some(parent_oid) = resolve_table(storage, &name).map(|d| d.object_id) {
+            if let Some(parent_oid) = resolve_table(storage, db_id, &name).map(|d| d.object_id) {
                 let orphan_triggers: Vec<String> = storage
                     .rel_tables()
                     .into_iter()
@@ -5956,12 +6024,12 @@ fn exec_drop_table(storage: &Storage, drop: &DropTable) -> Result<StatementResul
                     .collect();
                 for trigger_name in orphan_triggers {
                     storage
-                        .rel_drop_table(&trigger_name)
+                        .rel_drop_table(db_id, &trigger_name)
                         .map_err(|err| map_storage_err(err, &trigger_name))?;
                 }
             }
             storage
-                .rel_drop_table(&name)
+                .rel_drop_table(db_id, &name)
                 .map_err(|err| map_storage_err(err, &drop.table.value))?;
             Ok(StatementResult::Done)
         }
@@ -5992,9 +6060,13 @@ fn parse_view_query(text: &str, view_name: &str) -> Result<Select, SqlError> {
     }
 }
 
-fn exec_create_view(storage: &Storage, create: &CreateView) -> Result<StatementResult, SqlError> {
+fn exec_create_view(
+    storage: &Storage,
+    db_id: u32,
+    create: &CreateView,
+) -> Result<StatementResult, SqlError> {
     let bare = strip_schema(&create.name.value);
-    if resolve_table(storage, &create.name.value).is_some() {
+    if resolve_table(storage, db_id, &create.name.value).is_some() {
         return Err(SqlError::new(
             2714,
             16,
@@ -6007,7 +6079,7 @@ fn exec_create_view(storage: &Storage, create: &CreateView) -> Result<StatementR
     // resolution — a view over a not-yet-created table is allowed).
     parse_view_query(&create.query_text, bare)?;
     storage
-        .rel_create_view(bare, &create.query_text)
+        .rel_create_view(db_id, bare, &create.query_text)
         .map_err(|e| map_storage_err(e, &create.name.value))?;
     Ok(StatementResult::Done)
 }
@@ -6030,6 +6102,7 @@ fn constant_default(expr: &Expr) -> bool {
 
 fn exec_create_procedure(
     storage: &Storage,
+    db_id: u32,
     create: &CreateProcedure,
 ) -> Result<StatementResult, SqlError> {
     let bare = strip_schema(&create.name.value);
@@ -6080,10 +6153,10 @@ fn exec_create_procedure(
         body: create.body.clone(),
     };
     if create.alter {
-        match resolve_table(storage, &create.name.value) {
+        match resolve_table(storage, db_id, &create.name.value) {
             Some(def) if def.is_procedure() => {
                 storage
-                    .rel_alter_procedure(&def.name, procedure)
+                    .rel_alter_procedure(def.database_id, &def.name, procedure)
                     .map_err(|e| map_storage_err(e, &create.name.value))?;
                 return Ok(StatementResult::Done);
             }
@@ -6092,7 +6165,7 @@ fn exec_create_procedure(
             }
         }
     }
-    if resolve_table(storage, &create.name.value).is_some() {
+    if resolve_table(storage, db_id, &create.name.value).is_some() {
         return Err(SqlError::new(
             2714,
             16,
@@ -6101,20 +6174,21 @@ fn exec_create_procedure(
         ));
     }
     storage
-        .rel_create_procedure(bare, procedure)
+        .rel_create_procedure(db_id, bare, procedure)
         .map_err(|e| map_storage_err(e, &create.name.value))?;
     Ok(StatementResult::Done)
 }
 
 fn exec_drop_procedure(
     storage: &Storage,
+    db_id: u32,
     name: &Name,
     if_exists: bool,
 ) -> Result<StatementResult, SqlError> {
-    match resolve_table(storage, &name.value) {
+    match resolve_table(storage, db_id, &name.value) {
         Some(def) if def.is_procedure() => {
             storage
-                .rel_drop_table(&def.name)
+                .rel_drop_table(def.database_id, &def.name)
                 .map_err(|e| map_storage_err(e, &def.name))?;
             Ok(StatementResult::Done)
         }
@@ -6134,6 +6208,7 @@ fn exec_drop_procedure(
 
 fn exec_create_function(
     storage: &Storage,
+    db_id: u32,
     create: &CreateFunction,
 ) -> Result<StatementResult, SqlError> {
     let bare = strip_schema(&create.name.value);
@@ -6207,10 +6282,10 @@ fn exec_create_function(
     };
     let function = FunctionDef { params, returns };
     if create.alter {
-        match resolve_table(storage, &create.name.value) {
+        match resolve_table(storage, db_id, &create.name.value) {
             Some(def) if def.is_function() => {
                 storage
-                    .rel_alter_function(&def.name, function)
+                    .rel_alter_function(def.database_id, &def.name, function)
                     .map_err(|e| map_storage_err(e, &create.name.value))?;
                 return Ok(StatementResult::Done);
             }
@@ -6219,7 +6294,7 @@ fn exec_create_function(
             }
         }
     }
-    if resolve_table(storage, &create.name.value).is_some() {
+    if resolve_table(storage, db_id, &create.name.value).is_some() {
         return Err(SqlError::new(
             2714,
             16,
@@ -6228,7 +6303,7 @@ fn exec_create_function(
         ));
     }
     storage
-        .rel_create_function(bare, function)
+        .rel_create_function(db_id, bare, function)
         .map_err(|e| map_storage_err(e, &create.name.value))?;
     Ok(StatementResult::Done)
 }
@@ -6368,13 +6443,14 @@ fn check_multi_tvf_statement(statement: &Statement) -> Result<(), SqlError> {
 
 fn exec_drop_function(
     storage: &Storage,
+    db_id: u32,
     name: &Name,
     if_exists: bool,
 ) -> Result<StatementResult, SqlError> {
-    match resolve_table(storage, &name.value) {
+    match resolve_table(storage, db_id, &name.value) {
         Some(def) if def.is_function() => {
             storage
-                .rel_drop_table(&def.name)
+                .rel_drop_table(def.database_id, &def.name)
                 .map_err(|e| map_storage_err(e, &def.name))?;
             Ok(StatementResult::Done)
         }
@@ -6396,12 +6472,13 @@ fn exec_drop_function(
 /// an AFTER DML trigger as a catalog object attached to its target table.
 fn exec_create_trigger(
     storage: &Storage,
+    db_id: u32,
     create: &CreateTrigger,
 ) -> Result<StatementResult, SqlError> {
     let bare = strip_schema(&create.name.value);
     // The target must be an existing base table (not a view/procedure/function/
     // trigger). SQL Server 4929-class.
-    let target = resolve_table(storage, &create.target.value)
+    let target = resolve_table(storage, db_id, &create.target.value)
         .ok_or_else(|| SqlError::invalid_object(&create.target.value).at(create.target.span))?;
     if target.is_view() || target.is_procedure() || target.is_function() || target.is_trigger() {
         return Err(SqlError::new(
@@ -6458,10 +6535,10 @@ fn exec_create_trigger(
         is_instead_of: create.instead_of,
     };
     if create.alter {
-        match resolve_table(storage, &create.name.value) {
+        match resolve_table(storage, db_id, &create.name.value) {
             Some(def) if def.is_trigger() => {
                 storage
-                    .rel_alter_trigger(&def.name, trigger)
+                    .rel_alter_trigger(def.database_id, &def.name, trigger)
                     .map_err(|e| map_storage_err(e, &create.name.value))?;
                 return Ok(StatementResult::Done);
             }
@@ -6470,7 +6547,7 @@ fn exec_create_trigger(
             }
         }
     }
-    if resolve_table(storage, &create.name.value).is_some() {
+    if resolve_table(storage, db_id, &create.name.value).is_some() {
         return Err(SqlError::new(
             2714,
             16,
@@ -6479,20 +6556,21 @@ fn exec_create_trigger(
         ));
     }
     storage
-        .rel_create_trigger(bare, trigger)
+        .rel_create_trigger(db_id, bare, trigger)
         .map_err(|e| map_storage_err(e, &create.name.value))?;
     Ok(StatementResult::Done)
 }
 
 fn exec_drop_trigger(
     storage: &Storage,
+    db_id: u32,
     name: &Name,
     if_exists: bool,
 ) -> Result<StatementResult, SqlError> {
-    match resolve_table(storage, &name.value) {
+    match resolve_table(storage, db_id, &name.value) {
         Some(def) if def.is_trigger() => {
             storage
-                .rel_drop_table(&def.name)
+                .rel_drop_table(def.database_id, &def.name)
                 .map_err(|e| map_storage_err(e, &def.name))?;
             Ok(StatementResult::Done)
         }
@@ -6515,11 +6593,12 @@ fn exec_drop_trigger(
 /// in the catalog but does not fire.
 fn exec_set_trigger_state(
     storage: &Storage,
+    db_id: u32,
     trigger: &Option<Name>,
     table: &Name,
     enable: bool,
 ) -> Result<StatementResult, SqlError> {
-    let target = resolve_table(storage, &table.value)
+    let target = resolve_table(storage, db_id, &table.value)
         .ok_or_else(|| SqlError::invalid_object(&table.value).at(table.span))?;
     if target.is_view() || target.is_procedure() || target.is_function() || target.is_trigger() {
         return Err(SqlError::invalid_object(&table.value).at(table.span));
@@ -6528,12 +6607,12 @@ fn exec_set_trigger_state(
         let mut td = def.trigger.clone().expect("is_trigger");
         td.is_disabled = !enable;
         storage
-            .rel_alter_trigger(&def.name, td)
+            .rel_alter_trigger(def.database_id, &def.name, td)
             .map_err(|e| map_storage_err(e, &def.name))
     };
     match trigger {
         Some(name) => {
-            let def = resolve_table(storage, &name.value)
+            let def = resolve_table(storage, db_id, &name.value)
                 .filter(|d| d.is_trigger())
                 .filter(|d| {
                     d.trigger.as_ref().map(|t| t.parent_object_id) == Some(target.object_id)
@@ -6773,11 +6852,12 @@ fn map_perm_action(action: PermissionAction) -> PermAction {
 /// resolve the securable and apply each (grantee, action).
 fn exec_permission(
     storage: &Storage,
+    db_id: u32,
     stmt: &PermissionStatement,
     _sec: &SecurityContext,
 ) -> Result<StatementResult, SqlError> {
     // The securable must be a schema object (table, view, procedure, function).
-    let Some(def) = resolve_table(storage, &stmt.object.value) else {
+    let Some(def) = resolve_table(storage, db_id, &stmt.object.value) else {
         return Err(SqlError::invalid_object(&stmt.object.value).at(stmt.object.span));
     };
     if def.is_trigger() {
@@ -6789,15 +6869,26 @@ fn exec_permission(
         for action in &stmt.actions {
             let catalog_action = map_perm_action(*action);
             match stmt.kind {
-                PermissionKind::Grant => {
-                    storage.rel_grant_object(&object, grantee_bare, catalog_action, false)
-                }
-                PermissionKind::Deny => {
-                    storage.rel_grant_object(&object, grantee_bare, catalog_action, true)
-                }
-                PermissionKind::Revoke => {
-                    storage.rel_revoke_object(&object, grantee_bare, catalog_action)
-                }
+                PermissionKind::Grant => storage.rel_grant_object(
+                    def.database_id,
+                    &object,
+                    grantee_bare,
+                    catalog_action,
+                    false,
+                ),
+                PermissionKind::Deny => storage.rel_grant_object(
+                    def.database_id,
+                    &object,
+                    grantee_bare,
+                    catalog_action,
+                    true,
+                ),
+                PermissionKind::Revoke => storage.rel_revoke_object(
+                    def.database_id,
+                    &object,
+                    grantee_bare,
+                    catalog_action,
+                ),
             }
             .map_err(|e| map_storage_err(e, &grantee.value).at(grantee.span))?;
         }
@@ -6849,13 +6940,14 @@ fn is_privileged_ddl(stmt: &Statement) -> bool {
 /// after the DML) and the at-most-one INSTEAD OF trigger (fired in place of it).
 fn triggers_for(
     storage: &Storage,
+    db_id: u32,
     target_name: &str,
     event: catalog::TriggerEvent,
 ) -> (Option<TableDef>, Vec<TableDef>, Option<TableDef>) {
     if !storage.rel_has_triggers() {
         return (None, Vec::new(), None);
     }
-    match resolve_table(storage, target_name) {
+    match resolve_table(storage, db_id, target_name) {
         Some(def)
             if def.trigger.is_none()
                 && def.procedure.is_none()
@@ -7054,7 +7146,7 @@ fn instead_of_update_images(
     let mut old_rows = Vec::new();
     let mut new_rows = Vec::new();
     for row in storage
-        .rel_scan(&def.name)
+        .rel_scan(def.database_id, &def.name)
         .map_err(|e| map_storage_err(e, &def.name))?
     {
         check_cancelled()?;
@@ -7090,7 +7182,7 @@ fn instead_of_delete_images(
     let types = schema_types(&schema);
     let mut deleted = Vec::new();
     for row in storage
-        .rel_scan(&def.name)
+        .rel_scan(def.database_id, &def.name)
         .map_err(|e| map_storage_err(e, &def.name))?
     {
         check_cancelled()?;
@@ -7175,11 +7267,15 @@ fn fire_one_trigger(
     result
 }
 
-fn exec_drop_view(storage: &Storage, drop: &DropView) -> Result<StatementResult, SqlError> {
-    match resolve_table(storage, &drop.name.value) {
+fn exec_drop_view(
+    storage: &Storage,
+    db_id: u32,
+    drop: &DropView,
+) -> Result<StatementResult, SqlError> {
+    match resolve_table(storage, db_id, &drop.name.value) {
         Some(def) if def.is_view() => {
             storage
-                .rel_drop_table(&def.name)
+                .rel_drop_table(def.database_id, &def.name)
                 .map_err(|e| map_storage_err(e, &def.name))?;
             Ok(StatementResult::Done)
         }
@@ -7221,8 +7317,12 @@ fn max_key_column_error(column: &str, table: &str) -> SqlError {
     )
 }
 
-fn exec_create_index(storage: &Storage, create: &CreateIndex) -> Result<StatementResult, SqlError> {
-    let def = resolve_table(storage, &create.table.value)
+fn exec_create_index(
+    storage: &Storage,
+    db_id: u32,
+    create: &CreateIndex,
+) -> Result<StatementResult, SqlError> {
+    let def = resolve_table(storage, db_id, &create.table.value)
         .ok_or_else(|| SqlError::invalid_object(&create.table.value).at(create.table.span))?;
     reject_view_as_table(&def)?;
     let schema = def.schema().map_err(|e| map_storage_err(e, &def.name))?;
@@ -7272,6 +7372,7 @@ fn exec_create_index(storage: &Storage, create: &CreateIndex) -> Result<Statemen
     }
     storage
         .rel_create_index(
+            def.database_id,
             &def.name,
             create.name.value.clone(),
             columns,
@@ -7293,13 +7394,17 @@ fn index_column_missing(column: &str, table: &str) -> SqlError {
     )
 }
 
-fn exec_drop_index(storage: &Storage, drop: &DropIndex) -> Result<StatementResult, SqlError> {
+fn exec_drop_index(
+    storage: &Storage,
+    db_id: u32,
+    drop: &DropIndex,
+) -> Result<StatementResult, SqlError> {
     // Resolve the table so the index lookup is scoped to it (index names are
     // per-table; two tables may share an index name).
-    let table = resolve_table(storage, &drop.table.value)
+    let table = resolve_table(storage, db_id, &drop.table.value)
         .ok_or_else(|| SqlError::invalid_object(&drop.table.value).at(drop.table.span))?;
     let existed = storage
-        .rel_drop_index(&table.name, &drop.name.value)
+        .rel_drop_index(table.database_id, &table.name, &drop.name.value)
         .map_err(|e| map_storage_err(e, &drop.name.value))?;
     if !existed {
         return Err(SqlError::new(
@@ -7395,16 +7500,17 @@ fn exec_alter_database(
 
 fn exec_alter_table(
     storage: &Storage,
+    db_id: u32,
     alter: &AlterTable,
     eval_ctx: &EvalContext,
 ) -> Result<StatementResult, SqlError> {
-    let def = resolve_table(storage, &alter.table.value)
+    let def = resolve_table(storage, db_id, &alter.table.value)
         .ok_or_else(|| SqlError::invalid_object(&alter.table.value).at(alter.table.span))?;
     reject_view_as_table(&def)?;
     match &alter.action {
         AlterAction::AddColumn(column) => alter_add_column(storage, &def, column, eval_ctx),
         AlterAction::AddCheck(check) => alter_add_check(storage, &def, check, eval_ctx),
-        AlterAction::AddForeignKey(fk) => alter_add_foreign_key(storage, &def, fk),
+        AlterAction::AddForeignKey(fk) => alter_add_foreign_key(storage, db_id, &def, fk),
         AlterAction::DropConstraint(name) => alter_drop_constraint(storage, &def, name),
     }
 }
@@ -7414,6 +7520,7 @@ fn exec_alter_table(
 /// referencing a missing parent is 547 and the constraint is not added.
 fn alter_add_foreign_key(
     storage: &Storage,
+    db_id: u32,
     def: &TableDef,
     fk: &ForeignKey,
 ) -> Result<StatementResult, SqlError> {
@@ -7430,7 +7537,7 @@ fn alter_add_foreign_key(
             })
             .collect()
     } else {
-        let parent = resolve_table(storage, &fk.parent.value)
+        let parent = resolve_table(storage, db_id, &fk.parent.value)
             .ok_or_else(|| SqlError::invalid_object(&fk.parent.value).at(fk.parent.span))?;
         let pschema = parent
             .schema()
@@ -7464,7 +7571,7 @@ fn alter_add_foreign_key(
     // WITH CHECK: every existing child row must satisfy the new foreign key
     // (its sibling rows count for a self-reference).
     let rows = storage
-        .rel_scan(&def.name)
+        .rel_scan(def.database_id, &def.name)
         .map_err(|e| map_storage_err(e, &def.name))?;
     for row in &rows {
         if let Some(key) = fk_key(&new_def, row)
@@ -7481,7 +7588,7 @@ fn alter_add_foreign_key(
     let mut fks = def.foreign_keys.clone();
     fks.push(new_def);
     storage
-        .rel_set_foreign_keys(&def.name, fks)
+        .rel_set_foreign_keys(def.database_id, &def.name, fks)
         .map_err(|e| map_storage_err(e, &def.name))?;
     Ok(StatementResult::Done)
 }
@@ -7541,7 +7648,14 @@ fn alter_add_column(
     let has_rows = {
         let mut probe = Vec::new();
         storage
-            .rel_scan_slice(&def.name, ScanCursor::start(), 1, None, &mut probe)
+            .rel_scan_slice(
+                def.database_id,
+                &def.name,
+                ScanCursor::start(),
+                1,
+                None,
+                &mut probe,
+            )
             .map_err(|err| map_storage_err(err, &def.name))?;
         !probe.is_empty()
     };
@@ -7566,7 +7680,13 @@ fn alter_add_column(
         .at(column.span));
     }
     storage
-        .rel_alter_add_column(&def.name, bound, column.default.clone(), fill)
+        .rel_alter_add_column(
+            def.database_id,
+            &def.name,
+            bound,
+            column.default.clone(),
+            fill,
+        )
         .map_err(|err| map_storage_err(err, &def.name))?;
     Ok(StatementResult::Done)
 }
@@ -7598,7 +7718,7 @@ fn alter_add_check(
     let resolver = SchemaScope { schema: &schema };
     let types = schema_types(&schema);
     let rows = storage
-        .rel_scan(&def.name)
+        .rel_scan(def.database_id, &def.name)
         .map_err(|e| map_storage_err(e, &def.name))?;
     for row in &rows {
         let scope = row_values(row, &types);
@@ -7616,7 +7736,7 @@ fn alter_add_check(
     let mut checks = def.check_constraints.clone();
     checks.push(new_def);
     storage
-        .rel_set_check_constraints(&def.name, checks)
+        .rel_set_check_constraints(def.database_id, &def.name, checks)
         .map_err(|e| map_storage_err(e, &def.name))?;
     Ok(StatementResult::Done)
 }
@@ -7640,7 +7760,7 @@ fn alter_drop_constraint(
             .cloned()
             .collect();
         storage
-            .rel_set_check_constraints(&def.name, checks)
+            .rel_set_check_constraints(def.database_id, &def.name, checks)
             .map_err(|e| map_storage_err(e, &def.name))?;
         return Ok(StatementResult::Done);
     }
@@ -7656,7 +7776,7 @@ fn alter_drop_constraint(
             .cloned()
             .collect();
         storage
-            .rel_set_foreign_keys(&def.name, fks)
+            .rel_set_foreign_keys(def.database_id, &def.name, fks)
             .map_err(|e| map_storage_err(e, &def.name))?;
         return Ok(StatementResult::Done);
     }
@@ -7677,7 +7797,7 @@ fn exec_insert(
     scope: &mut TxnScope,
     eval_ctx: &EvalContext,
 ) -> Result<(StatementResult, Option<i64>), SqlError> {
-    let def = resolve_table(storage, &insert.table.value)
+    let def = resolve_table(storage, eval_ctx.database_id, &insert.table.value)
         .ok_or_else(|| SqlError::invalid_object(&insert.table.value).at(insert.table.span))?;
     reject_dml_on_view(&def)?;
     enforce_object_permission(&def, &eval_ctx.security, PermAction::Insert)
@@ -7741,7 +7861,7 @@ fn exec_insert(
     // consumes them (a gap), but a value is never reused (SQL Server-faithful).
     let identity_first = if identity_col.is_some() {
         storage
-            .rel_reserve_identity(&def.name, input_rows.len())
+            .rel_reserve_identity(def.database_id, &def.name, input_rows.len())
             .map_err(|e| map_storage_err(e, &def.name))?
     } else {
         None
@@ -7817,7 +7937,7 @@ fn exec_insert(
     capture_trigger_updated((0..ncols).collect());
     let inserted = rows.len() as u64;
     storage
-        .rel_insert_many(&def.name, rows, scope)
+        .rel_insert_many(def.database_id, &def.name, rows, scope)
         .map_err(|err| map_storage_err(err, &def.name))?;
     // The last identity value generated (for SCOPE_IDENTITY()): the reserved
     // first value plus the increment for each subsequent row. `None` when the
@@ -8058,10 +8178,10 @@ fn scan_located_for_dml(
 ) -> Result<Vec<(RowLocator, Vec<Datum>, bool)>, SqlError> {
     match current_snapshot() {
         Some(snap) => storage
-            .rel_scan_located_snapshot(&def.name, snap)
+            .rel_scan_located_snapshot(def.database_id, &def.name, snap)
             .map_err(|e| map_storage_err(e, &def.name)),
         None => Ok(storage
-            .rel_scan_located(&def.name)
+            .rel_scan_located(def.database_id, &def.name)
             .map_err(|e| map_storage_err(e, &def.name))?
             .into_iter()
             .map(|(locator, row)| (locator, row, false))
@@ -8093,7 +8213,7 @@ fn exec_update(
     scope: &mut TxnScope,
     eval_ctx: &EvalContext,
 ) -> Result<StatementResult, SqlError> {
-    let def = resolve_table(storage, &update.table.value)
+    let def = resolve_table(storage, eval_ctx.database_id, &update.table.value)
         .ok_or_else(|| SqlError::invalid_object(&update.table.value).at(update.table.span))?;
     reject_dml_on_view(&def)?;
     enforce_object_permission(&def, &eval_ctx.security, PermAction::Update)
@@ -8206,7 +8326,7 @@ fn exec_update(
     {
         let old_pks: Vec<Vec<Datum>> = updates.iter().map(|(_, old, _)| pk_of(&def, old)).collect();
         let mut post_rows: Vec<Vec<Datum>> = storage
-            .rel_scan(&def.name)
+            .rel_scan(def.database_id, &def.name)
             .map_err(|e| map_storage_err(e, &def.name))?
             .into_iter()
             .filter(|r| !old_pks.contains(&pk_of(&def, r)))
@@ -8251,7 +8371,7 @@ fn exec_update(
     });
     capture_trigger_updated(assignments.iter().map(|(i, _)| *i).collect());
     let count = storage
-        .rel_update_located(&def.name, updates, scope)
+        .rel_update_located(def.database_id, &def.name, updates, scope)
         .map_err(|e| map_storage_err(e, &def.name))?;
     Ok(StatementResult::RowsAffected(count as u64))
 }
@@ -8262,7 +8382,7 @@ fn exec_delete(
     scope: &mut TxnScope,
     eval_ctx: &EvalContext,
 ) -> Result<StatementResult, SqlError> {
-    let def = resolve_table(storage, &delete.table.value)
+    let def = resolve_table(storage, eval_ctx.database_id, &delete.table.value)
         .ok_or_else(|| SqlError::invalid_object(&delete.table.value).at(delete.table.span))?;
     reject_dml_on_view(&def)?;
     enforce_object_permission(&def, &eval_ctx.security, PermAction::Delete)
@@ -8299,7 +8419,7 @@ fn exec_delete(
         )
     });
     let count = storage
-        .rel_delete_located(&def.name, targets, scope)
+        .rel_delete_located(def.database_id, &def.name, targets, scope)
         .map_err(|e| map_storage_err(e, &def.name))?;
     Ok(StatementResult::RowsAffected(count as u64))
 }
@@ -8399,6 +8519,7 @@ enum SourceRows {
 /// either (the cursor's per-page object check safe-stops on a recycled
 /// page, as the B+ tree layer documents).
 struct ScanStream {
+    db_id: u32,
     table: String,
     cursor: ScanCursor,
 }
@@ -8409,7 +8530,14 @@ impl ScanStream {
         while !self.cursor.done() && slice.is_empty() {
             check_cancelled()?;
             self.cursor = storage
-                .rel_scan_slice(&self.table, self.cursor, SCAN_SLICE_ROWS, None, &mut slice)
+                .rel_scan_slice(
+                    self.db_id,
+                    &self.table,
+                    self.cursor,
+                    SCAN_SLICE_ROWS,
+                    None,
+                    &mut slice,
+                )
                 .map_err(|err| map_storage_err(err, &self.table))?;
         }
         Ok(if slice.is_empty() { None } else { Some(slice) })
@@ -8857,7 +8985,7 @@ fn rewrite_select_subqueries(
     let self_scope = select
         .from
         .as_ref()
-        .and_then(|from| from_column_names(storage, from))
+        .and_then(|from| from_column_names(storage, eval_ctx.database_id, from))
         .map(|columns| JoinScope {
             collations: Vec::new(),
             columns,
@@ -8934,7 +9062,8 @@ fn rewrite_subqueries(
     // in place — the per-row WHERE loop substitutes its outer references and runs
     // it once per outer row (`substitute_correlated_in_expr`).
     let leave_correlated = |select: &Select| {
-        correlated_scope.is_some_and(|scope| is_correlated(storage, select, scope))
+        correlated_scope
+            .is_some_and(|scope| is_correlated(storage, eval_ctx.database_id, select, scope))
     };
     let kind = match &expr.kind {
         ExprKind::Subquery(select) if leave_correlated(select) => expr.kind.clone(),
@@ -9131,10 +9260,14 @@ fn scalar_subquery_shape_err() -> SqlError {
 /// The `(qualifier, bare column name)` columns a FROM clause exposes, read from
 /// the catalog WITHOUT materializing rows. `None` if the FROM has a derived
 /// table or a view, whose output columns need binding to determine.
-fn from_column_names(storage: &Storage, from: &TableRef) -> Option<Vec<(Option<String>, String)>> {
+fn from_column_names(
+    storage: &Storage,
+    db_id: u32,
+    from: &TableRef,
+) -> Option<Vec<(Option<String>, String)>> {
     match from {
         TableRef::Table { name, alias } => {
-            let def = resolve_table(storage, &name.value)?;
+            let def = resolve_table(storage, db_id, &name.value)?;
             // A view defers to its expansion; a PROCEDURE/FUNCTION/TRIGGER must
             // not read as a zero-column table — bailing here routes to the
             // collecting path, which errors 2809/208.
@@ -9153,8 +9286,8 @@ fn from_column_names(storage: &Storage, from: &TableRef) -> Option<Vec<(Option<S
             )
         }
         TableRef::Join { left, right, .. } => {
-            let mut cols = from_column_names(storage, left)?;
-            cols.extend(from_column_names(storage, right)?);
+            let mut cols = from_column_names(storage, db_id, left)?;
+            cols.extend(from_column_names(storage, db_id, right)?);
             Some(cols)
         }
         TableRef::Derived { subquery, alias } => {
@@ -9169,7 +9302,7 @@ fn from_column_names(storage: &Storage, from: &TableRef) -> Option<Vec<(Option<S
                         cols.push((Some(alias.value.clone()), name));
                     }
                     SelectItem::Wildcard => {
-                        let inner = from_column_names(storage, subquery.from.as_ref()?)?;
+                        let inner = from_column_names(storage, db_id, subquery.from.as_ref()?)?;
                         cols.extend(
                             inner
                                 .into_iter()
@@ -9177,7 +9310,7 @@ fn from_column_names(storage: &Storage, from: &TableRef) -> Option<Vec<(Option<S
                         );
                     }
                     SelectItem::QualifiedWildcard(q) => {
-                        let inner = from_column_names(storage, subquery.from.as_ref()?)?;
+                        let inner = from_column_names(storage, db_id, subquery.from.as_ref()?)?;
                         cols.extend(
                             inner
                                 .into_iter()
@@ -9201,9 +9334,9 @@ fn from_column_names(storage: &Storage, from: &TableRef) -> Option<Vec<(Option<S
 
 /// The inner scope of a subquery (its own FROM columns), or `None` if it cannot
 /// be determined from the catalog alone.
-fn subquery_inner_scope(storage: &Storage, subquery: &Select) -> Option<JoinScope> {
+fn subquery_inner_scope(storage: &Storage, db_id: u32, subquery: &Select) -> Option<JoinScope> {
     let columns = match &subquery.from {
-        Some(from) => from_column_names(storage, from)?,
+        Some(from) => from_column_names(storage, db_id, from)?,
         None => Vec::new(),
     };
     Some(JoinScope {
@@ -9214,8 +9347,8 @@ fn subquery_inner_scope(storage: &Storage, subquery: &Select) -> Option<JoinScop
 
 /// True if `subquery` references a column that resolves in the enclosing `outer`
 /// scope but not in its own FROM — i.e. it is correlated.
-fn is_correlated(storage: &Storage, subquery: &Select, outer: &JoinScope) -> bool {
-    let Some(inner) = subquery_inner_scope(storage, subquery) else {
+fn is_correlated(storage: &Storage, db_id: u32, subquery: &Select, outer: &JoinScope) -> bool {
+    let Some(inner) = subquery_inner_scope(storage, db_id, subquery) else {
         return false;
     };
     let mut correlated = false;
@@ -9228,7 +9361,7 @@ fn is_correlated(storage: &Storage, subquery: &Select, outer: &JoinScope) -> boo
     });
     // A correlated reference may live inside a derived table's body — its own
     // clauses resolve in the derived scope, so the walk above never sees it.
-    correlated || from_has_correlated_derived(storage, subquery.from.as_ref(), outer)
+    correlated || from_has_correlated_derived(storage, db_id, subquery.from.as_ref(), outer)
 }
 
 /// Calls `f` on every column reference inside an AGGREGATE argument anywhere
@@ -9298,16 +9431,17 @@ fn select_aggregate_arg_refs(select: &Select, f: &mut impl FnMut(&Name)) {
 /// Whether any derived-table body in a FROM tree is correlated to `outer`.
 fn from_has_correlated_derived(
     storage: &Storage,
+    db_id: u32,
     from: Option<&TableRef>,
     outer: &JoinScope,
 ) -> bool {
     match from {
         None | Some(TableRef::Table { .. }) => false,
         Some(TableRef::Join { left, right, .. }) => {
-            from_has_correlated_derived(storage, Some(left), outer)
-                || from_has_correlated_derived(storage, Some(right), outer)
+            from_has_correlated_derived(storage, db_id, Some(left), outer)
+                || from_has_correlated_derived(storage, db_id, Some(right), outer)
         }
-        Some(TableRef::Derived { subquery, .. }) => is_correlated(storage, subquery, outer),
+        Some(TableRef::Derived { subquery, .. }) => is_correlated(storage, db_id, subquery, outer),
         // A TVF's literal/non-outer arguments do not correlate it to the outer
         // FROM (APPLY, with outer-referencing args, is out of scope).
         Some(TableRef::Function { .. }) => false,
@@ -9629,11 +9763,12 @@ fn map_expr_columns(expr: &Expr, f: &impl Fn(&Name) -> Option<Expr>) -> Expr {
 /// cannot be determined; the caller then runs the subquery unchanged.
 fn substitute_subquery_outer_refs(
     storage: &Storage,
+    db_id: u32,
     subquery: &Select,
     outer: &dyn Fn(&str) -> Option<usize>,
     outer_row: &[SqlValue],
 ) -> Option<Select> {
-    let inner = subquery_inner_scope(storage, subquery)?;
+    let inner = subquery_inner_scope(storage, db_id, subquery)?;
     let substitute = |name: &Name| -> Option<Expr> {
         if inner.matches_any(&name.value) {
             return None; // the subquery's own column wins (even if ambiguous)
@@ -9694,7 +9829,7 @@ fn substitute_subquery_outer_refs(
     // not in any expression above — descend and substitute there too. The
     // recursive call's own inner-scope check handles shadowing.
     if let Some(from) = out.from.as_mut() {
-        substitute_from_outer_refs(storage, from, outer, outer_row)?;
+        substitute_from_outer_refs(storage, db_id, from, outer, outer_row)?;
     }
     Some(out)
 }
@@ -9703,6 +9838,7 @@ fn substitute_subquery_outer_refs(
 /// tree. `None` when any derived body's scope cannot be determined.
 fn substitute_from_outer_refs(
     storage: &Storage,
+    db_id: u32,
     from: &mut TableRef,
     outer: &dyn Fn(&str) -> Option<usize>,
     outer_row: &[SqlValue],
@@ -9710,11 +9846,12 @@ fn substitute_from_outer_refs(
     match from {
         TableRef::Table { .. } => Some(()),
         TableRef::Join { left, right, .. } => {
-            substitute_from_outer_refs(storage, left, outer, outer_row)?;
-            substitute_from_outer_refs(storage, right, outer, outer_row)
+            substitute_from_outer_refs(storage, db_id, left, outer, outer_row)?;
+            substitute_from_outer_refs(storage, db_id, right, outer, outer_row)
         }
         TableRef::Derived { subquery, .. } => {
-            **subquery = substitute_subquery_outer_refs(storage, subquery, outer, outer_row)?;
+            **subquery =
+                substitute_subquery_outer_refs(storage, db_id, subquery, outer, outer_row)?;
             Some(())
         }
         // A TVF's body lives in the catalog (bound at expansion, not here) and
@@ -9742,7 +9879,7 @@ impl truthdb_sql::eval::ColumnResolver for FnResolver<'_> {
 /// (`dbo.f`) and bare names both resolve; a bare name that shadows a built-in
 /// takes the user function (a documented minor divergence from SQL Server, which
 /// requires schema-qualified UDF calls).
-fn resolve_scalar_function(storage: &Storage, name: &str) -> Option<TableDef> {
+fn resolve_scalar_function(storage: &Storage, db_id: u32, name: &str) -> Option<TableDef> {
     // A bare (unqualified) name that matches a built-in always binds to the
     // built-in — a same-named UDF is reached only by its schema-qualified name
     // (`dbo.abs`), as SQL Server requires. Without this a UDF named like a
@@ -9750,7 +9887,7 @@ fn resolve_scalar_function(storage: &Storage, name: &str) -> Option<TableDef> {
     if !name.contains('.') && truthdb_sql::functions::is_builtin_function(name) {
         return None;
     }
-    let def = resolve_table(storage, name)?;
+    let def = resolve_table(storage, db_id, name)?;
     match def.function.as_ref()?.returns {
         FunctionReturns::Scalar { .. } => Some(def),
         // A table-valued function is not a scalar call (it resolves in FROM).
@@ -9761,11 +9898,11 @@ fn resolve_scalar_function(storage: &Storage, name: &str) -> Option<TableDef> {
 /// True if an expression contains a call to a user-defined scalar function —
 /// which, like a subquery, cannot be evaluated by the pure eval crate and must
 /// be rewritten to a literal per row first.
-fn expr_has_user_function(storage: &Storage, expr: &Expr) -> bool {
-    let has = |e: &Expr| expr_has_user_function(storage, e);
+fn expr_has_user_function(storage: &Storage, db_id: u32, expr: &Expr) -> bool {
+    let has = |e: &Expr| expr_has_user_function(storage, db_id, e);
     match &expr.kind {
         ExprKind::Function { name, args } => {
-            resolve_scalar_function(storage, name).is_some() || args.iter().any(has)
+            resolve_scalar_function(storage, db_id, name).is_some() || args.iter().any(has)
         }
         ExprKind::Null
         | ExprKind::Int(_)
@@ -9805,8 +9942,8 @@ fn expr_has_user_function(storage: &Storage, expr: &Expr) -> bool {
 
 /// True if an expression needs the per-row storage-aware rewrite (a subquery or
 /// a user scalar function) before the pure evaluator can run on it.
-fn expr_needs_binding(storage: &Storage, expr: &Expr) -> bool {
-    expr_has_subquery(expr) || expr_has_user_function(storage, expr)
+fn expr_needs_binding(storage: &Storage, db_id: u32, expr: &Expr) -> bool {
+    expr_has_subquery(expr) || expr_has_user_function(storage, db_id, expr)
 }
 
 fn substitute_correlated_in_expr(
@@ -9819,7 +9956,8 @@ fn substitute_correlated_in_expr(
     let recur = |e: &Expr| substitute_correlated_in_expr(storage, e, outer, outer_row, eval_ctx);
     let recur_box = |e: &Expr| -> Result<Box<Expr>, SqlError> { Ok(Box::new(recur(e)?)) };
     let bind = |sq: &Select| -> Select {
-        substitute_subquery_outer_refs(storage, sq, outer, outer_row).unwrap_or_else(|| sq.clone())
+        substitute_subquery_outer_refs(storage, eval_ctx.database_id, sq, outer, outer_row)
+            .unwrap_or_else(|| sq.clone())
     };
     let kind = match &expr.kind {
         ExprKind::Subquery(sq) => {
@@ -9911,7 +10049,7 @@ fn substitute_correlated_in_expr(
             // for this row (its arguments evaluated against the row) and folds to
             // the returned value — the same rewrite-to-literal discipline
             // subqueries use, keeping scalar evaluation free of storage access.
-            if let Some(def) = resolve_scalar_function(storage, name) {
+            if let Some(def) = resolve_scalar_function(storage, eval_ctx.database_id, name) {
                 let resolver = FnResolver(outer);
                 let values = args
                     .iter()
@@ -10039,7 +10177,7 @@ fn exec_select(
     let where_correlated = select
         .where_clause
         .as_ref()
-        .is_some_and(|w| expr_needs_binding(storage, w));
+        .is_some_and(|w| expr_needs_binding(storage, eval_ctx.database_id, w));
     let mut rows: Vec<Vec<Datum>> = Vec::new();
     // One row: filter it into `rows` or drop it. Shared by both input shapes.
     let take = |row: Vec<Datum>, rows: &mut Vec<Vec<Datum>>| -> Result<(), SqlError> {
@@ -10195,6 +10333,8 @@ pub(crate) fn without_scan_path<R>(f: impl FnOnce() -> R) -> R {
 /// filtered and projected without any stage that must see the whole input
 /// first. Produced by [`scan_plan`], consumed by [`scan_select`].
 struct ScanPlan {
+    /// The base table's database — the namespace the scan reads it from.
+    db_id: u32,
     /// The base table's catalog name — what the scan reads.
     table: String,
     /// How to read it: the planner's choice, made once (see [`scan_plan`]).
@@ -10295,7 +10435,7 @@ fn scan_plan(storage: &Storage, select: &Select, eval_ctx: &EvalContext) -> Opti
     if select
         .where_clause
         .as_ref()
-        .is_some_and(|w| expr_needs_binding(storage, w))
+        .is_some_and(|w| expr_needs_binding(storage, eval_ctx.database_id, w))
     {
         return None;
     }
@@ -10330,7 +10470,7 @@ fn scan_plan(storage: &Storage, select: &Select, eval_ctx: &EvalContext) -> Opti
     if is_sys_view(&name.value) {
         return None;
     }
-    let def = resolve_table(storage, &name.value)?;
+    let def = resolve_table(storage, eval_ctx.database_id, &name.value)?;
     // A view is its own SELECT, expanded as a derived table — and its TableDef
     // has no columns and a `root_page` of 0, so a wildcard over it would project
     // nothing and the scan would read the catalog root instead of the view. A
@@ -10447,7 +10587,7 @@ fn scan_plan(storage: &Storage, select: &Select, eval_ctx: &EvalContext) -> Opti
     let row_count = if def.indexes.is_empty() || select.where_clause.is_none() {
         None
     } else {
-        storage.rel_row_count(&def.name)
+        storage.rel_row_count(def.database_id, &def.name)
     };
     let access = plan::choose(
         &def,
@@ -10489,6 +10629,7 @@ fn scan_plan(storage: &Storage, select: &Select, eval_ctx: &EvalContext) -> Opti
     };
 
     Some(ScanPlan {
+        db_id: def.database_id,
         table: def.name,
         access,
         needed,
@@ -10703,7 +10844,7 @@ fn scan_select_rows(
                 // snapshot scan reads the table atomically and merges the
                 // version store.
                 let rows = storage
-                    .rel_scan_snapshot(&plan.table, Some(&plan.needed), snapshot)
+                    .rel_scan_snapshot(plan.db_id, &plan.table, Some(&plan.needed), snapshot)
                     .map_err(|err| map_storage_err(err, &plan.table))?;
                 for row in rows {
                     if !take(row)? {
@@ -10716,6 +10857,7 @@ fn scan_select_rows(
                 'scan: while !cursor.done() {
                     cursor = storage
                         .rel_scan_slice(
+                            plan.db_id,
                             &plan.table,
                             cursor,
                             SCAN_SLICE_ROWS,
@@ -10741,6 +10883,7 @@ fn scan_select_rows(
             // each one, so the result matches a full scan.
             let rows = storage
                 .rel_index_scan(
+                    plan.db_id,
                     &plan.table,
                     *index_object_id,
                     lower.clone(),
@@ -11138,7 +11281,7 @@ fn eval_maybe_bound(
     resolver: &impl ColumnResolver,
     eval_ctx: &EvalContext,
 ) -> Result<SqlValue, SqlError> {
-    if expr_needs_binding(storage, expr) {
+    if expr_needs_binding(storage, eval_ctx.database_id, expr) {
         let outer = |name: &str| resolver.resolve(name);
         let bound = substitute_correlated_in_expr(storage, expr, &outer, row, eval_ctx)?;
         eval::eval(&bound, row, resolver, eval_ctx)
@@ -11438,7 +11581,7 @@ fn project(
                 // subquery still present here is correlated (the rewrite pass
                 // left it for the per-row bind): substitute the outer row's
                 // values in, making it uncorrelated for that row.
-                let correlated = expr_needs_binding(storage, expr);
+                let correlated = expr_needs_binding(storage, eval_ctx.database_id, expr);
                 let mut values = Vec::with_capacity(rows.len());
                 for row in &row_sql {
                     let bound;
@@ -12152,7 +12295,7 @@ fn build_table_source(
         "sys.foreign_keys" => sys_foreign_keys(storage),
         "sys.default_constraints" => sys_default_constraints(storage),
         _ => {
-            let def = resolve_table(storage, &name.value)
+            let def = resolve_table(storage, eval_ctx.database_id, &name.value)
                 .ok_or_else(|| SqlError::invalid_object(&name.value).at(name.span))?;
             // A procedure is not a queryable object (SQL Server 2809).
             if def.is_procedure() {
@@ -12205,7 +12348,7 @@ fn build_table_source(
             let row_count = if def.indexes.is_empty() || where_clause.is_none() {
                 None
             } else {
-                storage.rel_row_count(&def.name)
+                storage.rel_row_count(def.database_id, &def.name)
             };
             let rows = match plan::choose(&def, &schema, where_clause, eval_ctx, None, row_count) {
                 // A scan is handed out LAZY: the consumer pulls slices, so a
@@ -12217,10 +12360,11 @@ fn build_table_source(
                 plan::AccessPath::TableScan => match current_snapshot() {
                     Some(snapshot) => SourceRows::Materialized(
                         storage
-                            .rel_scan_snapshot(&def.name, None, snapshot)
+                            .rel_scan_snapshot(def.database_id, &def.name, None, snapshot)
                             .map_err(|err| map_storage_err(err, &def.name))?,
                     ),
                     None => SourceRows::Scan(ScanStream {
+                        db_id: def.database_id,
                         table: def.name.clone(),
                         cursor: ScanCursor::start(),
                     }),
@@ -12233,6 +12377,7 @@ fn build_table_source(
                 } => SourceRows::Materialized(
                     storage
                         .rel_index_scan(
+                            def.database_id,
                             &def.name,
                             index_object_id,
                             lower,
@@ -12283,7 +12428,7 @@ fn build_function_source(
     alias: Option<&Name>,
     eval_ctx: &EvalContext,
 ) -> Result<Source, SqlError> {
-    let def = resolve_table(storage, &name.value)
+    let def = resolve_table(storage, eval_ctx.database_id, &name.value)
         .ok_or_else(|| SqlError::invalid_object(&name.value).at(name.span))?;
     let function = def
         .function
@@ -12671,8 +12816,14 @@ fn substitute_outer_in_tref(
             })
         }
         TableRef::Derived { subquery, alias } => {
-            let bound = substitute_subquery_outer_refs(storage, subquery, outer, outer_row)
-                .unwrap_or_else(|| (**subquery).clone());
+            let bound = substitute_subquery_outer_refs(
+                storage,
+                eval_ctx.database_id,
+                subquery,
+                outer,
+                outer_row,
+            )
+            .unwrap_or_else(|| (**subquery).clone());
             Ok(TableRef::Derived {
                 subquery: Box::new(bound),
                 alias: alias.clone(),
@@ -12784,7 +12935,8 @@ fn join_sources(
 
     // A subquery or user scalar function in the ON predicate is folded against
     // the joined row before the pure evaluator runs (per candidate pair).
-    let on_needs_binding = on.is_some_and(|pred| expr_needs_binding(storage, pred));
+    let on_needs_binding =
+        on.is_some_and(|pred| expr_needs_binding(storage, eval_ctx.database_id, pred));
     let concat = |l: &[Datum], r: &[Datum]| -> Vec<Datum> { l.iter().chain(r).cloned().collect() };
     let matches = |l: &[Datum], r: &[Datum]| -> Result<bool, SqlError> {
         match on {
@@ -14323,10 +14475,10 @@ fn strip_schema(name: &str) -> &str {
 /// views take no lock. Nested views (a view over a view) are not expanded here
 /// (they error at query time), so they contribute no locks; view expansion is
 /// one level deep, matching the executor.
-fn read_lock_object_ids(storage: &Storage, name: &str) -> Vec<u32> {
+fn read_lock_object_ids(storage: &Storage, db_id: u32, name: &str) -> Vec<u32> {
     let mut out = Vec::new();
     let mut visited = std::collections::HashSet::new();
-    collect_read_lock_ids(storage, name, 0, &mut out, &mut visited);
+    collect_read_lock_ids(storage, db_id, name, 0, &mut out, &mut visited);
     out
 }
 
@@ -14340,7 +14492,9 @@ fn read_lock_object_ids(storage: &Storage, name: &str) -> Vec<u32> {
 /// table with its own triggers) is bounded by `trigger_visited` (trigger
 /// object_ids), so a trigger cycle terminates cleanly rather than hanging
 /// analysis under the scheduler mutex.
+#[allow(clippy::too_many_arguments)]
 fn add_trigger_locks(
+    db_id: u32,
     storage: &Storage,
     parent_object_id: u32,
     event: catalog::TriggerEvent,
@@ -14355,9 +14509,14 @@ fn add_trigger_locks(
         }
         let Some(t) = &trig.trigger else { continue };
         if let Ok(statements) = truthdb_sql::parse_procedure_body(&t.body) {
-            for (resource, mode) in
-                analyze_statements_locks(storage, &statements, isolation, visited, trigger_visited)
-            {
+            for (resource, mode) in analyze_statements_locks(
+                storage,
+                db_id,
+                &statements,
+                isolation,
+                visited,
+                trigger_visited,
+            ) {
                 add(resource, mode);
             }
         }
@@ -14367,28 +14526,28 @@ fn add_trigger_locks(
 /// The base-table object ids the scalar functions called in a SELECT read
 /// through their bodies (deduped). Non-function names collected along the way
 /// resolve to nothing.
-fn select_function_read_ids(storage: &Storage, select: &Select) -> Vec<u32> {
+fn select_function_read_ids(storage: &Storage, db_id: u32, select: &Select) -> Vec<u32> {
     let mut tables = Vec::new();
     let mut funcs = Vec::new();
     collect_select_read_names(select, &mut tables, &mut funcs);
     let mut out = Vec::new();
     let mut visited = std::collections::HashSet::new();
     for func in &funcs {
-        collect_read_lock_ids(storage, func, 0, &mut out, &mut visited);
+        collect_read_lock_ids(storage, db_id, func, 0, &mut out, &mut visited);
     }
     out
 }
 
 /// Like [`select_function_read_ids`] but for a bare expression (an IF/WHILE
 /// condition).
-fn expr_function_read_ids(storage: &Storage, expr: &Expr) -> Vec<u32> {
+fn expr_function_read_ids(storage: &Storage, db_id: u32, expr: &Expr) -> Vec<u32> {
     let mut tables = Vec::new();
     let mut funcs = Vec::new();
     collect_expr_read_names(expr, &mut tables, &mut funcs);
     let mut out = Vec::new();
     let mut visited = std::collections::HashSet::new();
     for func in &funcs {
-        collect_read_lock_ids(storage, func, 0, &mut out, &mut visited);
+        collect_read_lock_ids(storage, db_id, func, 0, &mut out, &mut visited);
     }
     out
 }
@@ -14398,6 +14557,7 @@ fn expr_function_read_ids(storage: &Storage, expr: &Expr) -> Vec<u32> {
 /// base tables). Bounded by [`MAX_VIEW_NESTING`] so a view cycle terminates.
 fn collect_read_lock_ids(
     storage: &Storage,
+    db_id: u32,
     name: &str,
     depth: u32,
     out: &mut Vec<u32>,
@@ -14406,7 +14566,7 @@ fn collect_read_lock_ids(
     if depth > MAX_VIEW_NESTING || name.to_ascii_lowercase().starts_with("sys.") {
         return;
     }
-    let Some(def) = resolve_table(storage, name) else {
+    let Some(def) = resolve_table(storage, db_id, name) else {
         return;
     };
     // Expand each function/view body at most once per analysis. The depth guard
@@ -14451,7 +14611,7 @@ fn collect_read_lock_ids(
             }
         }
         for referenced in tables.iter().chain(funcs.iter()) {
-            collect_read_lock_ids(storage, referenced, depth + 1, out, visited);
+            collect_read_lock_ids(storage, db_id, referenced, depth + 1, out, visited);
         }
         return;
     }
@@ -14474,7 +14634,7 @@ fn collect_read_lock_ids(
     let mut funcs = Vec::new();
     collect_select_read_names(&expanded, &mut tables, &mut funcs);
     for referenced in tables.iter().chain(funcs.iter()) {
-        collect_read_lock_ids(storage, referenced, depth + 1, out, visited);
+        collect_read_lock_ids(storage, db_id, referenced, depth + 1, out, visited);
     }
 }
 
@@ -14557,15 +14717,15 @@ fn reject_view_as_table(def: &TableDef) -> Result<(), SqlError> {
     Ok(())
 }
 
-fn resolve_table(storage: &Storage, name: &str) -> Option<TableDef> {
+fn resolve_table(storage: &Storage, db_id: u32, name: &str) -> Option<TableDef> {
     let bare = strip_schema(name);
-    if let Some(def) = storage.rel_table(bare) {
+    if let Some(def) = storage.rel_table(db_id, bare) {
         return Some(def);
     }
     storage
         .rel_tables()
         .into_iter()
-        .find(|d| d.name.eq_ignore_ascii_case(bare))
+        .find(|d| d.database_id == db_id && d.name.eq_ignore_ascii_case(bare))
 }
 
 /// Maps a storage error to a SQL Server-numbered error. PK and NULL

--- a/crates/truthdb-core/src/relstore/catalog.rs
+++ b/crates/truthdb-core/src/relstore/catalog.rs
@@ -18,6 +18,17 @@ use crate::wal::records::RelRecord;
 pub const CATALOG_OBJECT_ID: u32 = 1;
 /// First object id handed to user tables.
 pub const FIRST_USER_OBJECT_ID: u32 = 2;
+/// The default database's id. The default database is synthesized (never
+/// stored): it always exists, cannot be dropped, and its name comes from the
+/// instance configuration. Every catalog row written before databases existed
+/// deserializes into it via `serde(default = ...)`.
+pub const DEFAULT_DATABASE_ID: u32 = 1;
+/// First database id handed to `CREATE DATABASE` (the default database is 1).
+pub const FIRST_USER_DATABASE_ID: u32 = 2;
+
+fn default_database_id() -> u32 {
+    DEFAULT_DATABASE_ID
+}
 
 /// An `IDENTITY(seed, increment)` column: which column it is (schema index),
 /// its seed/increment, and the next value to hand out (persisted so identity
@@ -147,6 +158,28 @@ pub struct TableDef {
     /// dropped. Empty for a freshly created object.
     #[serde(default)]
     pub permissions: Vec<PermissionEntry>,
+    /// The database this object belongs to. Pre-multidb catalog rows have no
+    /// field and deserialize into the default database. Meaningless (left at
+    /// the default) on server-scoped rows: logins, database principals, and
+    /// database rows themselves.
+    #[serde(default = "default_database_id")]
+    pub database_id: u32,
+    /// For a DATABASE (`CREATE DATABASE`): its id and metadata. A database is
+    /// NOT a schema object — the storage layer keeps these rows in a separate
+    /// in-memory map so they never enter the object namespace. `None` for
+    /// every other kind of row.
+    #[serde(default)]
+    pub database: Option<DatabaseDef>,
+}
+
+/// A database's catalog payload. The row's `name` is the database name; the
+/// payload carries the database id that objects reference via
+/// [`TableDef::database_id`]. Ids are allocated max+1 over stored rows
+/// (starting at [`FIRST_USER_DATABASE_ID`]) and capped at `u16::MAX` so the
+/// id fits the WAL container tag.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct DatabaseDef {
+    pub db_id: u32,
 }
 
 /// A privilege on a securable, per SQL Server's object permissions.
@@ -399,6 +432,12 @@ impl TableDef {
             self.principal.as_ref().map(|p| p.kind),
             Some(PrincipalKind::Role)
         )
+    }
+
+    /// True if this catalog entry is a database (a namespace container, not a
+    /// schema object — kept in its own map, out of the object namespace).
+    pub fn is_database(&self) -> bool {
+        self.database.is_some()
     }
 }
 

--- a/crates/truthdb-core/src/relstore/mod.rs
+++ b/crates/truthdb-core/src/relstore/mod.rs
@@ -38,8 +38,15 @@ pub(crate) struct RelState {
     /// Pages dirtied since the last checkpoint -> LSN of their first change.
     pub dpt: HashMap<u64, u64>,
     pub catalog_root: Option<u64>,
-    /// Catalog cache: table name -> definition.
-    pub tables: HashMap<String, TableDef>,
+    /// Catalog cache: database id -> (table name -> definition). Object names
+    /// are unique per database; the nested map is the namespace boundary.
+    pub tables: HashMap<u32, HashMap<String, TableDef>>,
+    /// Databases (`CREATE DATABASE` rows), keyed by lowercased database name.
+    /// The default database (id 1) is synthesized, never stored, and never in
+    /// this map. Persisted in the same catalog b-tree (a row with
+    /// `database: Some(..)`), partitioned out on load, never in the object
+    /// namespace.
+    pub databases: HashMap<String, TableDef>,
     /// Server logins (principals), keyed by lowercased login name. Persisted in
     /// the SAME catalog b-tree as `tables` (a row with `principal: Some(..)`),
     /// but partitioned into a separate map on load so a login never enters the
@@ -69,6 +76,7 @@ impl RelState {
             dpt: HashMap::new(),
             catalog_root: None,
             tables: HashMap::new(),
+            databases: HashMap::new(),
             principals: HashMap::new(),
             database_principals: HashMap::new(),
             next_txn_id: 1,
@@ -85,7 +93,7 @@ impl RelState {
         if let Some(root) = self.catalog_root {
             roots.insert(CATALOG_OBJECT_ID, root);
         }
-        for def in self.tables.values() {
+        for def in self.all_tables() {
             if def.is_tree() {
                 roots.insert(def.object_id, def.root_page);
             }
@@ -94,5 +102,44 @@ impl RelState {
             }
         }
         roots
+    }
+
+    /// The named object in the given database, if any (exact-case).
+    pub fn table(&self, db_id: u32, name: &str) -> Option<&TableDef> {
+        self.tables.get(&db_id)?.get(name)
+    }
+
+    /// True if the database holds an object with this exact-case name.
+    pub fn contains_table(&self, db_id: u32, name: &str) -> bool {
+        self.table(db_id, name).is_some()
+    }
+
+    /// Caches a definition under its own `database_id` and `name`.
+    pub fn cache_table(&mut self, def: TableDef) {
+        self.tables
+            .entry(def.database_id)
+            .or_default()
+            .insert(def.name.clone(), def);
+    }
+
+    /// Removes a cached definition; drops the database's (empty) inner map so
+    /// a dropped database leaves nothing behind.
+    pub fn uncache_table(&mut self, db_id: u32, name: &str) {
+        if let Some(inner) = self.tables.get_mut(&db_id) {
+            inner.remove(name);
+            if inner.is_empty() {
+                self.tables.remove(&db_id);
+            }
+        }
+    }
+
+    /// Every object definition across all databases.
+    pub fn all_tables(&self) -> impl Iterator<Item = &TableDef> {
+        self.tables.values().flat_map(|inner| inner.values())
+    }
+
+    /// Every object definition in one database.
+    pub fn tables_in(&self, db_id: u32) -> impl Iterator<Item = &TableDef> {
+        self.tables.get(&db_id).into_iter().flat_map(|m| m.values())
     }
 }

--- a/crates/truthdb-core/src/relstore/tests.rs
+++ b/crates/truthdb-core/src/relstore/tests.rs
@@ -1529,3 +1529,69 @@ fn the_default_database_cannot_be_dropped_and_missing_drop_is_false() {
     assert!(!storage.rel_drop_database("ghost").expect("missing drop"));
     let _ = std::fs::remove_file(path);
 }
+
+#[test]
+fn drop_database_redo_survives_reopen() {
+    // DROP DATABASE is the first statement deleting many catalog rows in one
+    // transaction; a reopen must recover to the dropped state (redo of the
+    // committed multi-delete), and recreating the name allocates a fresh id.
+    let path = unique_temp_path("multidb-drop-reopen");
+    let mut storage = create_storage(&path);
+    let hr = storage.rel_create_database("hr").expect("create hr");
+    create_tree_table(&mut storage, "keep");
+    for name in ["a", "b", "c"] {
+        storage
+            .rel_create_table(
+                hr,
+                name,
+                vec![int_column("id", false)],
+                &["id".to_string()],
+                Vec::new(),
+                None,
+                Vec::new(),
+                Vec::new(),
+            )
+            .expect("hr table");
+    }
+    assert!(storage.rel_drop_database("hr").expect("drop"));
+    drop(storage);
+
+    let storage = Storage::open(path.clone()).expect("reopen");
+    assert_eq!(
+        storage.rel_database_id_by_name("hr"),
+        None,
+        "drop is durable"
+    );
+    for name in ["a", "b", "c"] {
+        assert!(
+            storage.rel_table(hr, name).is_none(),
+            "objects gone after redo"
+        );
+    }
+    assert!(
+        storage
+            .rel_table(crate::relstore::catalog::DEFAULT_DATABASE_ID, "keep")
+            .is_some(),
+        "other databases untouched"
+    );
+    let recreated = storage.rel_create_database("hr").expect("recreate");
+    assert_eq!(recreated, 2, "id allocation continues from surviving max");
+    let _ = std::fs::remove_file(path);
+}
+
+#[test]
+fn configured_default_database_name_must_not_shadow_a_stored_database() {
+    let path = unique_temp_path("multidb-default-collision");
+    let storage = create_storage(&path);
+    storage.rel_create_database("prod").expect("create prod");
+    assert!(matches!(
+        storage.set_default_database_name("prod"),
+        Err(StorageError::InvalidConfig(_))
+    ));
+    storage
+        .set_default_database_name("main")
+        .expect("a fresh name is fine");
+    assert_eq!(storage.rel_database_id_by_name("main"), Some(1));
+    assert_eq!(storage.rel_database_id_by_name("truthdb"), None, "renamed");
+    let _ = std::fs::remove_file(path);
+}

--- a/crates/truthdb-core/src/relstore/tests.rs
+++ b/crates/truthdb-core/src/relstore/tests.rs
@@ -76,6 +76,7 @@ fn varchar_column(name: &str, max_len: u16) -> Column {
 fn create_tree_table(storage: &mut Storage, name: &str) {
     storage
         .rel_create_table(
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
             name,
             vec![int_column("id", false), varchar_column("payload", 4000)],
             &["id".to_string()],
@@ -90,6 +91,7 @@ fn create_tree_table(storage: &mut Storage, name: &str) {
 fn create_heap_table(storage: &mut Storage, name: &str) {
     storage
         .rel_create_table(
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
             name,
             vec![int_column("id", false), varchar_column("payload", 4000)],
             &[],
@@ -107,7 +109,7 @@ fn row(id: i32, payload: &str) -> Vec<Datum> {
 
 fn scan_ids(storage: &mut Storage, table: &str) -> Vec<i32> {
     storage
-        .rel_scan(table)
+        .rel_scan(crate::relstore::catalog::DEFAULT_DATABASE_ID, table)
         .expect("scan")
         .into_iter()
         .map(|r| match r[0] {
@@ -125,17 +127,31 @@ fn committed_statements_survive_crash_without_checkpoint() {
     create_heap_table(&mut storage, "h");
     for i in 0..20 {
         storage
-            .rel_insert("t", row(i, &format!("tree-{i}")))
+            .rel_insert(
+                crate::relstore::catalog::DEFAULT_DATABASE_ID,
+                "t",
+                row(i, &format!("tree-{i}")),
+            )
             .expect("insert");
         storage
-            .rel_insert("h", row(i, &format!("heap-{i}")))
+            .rel_insert(
+                crate::relstore::catalog::DEFAULT_DATABASE_ID,
+                "h",
+                row(i, &format!("heap-{i}")),
+            )
             .expect("insert");
     }
     storage
-        .rel_delete_where("t", "id", &Datum::Int(3))
+        .rel_delete_where(
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
+            "t",
+            "id",
+            &Datum::Int(3),
+        )
         .expect("delete");
     storage
         .rel_update_where(
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
             "t",
             "id",
             &Datum::Int(4),
@@ -148,7 +164,11 @@ fn committed_statements_survive_crash_without_checkpoint() {
     let ids = scan_ids(&mut storage, "t");
     assert_eq!(ids, (0..20).filter(|i| *i != 3).collect::<Vec<_>>());
     let updated = storage
-        .rel_get("t", &[Datum::Int(4)])
+        .rel_get(
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
+            "t",
+            &[Datum::Int(4)],
+        )
         .expect("get")
         .expect("row 4 exists");
     assert_eq!(updated[1], Datum::VarChar("updated".to_string()));
@@ -200,12 +220,17 @@ fn fuzzy_checkpoint_with_open_txn_then_crash_undoes_it() {
     let mut storage = create_storage(&path);
     create_tree_table(&mut storage, "t");
     storage
-        .rel_insert("t", row(1, "committed"))
+        .rel_insert(
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
+            "t",
+            row(1, "committed"),
+        )
         .expect("insert 1");
 
     let mut txn = storage.rel_begin().expect("begin");
     storage
         .rel_insert_many(
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
             "t",
             vec![row(99, "uncommitted")],
             &mut TxnScope::Explicit(&mut txn),
@@ -244,6 +269,7 @@ fn fuzzy_checkpoint_then_commit_survives_crash() {
     let mut txn = storage.rel_begin().expect("begin");
     storage
         .rel_insert_many(
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
             "t",
             vec![row(50, "before-ckpt")],
             &mut TxnScope::Explicit(&mut txn),
@@ -254,6 +280,7 @@ fn fuzzy_checkpoint_then_commit_survives_crash() {
         .expect("checkpoint with open txn");
     storage
         .rel_insert_many(
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
             "t",
             vec![row(51, "after-ckpt")],
             &mut TxnScope::Explicit(&mut txn),
@@ -280,10 +307,18 @@ fn uncommitted_statement_is_undone_and_recovery_rerun_is_clean() {
     create_tree_table(&mut storage, "t");
     create_heap_table(&mut storage, "h");
     storage
-        .rel_insert("t", row(1, "committed"))
+        .rel_insert(
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
+            "t",
+            row(1, "committed"),
+        )
         .expect("insert");
     storage
-        .rel_insert("h", row(1, "committed"))
+        .rel_insert(
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
+            "h",
+            row(1, "committed"),
+        )
         .expect("insert");
     // Crash mid-statement: ops durable, commit record never written.
     storage
@@ -307,7 +342,11 @@ fn uncommitted_statement_is_undone_and_recovery_rerun_is_clean() {
     assert_eq!(scan_ids(&mut storage, "h"), vec![1]);
     // The store stays fully usable.
     storage
-        .rel_insert("t", row(2, "fresh"))
+        .rel_insert(
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
+            "t",
+            row(2, "fresh"),
+        )
         .expect("insert after recovery");
     assert_eq!(scan_ids(&mut storage, "t"), vec![1, 2]);
     drop(storage);
@@ -320,12 +359,21 @@ fn torn_page_is_repaired_from_full_page_image() {
     let mut storage = create_storage(&path);
     create_tree_table(&mut storage, "t");
     for i in 0..5 {
-        storage.rel_insert("t", row(i, "payload")).expect("insert");
+        storage
+            .rel_insert(
+                crate::relstore::catalog::DEFAULT_DATABASE_ID,
+                "t",
+                row(i, "payload"),
+            )
+            .expect("insert");
     }
     // Flush dirty pages to disk without advancing the WAL head (the
     // mid-checkpoint crash window), then tear the table's root page.
     storage.rel_flush_pool_only().expect("flush");
-    let root_page = storage.rel_table("t").expect("def").root_page;
+    let root_page = storage
+        .rel_table(crate::relstore::catalog::DEFAULT_DATABASE_ID, "t")
+        .expect("def")
+        .root_page;
     let offset = storage.data_page_offset(root_page);
     drop(storage);
     overwrite_bytes(&path, offset + 1000, &[0xDBu8; 2000]);
@@ -363,7 +411,11 @@ fn btree_matches_btreemap_oracle_through_splits_and_crash() {
             // Insert (duplicate key must be rejected and change nothing).
             0 | 1 => {
                 let payload = format!("{id}-{}", "x".repeat(180 + (rng.next() % 200) as usize));
-                let result = storage.rel_insert("t", row(id, &payload));
+                let result = storage.rel_insert(
+                    crate::relstore::catalog::DEFAULT_DATABASE_ID,
+                    "t",
+                    row(id, &payload),
+                );
                 match oracle.entry(id) {
                     std::collections::btree_map::Entry::Occupied(_) => assert!(
                         matches!(result, Err(StorageError::Constraint(_))),
@@ -378,7 +430,12 @@ fn btree_matches_btreemap_oracle_through_splits_and_crash() {
             2 => {
                 let expected = oracle.remove(&id).is_some();
                 let count = storage
-                    .rel_delete_where("t", "id", &Datum::Int(id))
+                    .rel_delete_where(
+                        crate::relstore::catalog::DEFAULT_DATABASE_ID,
+                        "t",
+                        "id",
+                        &Datum::Int(id),
+                    )
                     .expect("delete");
                 assert_eq!(count == 1, expected, "delete count diverged");
             }
@@ -386,6 +443,7 @@ fn btree_matches_btreemap_oracle_through_splits_and_crash() {
                 let payload = format!("{id}-upd-{}", "y".repeat(100 + (rng.next() % 500) as usize));
                 let count = storage
                     .rel_update_where(
+                        crate::relstore::catalog::DEFAULT_DATABASE_ID,
                         "t",
                         "id",
                         &Datum::Int(id),
@@ -402,7 +460,13 @@ fn btree_matches_btreemap_oracle_through_splits_and_crash() {
         }
         // Periodic point-lookup and checkpoint (fresh FPI epochs).
         if step % 97 == 0 {
-            let got = storage.rel_get("t", &[Datum::Int(id)]).expect("get");
+            let got = storage
+                .rel_get(
+                    crate::relstore::catalog::DEFAULT_DATABASE_ID,
+                    "t",
+                    &[Datum::Int(id)],
+                )
+                .expect("get");
             assert_eq!(got.is_some(), oracle.contains_key(&id));
             storage
                 .write_checkpoint(b"oracle-checkpoint", 1, 2, 1)
@@ -411,7 +475,9 @@ fn btree_matches_btreemap_oracle_through_splits_and_crash() {
     }
 
     let verify = |storage: &mut Storage, oracle: &BTreeMap<i32, String>| {
-        let rows = storage.rel_scan("t").expect("scan");
+        let rows = storage
+            .rel_scan(crate::relstore::catalog::DEFAULT_DATABASE_ID, "t")
+            .expect("scan");
         assert_eq!(rows.len(), oracle.len(), "row count diverged");
         for (row, (id, payload)) in rows.iter().zip(oracle.iter()) {
             assert_eq!(row[0], Datum::Int(*id), "scan must be in key order");
@@ -436,7 +502,13 @@ fn multi_level_splits_survive_crash() {
     // Insert in descending order to exercise inserts at position 0.
     for i in (0..300).rev() {
         let payload = format!("{i}-{}", "z".repeat(380));
-        storage.rel_insert("t", row(i, &payload)).expect("insert");
+        storage
+            .rel_insert(
+                crate::relstore::catalog::DEFAULT_DATABASE_ID,
+                "t",
+                row(i, &payload),
+            )
+            .expect("insert");
     }
     drop(storage); // crash: splits only exist as WAL images
 
@@ -446,7 +518,11 @@ fn multi_level_splits_survive_crash() {
     for i in 300..340 {
         let payload = format!("{i}-{}", "z".repeat(380));
         storage
-            .rel_insert("t", row(i, &payload))
+            .rel_insert(
+                crate::relstore::catalog::DEFAULT_DATABASE_ID,
+                "t",
+                row(i, &payload),
+            )
             .expect("insert after recovery");
     }
     assert_eq!(scan_ids(&mut storage, "t"), (0..340).collect::<Vec<_>>());
@@ -462,12 +538,17 @@ fn heap_updates_move_rows_with_forwarding_stubs() {
     // Fill the first page almost completely.
     for i in 0..3 {
         storage
-            .rel_insert("h", row(i, &"a".repeat(1200)))
+            .rel_insert(
+                crate::relstore::catalog::DEFAULT_DATABASE_ID,
+                "h",
+                row(i, &"a".repeat(1200)),
+            )
             .expect("insert");
     }
     // Growing row 0 beyond the page's free space forces a move + stub.
     let count = storage
         .rel_update_where(
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
             "h",
             "id",
             &Datum::Int(0),
@@ -481,7 +562,9 @@ fn heap_updates_move_rows_with_forwarding_stubs() {
     drop(storage); // crash
 
     let mut storage = Storage::open(path.clone()).expect("reopen");
-    let rows = storage.rel_scan("h").expect("scan");
+    let rows = storage
+        .rel_scan(crate::relstore::catalog::DEFAULT_DATABASE_ID, "h")
+        .expect("scan");
     let moved = rows
         .iter()
         .find(|r| r[0] == Datum::Int(0))
@@ -490,7 +573,12 @@ fn heap_updates_move_rows_with_forwarding_stubs() {
     // Deleting through the stub removes the row entirely.
     assert_eq!(
         storage
-            .rel_delete_where("h", "id", &Datum::Int(0))
+            .rel_delete_where(
+                crate::relstore::catalog::DEFAULT_DATABASE_ID,
+                "h",
+                "id",
+                &Datum::Int(0)
+            )
             .expect("delete"),
         1
     );
@@ -507,12 +595,19 @@ fn failing_statement_rolls_back_all_its_rows() {
     let mut storage = create_storage(&path);
     create_tree_table(&mut storage, "t");
     for i in 0..5 {
-        storage.rel_insert("t", row(i, "small")).expect("insert");
+        storage
+            .rel_insert(
+                crate::relstore::catalog::DEFAULT_DATABASE_ID,
+                "t",
+                row(i, "small"),
+            )
+            .expect("insert");
     }
     // A multi-row update where the grown rows exceed the tree cell cap: the
     // first rows update fine, then the statement fails and must roll back.
     let err = storage
         .rel_update_where(
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
             "t",
             "payload",
             &Datum::VarChar("small".to_string()),
@@ -520,7 +615,9 @@ fn failing_statement_rolls_back_all_its_rows() {
         )
         .expect_err("oversized tree rows must fail the statement");
     assert!(matches!(err, StorageError::InvalidConfig(_)), "got: {err}");
-    let rows = storage.rel_scan("t").expect("scan");
+    let rows = storage
+        .rel_scan(crate::relstore::catalog::DEFAULT_DATABASE_ID, "t")
+        .expect("scan");
     assert_eq!(rows.len(), 5);
     for row in &rows {
         assert_eq!(
@@ -532,7 +629,9 @@ fn failing_statement_rolls_back_all_its_rows() {
     // And the same holds across a crash (the rollback CLRs replay).
     drop(storage);
     let mut storage = Storage::open(path.clone()).expect("reopen");
-    let rows = storage.rel_scan("t").expect("scan");
+    let rows = storage
+        .rel_scan(crate::relstore::catalog::DEFAULT_DATABASE_ID, "t")
+        .expect("scan");
     assert_eq!(rows.len(), 5);
     for row in &rows {
         assert_eq!(row[1], Datum::VarChar("small".to_string()));
@@ -546,17 +645,31 @@ fn create_table_crash_before_commit_rolls_back_catalog() {
     let path = unique_temp_path("create-table-loser");
     let mut storage = create_storage(&path);
     create_tree_table(&mut storage, "keep");
-    storage.rel_insert("keep", row(1, "x")).expect("insert");
+    storage
+        .rel_insert(
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
+            "keep",
+            row(1, "x"),
+        )
+        .expect("insert");
     drop(storage);
 
     // Committed table survives; the catalog itself recovered.
     let mut storage = Storage::open(path.clone()).expect("reopen");
-    assert!(storage.rel_table("keep").is_some());
+    assert!(
+        storage
+            .rel_table(crate::relstore::catalog::DEFAULT_DATABASE_ID, "keep")
+            .is_some()
+    );
     assert_eq!(scan_ids(&mut storage, "keep"), vec![1]);
 
     // NOT NULL constraint failures roll the whole insert statement back.
     let err = storage
-        .rel_insert("keep", vec![Datum::Null, Datum::VarChar("x".to_string())])
+        .rel_insert(
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
+            "keep",
+            vec![Datum::Null, Datum::VarChar("x".to_string())],
+        )
         .expect_err("null pk must fail");
     assert!(matches!(err, StorageError::Constraint(_)), "got: {err}");
     assert_eq!(scan_ids(&mut storage, "keep"), vec![1]);
@@ -571,7 +684,11 @@ fn checkpoint_persists_relational_pages_and_truncates_wal() {
     create_tree_table(&mut storage, "t");
     for i in 0..50 {
         storage
-            .rel_insert("t", row(i, &"c".repeat(200)))
+            .rel_insert(
+                crate::relstore::catalog::DEFAULT_DATABASE_ID,
+                "t",
+                row(i, &"c".repeat(200)),
+            )
             .expect("insert");
     }
     storage
@@ -580,7 +697,11 @@ fn checkpoint_persists_relational_pages_and_truncates_wal() {
     // Post-checkpoint work lands in a fresh WAL epoch.
     for i in 50..60 {
         storage
-            .rel_insert("t", row(i, &"c".repeat(200)))
+            .rel_insert(
+                crate::relstore::catalog::DEFAULT_DATABASE_ID,
+                "t",
+                row(i, &"c".repeat(200)),
+            )
             .expect("insert");
     }
     drop(storage);
@@ -588,7 +709,11 @@ fn checkpoint_persists_relational_pages_and_truncates_wal() {
     let mut storage = Storage::open(path.clone()).expect("reopen");
     assert_eq!(scan_ids(&mut storage, "t"), (0..60).collect::<Vec<_>>());
     // The catalog root survived via the superblock (not just the WAL).
-    assert!(storage.rel_table("t").is_some());
+    assert!(
+        storage
+            .rel_table(crate::relstore::catalog::DEFAULT_DATABASE_ID, "t")
+            .is_some()
+    );
     drop(storage);
     let _ = std::fs::remove_file(path);
 }
@@ -603,12 +728,19 @@ fn mid_statement_failure_rolls_back_applied_ops() {
     let mut storage = create_storage(&path);
     create_tree_table(&mut storage, "t");
     for i in 0..5 {
-        storage.rel_insert("t", row(i, "original")).expect("insert");
+        storage
+            .rel_insert(
+                crate::relstore::catalog::DEFAULT_DATABASE_ID,
+                "t",
+                row(i, "original"),
+            )
+            .expect("insert");
     }
     // Let 3 update ops apply, then fail the 4th (simulated WAL failure).
     crate::relstore::ctx::FAIL_APPLY_OPS_AFTER.with(|c| c.set(Some(3)));
     let err = storage
         .rel_update_where(
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
             "t",
             "payload",
             &Datum::VarChar("original".to_string()),
@@ -619,7 +751,9 @@ fn mid_statement_failure_rolls_back_applied_ops() {
     assert!(matches!(err, StorageError::InvalidConfig(_)), "got: {err}");
 
     let verify = |storage: &mut Storage| {
-        let rows = storage.rel_scan("t").expect("scan");
+        let rows = storage
+            .rel_scan(crate::relstore::catalog::DEFAULT_DATABASE_ID, "t")
+            .expect("scan");
         assert_eq!(rows.len(), 5);
         for row in &rows {
             assert_eq!(
@@ -635,7 +769,11 @@ fn mid_statement_failure_rolls_back_applied_ops() {
     verify(&mut storage);
     // Store is not wedged (rollback succeeded) and stays writable.
     storage
-        .rel_insert("t", row(100, "after"))
+        .rel_insert(
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
+            "t",
+            row(100, "after"),
+        )
         .expect("insert after rollback");
     drop(storage);
     let _ = std::fs::remove_file(path);
@@ -651,7 +789,11 @@ fn crash_during_recovery_undo_reruns_cleanly() {
     let mut storage = create_storage(&path);
     create_tree_table(&mut storage, "t");
     storage
-        .rel_insert("t", row(1, "committed"))
+        .rel_insert(
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
+            "t",
+            row(1, "committed"),
+        )
         .expect("insert");
     storage
         .rel_insert_without_commit("t", row(2, "loser-a"))
@@ -676,7 +818,11 @@ fn crash_during_recovery_undo_reruns_cleanly() {
     let mut storage = Storage::open(path.clone()).expect("recovery rerun");
     assert_eq!(scan_ids(&mut storage, "t"), vec![1], "only committed data");
     storage
-        .rel_insert("t", row(2, "fresh"))
+        .rel_insert(
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
+            "t",
+            row(2, "fresh"),
+        )
         .expect("insert after rerun");
     assert_eq!(scan_ids(&mut storage, "t"), vec![1, 2]);
     drop(storage);
@@ -700,24 +846,36 @@ fn counter_compensation_clr_points_past_its_record() {
     let mut storage = create_storage(&path);
     create_tree_table(&mut storage, "t");
     storage
-        .rel_insert("t", row(1, "committed"))
+        .rel_insert(
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
+            "t",
+            row(1, "committed"),
+        )
         .expect("insert");
 
     let mut txn = storage.rel_begin().expect("begin");
     storage
         .rel_insert_many(
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
             "t",
             vec![row(2, "rolled back")],
             &mut TxnScope::Explicit(&mut txn),
         )
         .expect("insert under txn");
     storage.rel_rollback(txn).expect("rollback");
-    assert_eq!(storage.rel_row_count("t"), Some(1), "count restored");
+    assert_eq!(
+        storage.rel_row_count(crate::relstore::catalog::DEFAULT_DATABASE_ID, "t"),
+        Some(1),
+        "count restored"
+    );
     // The record scan reads the open-time replay cache, so reopen: the ring
     // still holds the rollback's records (nothing checkpointed).
     drop(storage);
     let mut storage = Storage::open(path.clone()).expect("reopen");
-    assert_eq!(storage.rel_row_count("t"), Some(1));
+    assert_eq!(
+        storage.rel_row_count(crate::relstore::catalog::DEFAULT_DATABASE_ID, "t"),
+        Some(1)
+    );
 
     let records = storage.rel_wal_records().expect("scan");
     // The rolled-back statement's forward CounterAdd record. It may have been
@@ -783,9 +941,16 @@ fn counter_compensation_survives_a_crash_during_recovery_undo() {
     let mut storage = create_storage(&path);
     create_tree_table(&mut storage, "t");
     storage
-        .rel_insert("t", row(1, "committed"))
+        .rel_insert(
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
+            "t",
+            row(1, "committed"),
+        )
         .expect("insert");
-    assert_eq!(storage.rel_row_count("t"), Some(1));
+    assert_eq!(
+        storage.rel_row_count(crate::relstore::catalog::DEFAULT_DATABASE_ID, "t"),
+        Some(1)
+    );
     storage
         .rel_insert_without_commit("t", row(2, "loser"))
         .expect("loser");
@@ -805,7 +970,7 @@ fn counter_compensation_survives_a_crash_during_recovery_undo() {
     let mut storage = Storage::open(path.clone()).expect("recovery rerun");
     assert_eq!(scan_ids(&mut storage, "t"), vec![1], "loser row undone");
     assert_eq!(
-        storage.rel_row_count("t"),
+        storage.rel_row_count(crate::relstore::catalog::DEFAULT_DATABASE_ID, "t"),
         Some(1),
         "the compensation applied exactly once across the re-run"
     );
@@ -822,6 +987,7 @@ fn heap_update_on_stub_starved_page_fails_cleanly() {
     let mut storage = create_storage(&path);
     storage
         .rel_create_table(
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
             "h",
             vec![
                 int_column("id", false),
@@ -843,16 +1009,25 @@ fn heap_update_on_stub_starved_page_fails_cleanly() {
     // with slot) + one row with a 2-byte value (14 bytes with slot).
     for i in 0..336 {
         storage
-            .rel_insert("h", vec![Datum::Int(i), Datum::Null])
+            .rel_insert(
+                crate::relstore::catalog::DEFAULT_DATABASE_ID,
+                "h",
+                vec![Datum::Int(i), Datum::Null],
+            )
             .expect("filler");
     }
     storage
-        .rel_insert("h", vec![Datum::Int(999), Datum::VarBinary(vec![7u8; 2])])
+        .rel_insert(
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
+            "h",
+            vec![Datum::Int(999), Datum::VarBinary(vec![7u8; 2])],
+        )
         .expect("pad row");
 
     // Row id=0's cell is 8 bytes; a stub needs 11 and the page has 1 free.
     let err = storage
         .rel_update_where(
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
             "h",
             "id",
             &Datum::Int(0),
@@ -862,7 +1037,9 @@ fn heap_update_on_stub_starved_page_fails_cleanly() {
     assert!(matches!(err, StorageError::Constraint(_)), "got: {err}");
 
     // Nothing changed and the store keeps working.
-    let rows = storage.rel_scan("h").expect("scan");
+    let rows = storage
+        .rel_scan(crate::relstore::catalog::DEFAULT_DATABASE_ID, "h")
+        .expect("scan");
     assert_eq!(rows.len(), 337);
     let row0 = rows.iter().find(|r| r[0] == Datum::Int(0)).expect("row 0");
     assert_eq!(row0[1], Datum::Null);
@@ -937,10 +1114,18 @@ fn batched_scan_matches_a_whole_scan_at_every_budget() {
     // Enough rows, each large, to span many pages.
     for i in 0..200 {
         storage
-            .rel_insert("t", row(i, &"x".repeat(200)))
+            .rel_insert(
+                crate::relstore::catalog::DEFAULT_DATABASE_ID,
+                "t",
+                row(i, &"x".repeat(200)),
+            )
             .expect("insert t");
         storage
-            .rel_insert("h", row(i, &"x".repeat(200)))
+            .rel_insert(
+                crate::relstore::catalog::DEFAULT_DATABASE_ID,
+                "h",
+                row(i, &"x".repeat(200)),
+            )
             .expect("insert h");
     }
     for table in ["t", "h"] {
@@ -1019,6 +1204,7 @@ fn a_column_keeps_the_default_it_was_created_under() {
     .expect("create");
     storage
         .rel_create_table(
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
             "t",
             vec![
                 Column {
@@ -1054,6 +1240,7 @@ fn no_configured_default_leaves_columns_on_the_builtin() {
     assert_eq!(storage.default_collation(), None);
     storage
         .rel_create_table(
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
             "t",
             vec![Column {
                 nullable: false,
@@ -1107,10 +1294,18 @@ fn a_sliced_scan_reads_the_same_rows_as_a_whole_one() {
     create_heap_table(&mut storage, "h");
     for i in 0..300 {
         storage
-            .rel_insert("t", row(i, &"x".repeat(150)))
+            .rel_insert(
+                crate::relstore::catalog::DEFAULT_DATABASE_ID,
+                "t",
+                row(i, &"x".repeat(150)),
+            )
             .expect("insert t");
         storage
-            .rel_insert("h", row(i, &"x".repeat(150)))
+            .rel_insert(
+                crate::relstore::catalog::DEFAULT_DATABASE_ID,
+                "h",
+                row(i, &"x".repeat(150)),
+            )
             .expect("insert h");
     }
     for table in ["t", "h"] {
@@ -1118,7 +1313,7 @@ fn a_sliced_scan_reads_the_same_rows_as_a_whole_one() {
         assert_eq!(whole.len(), 300, "{table}: precondition");
         for budget in [1, 3, 64, 299, 300, 301, 4096] {
             let sliced: Vec<i32> = storage
-                .rel_scan_sliced(table, budget)
+                .rel_scan_sliced(crate::relstore::catalog::DEFAULT_DATABASE_ID, table, budget)
                 .expect("sliced scan")
                 .iter()
                 .map(|r| match r[0] {
@@ -1162,12 +1357,18 @@ fn a_sliced_scan_takes_the_storage_lock_once_per_slice_not_once_per_table() {
     create_tree_table(&mut storage, "t");
     for i in 0..1500 {
         storage
-            .rel_insert("t", row(i, &"x".repeat(400)))
+            .rel_insert(
+                crate::relstore::catalog::DEFAULT_DATABASE_ID,
+                "t",
+                row(i, &"x".repeat(400)),
+            )
             .expect("insert");
     }
 
     let before = storage.scan_slices();
-    let rows = storage.rel_scan_sliced("t", 8).expect("sliced scan");
+    let rows = storage
+        .rel_scan_sliced(crate::relstore::catalog::DEFAULT_DATABASE_ID, "t", 8)
+        .expect("sliced scan");
     let slices = storage.scan_slices() - before;
 
     assert_eq!(rows.len(), 1500, "the scan still reads everything");
@@ -1180,11 +1381,151 @@ fn a_sliced_scan_takes_the_storage_lock_once_per_slice_not_once_per_table() {
     // takes the lock once. Without this, `slices` could be counting something
     // else entirely and the test would still pass.
     let before = storage.scan_slices();
-    storage.rel_scan("t").expect("whole scan");
+    storage
+        .rel_scan(crate::relstore::catalog::DEFAULT_DATABASE_ID, "t")
+        .expect("whole scan");
     assert_eq!(
         storage.scan_slices() - before,
         0,
         "rel_scan is the single-hold path and takes no slices"
     );
+    let _ = std::fs::remove_file(path);
+}
+
+// ---- Multiple databases (A1: the catalog layer) ----
+
+#[test]
+fn databases_create_list_resolve_and_survive_reopen() {
+    let path = unique_temp_path("multidb-create");
+    let storage = create_storage(&path);
+
+    assert_eq!(
+        storage.rel_databases(),
+        vec![(
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
+            "truthdb".to_string()
+        )],
+        "a fresh instance has exactly the synthesized default database"
+    );
+    assert_eq!(storage.rel_create_database("hr").expect("create hr"), 2);
+    assert_eq!(
+        storage.rel_create_database("sales").expect("create sales"),
+        3
+    );
+    assert_eq!(
+        storage.rel_database_id_by_name("HR"),
+        Some(2),
+        "case-insensitive"
+    );
+    assert_eq!(storage.rel_database_id_by_name("TruthDB"), Some(1));
+    assert_eq!(storage.rel_database_id_by_name("nope"), None);
+
+    drop(storage);
+    let storage = Storage::open(path.clone()).expect("reopen");
+    assert_eq!(
+        storage.rel_databases(),
+        vec![
+            (1, "truthdb".to_string()),
+            (2, "hr".to_string()),
+            (3, "sales".to_string()),
+        ],
+        "database rows reload from the catalog"
+    );
+    // The id allocator continues past the surviving maximum.
+    assert_eq!(storage.rel_create_database("audit").expect("create"), 4);
+    let _ = std::fs::remove_file(path);
+}
+
+#[test]
+fn duplicate_database_names_are_refused_case_insensitively() {
+    let path = unique_temp_path("multidb-dup");
+    let storage = create_storage(&path);
+    storage.rel_create_database("hr").expect("create");
+    assert!(matches!(
+        storage.rel_create_database("HR"),
+        Err(StorageError::Constraint(_))
+    ));
+    assert!(
+        matches!(
+            storage.rel_create_database("TRUTHDB"),
+            Err(StorageError::Constraint(_))
+        ),
+        "the synthesized default database's name is reserved"
+    );
+    let _ = std::fs::remove_file(path);
+}
+
+#[test]
+fn same_table_name_resolves_per_database_and_drop_database_is_scoped() {
+    let path = unique_temp_path("multidb-scope");
+    let mut storage = create_storage(&path);
+    let hr = storage.rel_create_database("hr").expect("create hr");
+
+    create_tree_table(&mut storage, "t");
+    storage
+        .rel_create_table(
+            hr,
+            "t",
+            vec![int_column("id", false), varchar_column("payload", 4000)],
+            &["id".to_string()],
+            Vec::new(),
+            None,
+            Vec::new(),
+            Vec::new(),
+        )
+        .expect("same name in another database");
+
+    storage
+        .rel_insert(
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
+            "t",
+            row(1, "default"),
+        )
+        .expect("insert default");
+    storage
+        .rel_insert(hr, "t", row(7, "hr"))
+        .expect("insert hr");
+    storage
+        .rel_insert(hr, "t", row(8, "hr2"))
+        .expect("insert hr");
+
+    assert_eq!(
+        scan_ids(&mut storage, "t"),
+        vec![1],
+        "default db sees its own rows"
+    );
+    let hr_rows = storage.rel_scan(hr, "t").expect("scan hr");
+    assert_eq!(hr_rows.len(), 2, "hr sees its own rows");
+    let (d1, d2) = (
+        storage
+            .rel_table(crate::relstore::catalog::DEFAULT_DATABASE_ID, "t")
+            .expect("default t"),
+        storage.rel_table(hr, "t").expect("hr t"),
+    );
+    assert_ne!(d1.object_id, d2.object_id, "distinct objects");
+
+    assert!(storage.rel_drop_database("hr").expect("drop hr"));
+    assert!(
+        storage.rel_table(hr, "t").is_none(),
+        "hr's objects are gone"
+    );
+    assert_eq!(
+        scan_ids(&mut storage, "t"),
+        vec![1],
+        "the default database's same-named table is untouched"
+    );
+    assert_eq!(storage.rel_database_id_by_name("hr"), None);
+    let _ = std::fs::remove_file(path);
+}
+
+#[test]
+fn the_default_database_cannot_be_dropped_and_missing_drop_is_false() {
+    let path = unique_temp_path("multidb-drop-default");
+    let storage = create_storage(&path);
+    assert!(matches!(
+        storage.rel_drop_database("truthdb"),
+        Err(StorageError::Constraint(_))
+    ));
+    assert!(!storage.rel_drop_database("ghost").expect("missing drop"));
     let _ = std::fs::remove_file(path);
 }

--- a/crates/truthdb-core/src/session.rs
+++ b/crates/truthdb-core/src/session.rs
@@ -1478,7 +1478,9 @@ fn dispatch_batch(
         // Parameters are values, not statements, so they never change which
         // locks the batch needs — analyse the statement text as usual.
         let epoch = shared.engine.lock_analysis_epoch();
-        let needs = shared.engine.analyze_locks(&sql, isolation);
+        let needs = shared
+            .engine
+            .analyze_locks(sched.session_db(session), &sql, isolation);
         if sched.try_acquire(session.raw(), &needs, true) {
             sched.sessions.touch(session);
             let txn_ctx = sched.take_ctx(session);
@@ -1701,6 +1703,18 @@ impl Scheduler {
             .unwrap_or_default()
     }
 
+    /// The session's current database id — the namespace its batch's lock
+    /// analysis must resolve names in (the same one execution will use). The
+    /// default database for an unknown session or one whose context is
+    /// momentarily taken (a session has at most one in-flight batch, so its
+    /// own analysis never observes the placeholder).
+    fn session_db(&self, session: SessionId) -> u32 {
+        self.sessions
+            .get(session)
+            .map(|s| s.txn_ctx.database_id())
+            .unwrap_or(crate::relstore::catalog::DEFAULT_DATABASE_ID)
+    }
+
     /// Takes a session's transaction context out for a worker to run a batch
     /// with (a `Default` placeholder is left behind; [`Self::finish`] returns
     /// the real one). A session has at most one in-flight batch and no close
@@ -1827,7 +1841,11 @@ impl Scheduler {
             // does.
             if self.parked[i].epoch != current_epoch {
                 let isolation = self.isolation(self.parked[i].session);
-                self.parked[i].needs = engine.analyze_locks(&self.parked[i].sql, isolation);
+                self.parked[i].needs = engine.analyze_locks(
+                    self.session_db(self.parked[i].session),
+                    &self.parked[i].sql,
+                    isolation,
+                );
                 self.parked[i].epoch = current_epoch;
             }
             let owner = self.parked[i].session.raw();
@@ -2710,7 +2728,11 @@ mod tests {
         ));
         // Park an EXEC analyzed against the OLD (read-only) body.
         let epoch = engine.lock_analysis_epoch();
-        let needs = engine.analyze_locks("EXEC p", crate::rel::Isolation::ReadCommitted);
+        let needs = engine.analyze_locks(
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
+            "EXEC p",
+            crate::rel::Isolation::ReadCommitted,
+        );
         assert!(
             !needs
                 .iter()

--- a/crates/truthdb-core/src/storage.rs
+++ b/crates/truthdb-core/src/storage.rs
@@ -268,6 +268,8 @@ fn principal_table_def(
         principal: Some(principal),
         permissions: Vec::new(),
         counter_page: None,
+        database_id: catalog::DEFAULT_DATABASE_ID,
+        database: None,
     }
 }
 
@@ -1428,6 +1430,7 @@ impl Storage {
     #[allow(clippy::too_many_arguments)]
     pub fn rel_create_table(
         &self,
+        db_id: u32,
         name: &str,
         columns: Vec<Column>,
         key_names: &[String],
@@ -1437,6 +1440,7 @@ impl Storage {
         foreign_keys: Vec<catalog::ForeignKeyDef>,
     ) -> Result<(), StorageError> {
         self.lock().rel_create_table(
+            db_id,
             name,
             columns,
             key_names,
@@ -1447,16 +1451,22 @@ impl Storage {
         )
     }
 
-    pub fn rel_create_view(&self, name: &str, query_text: &str) -> Result<(), StorageError> {
-        self.lock().rel_create_view(name, query_text)
+    pub fn rel_create_view(
+        &self,
+        db_id: u32,
+        name: &str,
+        query_text: &str,
+    ) -> Result<(), StorageError> {
+        self.lock().rel_create_view(db_id, name, query_text)
     }
 
     pub fn rel_create_procedure(
         &self,
+        db_id: u32,
         name: &str,
         procedure: crate::relstore::catalog::ProcedureDef,
     ) -> Result<(), StorageError> {
-        let result = self.lock().rel_create_procedure(name, procedure);
+        let result = self.lock().rel_create_procedure(db_id, name, procedure);
         // A parked batch analyzed against the OLD catalog could carry a stale
         // lock set for an EXEC of this name — same class as the option-flip
         // epoch (Stage 13): bump so the grant path re-analyzes.
@@ -1466,20 +1476,22 @@ impl Storage {
 
     pub fn rel_alter_procedure(
         &self,
+        db_id: u32,
         name: &str,
         procedure: crate::relstore::catalog::ProcedureDef,
     ) -> Result<(), StorageError> {
-        let result = self.lock().rel_alter_procedure(name, procedure);
+        let result = self.lock().rel_alter_procedure(db_id, name, procedure);
         self.bump_lock_epoch();
         result
     }
 
     pub fn rel_create_function(
         &self,
+        db_id: u32,
         name: &str,
         function: crate::relstore::catalog::FunctionDef,
     ) -> Result<(), StorageError> {
-        let result = self.lock().rel_create_function(name, function);
+        let result = self.lock().rel_create_function(db_id, name, function);
         // Like a procedure: a table-reading function changes which locks a batch
         // that references it must hold, so a parked batch analyzed against the
         // old catalog carries a stale lock set — bump so the grant path
@@ -1490,20 +1502,22 @@ impl Storage {
 
     pub fn rel_alter_function(
         &self,
+        db_id: u32,
         name: &str,
         function: crate::relstore::catalog::FunctionDef,
     ) -> Result<(), StorageError> {
-        let result = self.lock().rel_alter_function(name, function);
+        let result = self.lock().rel_alter_function(db_id, name, function);
         self.bump_lock_epoch();
         result
     }
 
     pub fn rel_create_trigger(
         &self,
+        db_id: u32,
         name: &str,
         trigger: crate::relstore::catalog::TriggerDef,
     ) -> Result<(), StorageError> {
-        let result = self.lock().rel_create_trigger(name, trigger);
+        let result = self.lock().rel_create_trigger(db_id, name, trigger);
         // A trigger changes which locks a DML statement on its parent table must
         // hold (its body reads/writes other tables), so a parked batch analyzed
         // against the old catalog carries a stale lock set — bump to re-analyze.
@@ -1513,10 +1527,11 @@ impl Storage {
 
     pub fn rel_alter_trigger(
         &self,
+        db_id: u32,
         name: &str,
         trigger: crate::relstore::catalog::TriggerDef,
     ) -> Result<(), StorageError> {
-        let result = self.lock().rel_alter_trigger(name, trigger);
+        let result = self.lock().rel_alter_trigger(db_id, name, trigger);
         self.bump_lock_epoch();
         result
     }
@@ -1606,24 +1621,27 @@ impl Storage {
     // is recomputed next batch (like membership DDL).
     pub fn rel_grant_object(
         &self,
+        db_id: u32,
         object: &str,
         grantee: &str,
         action: crate::relstore::catalog::PermAction,
         deny: bool,
     ) -> Result<(), StorageError> {
         self.lock()
-            .rel_grant_object(object, grantee, action, deny)?;
+            .rel_grant_object(db_id, object, grantee, action, deny)?;
         self.bump_security_version();
         Ok(())
     }
 
     pub fn rel_revoke_object(
         &self,
+        db_id: u32,
         object: &str,
         grantee: &str,
         action: crate::relstore::catalog::PermAction,
     ) -> Result<(), StorageError> {
-        self.lock().rel_revoke_object(object, grantee, action)?;
+        self.lock()
+            .rel_revoke_object(db_id, object, grantee, action)?;
         self.bump_security_version();
         Ok(())
     }
@@ -1644,8 +1662,8 @@ impl Storage {
             .map(|d| d.name.clone())
     }
 
-    pub fn rel_table(&self, name: &str) -> Option<TableDef> {
-        self.lock().rel_table(name)
+    pub fn rel_table(&self, db_id: u32, name: &str) -> Option<TableDef> {
+        self.lock().rel_table(db_id, name)
     }
 
     /// The database's default collation, as stamped into the file at creation.
@@ -1677,12 +1695,45 @@ impl Storage {
         self.lock().rel_triggers_for(parent_object_id, event)
     }
 
-    pub fn rel_drop_table(&self, name: &str) -> Result<bool, StorageError> {
-        self.lock().rel_drop_table(name)
+    pub fn rel_drop_table(&self, db_id: u32, name: &str) -> Result<bool, StorageError> {
+        self.lock().rel_drop_table(db_id, name)
+    }
+
+    /// Creates a database (a naming namespace over the shared log and file);
+    /// returns its id. Bumps the lock epoch: a parked batch analyzed against
+    /// the old database list could resolve names differently.
+    pub fn rel_create_database(&self, name: &str) -> Result<u32, StorageError> {
+        let result = self.lock().rel_create_database(name);
+        self.bump_lock_epoch();
+        result
+    }
+
+    /// Drops a database and everything in it. Returns false if absent.
+    pub fn rel_drop_database(&self, name: &str) -> Result<bool, StorageError> {
+        let result = self.lock().rel_drop_database(name);
+        self.bump_lock_epoch();
+        result
+    }
+
+    /// Resolves a database name (case-insensitive) to its id.
+    pub fn rel_database_id_by_name(&self, name: &str) -> Option<u32> {
+        self.lock().rel_database_id_by_name(name)
+    }
+
+    /// Every database as `(id, canonical name)`, default database first.
+    pub fn rel_databases(&self) -> Vec<(u32, String)> {
+        self.lock().rel_databases()
+    }
+
+    /// Stamps the default database's name (id 1) from the instance
+    /// configuration. Called once at engine construction, before sessions.
+    pub fn set_default_database_name(&self, name: &str) {
+        self.lock().default_db_name = name.to_string();
     }
 
     pub(crate) fn rel_create_index(
         &self,
+        db_id: u32,
         table: &str,
         index_name: String,
         columns: Vec<(usize, bool)>,
@@ -1690,39 +1741,42 @@ impl Storage {
         include: Vec<usize>,
     ) -> Result<(), StorageError> {
         self.lock()
-            .rel_create_index(table, index_name, columns, unique, include)
+            .rel_create_index(db_id, table, index_name, columns, unique, include)
     }
 
     pub(crate) fn rel_drop_index(
         &self,
+        db_id: u32,
         table: &str,
         index_name: &str,
     ) -> Result<bool, StorageError> {
-        self.lock().rel_drop_index(table, index_name)
+        self.lock().rel_drop_index(db_id, table, index_name)
     }
 
     pub(crate) fn rel_alter_add_column(
         &self,
+        db_id: u32,
         table: &str,
         column: Column,
         default_text: Option<String>,
         fill: Datum,
     ) -> Result<(), StorageError> {
         self.lock()
-            .rel_alter_add_column(table, column, default_text, fill)
+            .rel_alter_add_column(db_id, table, column, default_text, fill)
     }
 
     /// The table's committed row count, when it has a counter page (tables
     /// created before counters existed do not — the planner then applies no
     /// tie-break). Errors degrade to `None`: the count is a statistic, never
     /// load-bearing for results.
-    pub(crate) fn rel_row_count(&self, table: &str) -> Option<u64> {
-        self.lock().rel_row_count(table)
+    pub(crate) fn rel_row_count(&self, db_id: u32, table: &str) -> Option<u64> {
+        self.lock().rel_row_count(db_id, table)
     }
 
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn rel_index_scan(
         &self,
+        db_id: u32,
         table: &str,
         index_object_id: u32,
         lower: Option<Vec<u8>>,
@@ -1737,6 +1791,7 @@ impl Storage {
                 .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         }
         self.lock().rel_index_scan(
+            db_id,
             table,
             index_object_id,
             lower,
@@ -2149,11 +2204,13 @@ impl Storage {
     /// restructured under it mid-walk), merged against the version store.
     pub(crate) fn rel_scan_snapshot(
         &self,
+        db_id: u32,
         name: &str,
         projection: Option<&[usize]>,
         snapshot: ReadSnapshot,
     ) -> Result<Vec<Vec<Datum>>, StorageError> {
-        self.lock().rel_scan_snapshot(name, projection, snapshot)
+        self.lock()
+            .rel_scan_snapshot(db_id, name, projection, snapshot)
     }
 
     /// Whether any read snapshot is registered (an idle SNAPSHOT transaction
@@ -2172,7 +2229,7 @@ impl Storage {
         let fallback = guard.version.durable_seq(durable);
         let watermark = guard.version.watermark(fallback);
         let alive: std::collections::HashSet<u32> =
-            guard.rel.tables.values().map(|def| def.object_id).collect();
+            guard.rel.all_tables().map(|def| def.object_id).collect();
         guard.version.prune(watermark, &alive);
     }
 
@@ -2182,34 +2239,40 @@ impl Storage {
         let guard = self.lock();
         guard
             .rel
-            .tables
-            .get(table)
+            .table(catalog::DEFAULT_DATABASE_ID, table)
             .map_or(0, |def| guard.version.chain_count(def.object_id))
     }
 
-    pub fn rel_insert(&self, name: &str, values: Vec<Datum>) -> Result<(), StorageError> {
-        self.lock().rel_insert(name, values)
+    pub fn rel_insert(
+        &self,
+        db_id: u32,
+        name: &str,
+        values: Vec<Datum>,
+    ) -> Result<(), StorageError> {
+        self.lock().rel_insert(db_id, name, values)
     }
 
     pub(crate) fn rel_insert_many(
         &self,
+        db_id: u32,
         name: &str,
         rows: Vec<Vec<Datum>>,
         scope: &mut TxnScope,
     ) -> Result<(), StorageError> {
-        self.lock().rel_insert_many(name, rows, scope)
+        self.lock().rel_insert_many(db_id, name, rows, scope)
     }
 
     pub fn rel_get(
         &self,
+        db_id: u32,
         name: &str,
         key_values: &[Datum],
     ) -> Result<Option<Vec<Datum>>, StorageError> {
-        self.lock().rel_get(name, key_values)
+        self.lock().rel_get(db_id, name, key_values)
     }
 
-    pub fn rel_scan(&self, name: &str) -> Result<Vec<Vec<Datum>>, StorageError> {
-        self.lock().rel_scan(name)
+    pub fn rel_scan(&self, db_id: u32, name: &str) -> Result<Vec<Vec<Datum>>, StorageError> {
+        self.lock().rel_scan(db_id, name)
     }
 
     /// Scans a table in bounded slices, dropping the storage lock between them,
@@ -2227,13 +2290,14 @@ impl Storage {
     /// violating row.
     pub fn rel_scan_sliced(
         &self,
+        db_id: u32,
         name: &str,
         budget: usize,
     ) -> Result<Vec<Vec<Datum>>, StorageError> {
         let mut out = Vec::new();
         let mut cursor = ScanCursor::start();
         while !cursor.done() {
-            cursor = self.rel_scan_slice(name, cursor, budget, None, &mut out)?;
+            cursor = self.rel_scan_slice(db_id, name, cursor, budget, None, &mut out)?;
         }
         Ok(out)
     }
@@ -2250,6 +2314,7 @@ impl Storage {
     /// a page between slices.
     pub(crate) fn rel_scan_slice(
         &self,
+        db_id: u32,
         name: &str,
         cursor: ScanCursor,
         budget: usize,
@@ -2266,7 +2331,7 @@ impl Storage {
             );
         }
         self.lock()
-            .rel_scan_slice(name, cursor, budget, projection, out)
+            .rel_scan_slice(db_id, name, cursor, budget, projection, out)
     }
 
     /// Test hook: a table's definition + schema, for driving a batched scan.
@@ -2281,7 +2346,7 @@ impl Storage {
         ),
         StorageError,
     > {
-        self.lock().rel_def(name)
+        self.lock().rel_def(catalog::DEFAULT_DATABASE_ID, name)
     }
 
     /// Test hook: runs `f` against a page context, taking the storage lock for
@@ -2299,57 +2364,63 @@ impl Storage {
 
     pub fn rel_delete_where(
         &self,
+        db_id: u32,
         name: &str,
         column: &str,
         value: &Datum,
     ) -> Result<usize, StorageError> {
-        self.lock().rel_delete_where(name, column, value)
+        self.lock().rel_delete_where(db_id, name, column, value)
     }
 
     pub fn rel_update_where(
         &self,
+        db_id: u32,
         name: &str,
         column: &str,
         value: &Datum,
         assignments: &[(String, Datum)],
     ) -> Result<usize, StorageError> {
         self.lock()
-            .rel_update_where(name, column, value, assignments)
+            .rel_update_where(db_id, name, column, value, assignments)
     }
 
     pub(crate) fn rel_scan_located(
         &self,
+        db_id: u32,
         name: &str,
     ) -> Result<Vec<(RowLocator, Vec<Datum>)>, StorageError> {
-        self.lock().rel_scan_located(name)
+        self.lock().rel_scan_located(db_id, name)
     }
 
     /// SNAPSHOT-isolation DML target scan: snapshot rows plus a conflict mark
     /// per row whose current state a snapshot-invisible writer produced.
     pub(crate) fn rel_scan_located_snapshot(
         &self,
+        db_id: u32,
         name: &str,
         snapshot: ReadSnapshot,
     ) -> Result<Vec<(RowLocator, Vec<Datum>, bool)>, StorageError> {
-        self.lock().rel_scan_located_snapshot(name, snapshot)
+        self.lock().rel_scan_located_snapshot(db_id, name, snapshot)
     }
 
     pub(crate) fn rel_delete_located(
         &self,
+        db_id: u32,
         name: &str,
         targets: Vec<(RowLocator, Vec<Datum>)>,
         scope: &mut TxnScope,
     ) -> Result<usize, StorageError> {
-        self.lock().rel_delete_located(name, targets, scope)
+        self.lock().rel_delete_located(db_id, name, targets, scope)
     }
 
     pub(crate) fn rel_update_located(
         &self,
+        db_id: u32,
         name: &str,
         updates: Vec<(RowLocator, Vec<Datum>, Vec<Datum>)>,
         scope: &mut TxnScope,
     ) -> Result<usize, StorageError> {
-        self.lock().rel_update_located(name, updates, scope)
+        self.lock().rel_update_located(db_id, name, updates, scope)
     }
 
     pub(crate) fn rel_begin(&self) -> Result<StorageTxn, StorageError> {
@@ -2387,27 +2458,30 @@ impl Storage {
 
     pub(crate) fn rel_reserve_identity(
         &self,
+        db_id: u32,
         name: &str,
         count: usize,
     ) -> Result<Option<i64>, StorageError> {
-        self.lock().rel_reserve_identity(name, count)
+        self.lock().rel_reserve_identity(db_id, name, count)
     }
 
     pub(crate) fn rel_set_check_constraints(
         &self,
+        db_id: u32,
         name: &str,
         check_constraints: Vec<catalog::CheckDef>,
     ) -> Result<(), StorageError> {
         self.lock()
-            .rel_set_check_constraints(name, check_constraints)
+            .rel_set_check_constraints(db_id, name, check_constraints)
     }
 
     pub(crate) fn rel_set_foreign_keys(
         &self,
+        db_id: u32,
         name: &str,
         foreign_keys: Vec<catalog::ForeignKeyDef>,
     ) -> Result<(), StorageError> {
-        self.lock().rel_set_foreign_keys(name, foreign_keys)
+        self.lock().rel_set_foreign_keys(db_id, name, foreign_keys)
     }
 
     #[cfg(test)]
@@ -2416,7 +2490,8 @@ impl Storage {
         name: &str,
         values: Vec<Datum>,
     ) -> Result<(), StorageError> {
-        self.lock().rel_insert_without_commit(name, values)
+        self.lock()
+            .rel_insert_without_commit(catalog::DEFAULT_DATABASE_ID, name, values)
     }
 
     #[cfg(test)]
@@ -2717,6 +2792,12 @@ struct StorageFile {
     /// this at CREATE TABLE and stored with it, so the column keeps the
     /// collation it was created under even if the default later changes.
     default_collation: Option<String>,
+    /// The DEFAULT database's name (database id 1). The default database is
+    /// synthesized — never a catalog row — and named by the instance
+    /// configuration (`[tds] database`), exactly where the session default
+    /// came from before databases existed. Stamped at engine construction;
+    /// "truthdb" until then.
+    default_db_name: String,
     /// Stage 13 version store: row-version chains for snapshot reads, plus
     /// the RCSI / ALLOW_SNAPSHOT_ISOLATION options (persisted in the
     /// superblock reserved area; the chains themselves are memory-only — no
@@ -2779,6 +2860,7 @@ impl StorageFile {
     #[allow(clippy::too_many_arguments)]
     pub fn rel_create_table(
         &mut self,
+        db_id: u32,
         name: &str,
         mut columns: Vec<Column>,
         key_names: &[String],
@@ -2807,7 +2889,7 @@ impl StorageFile {
                 }
             }
         }
-        if self.rel.tables.contains_key(name) {
+        if self.rel.contains_table(db_id, name) {
             return Err(StorageError::Constraint(format!(
                 "table '{name}' already exists"
             )));
@@ -2879,6 +2961,8 @@ impl StorageFile {
                 principal: None,
                 permissions: Vec::new(),
                 counter_page: Some(counter_page),
+                database_id: db_id,
+                database: None,
             };
             catalog::insert_table(ctx, &mut OpMode::Txn(txn), catalog_root, &def)?;
             Ok(def)
@@ -2889,16 +2973,21 @@ impl StorageFile {
         // same-named, post-DROP) new table as empty — its snapshot has no
         // history for an object that did not exist.
         self.version.stamp_schema(def.object_id);
-        self.rel.tables.insert(name.to_string(), def);
+        self.rel.cache_table(def);
         Ok(())
     }
 
     /// Creates a VIEW: a catalog entry that stores its `SELECT` source text and
     /// owns no data pages. The name shares the table namespace (a view and a
     /// table cannot share a name).
-    pub fn rel_create_view(&mut self, name: &str, query_text: &str) -> Result<(), StorageError> {
+    pub fn rel_create_view(
+        &mut self,
+        db_id: u32,
+        name: &str,
+        query_text: &str,
+    ) -> Result<(), StorageError> {
         self.ensure_rel_usable()?;
-        if self.rel.tables.contains_key(name) {
+        if self.rel.contains_table(db_id, name) {
             return Err(StorageError::Constraint(format!(
                 "object '{name}' already exists"
             )));
@@ -2935,12 +3024,14 @@ impl StorageFile {
                 principal: None,
                 permissions: Vec::new(),
                 counter_page: None,
+                database_id: db_id,
+                database: None,
             };
             catalog::insert_table(ctx, &mut OpMode::Txn(txn), catalog_root, &def)?;
             Ok(def)
         })?;
         self.rel.next_object_id += 1;
-        self.rel.tables.insert(name.to_string(), def);
+        self.rel.cache_table(def);
         Ok(())
     }
 
@@ -2948,11 +3039,12 @@ impl StorageFile {
     /// parameter list and body text (the view posture — re-parsed at EXEC).
     pub fn rel_create_procedure(
         &mut self,
+        db_id: u32,
         name: &str,
         procedure: crate::relstore::catalog::ProcedureDef,
     ) -> Result<(), StorageError> {
         self.ensure_rel_usable()?;
-        if self.rel.tables.contains_key(name) {
+        if self.rel.contains_table(db_id, name) {
             return Err(StorageError::Constraint(format!(
                 "object '{name}' already exists"
             )));
@@ -2987,12 +3079,14 @@ impl StorageFile {
                 principal: None,
                 permissions: Vec::new(),
                 counter_page: None,
+                database_id: db_id,
+                database: None,
             };
             catalog::insert_table(ctx, &mut OpMode::Txn(txn), catalog_root, &def)?;
             Ok(def)
         })?;
         self.rel.next_object_id += 1;
-        self.rel.tables.insert(name.to_string(), def);
+        self.rel.cache_table(def);
         Ok(())
     }
 
@@ -3001,11 +3095,12 @@ impl StorageFile {
     /// each call).
     pub fn rel_create_function(
         &mut self,
+        db_id: u32,
         name: &str,
         function: crate::relstore::catalog::FunctionDef,
     ) -> Result<(), StorageError> {
         self.ensure_rel_usable()?;
-        if self.rel.tables.contains_key(name) {
+        if self.rel.contains_table(db_id, name) {
             return Err(StorageError::Constraint(format!(
                 "object '{name}' already exists"
             )));
@@ -3040,12 +3135,14 @@ impl StorageFile {
                 principal: None,
                 permissions: Vec::new(),
                 counter_page: None,
+                database_id: db_id,
+                database: None,
             };
             catalog::insert_table(ctx, &mut OpMode::Txn(txn), catalog_root, &def)?;
             Ok(def)
         })?;
         self.rel.next_object_id += 1;
-        self.rel.tables.insert(name.to_string(), def);
+        self.rel.cache_table(def);
         Ok(())
     }
 
@@ -3053,11 +3150,12 @@ impl StorageFile {
     /// id is kept, the stored definition swapped.
     pub fn rel_alter_function(
         &mut self,
+        db_id: u32,
         name: &str,
         function: crate::relstore::catalog::FunctionDef,
     ) -> Result<(), StorageError> {
         self.ensure_rel_usable()?;
-        let Some(existing) = self.rel.tables.get(name) else {
+        let Some(existing) = self.rel.table(db_id, name) else {
             return Err(StorageError::Constraint(format!(
                 "function '{name}' does not exist"
             )));
@@ -3078,7 +3176,7 @@ impl StorageFile {
             catalog::update_table(ctx, &mut OpMode::Txn(txn), catalog_root, &write)?;
             Ok(())
         })?;
-        self.rel.tables.insert(name.to_string(), def);
+        self.rel.cache_table(def);
         Ok(())
     }
 
@@ -3086,11 +3184,12 @@ impl StorageFile {
     /// PROCEDURE`): the object id is kept, the stored text swapped.
     pub fn rel_alter_procedure(
         &mut self,
+        db_id: u32,
         name: &str,
         procedure: crate::relstore::catalog::ProcedureDef,
     ) -> Result<(), StorageError> {
         self.ensure_rel_usable()?;
-        let Some(existing) = self.rel.tables.get(name) else {
+        let Some(existing) = self.rel.table(db_id, name) else {
             return Err(StorageError::Constraint(format!(
                 "procedure '{name}' does not exist"
             )));
@@ -3111,7 +3210,7 @@ impl StorageFile {
             catalog::update_table(ctx, &mut OpMode::Txn(txn), catalog_root, &write)?;
             Ok(())
         })?;
-        self.rel.tables.insert(name.to_string(), def);
+        self.rel.cache_table(def);
         Ok(())
     }
 
@@ -3119,11 +3218,12 @@ impl StorageFile {
     /// whose stored form is its parent table, event set, and body text.
     pub fn rel_create_trigger(
         &mut self,
+        db_id: u32,
         name: &str,
         trigger: crate::relstore::catalog::TriggerDef,
     ) -> Result<(), StorageError> {
         self.ensure_rel_usable()?;
-        if self.rel.tables.contains_key(name) {
+        if self.rel.contains_table(db_id, name) {
             return Err(StorageError::Constraint(format!(
                 "object '{name}' already exists"
             )));
@@ -3158,23 +3258,26 @@ impl StorageFile {
                 principal: None,
                 permissions: Vec::new(),
                 counter_page: None,
+                database_id: db_id,
+                database: None,
             };
             catalog::insert_table(ctx, &mut OpMode::Txn(txn), catalog_root, &def)?;
             Ok(def)
         })?;
         self.rel.next_object_id += 1;
-        self.rel.tables.insert(name.to_string(), def);
+        self.rel.cache_table(def);
         Ok(())
     }
 
     /// Replaces a trigger's definition (`ALTER TRIGGER`).
     pub fn rel_alter_trigger(
         &mut self,
+        db_id: u32,
         name: &str,
         trigger: crate::relstore::catalog::TriggerDef,
     ) -> Result<(), StorageError> {
         self.ensure_rel_usable()?;
-        let Some(existing) = self.rel.tables.get(name) else {
+        let Some(existing) = self.rel.table(db_id, name) else {
             return Err(StorageError::Constraint(format!(
                 "trigger '{name}' does not exist"
             )));
@@ -3192,7 +3295,7 @@ impl StorageFile {
             catalog::update_table(ctx, &mut OpMode::Txn(txn), catalog_root, &write)?;
             Ok(())
         })?;
-        self.rel.tables.insert(name.to_string(), def);
+        self.rel.cache_table(def);
         Ok(())
     }
 
@@ -3241,6 +3344,8 @@ impl StorageFile {
                 principal: Some(principal),
                 permissions: Vec::new(),
                 counter_page: None,
+                database_id: catalog::DEFAULT_DATABASE_ID,
+                database: None,
             };
             catalog::insert_table(ctx, &mut OpMode::Txn(txn), catalog_root, &def)?;
             Ok(def)
@@ -3383,17 +3488,15 @@ impl StorageFile {
     /// Removes every object permission entry whose grantee is `grantee` (a
     /// dropped principal), rewriting each affected object's catalog row.
     fn scrub_grants_for(&mut self, grantee: u32) -> Result<(), StorageError> {
-        let affected: Vec<String> = self
+        let affected: Vec<TableDef> = self
             .rel
-            .tables
-            .iter()
-            .filter(|(_, def)| def.permissions.iter().any(|p| p.grantee == grantee))
-            .map(|(name, _)| name.clone())
+            .all_tables()
+            .filter(|def| def.permissions.iter().any(|p| p.grantee == grantee))
+            .cloned()
             .collect();
-        for name in affected {
-            let mut def = self.rel.tables.get(&name).cloned().expect("just listed");
+        for mut def in affected {
             def.permissions.retain(|p| p.grantee != grantee);
-            self.persist_object_permissions(&name, def)?;
+            self.persist_object_permissions(def)?;
         }
         Ok(())
     }
@@ -3527,6 +3630,7 @@ impl StorageFile {
     /// the same grantee do not coexist. Errors on an unknown grantee or object.
     pub fn rel_grant_object(
         &mut self,
+        db_id: u32,
         object: &str,
         grantee: &str,
         action: crate::relstore::catalog::PermAction,
@@ -3534,7 +3638,7 @@ impl StorageFile {
     ) -> Result<(), StorageError> {
         self.ensure_rel_usable()?;
         let grantee_id = self.resolve_grantee_id(grantee)?;
-        let Some(mut def) = self.rel.tables.get(object).cloned() else {
+        let Some(mut def) = self.rel.table(db_id, object).cloned() else {
             return Err(StorageError::Constraint(format!(
                 "cannot find the object '{object}', because it does not exist or you do not have permission"
             )));
@@ -3547,20 +3651,21 @@ impl StorageFile {
                 action,
                 deny,
             });
-        self.persist_object_permissions(object, def)
+        self.persist_object_permissions(def)
     }
 
     /// REVOKE an action on an object from a grantee — removes both the GRANT and
     /// the DENY of that (grantee, action). Idempotent (no error if absent).
     pub fn rel_revoke_object(
         &mut self,
+        db_id: u32,
         object: &str,
         grantee: &str,
         action: crate::relstore::catalog::PermAction,
     ) -> Result<(), StorageError> {
         self.ensure_rel_usable()?;
         let grantee_id = self.resolve_grantee_id(grantee)?;
-        let Some(mut def) = self.rel.tables.get(object).cloned() else {
+        let Some(mut def) = self.rel.table(db_id, object).cloned() else {
             return Err(StorageError::Constraint(format!(
                 "cannot find the object '{object}', because it does not exist or you do not have permission"
             )));
@@ -3571,7 +3676,7 @@ impl StorageFile {
         if def.permissions.len() == before {
             return Ok(()); // nothing to revoke
         }
-        self.persist_object_permissions(object, def)
+        self.persist_object_permissions(def)
     }
 
     /// Resolves a grantee NAME to a database principal_id (a stored user/role or
@@ -3586,18 +3691,14 @@ impl StorageFile {
 
     /// Writes an object's mutated permission list back through the catalog and
     /// the in-memory cache (one whole-row rewrite, like a role-member edit).
-    fn persist_object_permissions(
-        &mut self,
-        object: &str,
-        def: TableDef,
-    ) -> Result<(), StorageError> {
+    fn persist_object_permissions(&mut self, def: TableDef) -> Result<(), StorageError> {
         let catalog_root = self.rel.catalog_root.expect("objects live in the catalog");
         let write = def.clone();
         self.rel_statement(move |ctx, txn| {
             catalog::update_table(ctx, &mut OpMode::Txn(txn), catalog_root, &write)?;
             Ok(())
         })?;
-        self.rel.tables.insert(object.to_string(), def);
+        self.rel.cache_table(def);
         Ok(())
     }
 
@@ -3640,22 +3741,22 @@ impl StorageFile {
         seen
     }
 
-    /// The table's definition (schema and layout), if it exists.
-    pub fn rel_table(&self, name: &str) -> Option<TableDef> {
-        self.rel.tables.get(name).cloned()
+    /// The named object's definition in the given database, if it exists.
+    pub fn rel_table(&self, db_id: u32, name: &str) -> Option<TableDef> {
+        self.rel.table(db_id, name).cloned()
     }
 
-    /// All user table definitions, ordered by object id (for sys.tables /
-    /// sys.columns).
+    /// All user table definitions across every database, ordered by object id
+    /// (for sys.tables / sys.columns).
     pub fn rel_tables(&self) -> Vec<TableDef> {
-        let mut defs: Vec<TableDef> = self.rel.tables.values().cloned().collect();
+        let mut defs: Vec<TableDef> = self.rel.all_tables().cloned().collect();
         defs.sort_by_key(|d| d.object_id);
         defs
     }
 
     /// True if any trigger exists in the catalog (no clone).
     pub fn rel_has_triggers(&self) -> bool {
-        self.rel.tables.values().any(|d| d.is_trigger())
+        self.rel.all_tables().any(|d| d.is_trigger())
     }
 
     /// The enabled triggers attached to `parent_object_id` firing on `event`, in
@@ -3667,8 +3768,7 @@ impl StorageFile {
     ) -> Vec<TableDef> {
         let mut trigs: Vec<TableDef> = self
             .rel
-            .tables
-            .values()
+            .all_tables()
             .filter(|d| {
                 d.trigger.as_ref().is_some_and(|t| {
                     !t.is_disabled
@@ -3685,9 +3785,9 @@ impl StorageFile {
     /// Drops a table (logical: removes the catalog row; data pages leak
     /// until a later reclamation stage). Returns false if the table does not
     /// exist.
-    pub fn rel_drop_table(&mut self, name: &str) -> Result<bool, StorageError> {
+    pub fn rel_drop_table(&mut self, db_id: u32, name: &str) -> Result<bool, StorageError> {
         self.ensure_rel_usable()?;
-        let Some(def) = self.rel.tables.get(name).cloned() else {
+        let Some(def) = self.rel.table(db_id, name).cloned() else {
             return Ok(false);
         };
         let Some(catalog_root) = self.rel.catalog_root else {
@@ -3696,8 +3796,146 @@ impl StorageFile {
         self.rel_statement(move |ctx, txn| {
             catalog::delete_table(ctx, &mut OpMode::Txn(txn), catalog_root, def.object_id)
         })?;
-        self.rel.tables.remove(name);
+        self.rel.uncache_table(db_id, name);
         Ok(true)
+    }
+
+    /// Creates a database: a catalog row carrying a [`catalog::DatabaseDef`],
+    /// routed into the databases map so it never enters the object namespace.
+    /// Database ids allocate max+1 over stored rows (the synthesized default
+    /// database is id 1) and are capped at `u16::MAX` so an id always fits the
+    /// WAL container tag.
+    pub fn rel_create_database(&mut self, name: &str) -> Result<u32, StorageError> {
+        self.ensure_rel_usable()?;
+        if self.rel_database_id_by_name(name).is_some() {
+            return Err(StorageError::Constraint(format!(
+                "database '{name}' already exists"
+            )));
+        }
+        let db_id = self
+            .rel
+            .databases
+            .values()
+            .filter_map(|d| d.database.as_ref().map(|db| db.db_id))
+            .max()
+            .map_or(catalog::FIRST_USER_DATABASE_ID, |max| max + 1);
+        if db_id > u16::MAX as u32 {
+            return Err(StorageError::Constraint(
+                "too many databases: the database id space is exhausted".to_string(),
+            ));
+        }
+        if self.rel.catalog_root.is_none() {
+            let root = {
+                let mut ctx = self.rel_ctx();
+                catalog::create_catalog(&mut ctx)?
+            };
+            self.rel.catalog_root = Some(root);
+        }
+        let catalog_root = self.rel.catalog_root.expect("catalog exists");
+        let object_id = self.rel.next_object_id;
+        let db_name = name.to_string();
+        let def = self.rel_statement(move |ctx, txn| {
+            let def = TableDef {
+                object_id,
+                name: db_name,
+                columns: Vec::new(),
+                key_columns: Vec::new(),
+                root_page: 0,
+                defaults: Vec::new(),
+                collations: Vec::new(),
+                identity: None,
+                indexes: Vec::new(),
+                check_constraints: Vec::new(),
+                foreign_keys: Vec::new(),
+                view_query: None,
+                procedure: None,
+                function: None,
+                trigger: None,
+                principal: None,
+                permissions: Vec::new(),
+                counter_page: None,
+                database_id: catalog::DEFAULT_DATABASE_ID,
+                database: Some(catalog::DatabaseDef { db_id }),
+            };
+            catalog::insert_table(ctx, &mut OpMode::Txn(txn), catalog_root, &def)?;
+            Ok(def)
+        })?;
+        self.rel.next_object_id += 1;
+        self.rel
+            .databases
+            .insert(def.name.to_ascii_lowercase(), def);
+        Ok(db_id)
+    }
+
+    /// Drops a database and every object in it, in one statement transaction
+    /// (all-or-nothing; data pages leak like `rel_drop_table`'s). The default
+    /// database is refused. Returns false if no such database exists.
+    pub fn rel_drop_database(&mut self, name: &str) -> Result<bool, StorageError> {
+        self.ensure_rel_usable()?;
+        let key = name.to_ascii_lowercase();
+        if key == self.default_db_name.to_ascii_lowercase() {
+            return Err(StorageError::Constraint(format!(
+                "cannot drop the database '{name}' because it is a system database"
+            )));
+        }
+        let Some(row) = self.rel.databases.get(&key).cloned() else {
+            return Ok(false);
+        };
+        let Some(catalog_root) = self.rel.catalog_root else {
+            return Ok(false);
+        };
+        let db_id = row.database.expect("database row").db_id;
+        let objects: Vec<(u32, String)> = self
+            .rel
+            .tables_in(db_id)
+            .map(|d| (d.object_id, d.name.clone()))
+            .collect();
+        let object_ids: Vec<u32> = objects.iter().map(|(id, _)| *id).collect();
+        let row_object_id = row.object_id;
+        self.rel_statement(move |ctx, txn| {
+            for object_id in &object_ids {
+                catalog::delete_table(ctx, &mut OpMode::Txn(txn), catalog_root, *object_id)?;
+            }
+            catalog::delete_table(ctx, &mut OpMode::Txn(txn), catalog_root, row_object_id)
+        })?;
+        for (object_id, name) in objects {
+            // Same fence as DROP TABLE: a snapshot whose view predates the
+            // drop must 3961 rather than read a same-named successor.
+            self.version.stamp_schema(object_id);
+            self.rel.uncache_table(db_id, &name);
+        }
+        self.rel.databases.remove(&key);
+        Ok(true)
+    }
+
+    /// Resolves a database NAME to its id, case-insensitively: the synthesized
+    /// default database (id 1, named by the instance configuration) or a
+    /// stored `CREATE DATABASE` row. The single name→id derivation every
+    /// consumer (USE, login, three-part names) must share.
+    pub fn rel_database_id_by_name(&self, name: &str) -> Option<u32> {
+        if name.eq_ignore_ascii_case(&self.default_db_name) {
+            return Some(catalog::DEFAULT_DATABASE_ID);
+        }
+        self.rel
+            .databases
+            .get(&name.to_ascii_lowercase())
+            .and_then(|d| d.database.as_ref())
+            .map(|db| db.db_id)
+    }
+
+    /// Every database as `(id, canonical name)`, the synthesized default
+    /// first, then stored rows by id.
+    pub fn rel_databases(&self) -> Vec<(u32, String)> {
+        let mut out = vec![(catalog::DEFAULT_DATABASE_ID, self.default_db_name.clone())];
+        let mut stored: Vec<(u32, String)> = self
+            .rel
+            .databases
+            .values()
+            .filter_map(|d| d.database.as_ref().map(|db| (db.db_id, d.name.clone())))
+            .collect();
+        stored.sort_by_key(|(id, _)| *id);
+        out.extend(stored);
+        out
     }
 
     /// Creates a secondary index over `table` and backfills it from the
@@ -3706,6 +3944,7 @@ impl StorageFile {
     /// the table's catalog row.
     pub(crate) fn rel_create_index(
         &mut self,
+        db_id: u32,
         table: &str,
         index_name: String,
         columns: Vec<(usize, bool)>,
@@ -3715,8 +3954,7 @@ impl StorageFile {
         self.ensure_rel_usable()?;
         let mut def = self
             .rel
-            .tables
-            .get(table)
+            .table(db_id, table)
             .cloned()
             .ok_or_else(|| StorageError::InvalidConfig(format!("unknown table '{table}'")))?;
         if def
@@ -3734,7 +3972,7 @@ impl StorageFile {
             .ok_or_else(|| StorageError::InvalidFile("catalog root missing".to_string()))?;
         let object_id = self.rel.next_object_id;
         // Snapshot the rows to backfill (materialized before any mutation).
-        let located = self.rel_scan_located(table)?;
+        let located = self.rel_scan_located(db_id, table)?;
 
         let schema = def.schema()?;
         let updated = self.rel_statement(move |ctx, txn| {
@@ -3780,7 +4018,7 @@ impl StorageFile {
             Ok(def)
         })?;
         self.rel.next_object_id += 1;
-        self.rel.tables.insert(table.to_string(), updated);
+        self.rel.cache_table(updated);
         Ok(())
     }
 
@@ -3793,6 +4031,7 @@ impl StorageFile {
     /// by key, and heap RIDs are stable across an update.
     pub(crate) fn rel_alter_add_column(
         &mut self,
+        db_id: u32,
         table: &str,
         column: Column,
         default_text: Option<String>,
@@ -3813,8 +4052,7 @@ impl StorageFile {
         }
         let mut def = self
             .rel
-            .tables
-            .get(table)
+            .table(db_id, table)
             .cloned()
             .ok_or_else(|| StorageError::InvalidConfig(format!("unknown table '{table}'")))?;
         let catalog_root = self
@@ -3823,7 +4061,7 @@ impl StorageFile {
             .ok_or_else(|| StorageError::InvalidFile("catalog root missing".to_string()))?;
         // Snapshot every row under the OLD schema (with its locator), before
         // the definition widens.
-        let located = self.rel_scan_located(table)?;
+        let located = self.rel_scan_located(db_id, table)?;
 
         // Parallel catalog arrays: `defaults`/`collations` may be shorter than
         // `columns` (serde(default) on pre-upgrade tables) — pad before push.
@@ -3882,7 +4120,7 @@ impl StorageFile {
             catalog::update_table(ctx, &mut OpMode::Txn(txn), catalog_root, &def)?;
             Ok(def)
         })?;
-        self.rel.tables.insert(table.to_string(), updated);
+        self.rel.cache_table(updated);
         // ALTER ADD re-encodes every row: version images from before it
         // cannot decode under the widened schema, so a SNAPSHOT transaction
         // whose view predates this commit gets 3961 at its next access
@@ -3897,6 +4135,7 @@ impl StorageFile {
     /// false if no such index exists on any table.
     pub(crate) fn rel_drop_index(
         &mut self,
+        db_id: u32,
         table: &str,
         index_name: &str,
     ) -> Result<bool, StorageError> {
@@ -3906,12 +4145,11 @@ impl StorageFile {
         };
         // Index names are scoped to their table, so confine the lookup there.
         // The caller passes the table's canonical name.
-        let Some((table_key, mut def)) = self
+        let Some(mut def) = self
             .rel
-            .tables
-            .iter()
-            .find(|(name, _)| name.eq_ignore_ascii_case(table))
-            .map(|(name, def)| (name.clone(), def.clone()))
+            .tables_in(db_id)
+            .find(|def| def.name.eq_ignore_ascii_case(table))
+            .cloned()
         else {
             return Ok(false);
         };
@@ -3928,7 +4166,7 @@ impl StorageFile {
             catalog::update_table(ctx, &mut OpMode::Txn(txn), catalog_root, &def)?;
             Ok(def)
         })?;
-        self.rel.tables.insert(table_key, updated);
+        self.rel.cache_table(updated);
         Ok(true)
     }
 
@@ -3936,17 +4174,18 @@ impl StorageFile {
     /// `[lower, upper]`, then fetches each row by its locator. Returns a
     /// superset the caller re-filters with the full WHERE (so loose bounds are
     /// safe).
-    pub(crate) fn rel_row_count(&mut self, table: &str) -> Option<u64> {
+    pub(crate) fn rel_row_count(&mut self, db_id: u32, table: &str) -> Option<u64> {
         if self.ensure_rel_usable().is_err() {
             return None;
         }
-        let page = self.rel.tables.get(table)?.counter_page?;
+        let page = self.rel.table(db_id, table)?.counter_page?;
         self.rel_ctx().counter_read(page).ok()
     }
 
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn rel_index_scan(
         &mut self,
+        db_id: u32,
         table: &str,
         index_object_id: u32,
         lower: Option<Vec<u8>>,
@@ -3956,7 +4195,7 @@ impl StorageFile {
         snapshot: Option<ReadSnapshot>,
     ) -> Result<Vec<Vec<Datum>>, StorageError> {
         self.ensure_rel_usable()?;
-        let (def, schema) = self.rel_def(table)?;
+        let (def, schema) = self.rel_def(db_id, table)?;
         let index = def
             .indexes
             .iter()
@@ -4104,8 +4343,13 @@ impl StorageFile {
         Ok(rows)
     }
 
-    pub fn rel_insert(&mut self, name: &str, values: Vec<Datum>) -> Result<(), StorageError> {
-        self.rel_insert_many(name, vec![values], &mut TxnScope::Auto)
+    pub fn rel_insert(
+        &mut self,
+        db_id: u32,
+        name: &str,
+        values: Vec<Datum>,
+    ) -> Result<(), StorageError> {
+        self.rel_insert_many(db_id, name, vec![values], &mut TxnScope::Auto)
     }
 
     /// Inserts many rows as ONE atomic statement: all rows land or none do
@@ -4113,12 +4357,13 @@ impl StorageFile {
     /// matching T-SQL multi-row `INSERT ... VALUES` semantics).
     pub(crate) fn rel_insert_many(
         &mut self,
+        db_id: u32,
         name: &str,
         rows: Vec<Vec<Datum>>,
         scope: &mut TxnScope,
     ) -> Result<(), StorageError> {
         self.ensure_rel_usable()?;
-        let (def, schema) = self.rel_def(name)?;
+        let (def, schema) = self.rel_def(db_id, name)?;
         // Encode and validate every row up front (cheap failures before any
         // mutation), keeping the key alongside for tree tables. Rows with
         // (MAX) columns encode inside the statement instead: their oversize
@@ -4236,11 +4481,12 @@ impl StorageFile {
     /// Point lookup by primary key (clustered tables only).
     pub fn rel_get(
         &mut self,
+        db_id: u32,
         name: &str,
         key_values: &[Datum],
     ) -> Result<Option<Vec<Datum>>, StorageError> {
         self.ensure_rel_usable()?;
-        let (def, schema) = self.rel_def(name)?;
+        let (def, schema) = self.rel_def(db_id, name)?;
         if !def.is_tree() {
             return Err(StorageError::InvalidConfig(format!(
                 "table '{name}' has no primary key"
@@ -4288,6 +4534,7 @@ impl StorageFile {
     /// once per slice instead of once for the whole table.
     pub(crate) fn rel_scan_slice(
         &mut self,
+        db_id: u32,
         name: &str,
         cursor: ScanCursor,
         budget: usize,
@@ -4295,7 +4542,7 @@ impl StorageFile {
         out: &mut Vec<Vec<Datum>>,
     ) -> Result<ScanCursor, StorageError> {
         self.ensure_rel_usable()?;
-        let (def, schema) = self.rel_def(name)?;
+        let (def, schema) = self.rel_def(db_id, name)?;
         let mut ctx = self.rel_ctx();
         let mut raw: Vec<Vec<u8>> = Vec::new();
         let next = if def.is_tree() {
@@ -4327,9 +4574,9 @@ impl StorageFile {
         Ok(next)
     }
 
-    pub fn rel_scan(&mut self, name: &str) -> Result<Vec<Vec<Datum>>, StorageError> {
+    pub fn rel_scan(&mut self, db_id: u32, name: &str) -> Result<Vec<Vec<Datum>>, StorageError> {
         self.ensure_rel_usable()?;
-        let (def, schema) = self.rel_def(name)?;
+        let (def, schema) = self.rel_def(db_id, name)?;
         let mut ctx = self.rel_ctx();
         let raw: Vec<Vec<u8>> = if def.is_tree() {
             let tree = BTree {
@@ -4368,12 +4615,13 @@ impl StorageFile {
     /// sliced cursor could be restructured under it mid-walk.
     fn rel_scan_snapshot(
         &mut self,
+        db_id: u32,
         name: &str,
         projection: Option<&[usize]>,
         snapshot: ReadSnapshot,
     ) -> Result<Vec<Vec<Datum>>, StorageError> {
         self.ensure_rel_usable()?;
-        let (def, schema) = self.rel_def(name)?;
+        let (def, schema) = self.rel_def(db_id, name)?;
         if self.version.schema_changed_after(def.object_id, snapshot) {
             return Err(StorageError::SnapshotSchemaChange(def.name));
         }
@@ -4435,12 +4683,13 @@ impl StorageFile {
     /// staging. Resolve and stage before wiring it to anything real.
     pub fn rel_delete_where(
         &mut self,
+        db_id: u32,
         name: &str,
         column: &str,
         value: &Datum,
     ) -> Result<usize, StorageError> {
         self.ensure_rel_usable()?;
-        let (def, schema) = self.rel_def(name)?;
+        let (def, schema) = self.rel_def(db_id, name)?;
         let column_index = column_index(&schema, column)?;
         if def.is_tree() {
             let tree = BTree {
@@ -4500,13 +4749,14 @@ impl StorageFile {
     /// immutable here (delete + insert to change a key).
     pub fn rel_update_where(
         &mut self,
+        db_id: u32,
         name: &str,
         column: &str,
         value: &Datum,
         assignments: &[(String, Datum)],
     ) -> Result<usize, StorageError> {
         self.ensure_rel_usable()?;
-        let (def, schema) = self.rel_def(name)?;
+        let (def, schema) = self.rel_def(db_id, name)?;
         let column_index = column_index(&schema, column)?;
         let mut set: Vec<(usize, Datum)> = Vec::new();
         for (set_name, set_value) in assignments {
@@ -4599,10 +4849,11 @@ impl StorageFile {
     /// construction (matched targets are chosen from a snapshot of the table).
     pub(crate) fn rel_scan_located(
         &mut self,
+        db_id: u32,
         name: &str,
     ) -> Result<Vec<(RowLocator, Vec<Datum>)>, StorageError> {
         self.ensure_rel_usable()?;
-        let (def, schema) = self.rel_def(name)?;
+        let (def, schema) = self.rel_def(db_id, name)?;
         let mut ctx = self.rel_ctx();
         let mut out = Vec::new();
         if def.is_tree() {
@@ -4660,11 +4911,12 @@ impl StorageFile {
     /// it actually targets can only be a committed-invisible change.)
     fn rel_scan_located_snapshot(
         &mut self,
+        db_id: u32,
         name: &str,
         snapshot: ReadSnapshot,
     ) -> Result<Vec<(RowLocator, Vec<Datum>, bool)>, StorageError> {
         self.ensure_rel_usable()?;
-        let (def, schema) = self.rel_def(name)?;
+        let (def, schema) = self.rel_def(db_id, name)?;
         if self.version.schema_changed_after(def.object_id, snapshot) {
             return Err(StorageError::SnapshotSchemaChange(def.name));
         }
@@ -4755,12 +5007,13 @@ impl StorageFile {
     /// upkeep) in one atomic statement; returns the count.
     pub(crate) fn rel_delete_located(
         &mut self,
+        db_id: u32,
         name: &str,
         targets: Vec<(RowLocator, Vec<Datum>)>,
         scope: &mut TxnScope,
     ) -> Result<usize, StorageError> {
         self.ensure_rel_usable()?;
-        let (def, schema) = self.rel_def(name)?;
+        let (def, schema) = self.rel_def(db_id, name)?;
         let count = targets.len();
         if count == 0 {
             return Ok(0);
@@ -4859,12 +5112,13 @@ impl StorageFile {
     /// Returns the count.
     pub(crate) fn rel_update_located(
         &mut self,
+        db_id: u32,
         name: &str,
         updates: Vec<(RowLocator, Vec<Datum>, Vec<Datum>)>,
         scope: &mut TxnScope,
     ) -> Result<usize, StorageError> {
         self.ensure_rel_usable()?;
-        let (def, schema) = self.rel_def(name)?;
+        let (def, schema) = self.rel_def(db_id, name)?;
         let count = updates.len();
         if count == 0 {
             return Ok(0);
@@ -5054,14 +5308,14 @@ impl StorageFile {
     /// if the table has no identity column.
     pub(crate) fn rel_reserve_identity(
         &mut self,
+        db_id: u32,
         name: &str,
         count: usize,
     ) -> Result<Option<i64>, StorageError> {
         self.ensure_rel_usable()?;
         let mut def = self
             .rel
-            .tables
-            .get(name)
+            .table(db_id, name)
             .cloned()
             .ok_or_else(|| StorageError::InvalidConfig(format!("unknown table '{name}'")))?;
         let Some(mut spec) = def.identity else {
@@ -5085,7 +5339,7 @@ impl StorageFile {
             self.rel_statement(move |ctx, txn| {
                 catalog::update_table(ctx, &mut OpMode::Txn(txn), catalog_root, &persisted)
             })?;
-            self.rel.tables.insert(name.to_string(), def);
+            self.rel.cache_table(def);
         }
         Ok(Some(first))
     }
@@ -5094,14 +5348,14 @@ impl StorageFile {
     /// and persists the mutated catalog row. Undoable within its own statement.
     pub(crate) fn rel_set_check_constraints(
         &mut self,
+        db_id: u32,
         name: &str,
         check_constraints: Vec<catalog::CheckDef>,
     ) -> Result<(), StorageError> {
         self.ensure_rel_usable()?;
         let mut def = self
             .rel
-            .tables
-            .get(name)
+            .table(db_id, name)
             .cloned()
             .ok_or_else(|| StorageError::InvalidConfig(format!("unknown table '{name}'")))?;
         def.check_constraints = check_constraints;
@@ -5113,7 +5367,7 @@ impl StorageFile {
         self.rel_statement(move |ctx, txn| {
             catalog::update_table(ctx, &mut OpMode::Txn(txn), catalog_root, &persisted)
         })?;
-        self.rel.tables.insert(name.to_string(), def);
+        self.rel.cache_table(def);
         Ok(())
     }
 
@@ -5121,14 +5375,14 @@ impl StorageFile {
     /// CONSTRAINT) and persists the mutated catalog row.
     pub(crate) fn rel_set_foreign_keys(
         &mut self,
+        db_id: u32,
         name: &str,
         foreign_keys: Vec<catalog::ForeignKeyDef>,
     ) -> Result<(), StorageError> {
         self.ensure_rel_usable()?;
         let mut def = self
             .rel
-            .tables
-            .get(name)
+            .table(db_id, name)
             .cloned()
             .ok_or_else(|| StorageError::InvalidConfig(format!("unknown table '{name}'")))?;
         def.foreign_keys = foreign_keys;
@@ -5140,7 +5394,7 @@ impl StorageFile {
         self.rel_statement(move |ctx, txn| {
             catalog::update_table(ctx, &mut OpMode::Txn(txn), catalog_root, &persisted)
         })?;
-        self.rel.tables.insert(name.to_string(), def);
+        self.rel.cache_table(def);
         Ok(())
     }
 
@@ -5149,10 +5403,11 @@ impl StorageFile {
     #[cfg(test)]
     pub(crate) fn rel_insert_without_commit(
         &mut self,
+        db_id: u32,
         name: &str,
         values: Vec<Datum>,
     ) -> Result<(), StorageError> {
-        let (def, schema) = self.rel_def(name)?;
+        let (def, schema) = self.rel_def(db_id, name)?;
         let row = encode_row(&schema, &values)?;
         let txn_id = self.rel.next_txn_id;
         self.rel.next_txn_id += 1;
@@ -5206,11 +5461,10 @@ impl StorageFile {
         self.layout.data_offset + page * PAGE_SIZE as u64
     }
 
-    fn rel_def(&self, name: &str) -> Result<(TableDef, Schema), StorageError> {
+    fn rel_def(&self, db_id: u32, name: &str) -> Result<(TableDef, Schema), StorageError> {
         let def = self
             .rel
-            .tables
-            .get(name)
+            .table(db_id, name)
             .cloned()
             .ok_or_else(|| StorageError::InvalidConfig(format!("unknown table '{name}'")))?;
         let schema = def.schema()?;
@@ -5317,6 +5571,7 @@ impl StorageFile {
         let recovery_full = version.recovery_full;
         let mut storage = StorageFile {
             default_collation: header.default_collation(),
+            default_db_name: "truthdb".to_string(),
             file,
             wal,
             truncation_gate: LogTruncationGate::default(),
@@ -5484,6 +5739,7 @@ impl StorageFile {
 
         Ok(StorageFile {
             default_collation: header.default_collation(),
+            default_db_name: "truthdb".to_string(),
             file,
             wal,
             truncation_gate: LogTruncationGate::default(),
@@ -5572,13 +5828,13 @@ impl StorageFile {
             self.standby_capture_versions(&records);
             self.standby_version_floor = self.wal.tail();
         }
-        // Object ids are shared by tables, their secondary indexes, and logins
-        // (principals draw from the same counter), so the next id must clear all
-        // three — an index or a login can outrank every table.
+        // Object ids are shared by tables, their secondary indexes, logins,
+        // database principals, and database rows (all draw from the same
+        // counter), so the next id must clear every kind — an index or a login
+        // can outrank every table.
         self.rel.next_object_id = self
             .rel
-            .tables
-            .values()
+            .all_tables()
             .flat_map(|def| {
                 std::iter::once(def.object_id)
                     .chain(def.indexes.iter().map(|index| index.object_id))
@@ -5590,6 +5846,7 @@ impl StorageFile {
                     .values()
                     .map(|def| def.object_id),
             )
+            .chain(self.rel.databases.values().map(|def| def.object_id))
             .map(|object_id| object_id + 1)
             .max()
             .unwrap_or(FIRST_USER_OBJECT_ID)
@@ -5601,6 +5858,7 @@ impl StorageFile {
     fn reload_catalog(&mut self) -> Result<(), StorageError> {
         let Some(root) = self.rel.catalog_root else {
             self.rel.tables.clear();
+            self.rel.databases.clear();
             self.rel.principals.clear();
             self.rel.database_principals.clear();
             return Ok(());
@@ -5610,6 +5868,7 @@ impl StorageFile {
             catalog::load_tables(&mut ctx, root)?
         };
         self.rel.tables.clear();
+        self.rel.databases.clear();
         self.rel.principals.clear();
         self.rel.database_principals.clear();
         for def in defs {
@@ -5624,8 +5883,13 @@ impl StorageFile {
                 self.rel
                     .database_principals
                     .insert(def.name.to_ascii_lowercase(), def);
+            } else if def.is_database() {
+                // Databases: namespace containers, out of the object namespace.
+                self.rel
+                    .databases
+                    .insert(def.name.to_ascii_lowercase(), def);
             } else {
-                self.rel.tables.insert(def.name.clone(), def);
+                self.rel.cache_table(def);
             }
         }
         Ok(())
@@ -6025,7 +6289,7 @@ impl StorageFile {
             REL_KIND_SET_CATALOG_ROOT, REL_KIND_TXN_COMMIT, REL_KIND_TXN_END,
         };
         let alive: std::collections::HashSet<u32> =
-            self.rel.tables.values().map(|def| def.object_id).collect();
+            self.rel.all_tables().map(|def| def.object_id).collect();
         let mut freed_pages: std::collections::HashSet<u64> = std::collections::HashSet::new();
         for (_, record) in records {
             if record.kind == REL_KIND_FREE_EXTENT
@@ -8364,6 +8628,7 @@ mod tests {
         // locks the database exclusively rather than ever under-locking.
         let needs = crate::rel::analyze_locks(
             &storage,
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
             "DECLARE @s NVARCHAR(50) = N'SELECT v FROM t'; EXEC sp_executesql @s",
             Isolation::ReadCommitted,
         );
@@ -8375,6 +8640,7 @@ mod tests {
         // Direction 1: a SET raise BEFORE the EXEC locks the inner reads.
         let needs = crate::rel::analyze_locks(
             &storage,
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
             "SET TRANSACTION ISOLATION LEVEL SERIALIZABLE; EXEC sp_executesql N'SELECT v FROM t'",
             Isolation::ReadUncommitted,
         );
@@ -8389,6 +8655,7 @@ mod tests {
         // statements after it inside the same literal.
         let needs = crate::rel::analyze_locks(
             &storage,
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
             "EXEC sp_executesql N'SET TRANSACTION ISOLATION LEVEL SERIALIZABLE; SELECT v FROM t'",
             Isolation::ReadUncommitted,
         );
@@ -8477,7 +8744,12 @@ mod tests {
             let outcome = execute_batch(&storage, sql, &mut ctx);
             assert!(outcome.error.is_none(), "{sql}: {:?}", outcome.error);
         }
-        let needs = crate::rel::analyze_locks(&storage, "EXEC writer 1", Isolation::ReadCommitted);
+        let needs = crate::rel::analyze_locks(
+            &storage,
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
+            "EXEC writer 1",
+            Isolation::ReadCommitted,
+        );
         assert!(
             needs.iter().any(
                 |(r, m)| matches!(r, Resource::Table(_)) && *m == LockMode::Exclusive
@@ -8487,8 +8759,12 @@ mod tests {
              terminated): {needs:?}"
         );
         // An unknown procedure contributes no locks (2812 at execution).
-        let needs =
-            crate::rel::analyze_locks(&storage, "EXEC no_such_proc", Isolation::ReadCommitted);
+        let needs = crate::rel::analyze_locks(
+            &storage,
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
+            "EXEC no_such_proc",
+            Isolation::ReadCommitted,
+        );
         assert!(
             !needs
                 .iter()
@@ -8531,15 +8807,24 @@ mod tests {
                 .any(|(r, m)| matches!(r, Resource::Table(_)) && *m == LockMode::Shared)
         };
         // Control: analyzed alone, the escalated body read-locks.
-        let needs = crate::rel::analyze_locks(&storage, "EXEC pser", Isolation::ReadCommitted);
+        let needs = crate::rel::analyze_locks(
+            &storage,
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
+            "EXEC pser",
+            Isolation::ReadCommitted,
+        );
         assert!(
             table_s(&needs),
             "control: pser's escalated body takes Table S: {needs:?}"
         );
         // The seam: pread analyzed first under the versioned regime, then
         // pser's escalated re-entry is dropped by the visited set.
-        let needs =
-            crate::rel::analyze_locks(&storage, "EXEC pread; EXEC pser", Isolation::ReadCommitted);
+        let needs = crate::rel::analyze_locks(
+            &storage,
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
+            "EXEC pread; EXEC pser",
+            Isolation::ReadCommitted,
+        );
         assert!(
             table_s(&needs),
             "pser still runs pread's SELECT under SERIALIZABLE — Table S \
@@ -8569,6 +8854,7 @@ mod tests {
         }
         let needs = crate::rel::analyze_locks(
             &storage,
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
             "EXEC sp_executesql N'EXEC wtr 1'",
             Isolation::ReadCommitted,
         );
@@ -8614,6 +8900,7 @@ mod tests {
             // literal's INSERT locks must be in the analyzed set.
             let needs = crate::rel::analyze_locks(
                 &storage,
+                crate::relstore::catalog::DEFAULT_DATABASE_ID,
                 "EXEC sp_executesql N'INSERT INTO t VALUES (1)'",
                 Isolation::ReadCommitted,
             );
@@ -8647,6 +8934,7 @@ mod tests {
 
         let needs = crate::rel::analyze_locks(
             &storage,
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
             "DECLARE @i INT = 0; WHILE @i < 3 BEGIN INSERT INTO locked_t VALUES (@i); \
              SET @i = @i + 1; END",
             Isolation::ReadCommitted,
@@ -8661,6 +8949,7 @@ mod tests {
 
         let needs = crate::rel::analyze_locks(
             &storage,
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
             "IF EXISTS (SELECT * FROM locked_t) SELECT 1",
             Isolation::ReadCommitted,
         );
@@ -8714,7 +9003,12 @@ mod tests {
             "IF EXISTS (SELECT * FROM lv) SELECT 1",
             "IF (SELECT COUNT(*) FROM lt) = 0 SELECT 1",
         ] {
-            let needs = crate::rel::analyze_locks(&storage, sql, Isolation::ReadCommitted);
+            let needs = crate::rel::analyze_locks(
+                &storage,
+                crate::relstore::catalog::DEFAULT_DATABASE_ID,
+                sql,
+                Isolation::ReadCommitted,
+            );
             assert!(
                 table_s(&needs),
                 "{sql}: condition read takes Table S: {needs:?}"
@@ -8723,6 +9017,7 @@ mod tests {
         // Both IF branches analyze — an untaken ELSE's INSERT is still locked.
         let needs = crate::rel::analyze_locks(
             &storage,
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
             "IF 1 = 2 SELECT 1 ELSE INSERT INTO lt VALUES (9)",
             Isolation::ReadCommitted,
         );
@@ -8733,6 +9028,7 @@ mod tests {
         // An EXEC literal inside a WHILE body analyzes through the Exec arm.
         let needs = crate::rel::analyze_locks(
             &storage,
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
             "DECLARE @i INT = 0; WHILE @i < 1 BEGIN \
              EXEC sp_executesql N'INSERT INTO lt VALUES (7)'; SET @i = @i + 1; END",
             Isolation::ReadCommitted,
@@ -8765,6 +9061,7 @@ mod tests {
         assert!(outcome.error.is_none(), "{:?}", outcome.error);
         let needs = crate::rel::analyze_locks(
             &storage,
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
             "IF EXISTS (WITH x AS (SELECT id FROM lt) SELECT id FROM x) SELECT 1",
             Isolation::ReadCommitted,
         );
@@ -8800,8 +9097,12 @@ mod tests {
         };
 
         // Off: the SELECT read-locks, as ever.
-        let needs =
-            crate::rel::analyze_locks(&storage, "SELECT v FROM t", Isolation::ReadCommitted);
+        let needs = crate::rel::analyze_locks(
+            &storage,
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
+            "SELECT v FROM t",
+            Isolation::ReadCommitted,
+        );
         assert!(
             table_s(&needs),
             "without RCSI a RC SELECT takes Table S: {needs:?}"
@@ -8815,8 +9116,12 @@ mod tests {
         assert!(outcome.error.is_none(), "{:?}", outcome.error);
 
         // On: Database IS only — the DDL fence — and no Table S.
-        let needs =
-            crate::rel::analyze_locks(&storage, "SELECT v FROM t", Isolation::ReadCommitted);
+        let needs = crate::rel::analyze_locks(
+            &storage,
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
+            "SELECT v FROM t",
+            Isolation::ReadCommitted,
+        );
         assert!(
             !table_s(&needs),
             "under RCSI a RC SELECT takes no Table S: {needs:?}"
@@ -8829,14 +9134,23 @@ mod tests {
         // The other levels are untouched: RR still read-locks, RU still
         // takes nothing, and a batch that raises isolation falls back to
         // locking even though the session level is RC.
-        let needs =
-            crate::rel::analyze_locks(&storage, "SELECT v FROM t", Isolation::RepeatableRead);
+        let needs = crate::rel::analyze_locks(
+            &storage,
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
+            "SELECT v FROM t",
+            Isolation::RepeatableRead,
+        );
         assert!(table_s(&needs), "RR is not versioned: {needs:?}");
-        let needs =
-            crate::rel::analyze_locks(&storage, "SELECT v FROM t", Isolation::ReadUncommitted);
+        let needs = crate::rel::analyze_locks(
+            &storage,
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
+            "SELECT v FROM t",
+            Isolation::ReadUncommitted,
+        );
         assert!(needs.is_empty(), "RU takes no locks at all: {needs:?}");
         let needs = crate::rel::analyze_locks(
             &storage,
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
             "SET TRANSACTION ISOLATION LEVEL SERIALIZABLE; SELECT v FROM t",
             Isolation::ReadCommitted,
         );
@@ -8848,7 +9162,12 @@ mod tests {
         // SNAPSHOT isolation is versioned regardless of RCSI: Database IS
         // only, and the EXEC-literal recursion preserves the level (the
         // #120 review's collapse bug, from the other direction).
-        let needs = crate::rel::analyze_locks(&storage, "SELECT v FROM t", Isolation::Snapshot);
+        let needs = crate::rel::analyze_locks(
+            &storage,
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
+            "SELECT v FROM t",
+            Isolation::Snapshot,
+        );
         assert!(
             !table_s(&needs),
             "SNAPSHOT reads take no Table S: {needs:?}"
@@ -8856,6 +9175,7 @@ mod tests {
         assert!(needs.contains(&(Resource::Database, LockMode::IntentShared)));
         let needs = crate::rel::analyze_locks(
             &storage,
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
             "EXEC sp_executesql N'SELECT v FROM t'",
             Isolation::Snapshot,
         );
@@ -8867,6 +9187,7 @@ mod tests {
         // raise, but the batch still holds the Database IS fence.
         let needs = crate::rel::analyze_locks(
             &storage,
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
             "SET TRANSACTION ISOLATION LEVEL SNAPSHOT; SELECT v FROM t",
             Isolation::ReadUncommitted,
         );
@@ -9055,7 +9376,12 @@ mod tests {
         );
         // The pinned view still reads its consistent state through all of it.
         let rows = storage
-            .rel_scan_snapshot("t", Some(&[1]), pinned)
+            .rel_scan_snapshot(
+                crate::relstore::catalog::DEFAULT_DATABASE_ID,
+                "t",
+                Some(&[1]),
+                pinned,
+            )
             .expect("snapshot scan");
         assert_eq!(rows.len(), 100);
         assert!(
@@ -10126,7 +10452,12 @@ mod tests {
         };
 
         // At the threshold: per-row locks (plus the table intent).
-        let needs = crate::rel::analyze_locks(&storage, &insert(1000), Isolation::ReadCommitted);
+        let needs = crate::rel::analyze_locks(
+            &storage,
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
+            &insert(1000),
+            Isolation::ReadCommitted,
+        );
         let rows = needs
             .iter()
             .filter(|(r, _)| matches!(r, Resource::Row(_, _)))
@@ -10144,7 +10475,12 @@ mod tests {
         // declines to enumerate 1001 row hashes and the INSERT falls back to
         // one table-exclusive lock. (Reachable since the node budget became
         // per-expression — a 1001-tuple INSERT parses now.)
-        let needs = crate::rel::analyze_locks(&storage, &insert(1001), Isolation::ReadCommitted);
+        let needs = crate::rel::analyze_locks(
+            &storage,
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
+            &insert(1001),
+            Isolation::ReadCommitted,
+        );
         assert!(
             needs
                 .iter()
@@ -10168,7 +10504,12 @@ mod tests {
             .map(|i| format!("DELETE FROM t WHERE id = {i}"))
             .collect();
         let over = format!("{}; {}", insert(1000), deletes.join("; "));
-        let needs = crate::rel::analyze_locks(&storage, &over, Isolation::ReadCommitted);
+        let needs = crate::rel::analyze_locks(
+            &storage,
+            crate::relstore::catalog::DEFAULT_DATABASE_ID,
+            &over,
+            Isolation::ReadCommitted,
+        );
         assert!(
             needs
                 .iter()
@@ -10504,24 +10845,37 @@ mod tests {
             &mut ctx,
             "CREATE TABLE t (id INT NOT NULL PRIMARY KEY, v INT)",
         );
-        assert_eq!(storage.rel_row_count("t"), Some(0));
+        assert_eq!(
+            storage.rel_row_count(crate::relstore::catalog::DEFAULT_DATABASE_ID, "t"),
+            Some(0)
+        );
 
         run(
             &storage,
             &mut ctx,
             "INSERT INTO t VALUES (1, 10), (2, 20), (3, 30)",
         );
-        assert_eq!(storage.rel_row_count("t"), Some(3));
+        assert_eq!(
+            storage.rel_row_count(crate::relstore::catalog::DEFAULT_DATABASE_ID, "t"),
+            Some(3)
+        );
 
         run(&storage, &mut ctx, "DELETE FROM t WHERE id = 3");
         run(&storage, &mut ctx, "UPDATE t SET v = 99 WHERE id = 1");
-        assert_eq!(storage.rel_row_count("t"), Some(2), "delete -1, update 0");
+        assert_eq!(
+            storage.rel_row_count(crate::relstore::catalog::DEFAULT_DATABASE_ID, "t"),
+            Some(2),
+            "delete -1, update 0"
+        );
 
         // A failing multi-row statement (duplicate key on its last row) is
         // atomic: no rows land, and neither does its count.
         let dup = execute_batch(&storage, "INSERT INTO t VALUES (5, 1), (1, 1)", &mut ctx);
         assert!(dup.error.is_some(), "duplicate key must fail");
-        assert_eq!(storage.rel_row_count("t"), Some(2));
+        assert_eq!(
+            storage.rel_row_count(crate::relstore::catalog::DEFAULT_DATABASE_ID, "t"),
+            Some(2)
+        );
 
         // Transaction rollback restores the count with the rows.
         run(
@@ -10529,9 +10883,16 @@ mod tests {
             &mut ctx,
             "BEGIN TRANSACTION; INSERT INTO t VALUES (10, 1), (11, 1)",
         );
-        assert_eq!(storage.rel_row_count("t"), Some(4), "in-flight rows count");
+        assert_eq!(
+            storage.rel_row_count(crate::relstore::catalog::DEFAULT_DATABASE_ID, "t"),
+            Some(4),
+            "in-flight rows count"
+        );
         run(&storage, &mut ctx, "ROLLBACK");
-        assert_eq!(storage.rel_row_count("t"), Some(2));
+        assert_eq!(
+            storage.rel_row_count(crate::relstore::catalog::DEFAULT_DATABASE_ID, "t"),
+            Some(2)
+        );
 
         // A savepoint rollback restores exactly the statements behind it.
         run(
@@ -10540,14 +10901,17 @@ mod tests {
             "BEGIN TRANSACTION; INSERT INTO t VALUES (20, 1); SAVE TRANSACTION sp; \
              INSERT INTO t VALUES (21, 1); ROLLBACK TRANSACTION sp; COMMIT",
         );
-        assert_eq!(storage.rel_row_count("t"), Some(3));
+        assert_eq!(
+            storage.rel_row_count(crate::relstore::catalog::DEFAULT_DATABASE_ID, "t"),
+            Some(3)
+        );
 
         // Crash (no checkpoint, pool never flushed): recovery replays the ops,
         // counter page included.
         drop(storage);
         let storage = Storage::open(path.clone()).expect("reopen");
         assert_eq!(
-            storage.rel_row_count("t"),
+            storage.rel_row_count(crate::relstore::catalog::DEFAULT_DATABASE_ID, "t"),
             Some(3),
             "count survives recovery"
         );
@@ -10579,12 +10943,16 @@ mod tests {
             &mut open_txn,
         );
         assert!(pending.error.is_none(), "{:?}", pending.error);
-        assert_eq!(storage.rel_row_count("t"), Some(5), "in-flight rows count");
+        assert_eq!(
+            storage.rel_row_count(crate::relstore::catalog::DEFAULT_DATABASE_ID, "t"),
+            Some(5),
+            "in-flight rows count"
+        );
         drop(storage); // crash with the transaction open
 
         let storage = Storage::open(path.clone()).expect("reopen");
         assert_eq!(
-            storage.rel_row_count("t"),
+            storage.rel_row_count(crate::relstore::catalog::DEFAULT_DATABASE_ID, "t"),
             Some(2),
             "the loser transaction's rows and count are both undone"
         );
@@ -11083,7 +11451,11 @@ mod tests {
         // `flushed` stays put — nothing fsyncs.
         for i in 0..THREADS {
             storage
-                .rel_insert("t", vec![Datum::Int(i as i32)])
+                .rel_insert(
+                    crate::relstore::catalog::DEFAULT_DATABASE_ID,
+                    "t",
+                    vec![Datum::Int(i as i32)],
+                )
                 .expect("insert");
         }
         let target = storage.wal_tail();

--- a/crates/truthdb-core/src/storage.rs
+++ b/crates/truthdb-core/src/storage.rs
@@ -1726,9 +1726,19 @@ impl Storage {
     }
 
     /// Stamps the default database's name (id 1) from the instance
-    /// configuration. Called once at engine construction, before sessions.
-    pub fn set_default_database_name(&self, name: &str) {
-        self.lock().default_db_name = name.to_string();
+    /// configuration. Called once at startup, before sessions. Refuses a name
+    /// a stored `CREATE DATABASE` row already uses — the default database
+    /// would otherwise shadow it (the name→id resolution checks the default
+    /// first), leaving the stored database unreachable and undroppable.
+    pub fn set_default_database_name(&self, name: &str) -> Result<(), StorageError> {
+        let mut guard = self.lock();
+        if guard.rel.databases.contains_key(&name.to_ascii_lowercase()) {
+            return Err(StorageError::InvalidConfig(format!(
+                "the configured default database name '{name}' collides with a database                  created by CREATE DATABASE; rename one of them"
+            )));
+        }
+        guard.default_db_name = name.to_string();
+        Ok(())
     }
 
     pub(crate) fn rel_create_index(

--- a/crates/truthdb-sql/src/eval.rs
+++ b/crates/truthdb-sql/src/eval.rs
@@ -66,11 +66,16 @@ impl ColumnResolver for Vec<String> {
 /// kept small (heavy arms delegate to out-of-line helpers) so this is safe.
 const MAX_EVAL_DEPTH: usize = 500;
 
+/// The default database's id. Mirrors `truthdb-core`'s catalog constant
+/// (this crate is a dependency of truthdb-core and cannot import it); the
+/// mirror is asserted equal at truthdb-core's build.
+pub const DEFAULT_DATABASE_ID: u32 = 1;
+
 /// Session context available to expression evaluation: `@@`-variables, the
 /// batch's `@`-variables, and (in later stages) the current time /
 /// SCOPE_IDENTITY. `Default` is a no-transaction, no-variable context, used
 /// where no session is in scope.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct EvalContext {
     pub trancount: i32,
     /// Declared batch variables (name without `@`, lowercased) to their current
@@ -79,6 +84,10 @@ pub struct EvalContext {
     pub variables: std::collections::HashMap<String, SqlValue>,
     /// The connection's current database name — `DB_NAME()`.
     pub database: String,
+    /// The connection's current database id — the namespace unqualified
+    /// object names resolve in. Never 0: the manual `Default` lands in the
+    /// default database.
+    pub database_id: u32,
     /// The authenticated login name — `SUSER_SNAME()`.
     pub login: String,
     /// The session's database user name — `USER_NAME()` (with no argument).
@@ -118,6 +127,31 @@ pub struct EvalContext {
     /// `@@FETCH_STATUS` — the result of the last cursor FETCH: 0 success, -1 past
     /// the end / no more rows, -2 the fetched row is missing.
     pub fetch_status: i32,
+}
+
+impl Default for EvalContext {
+    fn default() -> Self {
+        EvalContext {
+            trancount: 0,
+            variables: Default::default(),
+            database: String::new(),
+            database_id: DEFAULT_DATABASE_ID,
+            login: String::new(),
+            user: String::new(),
+            server_roles: Default::default(),
+            db_roles: Default::default(),
+            security: Default::default(),
+            spid: 0,
+            rowcount: 0,
+            scope_identity: None,
+            error: None,
+            xact_state: 0,
+            last_error: 0,
+            nestlevel: 0,
+            updated_columns: None,
+            fetch_status: 0,
+        }
+    }
 }
 
 /// The columns a trigger's firing statement touched: the parent table's column

--- a/src/main.rs
+++ b/src/main.rs
@@ -93,6 +93,13 @@ async fn main() {
             return;
         }
     };
+    // The default database (id 1) is named by `[tds] database` — the one
+    // source the sessions' database identity already comes from; storage's
+    // name→id resolution must agree with it.
+    if let Err(err) = engine.set_default_database(&config.tds.database) {
+        eprintln!("Failed to set the default database name: {err}");
+        return;
+    }
     // First boot migrates `[tds.auth]` config users into catalog logins (and
     // always ensures `sa`), then config auth is dead. Runs before the engine
     // thread is spawned — single-threaded, no session — and is a no-op once any


### PR DESCRIPTION
First slice of the multiple-databases plan (docs/MULTIPLE_DATABASES_PLAN.md): the catalog layer.

- Databases are catalog rows with a `DatabaseDef { db_id }` payload, kept in their own map out of the object namespace (the principals pattern). Ids allocate max+1 from 2, capped at u16::MAX so an id always fits the future WAL container tag.
- The default database (id 1) is synthesized, never stored — named by configuration, no bootstrap write on open, nothing for read-only standbys to do. It cannot be dropped.
- `TableDef.database_id` with serde default 1: every pre-existing catalog row deserializes into the default database. Object-name uniqueness is now per database; the table cache is keyed db → name → def.
- Every name-keyed storage API gains the database dimension; the exec layer threads the session's database id through resolution, lock analysis (including `analyze_statements_locks`, trigger and view lock expansion), DML, DDL, and the planner. `TxnContext`/`EvalContext` gain `database_id` with defaults that land in database 1 (a wrapper type and a manual Default — one representation of "the default database", not two — plus a compile-time assertion welding the truthdb-sql mirror constant to the catalog's).
- `rel_create_database` / `rel_drop_database` (drops all contained objects in one statement transaction, stamping the same version fences as DROP TABLE) / `rel_database_id_by_name` (the single name→id derivation) / `rel_databases`.
- Standby: database rows replicate through ordinary catalog page redo + the existing unconditional `reload_catalog` per applied range — no replication changes.

Behaviorally still single-database: sessions always run in the default database until A2 (CREATE/DROP DATABASE SQL surface, real USE, three-part names, DB_ID, real sys.databases rows, login validation).

Tests: four new storage-level tests (persistence across reopen + id continuation, case-insensitive duplicate refusal incl. the default name, per-database name scoping + scoped drop, default-database drop refusal). `cargo test --workspace`: 817 passed, 0 failed. fmt + clippy `-D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)